### PR TITLE
perf(octane): reduce external-store overhead

### DIFF
--- a/.changeset/external-store-notification-lifecycle.md
+++ b/.changeset/external-store-notification-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid redundant external-store snapshot checks when an urgent DOM render is already queued. Keep universal-renderer subscriptions connected across snapshot and getter changes while preserving committed selectors, cleanup, and error handling. Avoid quadratic projection work for universal state-update queues that end in a replacement value.

--- a/.changeset/mcp-universal-external-store-benchmark.md
+++ b/.changeset/mcp-universal-external-store-benchmark.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/mcp-server': patch
+---
+
+Expose the universal external-store benchmark through the MCP benchmark tool.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -54,6 +54,7 @@ Some suites need no preview servers: **news**, **hydration-interactivity**, and
 the three runtime-stress suites vite-build and time each target themselves (the
 runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
+**universal-external-store**,
 **lynx-render**, and **lynx-bundle-size** are Node-only,
 **ssr-http** and **tanstack-start** boot (and kill) their own production HTTP
 servers per sample — that spawn/listen/first-byte cycle IS the measurement —
@@ -195,7 +196,7 @@ internally, get their own baseline and guard namespace.
 | `hydration-stress` | hydration-stress | none (builds) | withheld-chunk hydration, keyboard and pointer Send delivery, DOM adoption, and explicit replay/drop diagnostics at 6× CPU throttling |
 | `lifecycle-memory` | lifecycle-memory | none (builds) | 1,000+ effectful mount/update/unmount cycles, real listener/subscription/timer cleanup, post-teardown event probes, and explicitly collected Chromium heap across all six frameworks |
 | `controlled-form` | controlled-form | none (builds) | 512 controlled fields, real typing, DOM identity, focus and caret, validation cancellation, complete submit/reset, and native select/checkbox/radio correctness |
-| `external-store-fanout` | external-store-fanout | none (builds) | 512 subscribers, narrow and broad writes, rapid-write tearing checks, snapshots, notifications, renders, and exact subscription cleanup |
+| `external-store-fanout` | external-store-fanout | none (builds) | 512 subscribers, narrow and broad writes, rapid-write tearing checks, deterministic 100-notification work guards, and balanced subscription removal |
 | `external-store-integrations` | external-store-integrations | none (builds) | real Zustand stores, Jotai atoms, and TanStack Query caches with selector fan-out, query invalidation, and six-framework cleanup gates |
 | `store-selector-fanout` | store-selector-fanout | none (builds) | 512 subscribers reading one store through a `with-selector`-shaped selector, 20 unrelated parent re-renders with the store untouched, and deterministic selector-invocation counts beside render and snapshot counts |
 | `scheduler-responsiveness` | scheduler-responsiveness | none (builds) | real controlled typing during eight 512-subscriber store updates at 6× CPU throttling, with focus, caret, frame, and notification gates |
@@ -219,6 +220,7 @@ internally, get their own baseline and guard namespace.
 | `async-composition` | async-composition | octane-tsrx, react | dashboard composition: adjacent async panels, nested children, imported custom hook, and one true dependency |
 | `lynx-list` | lynx-list | none (Node-only) | deterministic 1,000-row native-list physical allocation, reuse, and teardown through a fake Element PAPI |
 | `universal-leaf-update` | universal-leaf-update | none (Node-only) | universal update locality beside 0–4,000 unrelated component siblings through the compiler and native object driver: plain leaf `setState`, keyed `@for` item state, a leaf under an idle `@try`, a structural (insert/remove) update, and compact-row list selection |
+| `universal-external-store` | universal-external-store | none (Node-only) | 128 native universal store subscribers, getter/subscribe identity controls, notification bursts, and deterministic subscription-lifetime and state-projection guards |
 | `lynx-render` | lynx-render | none (Node-only) | dual-thread Lynx render CPU: empty startup, create 1,000 and 10,000 keyed rows through the real background root, transport, and main receiver over a cheap fake Element PAPI, plus a gate that a native tap reaches its background handler via the engine `publishEvent` receiver |
 | `lynx-table` | lynx-table | none (Node-only; separate Chromium harness) | deterministic per-operation wire cost of the cross-framework krausest table (command counts and serialized commit bytes vs a changed-rows floor) through the real dual-thread path and real tap tokens |
 | `lynx-table-web` | lynx-table | none (headless Chromium) | Lynx-for-Web wall clock: the same table app for Octane and the vendored ReactLynx / Vue Lynx reference bundles under one byte-identical page driver; host-bound medians, no ratio guards |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -384,6 +384,46 @@
     "note": "Compact leaf rows driven by their list component's selection state replay only that component (its 100 rows), so unrelated siblings must not change the cost. Rejects the compact-range bail that forced list selection through a whole-root replay."
   },
   {
+    "suite": "universal-external-store",
+    "op": "lifetime_subscribe_calls",
+    "target": "stable-getter",
+    "reference": "subscription-reference",
+    "maxRatio": 1,
+    "note": "A stable subscribe function needs one subscription per universal reader for its mounted lifetime, including unrelated parent renders and store updates. Final host values and listener release are independently checked."
+  },
+  {
+    "suite": "universal-external-store",
+    "op": "lifetime_unsubscribe_calls",
+    "target": "stable-getter",
+    "reference": "subscription-reference",
+    "maxRatio": 1,
+    "note": "A stable universal store subscription should be released only at teardown; repeated renders must not add disconnect/reconnect work."
+  },
+  {
+    "suite": "universal-external-store",
+    "op": "lifetime_subscribe_calls",
+    "target": "inline-getter",
+    "reference": "subscription-reference",
+    "maxRatio": 1,
+    "note": "Fresh snapshot-getter closures must not reconnect a stable universal subscribe function. The subscription must continue to observe current selections and store values."
+  },
+  {
+    "suite": "universal-external-store",
+    "op": "lifetime_unsubscribe_calls",
+    "target": "inline-getter",
+    "reference": "subscription-reference",
+    "maxRatio": 1,
+    "note": "An inline getter changes what is read, not subscription ownership: each mounted universal reader needs one lifetime release."
+  },
+  {
+    "suite": "universal-external-store",
+    "op": "prefix_updater_calls",
+    "target": "state-replacement-burst",
+    "reference": "state-replacement-reference",
+    "maxRatio": 1,
+    "note": "Two thousand direct replacements supersede an earlier functional updater. Public getState observations and the final host value/order are checked independently. The constant three-call budget allows eager enqueue, the first prior-value read, and ordered commit; it rejects repeated replay of the superseded prefix without requiring a particular cheaper implementation. The frozen pre-fix runtime called the updater 4,002 times; the candidate called it three times."
+  },
+  {
     "suite": "lifecycle-memory",
     "op": "cycle",
     "target": "octane-tsrx",
@@ -406,6 +446,54 @@
     "reference": "react",
     "maxRatio": 2,
     "note": "Same-run 512-subscriber useSyncExternalStore fan-out, gated on complete visible updates, rapid-write consistency, and exact listener teardown. A verified quick run measured about 1.01x; 2x leaves real-browser scheduling headroom."
+  },
+  {
+    "suite": "external-store-fanout",
+    "op": "broad_burst_snapshot_reads",
+    "target": "octane-tsrx-work",
+    "reference": "required-work",
+    "maxRatio": 1,
+    "note": "Deterministic notification-phase work for 100 broad writes: one changed snapshot comparison is enough to schedule each of the 512 readers. Final DOM values, survivor identity, and balanced subscription cleanup gate the optimization."
+  },
+  {
+    "suite": "external-store-fanout",
+    "op": "unchanged_burst_snapshot_reads",
+    "target": "octane-tsrx-work",
+    "reference": "required-work",
+    "maxRatio": 1,
+    "note": "Unchanged-notification control: compare each reader's snapshot at most once per notification. The separate zero-render guard prevents trading getter work for unnecessary component renders."
+  },
+  {
+    "suite": "external-store-fanout",
+    "op": "narrow_burst_snapshot_reads",
+    "target": "octane-tsrx-work",
+    "reference": "required-work",
+    "maxRatio": 1,
+    "note": "Narrow-notification control: untouched readers still compare on every notification, while the one changed reader needs only its first comparison before the batched render. The visible final state must differ only at the selected index."
+  },
+  {
+    "suite": "external-store-fanout",
+    "op": "broad_burst_renders",
+    "target": "octane-tsrx-work",
+    "reference": "required-work",
+    "maxRatio": 1,
+    "note": "The 100-write broad burst must converge with at most one render per changed reader; every subscriber must display the final store value."
+  },
+  {
+    "suite": "external-store-fanout",
+    "op": "unchanged_burst_renders",
+    "target": "octane-tsrx-work",
+    "reference": "required-work",
+    "maxRatio": 0,
+    "note": "An unchanged snapshot must not cause subscriber render work. The reference is one count so a zero ceiling is expressible without a zero denominator."
+  },
+  {
+    "suite": "external-store-fanout",
+    "op": "narrow_burst_renders",
+    "target": "octane-tsrx-work",
+    "reference": "required-work",
+    "maxRatio": 1,
+    "note": "Only the reader whose selected value changed should render during the 100-write narrow burst; untouched subscriber DOM and identities must remain intact."
   },
   {
     "suite": "store-selector-fanout",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -330,7 +330,7 @@ const SUITES = [
 				script: 'run.mjs',
 				args: (n) => [target, String(n)],
 			})),
-			...(name === 'event-delegation'
+			...(name === 'event-delegation' || name === 'external-store-fanout'
 				? [{ label: 'work', script: 'work.mjs', args: () => [] }]
 				: []),
 		],
@@ -589,6 +589,15 @@ const SUITES = [
 		// fixture and measures one stateful leaf beside up to 4,000 unrelated owners.
 		name: 'universal-leaf-update',
 		cwd: 'universal-leaf-update',
+		servers: [],
+		iter: { normal: 5, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
+		// Native universal external-store hooks: stable subscription lifetimes and
+		// bounded state-projection work across parent renders and notification bursts.
+		name: 'universal-external-store',
+		cwd: 'universal-external-store',
 		servers: [],
 		iter: { normal: 5, quick: 3 },
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],

--- a/benchmarks/external-store-fanout/README.md
+++ b/benchmarks/external-store-fanout/README.md
@@ -8,11 +8,31 @@ Octane, React, and Preact use `useSyncExternalStore`; the signal-based renderers
 use their native lifecycle and reactive primitives. Real Chromium verifies that
 a narrow write changes only its intended visible subscriber, a broad write
 updates all 512 subscribers consistently, rapid consecutive writes do not tear,
-and teardown removes every store listener exactly once. Snapshot calls,
+and teardown balances subscription acquisition/removal without retaining listeners. Snapshot calls,
 notifications, subscriber renders, and subscription cleanup are published as
 diagnostics alongside timing.
 
 ```bash
 node benchmarks/bench.mjs --quick external-store-fanout
 node benchmarks/bench.mjs external-store-fanout
+```
+
+## Notification-work guard
+
+`work.mjs` builds the same Octane fixture and sends 100 notifications in one
+browser task. It runs unchanged, broad, and narrow bursts separately. The
+notification-phase snapshot reads are counted before rendering starts; later
+render and commit reads are reported separately. Every phase checks the final
+visible values and retained subscriber DOM, and teardown must release every
+listener.
+
+The `octane-tsrx-work` and `required-work` targets feed deterministic ratio
+guards. A broad burst needs at most one snapshot comparison to schedule each
+reader; a narrow burst still checks the untouched readers on every notification.
+Unchanged notifications must not render subscribers. These are work ceilings,
+so a future implementation can do less work without breaking the guard.
+
+```bash
+node benchmarks/external-store-fanout/work.mjs
+node benchmarks/bench.mjs --quick --ratios external-store-fanout
 ```

--- a/benchmarks/external-store-fanout/work.mjs
+++ b/benchmarks/external-store-fanout/work.mjs
@@ -1,0 +1,247 @@
+// Deterministic notification work over the existing production-built fan-out
+// fixture. Keep count instrumentation separate from the ordinary timing run.
+process.env.NODE_ENV = 'production';
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { STORE_SUBSCRIBER_COUNT } from '../runtime-stress/shared.js';
+
+const requireFromNews = createRequire(new URL('../news/package.json', import.meta.url));
+const { chromium } = requireFromNews('playwright');
+const appDirectory = fileURLToPath(new URL('../news/octane-tsrx/', import.meta.url));
+const NOTIFICATION_BURST = 100;
+const CHANGED_INDEX = 17;
+
+let browser;
+let productionServer;
+let observed;
+let failure;
+
+function ensure(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+try {
+	let target = process.env.EXTERNAL_STORE_WORK_URL;
+	if (!target) {
+		const { build, preview } = await import(pathToFileURL(requireFromNews.resolve('vite')).href);
+		await build({
+			root: appDirectory,
+			logLevel: 'error',
+			build: {
+				outDir: 'dist/runtime-stress',
+				emptyOutDir: true,
+				minify: 'esbuild',
+				rollupOptions: {
+					input: path.join(appDirectory, 'runtime-stress.html'),
+					output: {
+						chunkFileNames: 'assets/[name]-[hash].js',
+						entryFileNames: 'assets/[name]-[hash].js',
+					},
+				},
+			},
+		});
+		productionServer = await preview({
+			root: appDirectory,
+			logLevel: 'error',
+			build: { outDir: 'dist/runtime-stress' },
+			preview: { host: '127.0.0.1', port: 0, strictPort: true },
+		});
+		const address = productionServer.httpServer.address();
+		ensure(
+			address !== null && typeof address !== 'string',
+			'The production external-store fixture did not expose a TCP port',
+		);
+		target = `http://127.0.0.1:${address.port}/runtime-stress.html`;
+	}
+
+	browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+	const page = await browser.newPage();
+	const errors = [];
+	page.on('pageerror', (error) => errors.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'error') errors.push(message.text());
+	});
+	await page.goto(target, { waitUntil: 'load' });
+	await page.waitForFunction(() => window.__runtimeStress?.ready === true);
+	await page.locator('#store-toggle').click();
+	await page.waitForFunction(
+		(count) =>
+			document.querySelectorAll('[data-subscriber-index]').length === count &&
+			window.__runtimeStress.store.size === count,
+		STORE_SUBSCRIBER_COUNT,
+	);
+	await page.evaluate(() => {
+		window.__externalStoreWorkNodes = Array.from(
+			document.querySelectorAll('[data-subscriber-index]'),
+		);
+	});
+
+	const phases = {};
+	for (const name of ['unchanged', 'broad', 'narrow']) {
+		const notification = await page.evaluate(
+			({ name, burst, changedIndex }) => {
+				const {
+					store,
+					stats: { store: stats },
+				} = window.__runtimeStress;
+				const before = {
+					notifications: stats.notifications,
+					renders: stats.renders.reduce((sum, value) => sum + value, 0),
+					snapshotCalls: stats.snapshotCalls,
+				};
+				for (let index = 0; index < burst; index++) {
+					if (name === 'narrow') store.writeOne(changedIndex, burst + index + 1);
+					else store.writeAll(name === 'unchanged' ? 0 : index + 1);
+				}
+				// Read this before the browser task returns: later render/commit reads
+				// are a different, necessary part of observing the final snapshot.
+				return {
+					before,
+					notifications: stats.notifications - before.notifications,
+					notificationSnapshotCalls: stats.snapshotCalls - before.snapshotCalls,
+				};
+			},
+			{ name, burst: NOTIFICATION_BURST, changedIndex: CHANGED_INDEX },
+		);
+		await page.waitForFunction(
+			({ count, name, burst, changedIndex }) => {
+				const nodes = Array.from(document.querySelectorAll('[data-subscriber-index]'));
+				return (
+					nodes.length === count &&
+					nodes.every((node, index) => {
+						const value =
+							name === 'unchanged'
+								? 0
+								: name === 'narrow' && index === changedIndex
+									? burst * 2
+									: burst;
+						return (
+							node === window.__externalStoreWorkNodes[index] && node.textContent === String(value)
+						);
+					})
+				);
+			},
+			{
+				count: STORE_SUBSCRIBER_COUNT,
+				name,
+				burst: NOTIFICATION_BURST,
+				changedIndex: CHANGED_INDEX,
+			},
+		);
+		const settled = await page.evaluate((before) => {
+			const stats = window.__runtimeStress.stats.store;
+			return {
+				renders: stats.renders.reduce((sum, value) => sum + value, 0) - before.renders,
+				snapshotCalls: stats.snapshotCalls - before.snapshotCalls,
+			};
+		}, notification.before);
+		ensure(
+			notification.notifications === STORE_SUBSCRIBER_COUNT * NOTIFICATION_BURST,
+			`${name}: the notification burst did not reach every subscriber`,
+		);
+		phases[name] = {
+			notifications: notification.notifications,
+			notificationSnapshotCalls: notification.notificationSnapshotCalls,
+			...settled,
+		};
+	}
+
+	await page.locator('#store-toggle').click();
+	await page.waitForFunction(
+		() =>
+			document.querySelectorAll('[data-subscriber-index]').length === 0 &&
+			window.__runtimeStress.store.size === 0,
+	);
+	const cleanup = await page.evaluate(() => {
+		const {
+			store,
+			stats: { store: stats },
+		} = window.__runtimeStress;
+		delete window.__externalStoreWorkNodes;
+		return {
+			retainedSubscribers: store.size,
+			subscribeCalls: stats.subscribeCalls,
+			unsubscribeCalls: stats.unsubscribeCalls,
+		};
+	});
+	ensure(cleanup.subscribeCalls >= STORE_SUBSCRIBER_COUNT, 'Subscribers never connected');
+	ensure(
+		cleanup.subscribeCalls === cleanup.unsubscribeCalls,
+		'Subscription acquisition and removal were unbalanced',
+	);
+	ensure(cleanup.retainedSubscribers === 0, 'The store retained an unmounted subscriber');
+	ensure(errors.length === 0, errors.join('; '));
+	observed = { phases, cleanup };
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+} finally {
+	try {
+		await browser?.close();
+	} finally {
+		await productionServer?.close();
+	}
+}
+
+const requiredWork = {
+	unchanged_burst_snapshot_reads: STORE_SUBSCRIBER_COUNT * NOTIFICATION_BURST,
+	broad_burst_snapshot_reads: STORE_SUBSCRIBER_COUNT,
+	narrow_burst_snapshot_reads: (STORE_SUBSCRIBER_COUNT - 1) * NOTIFICATION_BURST + 1,
+	// A nonzero reference lets the ratio runner enforce a zero-render ceiling.
+	unchanged_burst_renders: 1,
+	broad_burst_renders: STORE_SUBSCRIBER_COUNT,
+	narrow_burst_renders: 1,
+};
+const work = observed
+	? Object.fromEntries(
+			Object.entries(observed.phases).flatMap(([name, phase]) => [
+				[`${name}_burst_snapshot_reads`, phase.notificationSnapshotCalls],
+				[`${name}_burst_renders`, phase.renders],
+			]),
+		)
+	: {};
+const stats = (values) =>
+	Object.fromEntries(
+		Object.entries(values).map(([name, value]) => [
+			name,
+			{ median: value, min: value, samples: 1 },
+		]),
+	);
+const payload = {
+	suite: 'external-store-fanout-work',
+	targets: [
+		{
+			name: 'octane-tsrx-work',
+			ops: stats(work),
+			meta: {
+				correctness: failure ? 'fail' : 'pass',
+				notificationBurst: NOTIFICATION_BURST,
+				subscriberCount: STORE_SUBSCRIBER_COUNT,
+				...observed,
+			},
+		},
+		{
+			name: 'required-work',
+			ops: stats(requiredWork),
+			meta: {
+				basis:
+					'One changed notification schedules each reader; unchanged readers still compare snapshots',
+			},
+		},
+	],
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+if (failure) {
+	console.error(`FAIL external-store-fanout-work: ${failure}`);
+	process.exitCode = 1;
+} else {
+	console.log('Production external-store notification work:');
+	console.table(work);
+	console.log('All external-store notification semantic gates passed.');
+}

--- a/benchmarks/universal-external-store/README.md
+++ b/benchmarks/universal-external-store/README.md
@@ -1,0 +1,57 @@
+# Universal external-store overhead
+
+This Node-only suite bundles the production native universal runtime and drives
+its public object renderer. It isolates store subscription lifetime and queued
+state work; it does not measure DOM, compiler, native-device, or transport cost.
+
+```bash
+node benchmarks/universal-external-store/run.mjs 5
+node benchmarks/bench.mjs --quick --ratios universal-external-store
+```
+
+The standard command uses the workspace's installed `esbuild`. For an exact
+before/after comparison, `OCTANE_UNIVERSAL_STORE_RUNTIME=/absolute/runtime.mjs`
+can select a separately bundled production `universal-native.ts` from either
+revision. Both runs must use the same bundle options, Node version, iteration
+count, and otherwise quiet machine. `BENCH_JSON` writes the normal benchmark
+result contract.
+
+## Workloads and controls
+
+- `stable-getter` and `inline-getter` mount 128 readers with stable subscription
+  functions. Each warms up with five parent renders and five store updates,
+  then measures 20 of each operation per sample. Timings are milliseconds per
+  parent render or flushed store update. Every phase checks current host values,
+  generation props, retained host identities, and live listener count. Teardown
+  must release every listener.
+- `changing-subscribe` does the same work with a fresh subscription function on
+  each render. Its required reconnects are the negative control: changing what
+  owns a subscription must still disconnect the previous source.
+- `subscription-reference` permits one lifetime subscription and cleanup per
+  reader. The deterministic `lifetime_subscribe_calls` and
+  `lifetime_unsubscribe_calls` operations feed the same-run ratio guards; both
+  stable targets have a maximum ratio of 1. Their counts do not depend on timing
+  noise or iteration count.
+- `notification-burst-2000` and `notification-burst-8000` time only the synchronous
+  notification loop, before the resulting render is flushed. Unchanged snapshots,
+  one repeatedly notified changed snapshot, and distinct snapshots separate
+  ordinary comparison overhead from queued invalidation cost. Two warmups precede
+  the requested samples. Final values and retained host identity are checked.
+  The `functional_updates` operation is a plain `useState` negative control:
+  ordered functional queues cannot take a direct-replacement shortcut.
+- `state-replacement-burst` queues one instrumented functional updater followed
+  by 2,000 direct replacements, reading the public state getter after each.
+  The committed state and a later functional suffix check value and ordering.
+  `prefix_updater_calls` is a deterministic work metric, not a public guarantee
+  about exact updater invocation counts. Its reference budget of 3 allows the
+  eager enqueue, first prior-value observation, and ordered commit; a different
+  correct implementation that invokes it fewer times also passes. This guards
+  both urgent and projected lookups against rescanning an irrelevant prefix.
+
+Stable subscription lifetime does not eliminate every notification read. An
+actual notification still uses the existing universal state/lane machinery so
+memoized owners update, urgent notifications can interrupt held transitions,
+and abandoned renders can retry. Repeated urgent notifications during a held
+transition may still enqueue rebase work. The suite's burst timings are
+diagnostics; the deterministic lifetime and replacement-work ratios are the
+durable performance gates.

--- a/benchmarks/universal-external-store/run.mjs
+++ b/benchmarks/universal-external-store/run.mjs
@@ -1,0 +1,372 @@
+// Public native-object renderer control for external-store subscription lifetime
+// and queued invalidation work. No compiler or host-device timing is involved.
+process.env.NODE_ENV = 'production';
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const rawIterations = process.argv[2] ?? '5';
+const iterations = Number(rawIterations);
+if (!Number.isSafeInteger(iterations) || iterations <= 0) {
+	throw new TypeError(`iterations must be a positive safe integer, received ${rawIterations}.`);
+}
+
+const SUBSCRIBERS = 128;
+const WARMUP_ROUNDS = 5;
+const OPERATIONS_PER_SAMPLE = 20;
+const BURST_WARMUPS = 2;
+const BURST_SIZES = [2_000, 8_000];
+const REPLACEMENTS = 2_000;
+const stat = (samples) => timingStatForJson(summarizeSamples(samples));
+const count = (value) => stat([value]);
+const ensure = (condition, message) => {
+	if (!condition) throw new Error(message);
+};
+
+function createStore() {
+	let value = 0;
+	const listeners = new Set();
+	const counters = { snapshotCalls: 0, subscribeCalls: 0, unsubscribeCalls: 0, notifications: 0 };
+	const notify = () => {
+		for (const listener of [...listeners]) {
+			counters.notifications++;
+			listener();
+		}
+	};
+	return {
+		get value() {
+			return value;
+		},
+		getSnapshot() {
+			counters.snapshotCalls++;
+			return value;
+		},
+		subscribe(listener) {
+			counters.subscribeCalls++;
+			listeners.add(listener);
+			return () => {
+				counters.unsubscribeCalls++;
+				listeners.delete(listener);
+			};
+		},
+		write(next) {
+			value = next;
+			notify();
+		},
+		notify,
+		listeners,
+		counters,
+	};
+}
+
+function createValuePlan(runtime) {
+	return runtime.universalPlan('object', {
+		kind: 'host',
+		type: 'store-value',
+		bindings: [
+			['value', 0],
+			['generation', 1],
+			['index', 2],
+		],
+	});
+}
+
+function runLifecycle(runtime, name) {
+	const store = createStore();
+	const plan = createValuePlan(runtime);
+	const Reader = runtime.defineUniversalComponent('object', (props) => {
+		const subscribe =
+			name === 'changing-subscribe' ? (listener) => store.subscribe(listener) : store.subscribe;
+		const getSnapshot = name === 'inline-getter' ? () => store.getSnapshot() : store.getSnapshot;
+		const value = runtime.useSyncExternalStore(subscribe, getSnapshot, undefined, 'store');
+		return runtime.universalValue(plan, [value + props.index, props.generation, props.index]);
+	});
+	const Scene = runtime.defineUniversalComponent('object', ({ generation }) =>
+		Array.from({ length: SUBSCRIBERS }, (_, index) =>
+			runtime.universalComponent('object', Reader, { index, generation }, index),
+		),
+	);
+	const container = runtime.createObjectContainer();
+	const root = runtime.createUniversalRoot(container, runtime.createObjectDriver());
+	let generation = 0;
+	let storeUpdates = 0;
+	const samples = { parent_rerenders: [], store_updates: [] };
+	try {
+		root.render(Scene, { generation });
+		const hosts = [...container.children];
+		const verify = () => {
+			ensure(container.children.length === SUBSCRIBERS, `${name}: wrong host count`);
+			ensure(store.listeners.size === SUBSCRIBERS, `${name}: disconnected live readers`);
+			for (let index = 0; index < SUBSCRIBERS; index++) {
+				const host = container.children[index];
+				ensure(host === hosts[index], `${name}: reader ${index} lost host identity`);
+				ensure(
+					host.props.value === store.value + index &&
+						host.props.generation === generation &&
+						host.props.index === index,
+					`${name}: reader ${index} has stale output`,
+				);
+			}
+		};
+		const renderParent = () => root.render(Scene, { generation: ++generation });
+		const updateStore = () => {
+			storeUpdates++;
+			runtime.flushUniversalSync(() => store.write(store.value + 1));
+		};
+		verify();
+		for (let index = 0; index < WARMUP_ROUNDS; index++) {
+			renderParent();
+			updateStore();
+		}
+		for (let iteration = 0; iteration < iterations; iteration++) {
+			let start = performance.now();
+			for (let index = 0; index < OPERATIONS_PER_SAMPLE; index++) renderParent();
+			samples.parent_rerenders.push((performance.now() - start) / OPERATIONS_PER_SAMPLE);
+			verify();
+			start = performance.now();
+			for (let index = 0; index < OPERATIONS_PER_SAMPLE; index++) updateStore();
+			samples.store_updates.push((performance.now() - start) / OPERATIONS_PER_SAMPLE);
+			verify();
+		}
+		if (name === 'changing-subscribe') {
+			ensure(
+				store.counters.subscribeCalls === SUBSCRIBERS * (1 + generation + storeUpdates),
+				'Changing subscribe identities did not replace their subscriptions',
+			);
+		}
+	} finally {
+		root.unmount();
+	}
+	ensure(store.listeners.size === 0, `${name}: listeners survived unmount`);
+	ensure(
+		store.counters.subscribeCalls === store.counters.unsubscribeCalls,
+		`${name}: subscription acquisition and release are unbalanced`,
+	);
+	return {
+		name,
+		ops: {
+			parent_rerenders: stat(samples.parent_rerenders),
+			store_updates: stat(samples.store_updates),
+			lifetime_subscribe_calls: count(store.counters.subscribeCalls),
+			lifetime_unsubscribe_calls: count(store.counters.unsubscribeCalls),
+		},
+		meta: {
+			subscribers: SUBSCRIBERS,
+			parentRenders: generation,
+			storeUpdates,
+			finalStoreValue: store.value,
+			...store.counters,
+		},
+	};
+}
+
+function runNotificationBurst(runtime, size, kind) {
+	const store = createStore();
+	const plan = createValuePlan(runtime);
+	const Reader = runtime.defineUniversalComponent('object', () =>
+		runtime.universalValue(plan, [
+			runtime.useSyncExternalStore(store.subscribe, store.getSnapshot, undefined, 'store'),
+			0,
+			0,
+		]),
+	);
+	const container = runtime.createObjectContainer();
+	const root = runtime.createUniversalRoot(container, runtime.createObjectDriver());
+	const samples = [];
+	let notificationReads = 0;
+	try {
+		root.render(Reader, undefined);
+		const host = container.children[0];
+		for (let iteration = -BURST_WARMUPS; iteration < iterations; iteration++) {
+			runtime.flushUniversalSync(() => store.write(0));
+			let elapsed = 0;
+			runtime.flushUniversalSync(() => {
+				const before = store.counters.snapshotCalls;
+				const start = performance.now();
+				for (let index = 0; index < size; index++) {
+					if (kind === 'unchanged') store.notify();
+					else store.write(kind === 'repeated' ? 1 : index + 1);
+				}
+				elapsed = performance.now() - start;
+				notificationReads = store.counters.snapshotCalls - before;
+			});
+			const expected = kind === 'unchanged' ? 0 : kind === 'repeated' ? 1 : size;
+			ensure(container.children[0] === host, `${kind}/${size}: lost host identity`);
+			ensure(host.props.value === expected, `${kind}/${size}: wrong committed snapshot`);
+			ensure(store.listeners.size === 1, `${kind}/${size}: reader disconnected`);
+			if (iteration >= 0) samples.push(elapsed);
+		}
+	} finally {
+		root.unmount();
+	}
+	ensure(store.listeners.size === 0, `${kind}/${size}: listener survived unmount`);
+	return { stats: stat(samples), notificationReads };
+}
+
+function createStateReader(runtime) {
+	const plan = createValuePlan(runtime);
+	let set;
+	let get;
+	const Reader = runtime.defineUniversalComponent('object', () => {
+		const [value, update, read] = runtime.useState(0, 'state');
+		set = update;
+		get = read;
+		return runtime.universalValue(plan, [value, 0, 0]);
+	});
+	const container = runtime.createObjectContainer();
+	const root = runtime.createUniversalRoot(container, runtime.createObjectDriver());
+	root.render(Reader, undefined);
+	return { container, root, set: (value) => set(value), get: () => get() };
+}
+
+function runFunctionalBurst(runtime, size) {
+	const state = createStateReader(runtime);
+	const host = state.container.children[0];
+	const samples = [];
+	const increment = (value) => value + 1;
+	try {
+		for (let iteration = -BURST_WARMUPS; iteration < iterations; iteration++) {
+			runtime.flushUniversalSync(() => state.set(0));
+			let elapsed = 0;
+			runtime.flushUniversalSync(() => {
+				const start = performance.now();
+				for (let index = 0; index < size; index++) state.set(increment);
+				elapsed = performance.now() - start;
+			});
+			ensure(state.container.children[0] === host, `functional/${size}: lost host identity`);
+			ensure(host.props.value === size && state.get() === size, `functional/${size}: wrong state`);
+			if (iteration >= 0) samples.push(elapsed);
+		}
+	} finally {
+		state.root.unmount();
+	}
+	return stat(samples);
+}
+
+function runReplacementWork(runtime) {
+	const state = createStateReader(runtime);
+	let prefixCalls = 0;
+	let measuredCalls = 0;
+	try {
+		runtime.flushUniversalSync(() => {
+			state.set((value) => {
+				prefixCalls++;
+				return value + 1;
+			});
+			// Start beyond the prefix result so the first replacement is not elided.
+			for (let value = 2; value <= REPLACEMENTS + 1; value++) {
+				state.set(value);
+				ensure(state.get() === value, 'Replacement getter returned stale state');
+			}
+		});
+		measuredCalls = prefixCalls;
+		ensure(
+			state.container.children[0].props.value === REPLACEMENTS + 1,
+			'Replacement burst committed the wrong state',
+		);
+		// Keep this order control outside the counted prefix window.
+		runtime.flushUniversalSync(() => state.set((value) => value * 2));
+		ensure(
+			state.get() === (REPLACEMENTS + 1) * 2 &&
+				state.container.children[0].props.value === (REPLACEMENTS + 1) * 2,
+			'A functional suffix did not observe the final replacement',
+		);
+	} finally {
+		state.root.unmount();
+	}
+	return {
+		name: 'state-replacement-burst',
+		ops: { prefix_updater_calls: count(measuredCalls) },
+		meta: { replacements: REPLACEMENTS, finalValue: (REPLACEMENTS + 1) * 2 },
+	};
+}
+
+let tempDir;
+let failure;
+const targets = [];
+try {
+	let runtimePath = process.env.OCTANE_UNIVERSAL_STORE_RUNTIME;
+	if (runtimePath === undefined) {
+		const require = createRequire(new URL('../../package.json', import.meta.url));
+		const { build } = require('esbuild');
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-universal-external-store-'));
+		runtimePath = path.join(tempDir, 'runtime.mjs');
+		await build({
+			entryPoints: [path.join(REPO, 'packages/octane/src/universal-native.ts')],
+			outfile: runtimePath,
+			bundle: true,
+			platform: 'node',
+			format: 'esm',
+			define: {
+				'process.env.NODE_ENV': '"production"',
+				__OCTANE_PROFILE_ENABLED__: 'false',
+			},
+			logLevel: 'silent',
+		});
+	}
+	const runtime = await import(pathToFileURL(path.resolve(runtimePath)).href);
+	for (const name of ['stable-getter', 'inline-getter', 'changing-subscribe']) {
+		targets.push(runLifecycle(runtime, name));
+	}
+	targets.push({
+		name: 'subscription-reference',
+		ops: {
+			lifetime_subscribe_calls: count(SUBSCRIBERS),
+			lifetime_unsubscribe_calls: count(SUBSCRIBERS),
+		},
+		meta: { basis: 'One acquisition and release per mounted reader' },
+	});
+	for (const size of BURST_SIZES) {
+		const ops = {};
+		const notificationReads = {};
+		for (const kind of ['unchanged', 'repeated', 'distinct']) {
+			const result = runNotificationBurst(runtime, size, kind);
+			ops[`notify_${kind}`] = result.stats;
+			notificationReads[kind] = result.notificationReads;
+		}
+		ops.functional_updates = runFunctionalBurst(runtime, size);
+		targets.push({ name: `notification-burst-${size}`, ops, meta: { size, notificationReads } });
+	}
+	targets.push(runReplacementWork(runtime));
+	targets.push({
+		name: 'state-replacement-reference',
+		ops: { prefix_updater_calls: count(3) },
+		meta: {
+			basis: 'At most eager enqueue, first prior-value read, and ordered commit; fewer calls pass',
+		},
+	});
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+} finally {
+	if (tempDir !== undefined) fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+const payload = {
+	suite: 'universal-external-store',
+	iterations,
+	targets,
+	...(failure ? { failed: failure } : {}),
+};
+
+console.log(`Universal external stores (${iterations} samples; timings in ms):`);
+console.table(
+	targets.map(({ name, ops }) => ({
+		target: name,
+		...Object.fromEntries(Object.entries(ops).map(([op, value]) => [op, value.score])),
+	})),
+);
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+if (failure) {
+	console.error(`FAIL universal-external-store: ${failure}`);
+	process.exitCode = 1;
+} else {
+	console.log('All universal external-store semantic gates passed.');
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -82,6 +82,7 @@ export const BENCHMARK_SUITES = [
 	'async-composition',
 	'lynx-list',
 	'universal-leaf-update',
+	'universal-external-store',
 	'lynx-render',
 	'lynx-table',
 	'lynx-table-web',

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6643,6 +6643,27 @@ export function useSyncExternalStore<T>(
 						}
 					: () => scheduleRender(block),
 			onStoreChange: () => {
+				if (block.disposed) return;
+				// An urgent, non-deferred render already queued for this owner will
+				// read every reached store again. Repeated notifications in the same
+				// task need not run selectors merely to rediscover that pending work.
+				// Do not skip transition/deferred upgrades or render-phase diagnostics;
+				// renderBlock also clears pending before the body, so a notification
+				// after its snapshot read can still request a replay. Profiling and
+				// unwrapped-act diagnostics retain the ordinary scheduling path.
+				if (
+					CURRENT_BLOCK === null &&
+					block.pending &&
+					block.pendingMode === 'urgent' &&
+					!block.pendingDeferred &&
+					!(typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__) &&
+					(process.env.NODE_ENV === 'production' ||
+						!IS_OCTANE_ACT_ENVIRONMENT ||
+						actScopeDepth !== 0 ||
+						syncFlush)
+				) {
+					return;
+				}
 				if (checkStoreChanged(created)) created.forceUpdate();
 			},
 			block,

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -5138,6 +5138,13 @@ function projectedStateValue<T>(record: UniversalOwnerRecord, slot: unknown, fal
 	const hook = record.hooks.get(slot) as StateHook<T> | undefined;
 	const queue = record.updates.get(slot);
 	if (queue === undefined) return hook?.kind === 'state' ? hook.value : fallback;
+	// A trailing replacement determines the projected value by itself. External
+	// store invalidations use replacement tokens, so replaying every earlier
+	// update here would make a burst of N notifications quadratic.
+	if (queue.length !== 0) {
+		const last = queue[queue.length - 1];
+		if (typeof last !== 'function') return last as T;
+	}
 	let value =
 		queue.batches === undefined
 			? hook?.kind === 'state'
@@ -5157,13 +5164,19 @@ function visibleStateValue<T>(record: UniversalOwnerRecord, slot: unknown, fallb
 	const hook = record.hooks.get(slot) as StateHook<T> | undefined;
 	const queue = record.updates.get(slot);
 	if (queue === undefined) return hook?.kind === 'state' ? hook.value : fallback;
+	// Urgent reads exclude transition lanes. Only the last applicable update
+	// can take the replacement shortcut; a trailing functional updater still
+	// needs the ordinary ordered replay below.
+	let last = queue.length - 1;
+	while (last >= 0 && queue.batches !== undefined && queue.batches[last] !== null) last--;
+	if (last >= 0 && typeof queue[last] !== 'function') return queue[last] as T;
 	let value =
 		queue.batches === undefined
 			? hook?.kind === 'state'
 				? hook.value
 				: fallback
 			: (queue.baseState as T);
-	for (let index = 0; index < queue.length; index++) {
+	for (let index = 0; index <= last; index++) {
 		if (queue.batches !== undefined && queue.batches[index] !== null) continue;
 		const update = queue[index];
 		value = typeof update === 'function' ? (update as (previous: T) => T)(value) : (update as T);
@@ -5685,6 +5698,118 @@ export function useId(slot?: unknown): string {
 	return hook.value;
 }
 
+interface UniversalStoreState<T> {
+	instance: UniversalStoreInstance<T>;
+}
+
+interface UniversalStoreInstance<T> {
+	value: T;
+	getSnapshot: () => T;
+	committedState: UniversalStoreState<T>;
+	notificationState: UniversalStoreState<T>;
+	notificationValue: T;
+	notificationFailed: boolean;
+	forceUpdate: (state: UniversalStoreState<T>) => void;
+}
+
+function enqueueUniversalStoreSnapshot(
+	instance: UniversalStoreInstance<any>,
+	value: unknown,
+): void {
+	if (instance.notificationFailed || !Object.is(instance.notificationValue, value)) {
+		instance.notificationFailed = false;
+		instance.notificationValue = value;
+		instance.notificationState = Object.is(instance.value, value)
+			? instance.committedState
+			: { instance };
+	}
+	// Reuse the token for identical notifications. The state setter then keeps
+	// one ordinary pending update instead of appending and rescanning an
+	// ever-growing queue. A held transition can still require urgent rebases.
+	// Distinct snapshots receive distinct tokens, including while
+	// an earlier transition is held; returning to the committed value uses its
+	// token so the setter can preserve an urgent rebase over a pending transition.
+	instance.forceUpdate(instance.notificationState);
+}
+
+function enqueueUniversalStoreError(instance: UniversalStoreInstance<any>): void {
+	// A snapshot failure belongs to the next render, where the owning boundary
+	// can handle it, rather than escaping through the store notifier.
+	if (!instance.notificationFailed) {
+		instance.notificationFailed = true;
+		instance.notificationState = { instance };
+	}
+	instance.forceUpdate(instance.notificationState);
+}
+
+function notifyUniversalStore(instance: UniversalStoreInstance<any>): void {
+	let value: unknown;
+	try {
+		value = instance.getSnapshot();
+	} catch {
+		enqueueUniversalStoreError(instance);
+		return;
+	}
+	enqueueUniversalStoreSnapshot(instance, value);
+}
+
+function checkUniversalStore(instance: UniversalStoreInstance<any>): void {
+	let value: unknown;
+	try {
+		value = instance.getSnapshot();
+	} catch {
+		enqueueUniversalStoreError(instance);
+		return;
+	}
+	// Unlike an actual notification, an internal consistency read must not
+	// promote an unrelated queued transition when the committed value still fits.
+	if (!Object.is(instance.value, value)) enqueueUniversalStoreSnapshot(instance, value);
+}
+
+// Effect callbacks receive their dependency values as positional arguments.
+// Publish only after host acceptance: an abandoned or rejected draft must not
+// replace the getter used by the still-connected committed subscription.
+function updateUniversalStoreInstance<T>(
+	instance: UniversalStoreInstance<T>,
+	value: T,
+	getSnapshot: () => T,
+	state: UniversalStoreState<T>,
+): void {
+	instance.value = value;
+	instance.getSnapshot = getSnapshot;
+	instance.committedState = state;
+	instance.notificationState = state;
+	instance.notificationValue = value;
+	instance.notificationFailed = false;
+	checkUniversalStore(instance);
+}
+
+function subscribeToUniversalStore<T>(
+	instance: UniversalStoreInstance<T>,
+	subscribe: (onStoreChange: () => void) => () => void,
+): () => void {
+	let activeInstance: UniversalStoreInstance<T> | null = instance;
+	const onStoreChange = () => {
+		if (activeInstance !== null) notifyUniversalStore(activeInstance);
+	};
+	let unsubscribe: (() => void) | null = null;
+	try {
+		unsubscribe = subscribe(onStoreChange);
+	} catch (error) {
+		activeInstance = null;
+		throw error;
+	}
+	// subscribe itself can synchronously mutate the store. Checking after it
+	// returns also closes the interval between the render read and connection.
+	checkUniversalStore(instance);
+	return () => {
+		activeInstance = null;
+		const cleanup = unsubscribe;
+		unsubscribe = null;
+		cleanup?.();
+	};
+}
+
 export function useSyncExternalStore<T>(
 	subscribe: (onStoreChange: () => void) => () => void,
 	getSnapshot: () => T,
@@ -5717,21 +5842,32 @@ export function useSyncExternalStore<T>(
 	const base = resolveHookSlot(slot);
 	return withSlot(base, () => {
 		const snapshot = getSnapshot();
-		const [, invalidate] = useState(0, 'state');
+		const [state, forceUpdate] = useState<UniversalStoreState<T>>(() => {
+			const initial = {} as UniversalStoreState<T>;
+			const instance: UniversalStoreInstance<T> = {
+				value: snapshot,
+				getSnapshot,
+				committedState: initial,
+				notificationState: initial,
+				notificationValue: snapshot,
+				notificationFailed: false,
+				forceUpdate: (next) => forceUpdate(next),
+			};
+			initial.instance = instance;
+			return initial;
+		}, 'state');
+		const instance = state.instance;
+		// Getter/snapshot freshness and connection lifetime are independent. The
+		// first effect commits the fresh read; the second stays connected until
+		// subscribe changes or normal effect teardown hides/removes its owner.
 		useLayoutEffect(
-			() => {
-				let current = snapshot;
-				const check = () => {
-					const next = getSnapshot();
-					if (Object.is(current, next)) return;
-					current = next;
-					invalidate((value) => value + 1);
-				};
-				const unsubscribe = subscribe(check);
-				check();
-				return unsubscribe;
-			},
-			[subscribe, getSnapshot, snapshot],
+			updateUniversalStoreInstance as () => void,
+			[instance, snapshot, getSnapshot, state],
+			'snapshot',
+		);
+		useLayoutEffect(
+			subscribeToUniversalStore as () => () => void,
+			[instance, subscribe],
 			'subscribe',
 		);
 		return snapshot;

--- a/packages/octane/tests/_fixtures/external-store-behavior.tsrx
+++ b/packages/octane/tests/_fixtures/external-store-behavior.tsrx
@@ -1,9 +1,16 @@
-import { useSyncExternalStore, useLayoutEffect } from 'octane';
+import { use, useSyncExternalStore, useLayoutEffect } from 'octane';
+
+export interface ExternalStore<T> {
+	getState: () => T;
+	setState: (next: T) => void;
+	subscribe: (listener: () => void) => () => void;
+	listenerCount: () => number;
+}
 
 // A minimal external store with observable subscription cleanup.
-export function makeStore(initial) {
+export function makeStore<T>(initial: T): ExternalStore<T> {
 	let state = initial;
-	const listeners = new Set();
+	const listeners = new Set<() => void>();
 	return {
 		getState: () => state,
 		setState: (next) => {
@@ -21,44 +28,118 @@ export function makeStore(initial) {
 }
 
 // Use the inline selector shape common in Zustand and query-store adapters.
-export function StoreConsumer(props) @{
+export function StoreConsumer(props: { store: ExternalStore<number> }) @{
 	const value = useSyncExternalStore(props.store.subscribe, () => props.store.getState());
-	<span class="uc">{value as string}</span>
+	<span class="uc">{'' + value}</span>
 }
 
 // Select a field named by props so updates must use the latest selector.
-export function KeyedConsumer(props) @{
+export function KeyedConsumer(props: {
+	store: ExternalStore<{ a: number; b: number }>;
+	k: 'a' | 'b';
+}) @{
 	const value = useSyncExternalStore(props.store.subscribe, () => props.store.getState()[props.k]);
-	<span class="kc">{value as string}</span>
+	<span class="kc">{'' + value}</span>
 }
 
 // Throw after reading a negative snapshot so the nearest boundary handles it.
-function ThrowConsumer(props) @{
+function ThrowConsumer(props: { store: ExternalStore<number> }) @{
 	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
 	if (value < 0) throw new Error('boom-' + -value as string);
-	<span class="tc">{value as string}</span>
+	<span class="tc">{'' + value}</span>
 }
 
-export function ThrowBoundary(props) @{
+export function ThrowBoundary(props: { store: ExternalStore<number> }) @{
 	@try {
 		<ThrowConsumer store={props.store} />
-	} @catch (e) {
-		<span class="err">{'err:' + e.message as string}</span>
+	} @catch (e: unknown, _reset: () => void) {
+		<span class="err">{'err:' + (e instanceof Error ? e.message : String(e))}</span>
 	}
 }
 
 // A sibling mutates the store during layout; the consumer must converge to the
 // value visible after the commit.
-function LayoutMutator(props) @{
+function LayoutMutator(props: { store: ExternalStore<number>; to: number }) @{
 	useLayoutEffect(() => {
 		props.store.setState(props.to);
 	}, [props.to]);
 	<span class="mut" />
 }
 
-export function SiblingApp(props) @{
+export function SiblingApp(props: { store: ExternalStore<number>; to: number }) @{
 	<div>
 		<StoreConsumer store={props.store} />
 		<LayoutMutator store={props.store} to={props.to} />
+	</div>
+}
+
+export function PairedStoreConsumer(props: {
+	first: ExternalStore<number>;
+	second: ExternalStore<number>;
+}) @{
+	const first = useSyncExternalStore(props.first.subscribe, props.first.getState);
+	const second = useSyncExternalStore(props.second.subscribe, props.second.getState);
+	<output id="paired-store-value">{first + ':' + second}</output>
+}
+
+export function RenderPhaseStoreConsumer(props: {
+	store: ExternalStore<number>;
+	observeCommit: (snapshot: number, current: number) => void;
+}) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	if (value === 1) props.store.setState(2);
+	useLayoutEffect(() => {
+		props.observeCommit(value, props.store.getState());
+	}, [value, props.store, props.observeCommit]);
+	<output id="render-phase-store-value">{'value:' + value}</output>
+}
+
+function SuspensibleStoreConsumer(props: {
+	store: ExternalStore<number>;
+	firstPending: Promise<void>;
+	nextPending: Promise<void>;
+}) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	if (value === 1) use(props.firstPending);
+	if (value > 1) use(props.nextPending);
+	<output id="store-priority-value">{'value:' + value}</output>
+}
+
+export function StorePriorityBoundary(props: {
+	store: ExternalStore<number>;
+	firstPending: Promise<void>;
+	nextPending: Promise<void>;
+}) @{
+	@try {
+		<SuspensibleStoreConsumer
+			store={props.store}
+			firstPending={props.firstPending}
+			nextPending={props.nextPending}
+		/>
+	} @pending {
+		<span id="store-priority-fallback">{'loading'}</span>
+	}
+}
+
+function RenderNotificationMutator(props: {
+	store: ExternalStore<number>;
+	next: number | null;
+}) @{
+	if (props.next !== null) props.store.setState(props.next);
+	<span />
+}
+
+function PendingStoreReader(props: { store: ExternalStore<number> }) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	<output id="pending-store-value">{'value:' + value}</output>
+}
+
+export function CrossComponentStoreApp(props: {
+	store: ExternalStore<number>;
+	next: number | null;
+}) @{
+	<div>
+		<RenderNotificationMutator store={props.store} next={props.next} />
+		<PendingStoreReader store={props.store} />
 	</div>
 }

--- a/packages/octane/tests/external-store-behavior.test.ts
+++ b/packages/octane/tests/external-store-behavior.test.ts
@@ -1,13 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { mount, flushEffects } from './_helpers';
-import { flushSync } from '../src/index.js';
+import { describe, it, expect, vi } from 'vitest';
+import { act, mount, flushEffects } from './_helpers';
+import { flushSync, setIsOctaneActEnvironment, startTransition } from '../src/index.js';
 import {
+	CrossComponentStoreApp,
 	makeStore,
+	PairedStoreConsumer,
+	RenderPhaseStoreConsumer,
 	StoreConsumer,
+	StorePriorityBoundary,
 	KeyedConsumer,
 	ThrowBoundary,
 	SiblingApp,
 } from './_fixtures/external-store-behavior.tsrx';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((complete) => {
+		resolve = complete;
+	});
+	return { promise, resolve };
+}
 
 // These consumers use inline selectors, matching common Zustand and query-store
 // usage. The assertions stay at the public boundary: selected DOM state,
@@ -67,5 +79,138 @@ describe('useSyncExternalStore — live selectors and commit updates', () => {
 		// 5 during the same commit; the consumer must converge to the final value.
 		expect(r.find('.uc').textContent).toBe('5');
 		r.unmount();
+	});
+
+	it('reads the latest values from both stores when their notifications share a render', () => {
+		const first = makeStore(0);
+		const second = makeStore(10);
+		const r = mount(PairedStoreConsumer, { first, second });
+		flushEffects();
+		const output = r.find('#paired-store-value');
+		expect(output.textContent).toBe('0:10');
+
+		flushSync(() => {
+			first.setState(1);
+			second.setState(11);
+			first.setState(2);
+			second.setState(12);
+		});
+		expect(r.find('#paired-store-value')).toBe(output);
+		expect(output.textContent).toBe('2:12');
+
+		flushSync(() => {
+			second.setState(13);
+			first.setState(0);
+		});
+		expect(output.textContent).toBe('0:13');
+		r.unmount();
+		flushEffects();
+		expect(first.listenerCount()).toBe(0);
+		expect(second.listenerCount()).toBe(0);
+	});
+
+	it('replays a store change made after its snapshot was read during render', () => {
+		const store = makeStore(0);
+		const observations: Array<{ snapshot: number; current: number }> = [];
+		const r = mount(RenderPhaseStoreConsumer, {
+			store,
+			observeCommit: (snapshot: number, current: number) => {
+				observations.push({ snapshot, current });
+			},
+		});
+		flushEffects();
+		observations.length = 0;
+
+		flushSync(() => store.setState(1));
+		expect(r.find('#render-phase-store-value').textContent).toBe('value:2');
+		expect(observations).toContainEqual({ snapshot: 2, current: 2 });
+		// A layout effect must not observe the abandoned render's stale snapshot.
+		expect(observations.every(({ snapshot, current }) => snapshot === current)).toBe(true);
+		r.unmount();
+	});
+
+	it('an urgent store change upgrades a queued transition without changing held-transition behavior', async () => {
+		const store = makeStore(0);
+		const first = deferred();
+		const next = deferred();
+		const r = mount(StorePriorityBoundary, {
+			store,
+			firstPending: first.promise,
+			nextPending: next.promise,
+		});
+		flushEffects();
+		try {
+			flushSync(() => startTransition(() => store.setState(1)));
+			expect(r.find('#store-priority-value').textContent).toBe('value:0');
+			expect(r.container.querySelector('#store-priority-fallback')).toBeNull();
+
+			await act(() => first.resolve());
+			expect(r.find('#store-priority-value').textContent).toBe('value:1');
+			expect(r.container.querySelector('#store-priority-fallback')).toBeNull();
+
+			flushSync(() => {
+				startTransition(() => store.setState(2));
+				store.setState(3);
+			});
+			// The second notification is urgent before the transition gets to render.
+			// It must show the fallback, not begin holding the previous screen.
+			expect(r.find('#store-priority-fallback').textContent).toBe('loading');
+
+			await act(() => next.resolve());
+			expect(r.find('#store-priority-value').textContent).toBe('value:3');
+			expect(r.container.querySelector('#store-priority-fallback')).toBeNull();
+		} finally {
+			r.unmount();
+			flushEffects();
+		}
+	});
+
+	it('warns when another rendering component notifies an already-pending store reader', () => {
+		const store = makeStore(0);
+		const r = mount(CrossComponentStoreApp, { store, next: null });
+		flushEffects();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			flushSync(() => {
+				store.setState(1);
+				r.root.render(CrossComponentStoreApp, { store, next: 2 });
+			});
+			expect(r.find('#pending-store-value').textContent).toBe('value:2');
+			expect(
+				error.mock.calls.some(([message]) =>
+					String(message).includes('while rendering a different component'),
+				),
+			).toBe(process.env.NODE_ENV !== 'production');
+		} finally {
+			error.mockRestore();
+			r.unmount();
+			flushEffects();
+		}
+	});
+
+	it('keeps the outside-act diagnostic for a changed store whose reader is already pending', () => {
+		const store = makeStore(0);
+		const r = mount(StoreConsumer, { store });
+		flushEffects();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			setIsOctaneActEnvironment(false);
+			store.setState(1);
+			error.mockClear();
+			setIsOctaneActEnvironment(true);
+			store.setState(2);
+			expect(
+				error.mock.calls.some(([message]) => String(message).includes('not wrapped in act')),
+			).toBe(process.env.NODE_ENV !== 'production');
+
+			setIsOctaneActEnvironment(false);
+			flushSync(() => {});
+			expect(r.find('.uc').textContent).toBe('2');
+		} finally {
+			setIsOctaneActEnvironment(false);
+			error.mockRestore();
+			r.unmount();
+			flushEffects();
+		}
 	});
 });

--- a/packages/octane/tests/universal-external-store.test.ts
+++ b/packages/octane/tests/universal-external-store.test.ts
@@ -1,0 +1,532 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createObjectContainer,
+	createObjectDriver,
+	createUniversalRoot,
+	defineUniversalComponent,
+	flushUniversalSync,
+	memo,
+	startTransition,
+	universalActivity,
+	universalComponent,
+	universalPlan,
+	universalTry,
+	universalValue,
+	use,
+	useSyncExternalStore,
+	type UniversalAsyncCommitTransport,
+	type UniversalRootOptions,
+} from '../src/universal-native.js';
+
+interface ExternalStore<T> {
+	getSnapshot(): T;
+	subscribe(notify: () => void): () => void;
+}
+
+function createStore<T>(initial: T, name = 'store', lifecycle: string[] = []) {
+	let value = initial;
+	let failure: Error | undefined;
+	const listeners = new Set<() => void>();
+	const retained: Array<() => void> = [];
+	const notify = () => {
+		for (const listener of [...listeners]) listener();
+	};
+	return {
+		getSnapshot() {
+			if (failure !== undefined) throw failure;
+			return value;
+		},
+		subscribe(listener: () => void) {
+			lifecycle.push(`subscribe:${name}`);
+			listeners.add(listener);
+			retained.push(listener);
+			return () => {
+				lifecycle.push(`unsubscribe:${name}`);
+				listeners.delete(listener);
+			};
+		},
+		set(next: T) {
+			value = next;
+			notify();
+		},
+		setSilently(next: T) {
+			value = next;
+		},
+		fail(error: Error) {
+			failure = error;
+			notify();
+		},
+		notify,
+		listeners,
+		retained,
+	};
+}
+
+const valuePlan = universalPlan('object', {
+	kind: 'host',
+	type: 'store-value',
+	bindings: [
+		['value', 0],
+		['generation', 1],
+	],
+});
+
+type StoreState = { a: number; b: number };
+interface ReaderProps {
+	store: ExternalStore<StoreState>;
+	field: keyof StoreState;
+	generation?: number;
+	enabled?: boolean;
+	onRead?: (field: keyof StoreState) => void;
+	suspend?: Promise<void>;
+}
+
+const Reader = defineUniversalComponent('object', (props: ReaderProps) => {
+	const value =
+		props.enabled === false
+			? 'disabled'
+			: useSyncExternalStore(
+					props.store.subscribe,
+					() => {
+						props.onRead?.(props.field);
+						return props.store.getSnapshot()[props.field];
+					},
+					undefined,
+					'outer-store',
+				);
+	if (props.suspend !== undefined) use(props.suspend);
+	return universalValue(valuePlan, [value, props.generation ?? 0]);
+});
+
+const StableReader = defineUniversalComponent(
+	'object',
+	(props: { store: ExternalStore<number>; wait?: Promise<void>; duringRender?: () => void }) => {
+		const value = useSyncExternalStore(
+			props.store.subscribe,
+			props.store.getSnapshot,
+			undefined,
+			'store',
+		);
+		props.duringRender?.();
+		if (value === 1 && props.wait !== undefined) use(props.wait);
+		return universalValue(valuePlan, [value, 0]);
+	},
+);
+const MemoStableReader = memo(StableReader);
+
+async function flushMicrotasks(count = 8): Promise<void> {
+	for (let index = 0; index < count; index++) await Promise.resolve();
+}
+
+function objectRoot(options: UniversalRootOptions<ReturnType<typeof createObjectContainer>> = {}) {
+	const container = createObjectContainer();
+	const root = createUniversalRoot(container, createObjectDriver(), options);
+	return { container, root };
+}
+
+describe('universal useSyncExternalStore', () => {
+	it('keeps the same store connected when only the getter or snapshot changes', () => {
+		const lifecycle: string[] = [];
+		const store = createStore({ a: 1, b: 2 }, 'first', lifecycle);
+		const next = createStore({ a: 10, b: 20 }, 'second', lifecycle);
+		const { container, root } = objectRoot();
+
+		root.render(Reader, { store, field: 'a' });
+		const host = container.children[0];
+		root.render(Reader, { store, field: 'a', generation: 1 });
+		root.render(Reader, { store, field: 'b', generation: 2 });
+		flushUniversalSync(() => store.set({ a: 3, b: 4 }));
+		expect(container.children[0]).toBe(host);
+		expect(host.props).toMatchObject({ value: 4, generation: 2 });
+		// Subscription lifetime is part of the external-store API: a stable
+		// subscribe function must not disconnect a live store on ordinary renders.
+		expect(lifecycle).toEqual(['subscribe:first']);
+
+		root.render(Reader, { store: next, field: 'b' });
+		expect(host.props.value).toBe(20);
+		expect(lifecycle).toEqual(['subscribe:first', 'unsubscribe:first', 'subscribe:second']);
+		flushUniversalSync(() => store.set({ a: 30, b: 40 }));
+		expect(host.props.value).toBe(20);
+		flushUniversalSync(() => next.set({ a: 50, b: 60 }));
+		expect(host.props.value).toBe(60);
+		root.unmount();
+		expect(lifecycle).toEqual([
+			'subscribe:first',
+			'unsubscribe:first',
+			'subscribe:second',
+			'unsubscribe:second',
+		]);
+	});
+
+	it('updates memoized readers after a burst returns to the committed snapshot', () => {
+		const store = createStore(0);
+		const { container, root } = objectRoot();
+		root.render(MemoStableReader, { store });
+		const host = container.children[0];
+		flushUniversalSync(() => {
+			store.set(1);
+			for (let index = 0; index < 100; index++) store.notify();
+			store.set(0);
+		});
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(0);
+		flushUniversalSync(() => {
+			store.set(2);
+			for (let index = 0; index < 100; index++) store.notify();
+		});
+		expect(host.props.value).toBe(2);
+		root.unmount();
+	});
+
+	it('retries a held store transition when a later transition changes its snapshot', async () => {
+		const store = createStore(0);
+		const wait = new Promise<void>(() => {});
+		const Scene = defineUniversalComponent('object', () =>
+			universalTry(
+				() => universalComponent('object', MemoStableReader, { store, wait }),
+				() => universalValue(valuePlan, ['pending', 0]),
+			),
+		);
+		const { container, root } = objectRoot();
+		root.render(Scene, undefined);
+		const host = container.children[0];
+		startTransition(() => store.set(1));
+		await flushMicrotasks();
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(0);
+		startTransition(() => store.set(2));
+		await flushMicrotasks();
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(2);
+		root.unmount();
+	});
+
+	it('does not let a held transition swallow an urgent notification of the same snapshot', async () => {
+		const store = createStore(0);
+		let resolveWait!: () => void;
+		const wait = new Promise<void>((resolve) => {
+			resolveWait = resolve;
+		});
+		const Scene = defineUniversalComponent('object', () =>
+			universalTry(
+				() => universalComponent('object', MemoStableReader, { store, wait }),
+				() => universalValue(valuePlan, ['pending', 0]),
+			),
+		);
+		const { container, root } = objectRoot();
+		root.render(Scene, undefined);
+		startTransition(() => store.set(1));
+		await flushMicrotasks();
+		expect(container.children[0].props.value).toBe(0);
+		flushUniversalSync(() => store.notify());
+		expect(container.children.some((host) => host.props.value === 'pending')).toBe(true);
+		flushUniversalSync(() => store.set(2));
+		resolveWait();
+		await flushMicrotasks();
+		expect(container.children.some((host) => host.visible && host.props.value === 2)).toBe(true);
+		root.unmount();
+	});
+
+	it('does not promote a queued store transition from an unchanged commit-time read', () => {
+		const store = createStore({ a: 0, b: 10 });
+		const scheduled: Array<() => void> = [];
+		const { container, root } = objectRoot({
+			scheduleMicrotask: (callback) => scheduled.push(callback),
+		});
+		root.render(Reader, { store, field: 'a' });
+		const host = container.children[0];
+
+		// Leave the store's transition token queued while a separate urgent prop
+		// render commits a fresh inline getter. Its consistency check is not a new
+		// store notification and must not keep rebasing the held token urgently.
+		startTransition(() => store.set({ a: 1, b: 11 }));
+		expect(host.props.value).toBe(0);
+		expect(scheduled.length).toBeGreaterThan(0);
+		expect(root.render(Reader, { store, field: 'a', generation: 1 }).status).toBe('committed');
+		flushUniversalSync(() => {});
+		expect(container.children[0]).toBe(host);
+		expect(host.props).toMatchObject({ value: 1, generation: 1 });
+
+		for (let count = 0; scheduled.length !== 0; count++) {
+			if (count === 50) throw new Error('Universal store transition did not settle.');
+			scheduled.shift()!();
+		}
+		expect(container.children[0]).toBe(host);
+		expect(host.props).toMatchObject({ value: 1, generation: 1 });
+		expect(store.listeners.size).toBe(1);
+		root.unmount();
+		expect(store.listeners.size).toBe(0);
+	});
+
+	it('can retry the same notification after a render-time update is abandoned', () => {
+		const store = createStore(0);
+		const { container, root } = objectRoot();
+		root.render(StableReader, { store });
+		const host = container.children[0];
+		expect(() =>
+			root.prepare(StableReader, {
+				store,
+				duringRender() {
+					store.set(1);
+					throw new Error('abandoned render');
+				},
+			}),
+		).toThrow('abandoned render');
+		flushUniversalSync(() => store.notify());
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(1);
+		root.unmount();
+	});
+
+	it('keeps the committed selector after a prepared render is abandoned', () => {
+		const store = createStore({ a: 1, b: 10 });
+		const reads: Array<keyof StoreState> = [];
+		const onRead = (field: keyof StoreState) => reads.push(field);
+		const { container, root } = objectRoot();
+		root.render(Reader, { store, field: 'a', onRead });
+		const host = container.children[0];
+
+		const abandoned = root.prepare(Reader, { store, field: 'b', onRead });
+		expect(abandoned.status).toBe('prepared');
+		reads.length = 0;
+		store.notify();
+		expect(reads).toContain('a');
+		expect(reads).not.toContain('b');
+		abandoned.abort();
+		flushUniversalSync(() => store.set({ a: 2, b: 99 }));
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(2);
+		root.unmount();
+	});
+
+	it('keeps the committed selector while a transported render awaits acknowledgement and is rejected', async () => {
+		const store = createStore({ a: 1, b: 10 });
+		const reads: Array<keyof StoreState> = [];
+		const onRead = (field: keyof StoreState) => reads.push(field);
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const driver = {
+			...baseDriver,
+			capabilities: { ...baseDriver.capabilities, localHostCallbacks: false },
+			localCallbacks: undefined,
+		};
+		let hold = false;
+		let rejectPending!: (error: Error) => void;
+		let entered!: () => void;
+		const awaitingAcknowledgement = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		const transport: UniversalAsyncCommitTransport<typeof container> = {
+			mode: 'async',
+			prepareBatch(target, batch, identity) {
+				const prepared = driver.prepareBatch(target, batch, {
+					invokeLocalCallback: () => undefined,
+				});
+				return {
+					async apply(acknowledge) {
+						if (hold) {
+							await new Promise<void>((_resolve, reject) => {
+								rejectPending = reject;
+								entered();
+							});
+						}
+						prepared.apply();
+						acknowledge({ ...identity, type: 'ack' });
+					},
+					abort: () => prepared.abort(),
+				};
+			},
+		};
+		const root = createUniversalRoot(container, driver, { transport });
+		await root.renderAsync(Reader, { store, field: 'a', onRead });
+		const host = container.children[0];
+
+		hold = true;
+		const rejected = root.renderAsync(Reader, { store, field: 'b', onRead });
+		await awaitingAcknowledgement;
+		reads.length = 0;
+		store.notify();
+		expect(reads).toContain('a');
+		expect(reads).not.toContain('b');
+		rejectPending(new Error('host rejected draft'));
+		await expect(rejected).rejects.toThrow('host rejected draft');
+		hold = false;
+		store.set({ a: 2, b: 99 });
+		await root.flushTransport();
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(2);
+		await root.unmountAsync();
+		expect(store.listeners.size).toBe(0);
+	});
+
+	it('keeps the committed selector after a suspended render is aborted', () => {
+		const store = createStore({ a: 1, b: 10 });
+		const reads: Array<keyof StoreState> = [];
+		const onRead = (field: keyof StoreState) => reads.push(field);
+		const { container, root } = objectRoot();
+		root.render(Reader, { store, field: 'a', onRead });
+		const host = container.children[0];
+		const suspended = root.render(Reader, {
+			store,
+			field: 'b',
+			onRead,
+			suspend: new Promise<void>(() => {}),
+		});
+		expect(suspended.status).toBe('suspended');
+		reads.length = 0;
+		store.notify();
+		expect(reads).toContain('a');
+		expect(reads).not.toContain('b');
+		suspended.abort();
+		flushUniversalSync(() => store.set({ a: 2, b: 99 }));
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe(2);
+		root.unmount();
+	});
+
+	it('catches a new store change between preparation and subscription', () => {
+		const previous = createStore({ a: 1, b: 2 });
+		const next = createStore({ a: 10, b: 20 });
+		const { container, root } = objectRoot();
+		root.render(Reader, { store: previous, field: 'a' });
+		const prepared = root.prepare(Reader, { store: next, field: 'b' });
+		expect(prepared.status).toBe('prepared');
+		next.setSilently({ a: 30, b: 40 });
+		flushUniversalSync(() => {
+			if (prepared.status === 'prepared') prepared.commit();
+		});
+		expect(container.children[0].props.value).toBe(40);
+		expect(previous.listeners.size).toBe(0);
+		expect(next.listeners.size).toBe(1);
+		root.unmount();
+	});
+
+	it('converges when subscribe changes the snapshot and notifies synchronously', () => {
+		let value = { a: 1, b: 2 };
+		let connected = false;
+		const store: ExternalStore<StoreState> = {
+			getSnapshot: () => value,
+			subscribe(notify) {
+				connected = true;
+				value = { a: 3, b: 4 };
+				notify();
+				return () => {
+					connected = false;
+				};
+			},
+		};
+		const { container, root } = objectRoot();
+		flushUniversalSync(() => root.render(Reader, { store, field: 'b' }));
+		expect(container.children[0].props.value).toBe(4);
+		expect(connected).toBe(true);
+		root.unmount();
+		expect(connected).toBe(false);
+	});
+
+	it('ignores a retained callback after its conditional subscription is removed', () => {
+		const store = createStore({ a: 1, b: 2 });
+		const reads: Array<keyof StoreState> = [];
+		const onRead = (field: keyof StoreState) => reads.push(field);
+		const { container, root } = objectRoot();
+		root.render(Reader, { store, field: 'a', onRead });
+		const stale = store.retained[0];
+		root.render(Reader, { store, field: 'a', enabled: false, onRead });
+		const host = container.children[0];
+		expect(store.listeners.size).toBe(0);
+		reads.length = 0;
+		flushUniversalSync(stale);
+		expect(reads).toEqual([]);
+		expect(container.children[0]).toBe(host);
+		expect(host.props.value).toBe('disabled');
+
+		root.render(Reader, { store, field: 'b', onRead });
+		reads.length = 0;
+		flushUniversalSync(stale);
+		expect(reads).toEqual([]);
+		flushUniversalSync(() => store.set({ a: 3, b: 4 }));
+		expect(host.props.value).toBe(4);
+		root.unmount();
+	});
+
+	it('routes a snapshot error through the render boundary instead of the notifier', () => {
+		const store = createStore({ a: 1, b: 2 });
+		const caught: unknown[] = [];
+		const Boundary = defineUniversalComponent('object', () =>
+			universalTry(
+				() => universalComponent('object', Reader, { store, field: 'a' }),
+				null,
+				(error) => universalValue(valuePlan, [String(error), 0]),
+			),
+		);
+		const { container, root } = objectRoot({ onCaughtError: (error) => caught.push(error) });
+		root.render(Boundary, undefined);
+		const error = new Error('store unavailable');
+		expect(() => flushUniversalSync(() => store.fail(error))).not.toThrow();
+		expect(container.children[0].props.value).toBe('Error: store unavailable');
+		expect(caught).toEqual([error]);
+		expect(store.listeners.size).toBe(0);
+		root.unmount();
+	});
+
+	it('deactivates a removed store before a throwing cleanup can notify', () => {
+		const error = new Error('subscription cleanup failed');
+		const caught: unknown[] = [];
+		let reads = 0;
+		let cleanups = 0;
+		let stale!: () => void;
+		const store: ExternalStore<number> = {
+			getSnapshot() {
+				reads++;
+				return 0;
+			},
+			subscribe(notify) {
+				stale = notify;
+				return () => {
+					cleanups++;
+					notify();
+					throw error;
+				};
+			},
+		};
+		const { container, root } = objectRoot({ onUncaughtError: (failure) => caught.push(failure) });
+		root.render(StableReader, { store });
+		const readsBeforeCleanup = reads;
+		root.unmount();
+		expect(reads).toBe(readsBeforeCleanup);
+		expect(caught).toEqual([error]);
+		expect(container.children).toEqual([]);
+		expect(cleanups).toBe(1);
+
+		flushUniversalSync(stale);
+		root.unmount();
+		expect(reads).toBe(readsBeforeCleanup);
+		expect(caught).toEqual([error]);
+		expect(cleanups).toBe(1);
+	});
+
+	it('disconnects hidden Activity subscriptions and restores the latest snapshot on reveal', () => {
+		const lifecycle: string[] = [];
+		const store = createStore({ a: 1, b: 2 }, 'store', lifecycle);
+		const Scene = defineUniversalComponent(
+			'object',
+			(props: { mode: 'visible' | 'hidden'; field: keyof StoreState }) =>
+				universalActivity(props.mode, () =>
+					universalComponent('object', Reader, { store, field: props.field }),
+				),
+		);
+		const { container, root } = objectRoot();
+		root.render(Scene, { mode: 'visible', field: 'a' });
+		const host = container.children[0];
+		root.render(Scene, { mode: 'hidden', field: 'b' });
+		expect(store.listeners.size).toBe(0);
+		expect(host.visible).toBe(false);
+		store.set({ a: 3, b: 4 });
+		root.render(Scene, { mode: 'visible', field: 'b' });
+		expect(container.children[0]).toBe(host);
+		expect(host.visible).toBe(true);
+		expect(host.props.value).toBe(4);
+		expect(lifecycle).toEqual(['subscribe:store', 'unsubscribe:store', 'subscribe:store']);
+		root.unmount();
+		expect(lifecycle.at(-1)).toBe('unsubscribe:store');
+	});
+});

--- a/packages/octane/tests/universal-state-updates.test.ts
+++ b/packages/octane/tests/universal-state-updates.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createObjectContainer,
+	createObjectDriver,
+	createUniversalRoot,
+	defineUniversalComponent,
+	flushUniversalSync,
+	startTransition,
+	universalPlan,
+	universalValue,
+	useState,
+} from '../src/universal-native.js';
+
+const valuePlan = universalPlan('object', {
+	kind: 'host',
+	type: 'state-value',
+	bindings: [['value', 0]],
+});
+
+function stateRoot<T>(initial: T, display: (value: T) => unknown = (value) => value) {
+	let set!: (value: T | ((previous: T) => T)) => void;
+	let get!: () => T;
+	const Scene = defineUniversalComponent('object', (props: { duringRender?: () => void }) => {
+		const [value, update, read] = useState(() => initial, 'state');
+		set = update;
+		get = read;
+		props.duringRender?.();
+		return universalValue(valuePlan, [display(value)]);
+	});
+	const scheduled: Array<() => void> = [];
+	const container = createObjectContainer();
+	const root = createUniversalRoot(container, createObjectDriver(), {
+		scheduleMicrotask: (callback) => scheduled.push(callback),
+	});
+	root.render(Scene, {});
+	return {
+		container,
+		root,
+		Scene,
+		set: (value: T | ((previous: T) => T)) => set(value),
+		get: () => get(),
+		flush() {
+			for (let count = 0; scheduled.length !== 0; count++) {
+				if (count === 50) throw new Error('Universal state updates did not settle.');
+				scheduled.shift()!();
+			}
+		},
+	};
+}
+
+describe('universal queued state values', () => {
+	it('preserves the order of replacement values and functional updates', () => {
+		const state = stateRoot(1);
+		flushUniversalSync(() => {
+			state.set((value) => value + 2);
+			expect(state.get()).toBe(3);
+			state.set(10);
+			expect(state.get()).toBe(10);
+			state.set((value) => value * 3);
+			expect(state.get()).toBe(30);
+			state.set((value) => value + 4);
+			expect(state.get()).toBe(34);
+		});
+		expect(state.container.children[0].props.value).toBe(34);
+		flushUniversalSync(() => {
+			state.set((value) => value + 100);
+			state.set(0);
+			expect(state.get()).toBe(0);
+		});
+		expect(state.container.children[0].props.value).toBe(0);
+		state.root.unmount();
+	});
+
+	it('retains falsy replacements and function-valued state', () => {
+		const values = stateRoot<undefined | null | false | number>(1);
+		flushUniversalSync(() => {
+			values.set(undefined);
+			expect(values.get()).toBeUndefined();
+			values.set(null);
+			expect(values.get()).toBeNull();
+			values.set(false);
+			expect(values.get()).toBe(false);
+			values.set(0);
+			expect(values.get()).toBe(0);
+		});
+		expect(values.container.children[0].props.value).toBe(0);
+		values.root.unmount();
+
+		const functions = stateRoot(
+			() => 1,
+			(value) => value(),
+		);
+		flushUniversalSync(() => {
+			functions.set(() => () => 7);
+			expect(functions.get()()).toBe(7);
+		});
+		expect(functions.container.children[0].props.value).toBe(7);
+		functions.root.unmount();
+	});
+
+	it('uses urgent values for urgent updaters while projecting and rebasing transition values', () => {
+		const state = stateRoot(0);
+		flushUniversalSync(() => {
+			state.set(5);
+			startTransition(() => {
+				state.set(100);
+				expect(state.get()).toBe(100);
+			});
+			let urgentInput = -1;
+			state.set((value) => {
+				urgentInput = value;
+				return value + 1;
+			});
+			// The eager urgent calculation must not observe the parked transition.
+			expect(urgentInput).toBe(5);
+			expect(state.get()).toBe(101);
+		});
+		expect(state.container.children[0].props.value).toBe(6);
+		state.flush();
+		expect(state.container.children[0].props.value).toBe(101);
+		state.root.unmount();
+	});
+
+	it('keeps an urgent replacement when an older transition is later replayed', () => {
+		const state = stateRoot(0);
+		flushUniversalSync(() => {
+			startTransition(() => state.set(100));
+			state.set(0);
+			expect(state.get()).toBe(0);
+		});
+		expect(state.container.children[0].props.value).toBe(0);
+		state.flush();
+		expect(state.container.children[0].props.value).toBe(0);
+		state.root.unmount();
+	});
+
+	it('reads the active draft before pending replacements and discards an aborted draft', () => {
+		const state = stateRoot(0);
+		state.set(10);
+		let updated = false;
+		let observed = -1;
+		const prepared = state.root.prepare(state.Scene, {
+			duringRender() {
+				if (!updated) {
+					updated = true;
+					state.set((value) => value + 1);
+				}
+				observed = state.get();
+			},
+		});
+		expect(prepared.status).toBe('prepared');
+		expect(observed).toBe(11);
+		expect(state.container.children[0].props.value).toBe(0);
+		prepared.abort();
+		expect(state.get()).toBe(10);
+		state.root.render(state.Scene, {});
+		expect(state.container.children[0].props.value).toBe(10);
+		state.root.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

Reduce avoidable `useSyncExternalStore` work in the DOM and universal runtimes, with behavioral regressions and deterministic benchmark guards.

- Skip repeated DOM notification snapshot reads once the owner already has an urgent, non-deferred render queued. Preserve transition upgrades, render-phase replay, profiling, and development diagnostics.
- Keep universal subscriptions connected when only the snapshot or getter changes. Publish the current getter only after a commit is accepted, retain normal conditional/Activity cleanup, and route snapshot failures through render error handling.
- Reuse universal invalidation tokens where safe and avoid replaying an entire state queue when its last applicable update is a replacement value. Functional-update ordering, transition lanes, and aborted drafts retain their existing behavior.
- Release both the active store instance and the unsubscribe closure before calling user cleanup.
- Add an Octane patch changeset, six DOM notification-work guards, and five universal subscription/state-work guards.

## Why

The DOM runtime already has a gated store-consistency queue. The remaining burst cost was in notifications: every listener still ran its getter even after the scheduler had guaranteed that its owner would render again. The universal implementation had a different problem: its subscription effect depended on the current getter and snapshot, so ordinary updates repeatedly disconnected and reconnected the same store.

An initial universal invalidation design merely moved the cost into repeated state-queue projection. The final implementation uses the existing state/lane machinery and a narrow trailing-replacement shortcut. Review also caught and fixed a possible unchanged-commit/held-transition rebase loop and a retained unsubscribe closure.

## Performance evidence

Same-machine production baseline/candidate runs used Node 26.4.0 on Darwin arm64 and esbuild 0.28.1. The DOM probe used Playwright 1.61.1 Chromium, one warmup and eight samples. The universal suite used five samples, five lifecycle warmup rounds, 20 operations per sample, and two burst warmups. The original investigation baseline was `62785995151f726dcac5b572d25457dd684e8145`; the affected runtime/compiler baseline files are byte-identical to upstream `61230d2891875a4170ee708a975b04ddef2ff7c7`.

| Workload | Before | After |
| --- | ---: | ---: |
| DOM: 100 broad notifications × 512 one-hook readers, notification getter calls | 51,200 | 512 |
| DOM: same 512 hooks across 64 owners | 51,200 | 64 |
| DOM: unchanged-notification control | 51,200 reads, 0 renders | 51,200 reads, 0 renders |
| Universal: 128 stable-getter readers, lifetime subscriptions and cleanups | 13,568 each | 128 each |
| Universal: 128 inline-getter readers, lifetime subscriptions and cleanups | 27,008 each | 128 each |
| Universal: intentionally changing subscribe identity | 27,008 each | 27,008 each |
| Universal: superseded functional-prefix executions | 4,002 | 3 |
| Universal: 8,000 distinct notifications, notification-loop score | 87.494 ms | 0.399 ms |

The deterministic guards fail against the frozen pre-fix runtimes and pass against the candidate while checking final output, retained host/DOM identity, and subscription release. The actual compiled DOM fixture and the existing Zustand, Jotai, and TanStack Query integration assertions also passed.

This is not an across-the-board wall-time claim. With almost-free Set-based subscriptions, universal parent-render scores rose from 0.342 to 0.419 ms for stable getters and 0.283 to 0.316 ms for inline getters. At 8,000 notifications, unchanged/repeated scores rose from 0.260/0.181 ms to 0.381/0.341 ms. The additional commit bookkeeping buys correct subscription lifetime, committed selectors, and priority/abort handling. DOM wall-time windows also showed machine drift, so the count reductions are the stronger evidence.

Reproduce the durable workloads in an installed workspace:

```bash
node benchmarks/external-store-fanout/work.mjs
node benchmarks/universal-external-store/run.mjs 5
node benchmarks/bench.mjs --quick --ratios external-store-fanout universal-external-store
```

For paired universal runs, `OCTANE_UNIVERSAL_STORE_RUNTIME=/absolute/runtime.mjs` selects an independently bundled baseline or candidate; use identical build options and iteration counts.

## Validation

- [x] `pnpm sync` — completed on the upstream-based branch; no generated tracked changes. Used cached tools with `pnpm_config_verify_deps_before_run=warn` because the locked dependency install is unavailable.
- [x] Targeted dev tests: 192 passed across 15 files, covering external-store conformance, tearing, hydration, transitions, universal state/scheduling, retained Suspense, Activity, transport, linked state, and native bundle boundaries.
- [x] The same 192 targeted tests passed in production compile mode.
- [x] Profiling-mode tests: 14 passed.
- [x] Core source typecheck and strict scoped `tsrx-tsc --noEmit` for all four changed test/fixture files.
- [x] `pnpm format:files:check` for the changed files, changeset validation, and `git diff --check`.
- [x] Mutation checks for priority upgrades, render/act diagnostics, render-phase replay, state order/lanes, the held-transition commit loop, and cleanup-reference release. A 256-sequence public-API differential probe also matched the previous queue projection behavior.
- [x] Frozen baseline/candidate benchmark guard checks: six DOM guards and five universal guards. Real-store integration smoke passed for Zustand 5.0.14, Jotai 2.20.2, and query-core 5.101.3.
- [x] `node benchmarks/bench.mjs --quick --ratios universal-external-store` — all five guards pass through the normal unified runner.
- [ ] `pnpm format:check` — repo-wide check not run; scoped check passed.
- [ ] `pnpm typecheck` — full workspace check not run; core and changed-test checks passed.
- [ ] `pnpm test` — full locked-toolchain run not available.

The configured registry returned HTTP 403 for locked `@tsrx/core@0.1.58`, including the approved install retry. Compiler-backed tests and browser fixtures therefore used the current Octane compiler with cached patched core 0.1.56's pure-JavaScript parser and Vitest 4.1.10. The runtime-only production measurements do not depend on that compiler fallback. No dependency manifest or lockfile is changed by this PR; normal locked-toolchain CI remains necessary.

## Risk / follow-ups

- The universal replacement shortcut is shared by `useState` and linked state; mixed functional/replacement, lane/rebase, and abort behavior is explicitly covered. Functional-only queues still use ordered replay, and held transitions can still require repeated urgent rebases.
- Native-device and transported-renderer performance were not measured. Async transport rejection and acceptance semantics are covered by tests.
- Captured-selector identity churn in binding/compiler integration remains a separate follow-up. This PR does not add a global snapshot cache or change the existing opt-in `dataCallbackHooks` policy.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789683500&installation_model_id=432790&pr_number=784&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F784&signature=7a3858b3c7d8dc9cb7b76cec0682727b25bf0f176154b2e0ea57fedbcc956eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core DOM and universal external-store scheduling, state projection, and subscription lifecycles—areas where subtle tearing, transition, and cleanup bugs are easy to introduce despite broad new tests and ratio guards.
> 
> **Overview**
> **Reduces `useSyncExternalStore` cost in the DOM and universal runtimes** while adding regression tests and deterministic benchmark guards.
> 
> In the **DOM runtime**, store notifications no longer re-run snapshot getters when the owner already has an **urgent, non-deferred** render queued (profiling, act diagnostics, transition upgrades, and render-phase replay stay on the normal path).
> 
> The **universal runtime** splits snapshot commit from subscribe lifetime so **stable `subscribe` stays connected** when only the getter changes; notifications reuse invalidation tokens and **trailing replacement values** skip full queue replay in `projectedStateValue` / `visibleStateValue`.
> 
> **Benchmarking**: new Node **`universal-external-store`** suite and **`external-store-fanout/work.mjs`** notification-work probe, ratio baselines, runner/MCP wiring, and changesets. **Tests** expand DOM and universal external-store behavior (transitions, cross-component notify, transport/Activity, state ordering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897df114ef521bd194086fe88b9c80a9e5090e5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->