### PR TITLE
perf(octane): lower memo hooks to closure-free caches

### DIFF
--- a/.changeset/closure-free-hook-memo.md
+++ b/.changeset/closure-free-hook-memo.md
@@ -1,0 +1,9 @@
+---
+'octane': patch
+---
+
+Remove memo factory and dependency-array allocations from more production
+client cache hits, including nested expressions, returned JSX, custom hooks,
+plain TypeScript modules, and explicit hook slots. Preserve factory scope,
+declaration timing, callback identity, and held-transition rollback/promotion,
+and avoid the extra `useCallback` wrapper closure in every runtime.

--- a/.changeset/register-hook-memo-benchmark.md
+++ b/.changeset/register-hook-memo-benchmark.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/mcp-server': patch
+---
+
+Expose the hook-memo allocation benchmark through the MCP benchmark tool.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -233,6 +233,7 @@ internally, get their own baseline and guard namespace.
 | `lynx-table-web` | lynx-table | none (headless Chromium) | Lynx-for-Web wall clock: the same table app for Octane and the vendored ReactLynx / Vue Lynx reference bundles under one byte-identical page driver; host-bound medians, no ratio guards |
 | `lynx-bundle-size` | lynx-bundle-size | none (builds) | semantic-checksummed production Rspeedy artifact bytes for background preview and dual-thread IFR modes; source/build evidence only |
 | `codegen-size` | codegen-size | none (Node-only) | compiled-output bytes: fixed corpus through octane/compiler, raw/min/gzip, `compiled` vs `source` |
+| `hook-memo` | hook-memo | none (Node-only) | production hook-memo compiler on/off, clean semantic controls, deterministic function/array creation events, and compiled/bundled bytes |
 | `compiler-throughput` | compiler-throughput | none (Node-only) | six real production compiler pipelines, cold/warm/incremental transformations, 10/100/1,000 components, and heap diagnostics |
 | `bundle-size` | bundle-size | none (builds) | shipped JS bytes: production builds of js-framework, TodoMVC, chat-stream, and weather-app, normalized minify, raw/gzip/brotli |
 | `bundle-reachability` | bundle-size | none (builds and executes in jsdom) | isolated public feature imports, exact production-bundle behavior, forbidden-module reachability, and committed raw/gzip/brotli budgets |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -2501,5 +2501,101 @@
     "reference": "solid",
     "maxRatio": 1.2,
     "note": "Protects the existing mount win: 32-leaf teardown + 1024-leaf mount measured 0.94x solid (1.70 vs 1.80) on 2026-08-09. Octane mounts faster than the fine-grained peers despite marker traffic; a breach means the compiled mount path grew per-node cost."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "eligible_hit_functions",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "All compiler-eligible dependency-hit scenarios must evaluate zero application or Octane-runtime function expressions. Counts are observed after production tree-shaking, not heap-allocation estimates."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "eligible_hit_application_array_literals",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "The eligible hit paths must not recreate authored dependency arrays or replacement application array literals. Per-case counters and clean semantic controls live in the result metadata."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "eligible_hit_arrays",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 1,
+    "note": "Bounds all observed application/runtime array literals, constructors, and rest arrays. The fixture-derived budget permits only the 352 existing custom-hook/JSX caller arrays across 32 renders of each eligible scenario."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "eligible_miss_functions",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 1,
+    "note": "Dependency misses may create the 448 semantically required fresh callbacks (14 callback results times 32 renders), but must not add memo-factory or runtime-wrapper closures."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "declaration_miss_arrays",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "Protects the established flat-cache declaration tier: one-dependency memo/callback misses must not create dependency or publisher rest arrays."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "identifier_deps_hit_runtime_functions",
+    "target": "runtime-form",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "An identifier dependency array deliberately keeps the runtime fallback. Its cache-hit path must not recreate an internal useCallback factory wrapper."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "identifier_deps_miss_runtime_functions",
+    "target": "runtime-form",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "The runtime fallback must not allocate an internal useCallback factory wrapper on dependency misses either."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "null_deps_hit_functions",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 1,
+    "note": "Explicit null runs every render: the fresh returned callback is required, while the useMemo factory closure is avoidable."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "null_deps_hit_arrays",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "Explicit-null inline memo/callback calls have no dependency array and must not introduce a replacement array."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "callback_name_mismatches",
+    "target": "inline",
+    "reference": "one-per-render",
+    "maxRatio": 0,
+    "note": "The clean optimized callbacks must preserve the observable function names of the runtime-form control, including anonymous explicit-null callbacks."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "code_gzip",
+    "target": "inline",
+    "reference": "runtime-form",
+    "maxRatio": 1.4,
+    "note": "Same-input production compiler output-size guard for the closure-removal fixture. Allows the inlined checks' intentional code-size tradeoff without hiding further growth in the full runtime bundle."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "bundle_gzip",
+    "target": "inline",
+    "reference": "runtime-form",
+    "maxRatio": 1.02,
+    "note": "Same-run clean tree-shaken application plus Octane runtime: closure-free lowering must stay within 2% gzip of the runtime-form control. No instrumentation contributes to these bytes."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -682,6 +682,16 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: () => [] }],
 	},
 	{
+		// Hook memoization's production compiler A/B: execute identical clean
+		// programs, then count function/array creation expressions in separate
+		// observed bundles. Deterministic; no timing or browser server required.
+		name: 'hook-memo',
+		cwd: 'hook-memo',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'run.mjs', args: () => [] }],
+	},
+	{
 		name: 'compiler-throughput',
 		cwd: 'compiler-throughput',
 		servers: [],

--- a/benchmarks/hook-memo/README.md
+++ b/benchmarks/hook-memo/README.md
@@ -1,0 +1,176 @@
+# Hook memo allocation work
+
+This Node-only benchmark compares the same production application with
+`inlineHookMemo: false` and `inlineHookMemo: true`. It measures the work that
+ordinary `useMemo` and `useCallback` calls can perform before a dependency
+comparison discovers a cache hit.
+
+```bash
+node benchmarks/bench.mjs --ratios hook-memo
+node benchmarks/hook-memo/run.mjs
+BENCH_JSON=/tmp/hook-memo.json node benchmarks/hook-memo/run.mjs
+```
+
+There are no preview servers, browser downloads, or timing thresholds. Both
+variants use client production compilation with HMR, development metadata, and
+automatic region memoization disabled. The latter ensures an unrelated `tick`
+prop reaches every fixture body rather than being absorbed by another cache.
+Plain TypeScript hooks go through the real `slotHooks` entry point with the same
+explicit on/off setting. A separate manual-slot module uses `manualSlots: true`,
+matching bindings whose slots must not be automatically rewritten.
+
+## Scenarios and semantic controls
+
+The fixed fixtures cover declarations, identifier dependencies, direct returns,
+nested expressions, returned JSX, destructuring, custom hooks called twice,
+explicit third-slot arguments, plain-TypeScript and manual-slot hooks, explicit
+`null`, and a conditionally reached hook. Each mounts, renders 32 times with equal
+dependencies, renders 32 times with changed dependencies, and unmounts. The
+conditional case also deactivates and reactivates with unchanged dependencies.
+
+The real bundled Octane runtime renders into happy-dom. Every render checks its
+output, memo value, callback result, and identity. A deliberately omitted `tick`
+capture must remain stale on a hit and become current on a miss. `null` must
+produce fresh identities on every render. Calling a custom hook twice must not
+merge its caches. Teardown must empty the container.
+
+The entire sequence first runs without observation. It then runs in a separate
+observed bundle, whose final semantic snapshot must equal the clean run and the
+other compiler variant. The observer is applied **after** Octane compilation
+and bundler tree-shaking, using the clean bundle's source map for attribution.
+Putting allocation probes into authored source would change the program the
+compiler analyzes; adding them before bundling could also retain otherwise-dead
+code. A runtime-form control checks that both known callback and dependency-array
+sites remain visible to the observer.
+
+`callback_name_mismatches` records differences from the runtime-form callback
+names separately, so a historical compiler with a name-inference defect can
+still provide a before measurement. The current regression guard requires zero
+mismatches; clean and observed names must always agree within each variant.
+
+## What the numbers mean
+
+The observed copy counts evaluations of function expressions/arrows, array
+literals, `new Array(...)`, and rest-parameter array creation. Application and
+Octane-runtime counts are kept separately in each phase's JSON metadata. This
+exposes both call-site dependency arrays and costs moved into runtime helpers,
+including the runtime callback wrapper. The `one-per-render` target is a fixed
+reference for exact, noise-free count ceilings; it is not another framework.
+The aggregate guards exclude the deliberately ineligible identifier-dependency
+case and the always-fresh `null` case. Eligible hits must create no function
+expressions or application array literals. The total-array ceiling allows the
+existing custom-hook/JSX caller arrays, and the miss-function ceiling allows one
+fresh callback per observed pair. Separate guards protect the runtime fallback,
+explicit `null`, callback names, and allocation-free ordinary flat-cache misses.
+Per-case phase counters remain in the JSON so an aggregate change can be traced
+to its source.
+
+These are **source-level creation events, not a V8 heap-allocation census**.
+An engine can eliminate some source allocations. Conversely, object literals,
+function declarations, object/class methods, dynamically named function literals,
+native built-ins such as `slice`, and allocations inside external dependencies
+are not counted. Static inferred function names are preserved by the observer
+and included in the clean/observed semantic comparison. The application
+fixtures author arrays only for dependencies, but the application-array metric
+also includes any array literals introduced by compilation. Cache-array
+constructors and runtime rest arrays are visible separately in the metadata.
+
+`code_raw`, `code_minified`, and `code_gzip` aggregate the compiled fixture
+modules; gzip is the sum of independently compressed minified modules.
+`bundle_minified` and `bundle_gzip` include their tree-shaken Octane runtime.
+All size numbers come from the **clean** output. Mount counts exclude
+`createRoot` itself, and teardown has a separate count row.
+
+The fixture, entry, observer, and runner hashes, Node version, esbuild version,
+and installed `@tsrx/core` version accompany each result (also inside each
+measured target's metadata, which the unified runner preserves).
+`OCTANE_MEMO_ROOT` can select another source checkout, while
+`OCTANE_MEMO_EXTERNAL_ROOT` can select the checkout supplying an already-installed
+dependency tree. Keep those dependencies, hashes, and runner options identical
+for a before/after comparison. A nonstandard parser loader must be disclosed
+with the result.
+
+The observer's own copy-on-write and counting control can be run with:
+
+```bash
+node --test benchmarks/hook-memo/instrument.test.mjs
+```
+
+## Initial expansion measurement
+
+On 2026-08-19, the closure-free compiler expansion was compared with an archived
+copy of `62785995151f726dcac5b572d25457dd684e8145`. Both used this exact fixture
+and runner, Node 26.4.0, esbuild 0.28.1, and the same cached dependencies. The
+locked native parser could not be installed because its registry returned 403,
+so both runs redirected the compiler parser to the checked-in JavaScript/browser
+parser with `@tsrx/core` 0.1.56. These are reproducible source-count and byte
+measurements under that fallback toolchain; the locked native-parser run remains
+an additional validation requirement.
+
+The table compares the old default inline compiler with the expanded inline
+compiler. Eligible totals cover 11 scenarios, each with 32 hit and 32 miss
+renders; the miss sequence requires 14 fresh callback results per iteration.
+
+| Metric                                         |  Before |  After |
+| ---------------------------------------------- | ------: | -----: |
+| Eligible hit function expressions              |   1,088 |      0 |
+| Eligible hit application array literals        |     736 |      0 |
+| Eligible hit total array creations             |   1,824 |    352 |
+| Eligible miss function expressions             |   1,184 |    448 |
+| Eligible miss total array creations            |   1,824 |    992 |
+| Ordinary flat-declaration miss arrays          |       0 |      0 |
+| Runtime-fallback wrapper functions, hit / miss | 32 / 32 |  0 / 0 |
+| Explicit-null hit function expressions         |      32 |     32 |
+| Callback-name mismatches                       |       1 |      0 |
+| Compiled fixture gzip bytes                    |   2,169 |  2,654 |
+| Tree-shaken bundle gzip bytes                  |  44,139 | 44,603 |
+
+The already-optimized ordinary declaration and conditional-declaration hits
+remain at zero functions and arrays. The residual 352 hit arrays are caller
+plumbing, and generic invalidation paths still create arrays. Mount events also
+fell from 48 to 25 functions and from 72 to 48 arrays across eligible scenarios;
+teardown stayed at 12 functions and zero arrays. This is not an assertion that
+the full render performs no allocations.
+
+The cost is larger generated code: +485 gzip bytes for the fixtures (+22.4%) and
++464 for the bundled application/runtime (+1.05%). Within the candidate's
+same-run on/off comparison, gzip is 2,654 / 1,976 for compiler output (1.3431×)
+and 44,603 / 44,057 for the bundle (1.0124×). All 12 committed ratio guards
+passed; the archived baseline breaches seven of them, confirming the gate
+detects the intended regression. The initial variadic flat-cache publisher had
+added miss-side rest arrays; the benchmark exposed that transfer, and
+fixed-arity publishers restored the existing zero-array ordinary miss path
+before this result was recorded.
+
+The paired files recorded identical provenance hashes:
+
+```text
+fixture  40fb3be39918587e8bc60982da7039266ac167c654012d258d73400c93696037
+entry    274e868c669ce9a8c37b1b12aa2e025cf5a73361b414cbdff3b6c2e09384cd16
+observer 35e8695da302de113281c45ff5a0322447626e88660c7597070bd3b4365432d7
+runner   3f7a2b38bac1666c8987f6bf01b13906988eb333fc4cdc7a390fefa31a4f9137
+```
+
+### Revalidation against the PR base
+
+After rebasing onto upstream `922b2d46e50c3b434762c9a61450e7c4c9c1ecde`, a
+fresh paired run against that archived base and the rebased candidate reproduced
+every count and byte size above. The fixture, entry, observer, and runner hashes
+were unchanged. Both runs used the same fallback toolchain, including
+`@tsrx/core` 0.1.56 and esrap 2.3.0. The unified runner again checked all 12
+hook-memo guards: the base breached seven, the candidate passed all twelve, and
+the observer tests passed 2/2. This confirms the result on the current PR base;
+the original table remains the measurement against `627859951`.
+
+The archived package manifest and source-tree hashes were:
+
+```text
+base      560882e7122a52cbdfb6aa4340a49f71352c1d5301262c682aa87672e9bac00c
+candidate d7b8406219c6e7398ca1370d5754977842c957ec2f2853f5c4e34481a27a1981
+```
+
+For end-user latency, run a representative production browser workload such as
+`memo-wall` separately. This focused suite deliberately makes no speedup or
+garbage-collection claim from a smaller source count. It does not measure SSR,
+hydration, universal renderers, or concurrent abort/replay; their semantic
+contracts remain the responsibility of the owning runtime/compiler suites.

--- a/benchmarks/hook-memo/cases.tsrx
+++ b/benchmarks/hook-memo/cases.tsrx
@@ -1,0 +1,129 @@
+import { useCallback, useMemo } from 'octane';
+import { useManualPair } from './manual-hooks';
+import { usePlainBox, usePlainCallback, usePlainExplicitPair } from './plain-hooks';
+
+type Box = { value: number; tick: number };
+type Callback = () => number;
+type Observe = (box: Box, callback: Callback) => void;
+type Props = { dep: number; tick: number; enabled: boolean; observe: Observe };
+
+function publish(observe: Observe, box: Box, callback: Callback): number {
+	observe(box, callback);
+	return box.value;
+}
+
+export function Declaration({ dep, tick, observe }: Props) @{
+	const box = useMemo(() => ({ value: dep, tick }), [dep]);
+	const callback = useCallback(() => dep * 1000 + tick, [dep]);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+export function IdentifierDeps({ dep, tick, observe }: Props) @{
+	const deps = [dep];
+	const box = useMemo(() => ({ value: dep, tick }), deps);
+	const callback = useCallback(() => dep * 1000 + tick, deps);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+function useReturnedBox(dep: number, tick: number): Box {
+	return useMemo(() => ({ value: dep, tick }), [dep]);
+}
+
+function useReturnedCallback(dep: number, tick: number): Callback {
+	return useCallback(() => dep * 1000 + tick, [dep]);
+}
+
+export function DirectReturn({ dep, tick, observe }: Props) @{
+	const box = useReturnedBox(dep, tick);
+	const callback = useReturnedCallback(dep, tick);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+export function NestedExpression({ dep, tick, observe }: Props) @{
+	const value = publish(
+		observe,
+		useMemo(() => ({ value: dep, tick }), [dep]),
+		useCallback(() => dep * 1000 + tick, [dep]),
+	);
+	<output>{tick + ':' + value}</output>
+}
+
+export function Destructured({ dep, tick, observe }: Props) @{
+	const { box, callback } = useMemo(
+		() => ({
+			box: { value: dep, tick },
+			callback: () => dep * 1000 + tick,
+		}),
+		[dep],
+	);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+function usePair(dep: number, tick: number) {
+	const box = useMemo(() => ({ value: dep, tick }), [dep]);
+	const callback = useCallback(() => dep * 1000 + tick, [dep]);
+	return { box, callback };
+}
+
+export function CustomHook({ dep, tick, observe }: Props) @{
+	const first = usePair(dep, tick);
+	const second = usePair(dep + 1, tick);
+	observe(first.box, first.callback);
+	observe(second.box, second.callback);
+	<output>{tick + ':' + first.box.value + ',' + second.box.value}</output>
+}
+
+const EXPLICIT_MEMO = Symbol('hook-memo-bench:value');
+const EXPLICIT_CALLBACK = Symbol('hook-memo-bench:callback');
+
+export function ExplicitSlot({ dep, tick, observe }: Props) @{
+	const box = useMemo(() => ({ value: dep, tick }), [dep], EXPLICIT_MEMO);
+	const callback = useCallback(() => dep * 1000 + tick, [dep], EXPLICIT_CALLBACK);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+export function PlainHook({ dep, tick, observe }: Props) @{
+	const box = usePlainBox(dep, tick);
+	const callback = usePlainCallback(dep, tick);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+export function PlainExplicitSlot({ dep, tick, observe }: Props) @{
+	const first = usePlainExplicitPair(dep, tick);
+	const second = usePlainExplicitPair(dep + 1, tick);
+	observe(first.box, first.callback);
+	observe(second.box, second.callback);
+	<output>{tick + ':' + first.box.value + ',' + second.box.value}</output>
+}
+
+export function ManualSlotHook({ dep, tick, observe }: Props) @{
+	const first = useManualPair(dep, tick);
+	const second = useManualPair(dep + 1, tick);
+	observe(first.box, first.callback);
+	observe(second.box, second.callback);
+	<output>{tick + ':' + first.box.value + ',' + second.box.value}</output>
+}
+
+export function NullDeps({ dep, tick, observe }: Props) @{
+	const box = useMemo(() => ({ value: dep, tick }), null);
+	const callback = useCallback(() => dep * 1000 + tick, null);
+	observe(box, callback);
+	<output>{tick + ':' + box.value}</output>
+}
+
+export function Conditional({ dep, tick, enabled, observe }: Props) @{
+	let value = 'off';
+	if (enabled) {
+		const box = useMemo(() => ({ value: dep, tick }), [dep]);
+		const callback = useCallback(() => dep * 1000 + tick, [dep]);
+		observe(box, callback);
+		value = String(box.value);
+	}
+	<output>{tick + ':' + value}</output>
+}

--- a/benchmarks/hook-memo/entry.mjs
+++ b/benchmarks/hook-memo/entry.mjs
@@ -1,0 +1,3 @@
+export { createRoot, flushSync } from 'octane';
+export * from './cases.tsrx';
+export * from './returned-jsx.tsx';

--- a/benchmarks/hook-memo/instrument.mjs
+++ b/benchmarks/hook-memo/instrument.mjs
@@ -1,0 +1,138 @@
+// This is a benchmark observer over already-compiled JavaScript, not a compiler
+// pass. It deliberately runs after Octane's optimization decisions and the
+// clean bundle's tree-shaking. Counters
+// therefore cannot turn an otherwise-pure source region into an impure one.
+// The observed program is never used for code-size or timing measurements.
+
+const FUNCTION_TYPES = new Set([
+	'FunctionDeclaration',
+	'FunctionExpression',
+	'ArrowFunctionExpression',
+]);
+const SKIP_KEYS = new Set(['loc', 'start', 'end', 'metadata', 'comments', 'tokens']);
+const DYNAMIC_NAME = Symbol('dynamic inferred function name');
+
+function inferredFunctionName(node, parent, key) {
+	if (node.type === 'FunctionExpression' && node.id != null) return null;
+	if (parent?.type === 'VariableDeclarator' && key === 'init' && parent.id?.type === 'Identifier') {
+		return parent.id.name;
+	}
+	if (
+		parent?.type === 'AssignmentExpression' &&
+		key === 'right' &&
+		['=', '||=', '&&=', '??='].includes(parent.operator) &&
+		parent.left?.type === 'Identifier'
+	) {
+		return parent.left.name;
+	}
+	if (
+		parent?.type === 'AssignmentPattern' &&
+		key === 'right' &&
+		parent.left?.type === 'Identifier'
+	) {
+		return parent.left.name;
+	}
+	if (parent?.type === 'ExportDefaultDeclaration' && key === 'declaration') return 'default';
+	if ((parent?.type === 'Property' || parent?.type === 'PropertyDefinition') && key === 'value') {
+		if (!parent.computed && parent.key?.type === 'Identifier') return parent.key.name;
+		if (!parent.computed && parent.key?.type === 'PrivateIdentifier') return '#' + parent.key.name;
+		if (
+			parent.key?.type === 'Literal' &&
+			['string', 'number', 'bigint'].includes(typeof parent.key.value)
+		) {
+			return String(parent.key.value);
+		}
+		return DYNAMIC_NAME;
+	}
+	return null;
+}
+
+export const COUNTER_KINDS = ['functions', 'arrayLiterals', 'arrayConstructors', 'restArrays'];
+export const COUNTER_GLOBAL = '__octaneHookMemoAllocations';
+
+export function emptyCounters() {
+	return Object.fromEntries(
+		['application', 'runtime'].flatMap((owner) =>
+			COUNTER_KINDS.map((kind) => [`${owner}_${kind}`, 0]),
+		),
+	);
+}
+
+export function instrumentJavaScript(source, filename, owner, { parseModule, builders, print }) {
+	const b = builders;
+	const increment = (siteOwner, kind) =>
+		b.update('++', b.member(b.member(b.id('globalThis'), COUNTER_GLOBAL), `${siteOwner}_${kind}`));
+
+	function visit(node, parent = null, parentKey = null) {
+		if (Array.isArray(node)) return node.map((child) => visit(child, parent, parentKey));
+		if (node === null || typeof node !== 'object' || typeof node.type !== 'string') return node;
+		let rewritten = node;
+		for (const key of Object.keys(node)) {
+			if (SKIP_KEYS.has(key)) continue;
+			const child = node[key];
+			if (child === null || typeof child !== 'object') continue;
+			const next = visit(child, node, key);
+			if (next === child) continue;
+			if (rewritten === node) rewritten = { ...node };
+			rewritten[key] = next;
+		}
+		const siteOwner = typeof owner === 'function' ? owner(node) : owner;
+		if (siteOwner === null || siteOwner === undefined) return rewritten;
+
+		if (
+			FUNCTION_TYPES.has(node.type) &&
+			node.params?.some((param) => param.type === 'RestElement')
+		) {
+			const counter = increment(siteOwner, 'restArrays');
+			const body = rewritten.body;
+			rewritten = {
+				...rewritten,
+				body:
+					body.type === 'BlockStatement'
+						? { ...body, body: [b.stmt(counter), ...body.body] }
+						: b.sequence([counter, body]),
+			};
+		}
+
+		const methodValue =
+			parentKey === 'value' &&
+			(parent?.type === 'MethodDefinition' ||
+				(parent?.type === 'Property' &&
+					(parent.method || parent.kind === 'get' || parent.kind === 'set')));
+		if (
+			node.type === 'ArrowFunctionExpression' ||
+			(node.type === 'FunctionExpression' && !methodValue)
+		) {
+			const inferredName = inferredFunctionName(node, parent, parentKey);
+			// Re-evaluating a computed name could have side effects. Those rare
+			// naming contexts stay unobserved rather than changing the program.
+			if (inferredName === DYNAMIC_NAME) return rewritten;
+			// A comma wrapper suppresses NamedEvaluation. A static computed property
+			// gives the original anonymous function its exact inferred name without
+			// altering its lexical this/arguments/super environment. This observer-
+			// owned object is not a source allocation and is never timed.
+			const value =
+				inferredName === null
+					? rewritten
+					: b.member(
+							b.object([b.prop('init', b.literal(inferredName), rewritten, true)]),
+							b.literal(inferredName),
+							true,
+						);
+			return b.sequence([increment(siteOwner, 'functions'), value]);
+		}
+		if (node.type === 'ArrayExpression') {
+			return b.sequence([increment(siteOwner, 'arrayLiterals'), rewritten]);
+		}
+		if (
+			node.type === 'NewExpression' &&
+			node.callee?.type === 'Identifier' &&
+			node.callee.name === 'Array'
+		) {
+			return b.sequence([increment(siteOwner, 'arrayConstructors'), rewritten]);
+		}
+		return rewritten;
+	}
+
+	return print(visit(parseModule(source, filename)));
+}

--- a/benchmarks/hook-memo/instrument.test.mjs
+++ b/benchmarks/hook-memo/instrument.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import vm from 'node:vm';
+
+import { COUNTER_GLOBAL, emptyCounters, instrumentJavaScript } from './instrument.mjs';
+
+const dependencyRoot =
+	process.env.OCTANE_MEMO_EXTERNAL_ROOT || path.resolve(import.meta.dirname, '../..');
+const require = createRequire(path.join(dependencyRoot, 'packages/octane/package.json'));
+const { parseModule, builders } = require('@tsrx/core');
+const { print } = require('esrap');
+const tsx = require('esrap/languages/tsx').default;
+
+function freeze(value, visited = new WeakSet()) {
+	if (value === null || typeof value !== 'object' || visited.has(value)) return value;
+	visited.add(value);
+	for (const child of Object.values(value)) freeze(child, visited);
+	return Object.freeze(value);
+}
+
+function evaluate(source) {
+	const context = { [COUNTER_GLOBAL]: emptyCounters(), result: null };
+	vm.runInNewContext(source, context);
+	return { value: JSON.stringify(context.result), counters: context[COUNTER_GLOBAL] };
+}
+
+test('creation probes preserve values, methods, lexical closures, and rest arguments', () => {
+	const source = `
+		const make = (...items) => ({ items, read: () => items[0] });
+		const first = make(4, 5);
+		const second = make(6);
+		const holder = {
+			method(...values) { return values.length; },
+			get value() { return first.read(); }
+		};
+		const list = [first.read(), second.read(), holder.method(1, 2), holder.value];
+		const sized = new Array(2).fill(9);
+		globalThis.result = { list, sized, names: [make.name, first.read.name] };
+	`;
+	const ast = freeze(parseModule(source, 'observer-control.js'));
+	const observedSource = instrumentJavaScript(source, 'observer-control.js', 'application', {
+		parseModule: () => ast,
+		builders,
+		print: (program) => print(program, tsx()).code,
+	});
+	const clean = evaluate(source);
+	const observed = evaluate(observedSource);
+	assert.equal(observed.value, clean.value);
+	assert.equal(observed.value, '{"list":[4,6,2,4],"sized":[9,9],"names":["make","read"]}');
+	assert.deepEqual(observed.counters, {
+		...emptyCounters(),
+		application_functions: 3,
+		application_arrayLiterals: 2,
+		application_arrayConstructors: 1,
+		application_restArrays: 3,
+	});
+});
+
+test('computed function names are not re-evaluated or changed by observation', () => {
+	const source = `
+		let keyCalls = 0;
+		const key = () => { keyCalls++; return 'dynamic'; };
+		const holder = { [key()]: () => 5 };
+		let assigned;
+		assigned = function () { return this.value; };
+		globalThis.result = {
+			keyCalls,
+			dynamicName: holder.dynamic.name,
+			assignedName: assigned.name,
+			value: assigned.call({ value: 8 })
+		};
+	`;
+	const observedSource = instrumentJavaScript(source, 'observer-names.js', 'application', {
+		parseModule,
+		builders,
+		print: (program) => print(program, tsx()).code,
+	});
+	const observed = evaluate(observedSource);
+	assert.equal(observed.value, evaluate(source).value);
+	assert.equal(
+		observed.value,
+		'{"keyCalls":1,"dynamicName":"dynamic","assignedName":"assigned","value":8}',
+	);
+	assert.deepEqual(observed.counters, { ...emptyCounters(), application_functions: 2 });
+});

--- a/benchmarks/hook-memo/manual-hooks.ts
+++ b/benchmarks/hook-memo/manual-hooks.ts
@@ -1,0 +1,12 @@
+import { useCallback, useMemo } from 'octane';
+
+const MEMO_SLOT = Symbol('hook-memo-bench:manual-value');
+const CALLBACK_SLOT = Symbol('hook-memo-bench:manual-callback');
+
+// This module follows a binding package's manual-slot contract. The production
+// adapter may lower its memo expressions, but must not add another slot layer.
+export function useManualPair(dep: number, tick: number) {
+	const box = useMemo(() => ({ value: dep, tick }), [dep], MEMO_SLOT);
+	const callback = useCallback(() => dep * 1000 + tick, [dep], CALLBACK_SLOT);
+	return { box, callback };
+}

--- a/benchmarks/hook-memo/plain-hooks.ts
+++ b/benchmarks/hook-memo/plain-hooks.ts
@@ -1,0 +1,18 @@
+import { useCallback, useMemo } from 'octane';
+
+export function usePlainBox(dep: number, tick: number) {
+	return useMemo(() => ({ value: dep, tick }), [dep]);
+}
+
+export function usePlainCallback(dep: number, tick: number) {
+	return useCallback(() => dep * 1000 + tick, [dep]);
+}
+
+const EXPLICIT_MEMO = Symbol('hook-memo-bench:plain-value');
+const EXPLICIT_CALLBACK = Symbol('hook-memo-bench:plain-callback');
+
+export function usePlainExplicitPair(dep: number, tick: number) {
+	const box = useMemo(() => ({ value: dep, tick }), [dep], EXPLICIT_MEMO);
+	const callback = useCallback(() => dep * 1000 + tick, [dep], EXPLICIT_CALLBACK);
+	return { box, callback };
+}

--- a/benchmarks/hook-memo/returned-jsx.tsx
+++ b/benchmarks/hook-memo/returned-jsx.tsx
@@ -1,0 +1,19 @@
+/** @jsxImportSource octane */
+import { useCallback, useMemo } from 'octane';
+
+export function ReturnedJsx({
+	dep,
+	tick,
+	observe,
+}: {
+	dep: number;
+	tick: number;
+	observe: (box: { value: number; tick: number }, callback: () => number) => void;
+}) {
+	const box = useMemo(() => ({ value: dep, tick }), [dep]);
+	observe(
+		box,
+		useCallback(() => dep * 1000 + tick, [dep]),
+	);
+	return <output>{tick + ':' + box.value}</output>;
+}

--- a/benchmarks/hook-memo/run.mjs
+++ b/benchmarks/hook-memo/run.mjs
@@ -1,0 +1,560 @@
+// Deterministic, same-run production compiler A/B. The clean bundles establish
+// semantics and shipped-code cost. Separately instrumented copies count source
+// creation events; they are never timed and are not claims about V8 heap bytes.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { constants as zlibConstants, gzipSync } from 'node:zlib';
+
+import { COUNTER_GLOBAL, emptyCounters, instrumentJavaScript } from './instrument.mjs';
+
+const ROOT = import.meta.dirname;
+const REPO = path.resolve(process.env.OCTANE_MEMO_ROOT || path.join(ROOT, '../..'));
+const DEPENDENCY_REPO = path.resolve(process.env.OCTANE_MEMO_EXTERNAL_ROOT || REPO);
+const OCTANE_ROOT = path.join(REPO, 'packages/octane');
+const SOURCE_ROOT = path.join(OCTANE_ROOT, 'src');
+const requireDependencies = createRequire(
+	path.join(DEPENDENCY_REPO, 'packages/octane/package.json'),
+);
+const { build, transformSync, version: esbuildVersion } = requireDependencies('esbuild');
+const { parseModule, builders } = requireDependencies('@tsrx/core');
+const { print: esrapPrint } = requireDependencies('esrap');
+const esrapTsx = requireDependencies('esrap/languages/tsx').default;
+const { Window } = await import(pathToFileURL(requireDependencies.resolve('happy-dom')).href);
+const { compile } = await import(pathToFileURL(path.join(SOURCE_ROOT, 'compiler/index.js')).href);
+const { slotHooks } = await import(
+	pathToFileURL(path.join(SOURCE_ROOT, 'compiler/slot-hooks.js')).href
+);
+const { decodeSourceMappings } = await import(
+	pathToFileURL(path.join(SOURCE_ROOT, 'compiler/fat-segments.js')).href
+);
+const exportsMap = JSON.parse(
+	fs.readFileSync(path.join(OCTANE_ROOT, 'package.json'), 'utf8'),
+).exports;
+
+const REPEATS = 32;
+const CASES = [
+	{ name: 'declaration', component: 'Declaration' },
+	{ name: 'identifier_deps', component: 'IdentifierDeps', runtimeFallback: true },
+	{ name: 'direct_return', component: 'DirectReturn', hitArraysPerRender: 2 },
+	{ name: 'nested_expression', component: 'NestedExpression' },
+	{ name: 'returned_jsx', component: 'ReturnedJsx', hitArraysPerRender: 1 },
+	{ name: 'destructured', component: 'Destructured' },
+	{ name: 'custom_hook', component: 'CustomHook', pairs: 2, hitArraysPerRender: 2 },
+	{ name: 'explicit_slot', component: 'ExplicitSlot' },
+	{ name: 'plain_hook', component: 'PlainHook', hitArraysPerRender: 2 },
+	{
+		name: 'plain_explicit_slot',
+		component: 'PlainExplicitSlot',
+		pairs: 2,
+		hitArraysPerRender: 2,
+	},
+	{ name: 'manual_slot_hook', component: 'ManualSlotHook', pairs: 2, hitArraysPerRender: 2 },
+	{ name: 'null_deps', component: 'NullDeps', alwaysFresh: true },
+	{ name: 'conditional', component: 'Conditional', conditional: true },
+];
+const APP_FILES = [
+	path.join(ROOT, 'cases.tsrx'),
+	path.join(ROOT, 'plain-hooks.ts'),
+	path.join(ROOT, 'returned-jsx.tsx'),
+	path.join(ROOT, 'manual-hooks.ts'),
+];
+const val = (score) => ({ score, median: score, min: score, samples: 1 });
+const bytes = (source) => Buffer.byteLength(source);
+const gzipBytes = (source) => gzipSync(source, { level: zlibConstants.Z_BEST_COMPRESSION }).length;
+const print = (ast) => esrapPrint(ast, esrapTsx()).code;
+const instrument = (source, filename, owner) =>
+	instrumentJavaScript(source, filename, owner, { parseModule, builders, print });
+const asJavaScript = (source, filename) =>
+	transformSync(source, {
+		loader: filename.endsWith('.ts') ? 'ts' : 'js',
+		format: 'esm',
+		target: 'esnext',
+		sourcefile: filename,
+	}).code;
+
+function dependencyVersion(name) {
+	let directory = path.dirname(requireDependencies.resolve(name));
+	while (directory !== path.dirname(directory)) {
+		const manifest = path.join(directory, 'package.json');
+		if (fs.existsSync(manifest)) {
+			const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+			if (pkg.name === name) return pkg.version;
+		}
+		directory = path.dirname(directory);
+	}
+	return null;
+}
+
+function compileApplication(inlineHookMemo) {
+	const sources = new Map();
+	for (const filename of [APP_FILES[0], APP_FILES[2]]) {
+		const componentSource = fs.readFileSync(filename, 'utf8');
+		const compiled = compile(componentSource, filename, {
+			mode: 'client',
+			hmr: false,
+			dev: false,
+			autoMemo: false,
+			inlineHookMemo,
+		});
+		assert.equal(compiled.diagnostics.length, 0, 'benchmark fixture emitted compiler diagnostics');
+		sources.set(filename, compiled.code);
+	}
+	for (const [filename, manualSlots] of [
+		[APP_FILES[1], false],
+		[APP_FILES[3], true],
+	]) {
+		const plainSource = fs.readFileSync(filename, 'utf8');
+		const slotted = slotHooks(plainSource, filename, {
+			environment: 'client',
+			hmr: false,
+			profile: false,
+			inlineHookMemo,
+			manualSlots,
+		});
+		sources.set(filename, asJavaScript(slotted?.code ?? plainSource, filename));
+	}
+	return sources;
+}
+
+function octaneRequest(request) {
+	const key = request === 'octane' ? '.' : './' + request.slice('octane/'.length);
+	const entry = exportsMap[key];
+	const target = typeof entry === 'string' ? entry : entry?.import || entry?.default;
+	if (typeof target !== 'string') throw new Error(`Unmapped benchmark runtime import ${request}`);
+	return path.resolve(OCTANE_ROOT, target);
+}
+
+async function bundleApplication(sources, outfile) {
+	const result = await build({
+		entryPoints: [path.join(ROOT, 'entry.mjs')],
+		absWorkingDir: REPO,
+		outfile,
+		bundle: true,
+		write: false,
+		sourcemap: 'external',
+		format: 'esm',
+		platform: 'browser',
+		target: 'es2022',
+		logLevel: 'silent',
+		define: { 'process.env.NODE_ENV': '"production"' },
+		nodePaths: [
+			path.join(DEPENDENCY_REPO, 'packages/octane/node_modules'),
+			path.join(DEPENDENCY_REPO, 'node_modules'),
+		],
+		plugins: [
+			{
+				name: 'hook-memo-benchmark',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => ({
+						path: octaneRequest(request),
+					}));
+					plugin.onLoad({ filter: /\.(?:tsrx|tsx|ts|js)$/ }, ({ path: filename }) => {
+						const application = sources.get(filename);
+						if (application === undefined) return null;
+						return {
+							contents: application,
+							loader: 'js',
+							resolveDir: path.dirname(filename),
+						};
+					});
+				},
+			},
+		],
+	});
+	assert.equal(result.outputFiles.length, 2, 'expected one self-contained bundle and source map');
+	return {
+		code: result.outputFiles.find((file) => file.path === outfile).text,
+		map: JSON.parse(result.outputFiles.find((file) => file.path === outfile + '.map').text),
+	};
+}
+
+function sourceOwner(map, generatedFile) {
+	const applicationFiles = new Set(APP_FILES);
+	const owners = map.sources.map((source) => {
+		const filename = path.resolve(path.dirname(generatedFile), map.sourceRoot || '', source);
+		if (applicationFiles.has(filename)) return 'application';
+		if (filename.startsWith(SOURCE_ROOT + path.sep)) return 'runtime';
+		return null;
+	});
+	const lines = decodeSourceMappings(map.mappings);
+	return (node) => {
+		const position = node.loc?.start;
+		if (!position) return null;
+		const segments = lines[position.line - 1] || [];
+		let lower = 0;
+		let upper = segments.length;
+		while (lower < upper) {
+			const middle = (lower + upper) >>> 1;
+			if (segments[middle][0] <= position.column) lower = middle + 1;
+			else upper = middle;
+		}
+		const segment = segments[lower - 1];
+		return segment?.length >= 4 ? owners[segment[1]] : null;
+	};
+}
+
+function setupDom() {
+	const window = new Window({ url: 'http://localhost/' });
+	for (const key of [
+		'window',
+		'document',
+		'navigator',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'SVGElement',
+		'Text',
+		'Comment',
+		'DocumentFragment',
+		'Event',
+		'EventTarget',
+		'MutationObserver',
+		'HTMLInputElement',
+		'HTMLSelectElement',
+		'HTMLTextAreaElement',
+		'getComputedStyle',
+		'requestAnimationFrame',
+		'cancelAnimationFrame',
+	]) {
+		const value = key === 'window' ? window : window[key];
+		if (value !== undefined)
+			Object.defineProperty(globalThis, key, { value, writable: true, configurable: true });
+	}
+	return window;
+}
+
+function summarizedCounters(counters) {
+	return {
+		functions: counters.application_functions + counters.runtime_functions,
+		arrays:
+			counters.application_arrayLiterals +
+			counters.application_arrayConstructors +
+			counters.application_restArrays +
+			counters.runtime_arrayLiterals +
+			counters.runtime_arrayConstructors +
+			counters.runtime_restArrays,
+		application_functions: counters.application_functions,
+		application_array_literals: counters.application_arrayLiterals,
+		runtime_functions: counters.runtime_functions,
+		runtime_rest_arrays: counters.runtime_restArrays,
+	};
+}
+
+function eligibleTotals(measurements) {
+	const counts = {
+		eligible_hit_functions: 0,
+		eligible_hit_application_array_literals: 0,
+		eligible_hit_arrays: 0,
+		eligible_miss_functions: 0,
+	};
+	const budgets = { ...counts };
+	for (const fixture of CASES) {
+		if (fixture.runtimeFallback || fixture.alwaysFresh) continue;
+		const hit = summarizedCounters(measurements[`${fixture.name}_hit`].counters);
+		const miss = summarizedCounters(measurements[`${fixture.name}_miss`].counters);
+		counts.eligible_hit_functions += hit.functions;
+		counts.eligible_hit_application_array_literals += hit.application_array_literals;
+		counts.eligible_hit_arrays += hit.arrays;
+		counts.eligible_miss_functions += miss.functions;
+		// Positive references let the ratio runner enforce an exact zero ceiling.
+		budgets.eligible_hit_functions += REPEATS;
+		budgets.eligible_hit_application_array_literals += REPEATS;
+		// The residual arrays belong to custom-hook/JSX caller plumbing, not
+		// memo dependency literals. Each invalidation must create a fresh callback.
+		budgets.eligible_hit_arrays += REPEATS * (fixture.hitArraysPerRender ?? 0);
+		budgets.eligible_miss_functions += REPEATS * (fixture.pairs ?? 1);
+	}
+	return { counts, budgets };
+}
+
+function exercise(bundle, observed) {
+	const measurements = {};
+	const semanticSnapshot = {};
+	for (const fixture of CASES) {
+		const component = bundle[fixture.component];
+		assert.equal(typeof component, 'function', fixture.component);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = bundle.createRoot(container);
+		const pairs = fixture.pairs ?? 1;
+		let records = [];
+		let previous = null;
+		const observe = (box, callback) => records.push({ box, callback });
+
+		function render(dep, tick, enabled = true) {
+			records = [];
+			bundle.flushSync(() => root.render(component, { dep, tick, enabled, observe }));
+			const expectedValues = enabled
+				? Array.from({ length: pairs }, (_, index) => dep + index)
+				: [];
+			assert.equal(
+				container.textContent,
+				`${tick}:${enabled ? expectedValues.join(',') : 'off'}`,
+				fixture.name,
+			);
+			assert.equal(records.length, expectedValues.length, `${fixture.name} observations`);
+			for (let index = 0; index < records.length; index++) {
+				const record = records[index];
+				assert.equal(record.box.value, expectedValues[index], `${fixture.name} value`);
+				assert.equal(
+					record.callback(),
+					record.box.value * 1000 + record.box.tick,
+					`${fixture.name} closure capture`,
+				);
+			}
+			if (records.length === 2) {
+				assert.notEqual(records[0].box, records[1].box, `${fixture.name} isolated memo values`);
+				assert.notEqual(
+					records[0].callback,
+					records[1].callback,
+					`${fixture.name} isolated callbacks`,
+				);
+			}
+			return records;
+		}
+
+		function compare(next, mode, tick) {
+			for (let index = 0; index < next.length; index++) {
+				const record = next[index];
+				if (mode === 'same') {
+					assert.equal(record.box, previous[index].box, `${fixture.name} stable memo value`);
+					assert.equal(
+						record.callback,
+						previous[index].callback,
+						`${fixture.name} stable callback`,
+					);
+				} else {
+					assert.equal(record.box.tick, tick, `${fixture.name} refreshed capture`);
+					if (previous !== null) {
+						assert.notEqual(
+							record.box,
+							previous[index].box,
+							`${fixture.name} invalidated memo value`,
+						);
+						assert.notEqual(
+							record.callback,
+							previous[index].callback,
+							`${fixture.name} invalidated callback`,
+						);
+					}
+				}
+			}
+			previous = next;
+		}
+
+		function phase(name, renders, work) {
+			globalThis[COUNTER_GLOBAL] = emptyCounters();
+			work();
+			const counters = { ...globalThis[COUNTER_GLOBAL] };
+			if (observed) measurements[`${fixture.name}_${name}`] = { renders, counters };
+		}
+
+		phase('mount', 1, () => compare(render(1, 0), 'fresh', 0));
+		phase('hit', REPEATS, () => {
+			for (let index = 0; index < REPEATS; index++) {
+				const tick = index + 1;
+				compare(render(1, tick), fixture.alwaysFresh ? 'fresh' : 'same', tick);
+			}
+		});
+		phase('miss', REPEATS, () => {
+			for (let index = 0; index < REPEATS; index++) {
+				const tick = REPEATS + index + 1;
+				compare(render(index + 2, tick), 'fresh', tick);
+			}
+		});
+		if (fixture.conditional) {
+			phase('disabled', 1, () => render(REPEATS + 1, REPEATS * 2 + 1, false));
+			phase('reactivate', 1, () => compare(render(REPEATS + 1, REPEATS * 2 + 2), 'same'));
+		}
+		semanticSnapshot[fixture.name] = {
+			html: container.innerHTML,
+			values: previous.map(({ box, callback }) => ({
+				...box,
+				callbackResult: callback(),
+				callbackName: callback.name,
+			})),
+		};
+		phase('unmount', 0, () => root.unmount());
+		assert.equal(container.innerHTML, '', `${fixture.name} teardown`);
+		container.remove();
+	}
+	return { measurements, semanticSnapshot };
+}
+
+function codeSizes(sources, cleanBundle) {
+	const minified = [...sources].map(
+		([filename, code]) =>
+			transformSync(code, { loader: 'js', minify: true, sourcefile: filename }).code,
+	);
+	const minifiedBundle = transformSync(cleanBundle, { loader: 'js', minify: true }).code;
+	return {
+		code_raw: [...sources.values()].reduce((sum, code) => sum + bytes(code), 0),
+		code_minified: minified.reduce((sum, code) => sum + bytes(code), 0),
+		code_gzip: minified.reduce((sum, code) => sum + gzipBytes(code), 0),
+		bundle_minified: bytes(minifiedBundle),
+		bundle_gzip: gzipBytes(minifiedBundle),
+	};
+}
+
+function withoutCallbackNames(snapshot) {
+	return Object.fromEntries(
+		Object.entries(snapshot).map(([name, value]) => [
+			name,
+			{ ...value, values: value.values.map(({ callbackName, ...rest }) => rest) },
+		]),
+	);
+}
+
+function callbackNameDifferences(snapshot, reference) {
+	const differences = [];
+	for (const [fixture, value] of Object.entries(snapshot)) {
+		for (let index = 0; index < value.values.length; index++) {
+			const actual = value.values[index].callbackName;
+			const expected = reference[fixture].values[index].callbackName;
+			if (actual !== expected) differences.push({ fixture, index, actual, expected });
+		}
+	}
+	return differences;
+}
+
+const runMetadata = {
+	node: process.version,
+	esbuild: esbuildVersion,
+	tsrxCore: dependencyVersion('@tsrx/core'),
+	repeats: REPEATS,
+	cases: CASES,
+	fixtureSha256: createHash('sha256')
+		.update(
+			APP_FILES.map(
+				(filename) => path.basename(filename) + '\n' + fs.readFileSync(filename, 'utf8'),
+			).join('\n'),
+		)
+		.digest('hex'),
+	entrySha256: createHash('sha256')
+		.update(fs.readFileSync(path.join(ROOT, 'entry.mjs')))
+		.digest('hex'),
+	observerSha256: createHash('sha256')
+		.update(fs.readFileSync(path.join(ROOT, 'instrument.mjs')))
+		.digest('hex'),
+	runnerSha256: createHash('sha256')
+		.update(fs.readFileSync(path.join(ROOT, 'run.mjs')))
+		.digest('hex'),
+	measurement: 'source creation events, not V8 heap allocations or timing',
+};
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-hook-memo-'));
+const window = setupDom();
+const targets = [];
+const onePerRender = {};
+let expectedSemantics;
+try {
+	for (const [name, inlineHookMemo] of [
+		['runtime-form', false],
+		['inline', true],
+	]) {
+		const sources = compileApplication(inlineHookMemo);
+		const cleanFile = path.join(tempDir, `${name}-clean.mjs`);
+		const { code: cleanCode, map } = await bundleApplication(sources, cleanFile);
+		fs.writeFileSync(cleanFile, cleanCode);
+		const clean = exercise(await import(pathToFileURL(cleanFile).href), false);
+		if (expectedSemantics === undefined) expectedSemantics = clean.semanticSnapshot;
+		else
+			assert.deepEqual(
+				withoutCallbackNames(clean.semanticSnapshot),
+				withoutCallbackNames(expectedSemantics),
+				'compiler variants changed semantics',
+			);
+		const nameDifferences = callbackNameDifferences(clean.semanticSnapshot, expectedSemantics);
+
+		const observedCode = instrument(cleanCode, cleanFile, sourceOwner(map, cleanFile));
+		const observedFile = path.join(tempDir, `${name}-observed.mjs`);
+		fs.writeFileSync(observedFile, observedCode);
+		globalThis[COUNTER_GLOBAL] = emptyCounters();
+		const observed = exercise(await import(pathToFileURL(observedFile).href), true);
+		assert.deepEqual(
+			observed.semanticSnapshot,
+			clean.semanticSnapshot,
+			'allocation observer changed semantics',
+		);
+		if (!inlineHookMemo) {
+			const control = observed.measurements.declaration_hit.counters;
+			assert.equal(
+				control.application_functions,
+				REPEATS * 2,
+				'observer lost the two runtime-form callbacks',
+			);
+			assert.equal(
+				control.application_arrayLiterals,
+				REPEATS * 2,
+				'observer lost the two runtime-form dependency arrays',
+			);
+		}
+		const sizes = codeSizes(sources, cleanCode);
+		const ops = Object.fromEntries(Object.entries(sizes).map(([key, value]) => [key, val(value)]));
+		const totals = eligibleTotals(observed.measurements);
+		for (const [metric, count] of Object.entries(totals.counts)) {
+			ops[metric] = val(count);
+			onePerRender[metric] = val(totals.budgets[metric]);
+		}
+		ops.callback_name_mismatches = val(nameDifferences.length);
+		onePerRender.callback_name_mismatches = val(1);
+		for (const [phase, measurement] of Object.entries(observed.measurements)) {
+			for (const [metric, count] of Object.entries(summarizedCounters(measurement.counters))) {
+				ops[`${phase}_${metric}`] = val(count);
+				onePerRender[`${phase}_${metric}`] = val(measurement.renders || 1);
+			}
+		}
+		targets.push({
+			name,
+			ops,
+			meta: {
+				run: runMetadata,
+				measurements: observed.measurements,
+				semantics: observed.semanticSnapshot,
+				callbackNameDifferences: nameDifferences,
+			},
+		});
+		console.log(
+			`${name}: code ${sizes.code_minified} min / ${sizes.code_gzip} gzip; bundle ${sizes.bundle_minified} min / ${sizes.bundle_gzip} gzip`,
+		);
+		if (nameDifferences.length > 0) {
+			console.log(`  callback-name mismatches: ${JSON.stringify(nameDifferences)}`);
+		}
+		for (const fixture of CASES) {
+			const hit = summarizedCounters(observed.measurements[`${fixture.name}_hit`].counters);
+			console.log(
+				`  ${fixture.name}: ${hit.functions} function expressions, ${hit.arrays} array creations / ${REPEATS} dependency-hit renders`,
+			);
+		}
+	}
+	const payload = {
+		suite: 'hook-memo',
+		iterations: 1,
+		targets: [
+			...targets,
+			{
+				name: 'one-per-render',
+				ops: onePerRender,
+				meta: {
+					description:
+						'Fixed source-creation ceilings: one per render, per required fresh callback, or explicitly budgeted caller array.',
+				},
+			},
+		],
+		meta: runMetadata,
+	};
+	if (process.env.BENCH_JSON)
+		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');
+	console.log('Hook-memo value/identity and observer controls passed.');
+} finally {
+	delete globalThis[COUNTER_GLOBAL];
+	await window.happyDOM.close();
+	fs.rmSync(tempDir, { recursive: true, force: true });
+}

--- a/docs/decallback-memo.md
+++ b/docs/decallback-memo.md
@@ -1,59 +1,134 @@
 # The inline hook-memo tier (de-callbacked useMemo/useCallback + parallel-use)
 
-Production client compiles lower the hook memo tier from runtime-callback form
-to inline caches, eliminating the per-render allocations the runtime form
-carries (the factory closure and the deps array, allocated on every render even
-when the dependency compare hits). Dev/HMR/profile compiles, server output, and
-universal-renderer units keep the runtime-callback form; the `octane-prod`
-vitest project is the coverage for the inline branch. `inlineHookMemo: false`
-is a diagnostic escape hatch (like `autoMemo: false`) for one-line bisection.
+Production client compiles lower eligible memo hooks from runtime-callback form
+to compiler-owned cache operations. A dependency hit evaluates neither the
+`useMemo` factory nor a dependency-array literal; `useCallback` creates its
+retained function only on a miss. This applies to `.tsrx`, returned JSX, and
+eligible plain `.ts`/`.js` hook modules. Dev/HMR/profile compiles, server output,
+and universal-renderer units keep their runtime hook form. `inlineHookMemo:
+false` is a diagnostic escape hatch (like `autoMemo: false`) for one-line
+bisection. The public hook API and explicit dependency semantics do not change.
 
 ## Tier A — authored and auto-generated useMemo/useCallback
 
-`const x = useMemo(fn, deps)` / `const x = useCallback(fn, deps)` declarations
-in proven render-scope bodies (the `localHookSlots` numeric-slot proof) become
-inline regions over a per-body flat cell array stored as a non-index property
+Memo calls in proven render-scope bodies (the `localHookSlots` numeric-slot
+proof) become inline regions over a per-body flat cell array stored as a non-index property
 on `__s.slots` (`_k$N` — same trick as autoMemo's `_m$N`; named properties
 leave the slots array's packed elements kind alone). Layout per site:
 `[initFlag, dep0..depK-1, value]`; the array is pre-sized and `.fill`ed so
-conditional sites can't punch elements-kind holes.
+conditional sites can't punch elements-kind holes. Expression bodies and
+single-return factories also lower in nested expressions, destructuring and
+multi-declarator initializers, short-circuit branches, and value returns.
 
 ```js
-let filtered;
-{
-  const __hkd0 = items, __hkd1 = q;
-  if (__hk[0] !== true || !Object.is(__hk[1], __hkd0) || !Object.is(__hk[2], __hkd1)) {
-    __hk[3] = items.filter((x) => x.includes(q));
-    __hk[1] = __hkd0; __hk[2] = __hkd1; __hk[0] = true;
-  }
-  filtered = __hk[3];
-}
+let d0, d1;
+const filtered =
+	((d0 = items),
+	(d1 = q),
+	cache[0] !== true || !memoEqual(cache[1], d0) || !memoEqual(cache[2], d1)
+		? publish2(
+				cache,
+				0,
+				items.filter((x) => x.includes(q)),
+				d0,
+				d1,
+			)
+		: cache[3]);
 ```
+
+The names above are illustrative. The compiler imports collision-free private
+helpers from `octane/internal/client`; `memoEqual` uses the runtime's `Object.is`
+intrinsic, so an authored binding named `Object` cannot change equality.
+Fixed-arity publishers for zero through four dependencies also avoid creating a
+rest array on an ordinary miss. Larger flat sites use the variadic cold path.
 
 Contract notes:
 
-- **Immediate publish, not autoMemo's transactional copy-on-write.** The
+- **Immediate publish, not autoMemo's render-end copy-on-write.** The
   runtime hooks map these regions replace publishes mid-render, and values must
   survive a later suspension in the same body — a user-authored
   `useMemo(() => fetch(id), [id])` keeps its promise identity across replay
-  attempts. Publish order preserves the throw contract: value first, dep cells
-  + init flag after, so a throwing factory leaves the previous entry fully
-  usable.
+  attempts. A throwing factory leaves the previous entry fully usable.
+- **Held transitions own both versions.** During an active transition attempt,
+  the miss-side publisher records the old and new complete site ranges in the
+  same two-way journal as ordinary hook-map memos. The held screen sees its old
+  promise/callback identities; promotion restores the attempted values; an
+  urgent supersession of the first hold does not adopt them. Ordinary hits allocate no history. Compiler-owned
+  lifetime-invariant callbacks use the same rule with a one-cell range.
 - **Object.is compares** — byte-for-byte React/`depsChanged` semantics (NaN,
   ±0) in both compile modes.
-- **useCallback allocates the closure only on a dependency miss** (and block
-  bodies inline through a result local + labeled break so early returns
-  survive).
+- **Safe block factories** inline through a separate result local and labeled
+  break. The original declaration and binding kind remain intact, including
+  its temporal dead zone. Anonymous function/class results and dependencies do
+  not acquire a generated temporary's inferred `.name`.
 - **Explicit `null` deps** = recompute every render → evaluated inline with no
   cache at all.
 - Numeric-slot authored memos are unaddressable by the parallel-use warm system
   (warm caches key by Symbols), so the inline regions' lack of
   recordRealWarmMemo/adoptWarmValue interaction is observably equivalent.
-- Kept on the runtime path: dev/HMR/profile, server, universal units,
-  custom-hook-context bodies, non-declaration positions, multi-declarator or
-  destructured declarations, non-literal-array deps, positional-deps factories,
-  async/generator factories, factories containing hook-shaped calls, and block
-  bodies with own-scope `var`/function declarations.
+- Explicit third slots never use a private per-site flat cache: two authored
+  calls may intentionally share that slot. They use the path-aware tier below.
+
+## Tier A2 — callable helpers, custom hooks, and explicit slots
+
+These sites must keep their ordinary `scope.hooks` entry because their effective
+identity includes the caller's `withSlot` path. After normal slot assignment,
+the compiler splits lookup from computation without allocating a wrapper:
+
+```js
+let dependency, slot, entry;
+return (
+	(dependency = value),
+	(slot = memoSlot(rawSlot, 'useMemo')),
+	(entry = memoTake1(slot, dependency)),
+	entry === null ? memoPublish(slot, value + 1, dependency) : entry.value
+);
+```
+
+`memoTake0…4` return an entry or `null`, not an arbitrary-value sentinel. Cached
+`undefined`, `null`, and even the parallel-use sentinel remain valid values.
+The raw slot resolves exactly once; warm adoption, warm-episode bookkeeping,
+immediate publication, and held-transition ownership match runtime `useMemo`.
+Dependency expressions run once, left to right, before the authored slot
+expression. Explicit `null` uses `memoPublishAlways`, preserving every-render
+recomputation and entry sharing.
+
+The shared AST-only lowering covers expression positions and direct
+declaration/return positions for multi-statement factories. Plain-module
+production transforms use one TypeScript-preserving Program print and return a
+real source map. Manually slotted modules get memo-only lowering: no new slots,
+inferred dependencies, or custom-hook wrappers. Modules with imported `use()`
+or unsupported specialization/printing shapes retain the existing surgical
+slotting path. `octane-no-slot` remains a hard opt-out.
+
+Both authored tiers require a known literal dependency array (no spreads or
+holes), or explicit `null`. `useMemo` requires a synchronous, zero-parameter
+arrow whose invocation scope can be removed. Ordinary functions retain their
+own `this`, `arguments`, `new.target`, and self-name scope. Positional factories,
+async/generator factories, hook-containing factories, direct eval, opaque
+directives, own-scope `var`/function declarations, and block factories that
+cannot be placed safely at a statement boundary keep the runtime path. The
+path-aware tier currently supports up to four dependencies; flat sites have no
+such arity limit. `useCallback` does not inline its returned function's body.
+Any direct eval in a module disables this optimization for that module, since
+even a sibling eval can observe a newly imported helper binding. Opaque
+execution-directive functions retain their whole nested subtree.
+
+The client, server, and universal runtime fallbacks also cache a callback value
+directly instead of allocating an extra `() => callback` wrapper. Server and
+universal compilers do not emit the new client-only cache ABI.
+
+### Existing continuing-transition limitation
+
+After promotion suspends on a later dependency, Octane's existing transition
+machinery keeps memo entries forward so the next promotion can reuse in-flight
+work. An urgent render after that second hold can therefore retain an
+empty-dependency callback first created by the attempted render. This behavior
+also occurs on the ordinary runtime-hook path; the inline tier preserves that
+behavior rather than introducing a different cache view. Fixing it requires
+selecting the committed memo view before the urgent render starts, not merely
+reversing entries when the hold is discarded. That scheduler change is separate
+from closure removal.
 
 ## Tier B — parallel-use creations (Symbol slots stay warm-visible)
 
@@ -65,9 +140,10 @@ take/publish ABI instead:
 ```js
 let __pu$0;
 {
-  const __hkd0 = a, __hkd1 = b;
-  __pu$0 = _$puTake2(_h$0, __hkd0, __hkd1);
-  if (__pu$0 === _$puMiss) __pu$0 = _$puPub(_h$0, make(__hkd0, __hkd1), __hkd0, __hkd1);
+	const __hkd0 = a,
+		__hkd1 = b;
+	__pu$0 = _$puTake2(_h$0, __hkd0, __hkd1);
+	if (__pu$0 === _$puMiss) __pu$0 = _$puPub(_h$0, make(__hkd0, __hkd1), __hkd0, __hkd1);
 }
 ```
 
@@ -123,7 +199,16 @@ universal pipeline keep current behavior.
   path — identical expectations is the semantic-equivalence proof). The chain
   tests fail without Pass A′ (duplicate fetch on replay, refetch on unrelated
   re-render, stale derived promise on input change).
-- `tests/inline-hook-memo-codegen.test.ts` — compile-mode/shape routing and
+- `tests/compiler/inline-hook-memo-codegen.test.ts` — compile-mode/shape routing and
   the no-dead-import property.
+- `tests/transitions.test.ts` — ordinary and invariant callback/promise identity
+  through suspend replay, held-screen rollback, promotion, later suspension,
+  and urgent supersession, including dependency arities zero through five.
+- Plain-module compiler/runtime tests cover manual slots, inferred deps,
+  namespace imports, source maps, declaration timing, and safety fallbacks.
+- [`benchmarks/hook-memo`](../benchmarks/hook-memo/README.md) — production A/B
+  semantic controls, post-tree-shaking function/array creation counters, and
+  code/bundle gzip ratio guards. Counters describe source-level creation
+  events, not exhaustive heap allocation or a measured latency improvement.
 - The `octane-prod` project re-runs the full hook/parallel-use/conformance
   suites against the inline branch.

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -163,7 +163,7 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `controlled-form`, `external-store-fanout`, `external-store-integrations`,
 `scheduler-responsiveness`, `suspense-recovery`, `event-delegation`,
 `application-composition`, `scaling-curves`, `streaming-ssr`,
-`streaming-backpressure`, `compiler-throughput`, `codegen-size`,
+`streaming-backpressure`, `compiler-throughput`, `codegen-size`, `hook-memo`,
 `bundle-size`, `bundle-reachability`, `three-renderer`, `three-bundle-size`, …)
 or every suite with `all`; `quick` selects the reduced-iteration smoke pass. The
 suite list mirrors the runner manifest and `node benchmarks/bench.mjs --list`.

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -89,6 +89,7 @@ export const BENCHMARK_SUITES = [
 	'lynx-table-web',
 	'lynx-bundle-size',
 	'codegen-size',
+	'hook-memo',
 	'compiler-throughput',
 	'bundle-size',
 	'bundle-reachability',

--- a/packages/octane-mcp-server/src/index.test.js
+++ b/packages/octane-mcp-server/src/index.test.js
@@ -77,6 +77,21 @@ describe('@octanejs/mcp-server helpers', () => {
 			.map((line) => line.trim())
 			.filter((line) => line && line !== 'Available suites:');
 		expect(suites).toEqual(BENCHMARK_SUITES);
+
+		// The public MCP schema must accept every runner suite, not just keep
+		// an exported helper list in sync.
+		const server = createServer({ repoRoot });
+		const client = new Client({ name: 'octane-mcp-test', version: '1.0.0' });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		try {
+			await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+			const tools = await client.listTools();
+			const benchmark = tools.tools.find((tool) => tool.name === 'octane_benchmark');
+			expect(benchmark?.inputSchema.properties?.benchmark?.enum).toEqual(['all', ...suites]);
+		} finally {
+			await client.close();
+			await server.close();
+		}
 	});
 
 	it('classifies every maintained binding and recommends its test project', () => {

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -480,6 +480,7 @@ class OctaneBundlerCompiler {
 			hmr: normalizeHmrDialect(options.hmr),
 			dev: options.dev,
 			profile: options.profile === true,
+			inlineHookMemo: options.inlineHookMemo !== false,
 			strong: options.strong === true,
 			universalRuntime: normalizeUniversalRuntime(options.universalRuntime),
 		};
@@ -990,6 +991,7 @@ class OctaneBundlerCompiler {
 		// of both HMR and dev hydration diagnostics. Server transforms stay byte-for-
 		// byte identical even when a shared client/server bundler configuration opts in.
 		const profile = environment === 'client' && (options.profile ?? this.defaults.profile) === true;
+		const inlineHookMemo = (options.inlineHookMemo ?? this.defaults.inlineHookMemo) !== false;
 		// An application's global policy never leaks into installed or linked
 		// compatibility packages, including workspace packages nested inside the
 		// project root. Modules may still opt themselves in with their own
@@ -1087,6 +1089,7 @@ class OctaneBundlerCompiler {
 				dev,
 				profile,
 				profileFilename,
+				...(inlineHookMemo ? null : { inlineHookMemo: false }),
 				...(strong ? { strong: true } : null),
 				...(universalRuntime === undefined ? null : { universalRuntime }),
 				// Keep the established DOM compiler call byte-for-byte equivalent. A
@@ -1170,7 +1173,16 @@ class OctaneBundlerCompiler {
 				this._warnUnmarkedOctaneImport(code, filename);
 				return passThrough();
 			}
-			if (this._hasManualHookSlots(file, collected)) {
+			const manualSlots = this._hasManualHookSlots(file, collected);
+			const inlinePlainMemo =
+				inlineHookMemo &&
+				environment === 'client' &&
+				hmr === false &&
+				dev === false &&
+				profile === false &&
+				renderer.target === 'dom' &&
+				universalRuntime === undefined;
+			if (manualSlots && !inlinePlainMemo) {
 				// Hand-slotted bindings still own their authored policy. Opting one
 				// module in must not require changing its established slot ABI.
 				if (strong || code.includes('use strong')) {
@@ -1183,12 +1195,19 @@ class OctaneBundlerCompiler {
 			}
 			const profileFilename = profile ? this._profileModuleId(file, collected) : undefined;
 			const specializeVoidRoot =
-				environment === 'client' && hmr === false && dev === false && profile === false;
+				!manualSlots &&
+				environment === 'client' &&
+				hmr === false &&
+				dev === false &&
+				profile === false;
 			const out = slotHooks(code, filename, {
 				environment,
 				hmr: !!hmr,
+				dev,
 				profile,
 				profileFilename,
+				inlineHookMemo: inlinePlainMemo,
+				...(manualSlots ? { manualSlots: true } : null),
 				...(strong ? { strong: true } : null),
 				...(specializeVoidRoot
 					? {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -49,6 +49,14 @@ import {
 	isInvariantLiteral,
 } from './hook-deps.js';
 import {
+	analyzeInlineMemoCall,
+	hasInlineMemoDirectEval,
+	hasInlineMemoOpaqueDirective,
+	isInlineMemoOwnerSafe,
+	lowerSlotMemoFunctions,
+	withoutInferredMemoName,
+} from './inline-hook-memo.js';
+import {
 	compileUniversal,
 	UNIVERSAL_COMPILER_RUNTIME_IMPORTS,
 	UNIVERSAL_THREAD_RUNTIME_IMPORTS,
@@ -1001,13 +1009,25 @@ export function rtAlias(name) {
 // aliases imported from its renderer runtime. Ordinary DOM code keeps the
 // historical `_$name` aliases and merged `octane` import.
 function runtimeAliasForContext(ctx, name) {
-	return ctx._universalRuntimeUnit?.generatedRuntimeAliases?.[name] ?? rtAlias(name);
+	return (
+		ctx._universalRuntimeUnit?.generatedRuntimeAliases?.[name] ??
+		ctx.privateRuntimeAliases?.get(name) ??
+		rtAlias(name)
+	);
 }
 
 function requireRuntimeForContext(ctx, name) {
 	const alias = ctx._universalRuntimeUnit?.generatedRuntimeAliases?.[name];
 	if (alias !== undefined) return alias;
 	ctx.runtimeNeeded.add(name);
+	if (HOOK_MEMO_RUNTIME_HELPERS.has(name)) {
+		let local = ctx.privateRuntimeAliases?.get(name);
+		if (local === undefined) {
+			local = allocCompilerName(ctx, rtAlias(name));
+			(ctx.privateRuntimeAliases ??= new Map()).set(name, local);
+		}
+		return local;
+	}
 	return rtAlias(name);
 }
 
@@ -1051,14 +1071,37 @@ function importSpecifierPair(entry) {
 // Existing helpers remain on their historical public request so previously
 // compiled components and authored runtime imports retain their stable shape.
 // New compiler-only helpers use the private, renderer-specific ABI instead.
-const INTERNAL_CLIENT_RUNTIME_HELPERS = new Set(['replaceRef', 'queueOwnRefDetach']);
+const HOOK_MEMO_RUNTIME_HELPERS = new Set([
+	'hookMemoCreate',
+	'hookMemoEqual',
+	'hookMemoPublish',
+	'hookMemoPublish0',
+	'hookMemoPublish1',
+	'hookMemoPublish2',
+	'hookMemoPublish3',
+	'hookMemoPublish4',
+	'hookMemoPublishInvariant',
+	'memoSlot',
+	'memoTake0',
+	'memoTake1',
+	'memoTake2',
+	'memoTake3',
+	'memoTake4',
+	'memoPublish',
+	'memoPublishAlways',
+]);
+const INTERNAL_CLIENT_RUNTIME_HELPERS = new Set([
+	'replaceRef',
+	'queueOwnRefDetach',
+	...HOOK_MEMO_RUNTIME_HELPERS,
+]);
 const INTERNAL_SERVER_RUNTIME_HELPERS = new Set(['ssrSpreadContent']);
 
 function runtimeImportModuleFor(ctx, fallback, imported, local) {
 	for (const route of ctx.runtimeImportRoutes ?? []) {
 		if (route.locals?.has(local) || route.imported?.has(imported)) return route.module;
 	}
-	if (local === rtAlias(imported)) {
+	if (local === (ctx.privateRuntimeAliases?.get(imported) ?? rtAlias(imported))) {
 		if (fallback === 'octane' && INTERNAL_CLIENT_RUNTIME_HELPERS.has(imported)) {
 			return 'octane/internal/client';
 		}
@@ -1086,7 +1129,9 @@ function buildRuntimeImportNodes(ctx, moduleName, origin) {
 	const specifiers = new Set(ctx.userRuntimeNames);
 	for (const n of ctx.runtimeNeeded) {
 		const alias =
-			n === 'hookSlots' && ctx._hookSlotsHelperName ? ctx._hookSlotsHelperName : rtAlias(n);
+			n === 'hookSlots' && ctx._hookSlotsHelperName
+				? ctx._hookSlotsHelperName
+				: (ctx.privateRuntimeAliases?.get(n) ?? rtAlias(n));
 		specifiers.add(`${n} as ${alias}`);
 	}
 	const grouped = new Map();
@@ -6608,7 +6653,9 @@ function functionExpressionFromDeclaration(declaration, origin = declaration) {
 	expression.generator = !!declaration.generator;
 	if (declaration.returnType !== undefined) expression.returnType = declaration.returnType;
 	if (declaration.predicate !== undefined) expression.predicate = declaration.predicate;
-	return expression;
+	return declaration._octaneInlineMemoOpaqueOwner === true
+		? { ...expression, _octaneInlineMemoOpaqueOwner: true }
+		: expression;
 }
 
 // Split a multi-declarator statement only when it contains a component. Keeping
@@ -8105,9 +8152,16 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	// Like `autoMemo: false`, `inlineHookMemo: false` is a diagnostic escape
 	// hatch only: it re-routes useMemo/useCallback and parallel-use creations
 	// back through the runtime-callback form so a miscompare can be bisected
-	// inline-cache-vs-elsewhere in one line.
+	// inline-cache-vs-elsewhere in one line. Direct eval can observe new
+	// module-level helper imports from a sibling function, so the whole module
+	// retains the runtime form in that rare case. Escaped identifiers also pass
+	// the cheap source gate before the exact AST check.
 	const inlineHookMemoEnabled =
-		options?.inlineHookMemo !== false && !hmrEnabled && !devEnabled && !profileEnabled;
+		options?.inlineHookMemo !== false &&
+		!hmrEnabled &&
+		!devEnabled &&
+		!profileEnabled &&
+		!((source.includes('eval') || source.includes('\\u')) && hasInlineMemoDirectEval(ast));
 	// Same production-only gate as the tiers above, and for the same reason: a
 	// lifted callback has left the component, which dev tooling, HMR boundaries,
 	// and profile attribution all reason about. Runs AFTER dependency inference
@@ -8173,10 +8227,12 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		currentAutoCalculatedRenderableRefs: null, // proven non-escaping calculation holes, inherited by lexical child bodies
 		nextAutoMemoCacheId: 0, // unique non-index slots property per compiled render function
 		inlineHookMemo: inlineHookMemoEnabled, // de-callbacked useMemo/useCallback + pu creations
+		hasSlotMemoCandidates: false, // skip the final AST pass when no path-aware site survived
 		_puInlineLowering: false, // true only while a body pipeline ends in inlineHookMemoPass
 		currentHookMemoOffset: 0, // flat hook-memo cell offset for the body being emitted
 		currentHookMemoCacheProperty: null, // per-body `_k$N` slots property for the cell array
-		currentHookMemoNames: null, // lazily allocated { cache, result, label, temps[] } locals
+		currentHookMemoNames: null, // lazily allocated flat-cache and expression-temp locals
+		currentHookMemoOwnerSafe: false, // own scope permits compiler-introduced bindings
 		nextHookMemoCacheId: 0, // unique non-index slots property per compiled render function
 		currentInvariantLocals: null, // Set<string> of component-lifetime-stable local values
 		currentEventInvariantLocals: null, // Set<string> safe to retain in native event slots
@@ -9178,7 +9234,36 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		vtHintNodes.push(inheritOriginLoc(b.stmt(b.call(rtAlias('__vtSeen'))), moduleOrigin));
 	}
 
-	// Built after HMR wiring so the import list includes `hmr`/`HMR` when needed.
+	// All remaining authored memo sites have now received their real hook slots.
+	// Lower callable helpers, returned-JSX functions, explicit-slot calls and
+	// statement-safe block factories against that path-aware entry. The marker
+	// is minted only by DOM-client hook slotting, so mixed renderer modules never
+	// accidentally import DOM memo helpers for a universal renderer's scope.
+	let moduleBody = [
+		...vtHintNodes,
+		...delegateNodes,
+		...styleNodes,
+		...templateNodes,
+		...helperNodes,
+		...bodyNodes,
+		...stampNodes,
+		...hmrNodes,
+		...profileNodes,
+	];
+	if (ctx.inlineHookMemo && ctx.hasSlotMemoCandidates) {
+		moduleBody = lowerSlotMemoFunctions(moduleBody, {
+			allocateName: (preferred) => allocCompilerName(ctx, preferred),
+			requireRuntime: (helper) => requireRuntimeForContext(ctx, helper),
+			canonicalHookName: (call) => call._octaneInlineMemoHook ?? null,
+		}).ast;
+		for (const helper of ['useMemo', 'useCallback']) {
+			if (!hasIdentifierReference(moduleBody, runtimeAliasForContext(ctx, helper))) {
+				ctx.runtimeNeeded.delete(helper);
+			}
+		}
+	}
+
+	// Built after every lowering and HMR wiring so all generated imports exist.
 	const runtimeImportNodes = buildRuntimeImportNodes(ctx, 'octane', moduleOrigin);
 	const profileRuntimeImportNodes = buildProfileRuntimeImportNodes(ctx, moduleOrigin);
 
@@ -9188,19 +9273,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	const program = {
 		type: 'Program',
 		sourceType: 'module',
-		body: [
-			...runtimeImportNodes,
-			...profileRuntimeImportNodes,
-			...vtHintNodes,
-			...delegateNodes,
-			...styleNodes,
-			...templateNodes,
-			...helperNodes,
-			...bodyNodes,
-			...stampNodes,
-			...hmrNodes,
-			...profileNodes,
-		],
+		body: [...runtimeImportNodes, ...profileRuntimeImportNodes, ...moduleBody],
 		metadata: { path: [] },
 		start: ast.start,
 		end: ast.end,
@@ -13053,6 +13126,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	const prevHookMemoOffset = ctx.currentHookMemoOffset;
 	const prevHookMemoCacheProperty = ctx.currentHookMemoCacheProperty;
 	const prevHookMemoNames = ctx.currentHookMemoNames;
+	const prevHookMemoOwnerSafe = ctx.currentHookMemoOwnerSafe;
 	ctx.currentHookMemoOffset = 0;
 	ctx.currentHookMemoCacheProperty = `_k$${ctx.nextHookMemoCacheId++}`;
 	ctx.currentHookMemoNames = null;
@@ -13084,6 +13158,13 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			} else statements.push(child);
 		}
 	}
+	const hookMemoOpaqueOwner =
+		ctx.inlineHookMemo && hasInlineMemoOpaqueDirective({ body: b.block(statements) });
+	ctx.currentHookMemoOwnerSafe =
+		ctx.inlineHookMemo &&
+		options?.localHookSlots === true &&
+		!hookMemoOpaqueOwner &&
+		isInlineMemoOwnerSafe({ body: b.block([...statements, ...jsxNodes]) });
 
 	// Plan + emit JSX. Records any inline-sub-component code that needs to live
 	// INSIDE this function body (so for-of item bodies can capture parent state).
@@ -13211,7 +13292,8 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 
 	// De-callback the hook memo tier (production client compile). Authored and
 	// auto-generated useMemo/useCallback declarations become inline flat-cache
-	// regions (zero allocations on a dependency hit); Pass A parallel-use
+	// regions (zero allocations on a dependency hit); rewriteHookCalls handles
+	// the remaining safe expression positions with the same cache. Pass A parallel-use
 	// creations become closure-free puTake/puPub calls that keep their Symbol
 	// slot entries warm-visible in scope.hooks. Runs BEFORE rewriteHookCalls so
 	// consumed hook calls are never slotted (and add no runtime import); the
@@ -13221,7 +13303,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 		workingStatements = inlineHookMemoPass(
 			workingStatements,
 			ctx,
-			options?.localHookSlots === true,
+			options?.localHookSlots === true && ctx.currentHookMemoOwnerSafe,
 		);
 	}
 	ctx._puInlineLowering = prevPuInlineLowering;
@@ -13380,11 +13462,10 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			),
 		);
 	}
-	// Hook-memo cell array (inline useMemo/useCallback regions). Unlike the
-	// autoMemo cache above this is NOT transactional: cells publish immediately
-	// so values — promise identity in particular — survive a mid-body suspension
-	// exactly like the runtime hooks map they replace. Pre-sized + filled so the
-	// array stays packed under conditional sites.
+	// Hook-memo cells publish immediately so promise identity survives ordinary
+	// suspension. Miss-side runtime publication also records the previous/next
+	// site during a held transition. Allocate through the runtime so authored
+	// bindings named Array or undefined cannot change the cache representation.
 	const hookMemoSize = ctx.currentHookMemoOffset;
 	if (hookMemoSize > 0) {
 		const hkName = hookMemoNames(ctx).cache;
@@ -13392,7 +13473,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			inheritOriginLoc(b.let(hkName, slotsMember(ctx.currentHookMemoCacheProperty)), node),
 			inheritOriginLoc(
 				b.if(
-					b.binary('===', b.id(hkName), b.id('undefined')),
+					b.binary('===', b.id(hkName), b.void0),
 					b.stmt(
 						b.assignment(
 							'=',
@@ -13400,14 +13481,23 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 							b.assignment(
 								'=',
 								b.id(hkName),
-								b.call(
-									b.member(b.new('Array', undefined, b.literal(hookMemoSize)), 'fill'),
-									b.id('undefined'),
-								),
+								b.call(requireRuntimeForContext(ctx, 'hookMemoCreate'), b.literal(hookMemoSize)),
 							),
 						),
 					),
 					null,
+				),
+				node,
+			),
+		);
+	}
+	const hookMemoExpressionTemps = ctx.currentHookMemoNames?.expressionTemps;
+	if (hookMemoExpressionTemps?.length > 0) {
+		bodyStatements.push(
+			inheritOriginLoc(
+				b.declaration(
+					'let',
+					hookMemoExpressionTemps.map((temp) => b.declarator(temp, null)),
 				),
 				node,
 			),
@@ -13529,11 +13619,19 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	ctx.currentHookMemoOffset = prevHookMemoOffset;
 	ctx.currentHookMemoCacheProperty = prevHookMemoCacheProperty;
 	ctx.currentHookMemoNames = prevHookMemoNames;
+	ctx.currentHookMemoOwnerSafe = prevHookMemoOwnerSafe;
 	ctx.currentMapTemps = prevMapTemps;
 	// ONE FunctionDeclaration node — the caller prints it (once, with the full
 	// esrap map for top-level components) or embeds it in an enclosing body.
+	const emittedFunction = b.function_declaration(
+		b.id(name, node.id ?? node),
+		fnParams,
+		b.block(bodyStatements),
+	);
 	return inheritOriginLoc(
-		b.function_declaration(b.id(name, node.id ?? node), fnParams, b.block(bodyStatements)),
+		hookMemoOpaqueOwner
+			? { ...emittedFunction, _octaneInlineMemoOpaqueOwner: true }
+			: emittedFunction,
 		node.loc ? node : shellOrigin,
 	);
 }
@@ -15762,9 +15860,10 @@ function markStateGetterUsage(root, ctx) {
 
 // A compiled `@{}` render body always executes inside a runtime-owned Scope, so
 // its direct base-hook sites can use tiny module-local numbers. Do not extend
-// that proof through an arbitrary nested function: render props, callbacks and
-// helpers can execute in a caller's Scope, including alongside code from a
-// different module. Those sites retain globally unique, runtime-ranged Symbols.
+// that proof through an arbitrary nested function or class initializer: render
+// props, callbacks, helpers and later-created instances can execute in a caller's
+// Scope, including alongside code from a different module. Those sites retain
+// globally unique, runtime-ranged Symbols.
 function markHookSlotLocality(root, enabled) {
 	const marks = new WeakMap();
 	const walk = (node, functionDepth) => {
@@ -15780,7 +15879,9 @@ function markHookSlotLocality(root, enabled) {
 			functionDepth +
 			(node.type === 'FunctionDeclaration' ||
 			node.type === 'FunctionExpression' ||
-			node.type === 'ArrowFunctionExpression'
+			node.type === 'ArrowFunctionExpression' ||
+			node.type === 'ClassDeclaration' ||
+			node.type === 'ClassExpression'
 				? 1
 				: 0);
 		for (const key in node) {
@@ -15796,22 +15897,23 @@ function markHookSlotLocality(root, enabled) {
 // Inline hook-memo tier (production client compile — docs/decallback-memo.md)
 // ===========================================================================
 //
-// De-callbacks `const x = useMemo(fn, deps)` / `const x = useCallback(fn,
-// deps)` declarations in proven render-scope bodies: instead of allocating an
+// De-callbacks useMemo/useCallback in proven render-scope bodies: instead of allocating an
 // arrow + a deps array every render and paying a hooks-map lookup, each site
 // becomes an inline region over a per-body flat cell array stored as a
 // non-index property on `__s.slots` (`_k$N`, the same trick as autoMemo's
 // `_m$N` — named properties don't disturb the slots array's packed elements
 // kind). Layout per site: [initFlag, dep0..depK-1, value].
 //
-// Unlike the autoMemo region cache this one publishes IMMEDIATELY (no
-// copy-on-write, no commit swap): the runtime hooks map these regions replace
+// Unlike the autoMemo region cache this one publishes IMMEDIATELY: the runtime
+// hooks map these regions replace
 // also publishes mid-render, and values must survive a later suspension in the
 // same body — a user-authored `useMemo(() => fetch(id), [id])` must keep its
 // promise identity across replay attempts. Publish order preserves the
-// runtime's throw contract: the value cell is written first and the dep cells
-// + init flag only after, so a throwing compute leaves the previous entry
-// fully usable (old deps AND old value).
+// runtime's throw contract: a throwing compute leaves the previous entry fully
+// usable (old deps AND old value). Miss-side private publishers journal complete
+// old/new ranges only during an active held-transition attempt, sharing the
+// hook-map memo rollback/promotion machinery. Arity 0–4 publishers also avoid
+// introducing a rest-array allocation on ordinary misses.
 //
 // Dependency compares are Object.is — byte-for-byte React/`depsChanged`
 // semantics (NaN, ±0) in both compile modes.
@@ -15823,14 +15925,12 @@ function markHookSlotLocality(root, enabled) {
 // handled here — they must stay visible in scope.hooks for warm adoption and
 // get their own closure-free lowering.
 //
-// Kept on the runtime-callback path (correctness first): dev/HMR/profile
-// compiles, server mode, custom-hook-context bodies (no localHookSlots
-// proof), non-declaration positions, multi-declarator/destructured
-// declarations, deps that aren't a literal array (identifier/spread/elision),
-// omitted-deps calls inference declined, positional-deps factories
-// (params.length > 0), async/generator factories, factories containing
-// hook-shaped calls, and block bodies with own-scope `var`/function
-// declarations (their hoisting would leak into the component body).
+// Expression factories use sequence/conditional AST to preserve their exact
+// evaluation position. Multi-statement factories require a safe statement
+// boundary. Callable helpers and explicit slots instead use the shared
+// path-aware post-slot pass in inline-hook-memo.js. Both tiers keep unsafe
+// factory scopes and unknown dependency shapes on the runtime path; neither
+// changes dev/HMR/profile, server, or universal-renderer code generation.
 
 function hookMemoNames(ctx) {
 	let names = ctx.currentHookMemoNames;
@@ -15840,6 +15940,7 @@ function hookMemoNames(ctx) {
 			result: allocCompilerName(ctx, '__hkr'),
 			label: allocCompilerName(ctx, '__hkl'),
 			temps: [],
+			expressionTemps: [],
 		};
 	}
 	return names;
@@ -15853,82 +15954,13 @@ function hookMemoTemp(ctx, index) {
 	return names.temps[index];
 }
 
-// Hook-shaped call anywhere inside (including nested functions) — mirrors the
-// conservative gate of the parallel-use pipeline: a consumed factory must
-// never carry a call whose slot/occurrence bookkeeping belongs to the render
-// pass, and `use[A-Z]` names are reserved for hooks by convention.
-function containsHookShapedCall(root) {
-	let found = false;
-	walk(root);
-	return found;
-
-	function walk(n) {
-		if (found || n == null || typeof n !== 'object') return;
-		if (Array.isArray(n)) {
-			for (const child of n) walk(child);
-			return;
-		}
-		if (n.type === 'CallExpression') {
-			if (
-				typeof n._octaneImportedHook === 'string' ||
-				typeof n._octaneHookRuntimeImportedHook === 'string'
-			) {
-				found = true;
-				return;
-			}
-			const callee = unwrapTsExpr(n.callee);
-			if (
-				callee?.type === 'Identifier' &&
-				(callee.name === 'use' || /^use[A-Z]/.test(callee.name))
-			) {
-				found = true;
-				return;
-			}
-			if (
-				callee?.type === 'MemberExpression' &&
-				!callee.computed &&
-				callee.property?.type === 'Identifier' &&
-				(callee.property.name === 'use' || /^use[A-Z]/.test(callee.property.name))
-			) {
-				found = true;
-				return;
-			}
-		}
-		for (const key in n) {
-			if (key === 'loc' || key === 'start' || key === 'end' || key.startsWith('_octane')) continue;
-			walk(n[key]);
-		}
-	}
-}
-
-// Own-scope hazards for inlining a block body into the component function:
-// `var` hoists out of the inserted block and a FunctionDeclaration hoists
-// within it differently than within its original function scope.
-function blockBodyInlineSafe(body) {
-	let safe = true;
-	walk(body);
-	return safe;
-
-	function walk(n) {
-		if (!safe || n == null || typeof n !== 'object') return;
-		if (Array.isArray(n)) {
-			for (const child of n) walk(child);
-			return;
-		}
-		if (n.type === 'FunctionDeclaration') {
-			safe = false;
-			return;
-		}
-		if (FN_TYPES.has(n.type)) return;
-		if (n.type === 'VariableDeclaration' && n.kind === 'var') {
-			safe = false;
-			return;
-		}
-		for (const key in n) {
-			if (key === 'loc' || key === 'start' || key === 'end' || key.startsWith('_octane')) continue;
-			walk(n[key]);
-		}
-	}
+// Expression-position caches cannot introduce a block-local declaration. Each
+// site owns distinct function-local temps so a nested memo in a dependency
+// expression cannot overwrite its enclosing site's already-evaluated deps.
+function hookMemoExpressionTemp(ctx, preferred) {
+	const name = allocCompilerName(ctx, preferred);
+	hookMemoNames(ctx).expressionTemps.push(name);
+	return name;
 }
 
 // Rewrite the factory block body's OWN-scope `return` statements into
@@ -15944,7 +15976,7 @@ function replaceOwnReturns(node, names) {
 		if (FN_TYPES.has(n.type)) return n;
 		if (n.type === 'ReturnStatement') {
 			return b.block([
-				hkExprStmt(hkAssign(b.id(names.result), n.argument ?? b.id('undefined'))),
+				hkExprStmt(hkAssign(b.id(names.result), withoutInferredMemoName(n.argument ?? b.void0))),
 				{ type: 'BreakStatement', label: b.id(names.label) },
 			]);
 		}
@@ -15969,63 +16001,120 @@ function hkExprStmt(expression) {
 	return b.stmt(expression);
 }
 
-function hkObjectIs(left, right) {
-	return b.call(b.member(b.id('Object'), 'is'), left, right);
+function hkObjectIs(ctx, left, right) {
+	return b.call(requireRuntimeForContext(ctx, 'hookMemoEqual'), left, right);
 }
 
-// `const x = useMemo(fn, deps)` / `useCallback(fn, deps)` with trustworthy
-// hook provenance (same rules as rewriteHookCalls' isBuiltin) at declaration
-// statement position. Returns null for every shape the inline tier declines.
+function hookMemoPublishAlias(ctx, arity) {
+	return requireRuntimeForContext(ctx, arity <= 4 ? `hookMemoPublish${arity}` : 'hookMemoPublish');
+}
+
+// Only absent raw slots can use a private flat cache. An explicit third slot
+// may alias another call or compose with a custom-hook path, so it keeps the
+// path-aware runtime entry even when its closure can still be removed.
+function flatHookMemoOf(call) {
+	if (
+		call?._octaneHookRuntimeImportedHook !== undefined &&
+		call._octaneImportedHook === undefined
+	) {
+		return null;
+	}
+	const entry = analyzeInlineMemoCall(call, {
+		allowMissingSlot: true,
+		allowUnbound: true,
+		maxDeps: Infinity,
+	});
+	if (entry === null || entry.call.arguments.length !== 2) return null;
+	const callee = entry.call.callee;
+	return {
+		...entry,
+		immutableArrayFilter: callee._octaneImmutableArrayFilter ?? null,
+		generatedInvariant:
+			entry.name === 'useCallback' &&
+			callee._octaneGenerated === true &&
+			callee._octaneLifetimeInvariant === true,
+	};
+}
+
 function authoredHookMemoOf(stmt) {
 	if (stmt.type !== 'VariableDeclaration' || stmt.declarations?.length !== 1) return null;
 	const decl = stmt.declarations[0];
 	if (!decl || decl.id?.type !== 'Identifier' || !decl.init) return null;
-	const call = unwrapTsExpr(decl.init);
-	if (call?.type !== 'CallExpression' || call.optional) return null;
-	const callee = call.callee;
-	if (callee?.type !== 'Identifier') return null;
-	const imported = call._octaneImportedHook ?? call._octaneHookRuntimeImportedHook;
-	const name = imported ?? callee.name;
-	if (name !== 'useMemo' && name !== 'useCallback') return null;
-	if (
-		callee._octaneGenerated !== true &&
-		imported === undefined &&
-		call._octaneUnboundCallee !== true
-	) {
-		return null;
+	const entry = flatHookMemoOf(unwrapTsExpr(decl.init));
+	return entry === null ? null : { ...entry, decl };
+}
+
+function hookMemoMissTest(entry, ctx, base, depNames) {
+	const cell = (index) => b.member(b.id(hookMemoNames(ctx).cache), hkNumLit(index), true);
+	let miss = b.binary('!==', cell(base), b.literal(true, 'true'));
+	for (let i = 0; i < depNames.length; i++) {
+		miss = b.logical(
+			'||',
+			miss,
+			b.unary('!', hkObjectIs(ctx, cell(base + 1 + i), b.id(depNames[i]))),
+		);
 	}
-	if (call.arguments.length !== 2) return null;
-	if (call.arguments.some((a) => a.type === 'SpreadElement')) return null;
-	const fn = unwrapTsExpr(call.arguments[0]);
-	if (fn?.type !== 'ArrowFunctionExpression' && fn?.type !== 'FunctionExpression') return null;
-	const depsNode = unwrapTsExpr(call.arguments[1]);
-	let deps = null;
-	if (depsNode?.type === 'ArrayExpression') {
-		const elements = depsNode.elements || [];
-		for (const el of elements) {
-			if (el == null || el.type === 'SpreadElement') return null;
-		}
-		deps = elements;
-	} else if (!(depsNode?.type === 'Literal' && depsNode.value === null)) {
-		return null;
+	if (entry.immutableArrayFilter !== null) {
+		const { receiver, property } = entry.immutableArrayFilter;
+		miss = b.logical(
+			'||',
+			miss,
+			b.unary(
+				'!',
+				b.call(
+					requireRuntimeForContext(ctx, 'compilerCacheImmutableArrayFilter'),
+					b.id(receiver),
+					b.literal(property),
+				),
+			),
+		);
 	}
-	if (name === 'useMemo') {
-		if (fn.async || fn.generator || (fn.params?.length ?? 0) > 0) return null;
-		if (containsHookShapedCall(fn.body)) return null;
-		if (fn.body.type === 'BlockStatement' && !blockBodyInlineSafe(fn.body)) return null;
+	return miss;
+}
+
+// Sequence/conditional expressions keep the authored evaluation position,
+// short-circuiting and declaration TDZ. No IIFE, deps array, or memo factory is
+// evaluated on a hit. The retained useCallback function is created on a miss.
+function buildFlatHookMemoExpression(entry, ctx) {
+	if (entry.expression === null) return null;
+	if (entry.deps === null) return withoutInferredMemoName(entry.expression);
+	const names = hookMemoNames(ctx);
+	const base = ctx.currentHookMemoOffset;
+	const cell = (index) => b.member(b.id(names.cache), hkNumLit(index), true);
+	if (entry.generatedInvariant) {
+		ctx.currentHookMemoOffset = base + 1;
+		return b.logical(
+			'??',
+			cell(base),
+			b.call(
+				requireRuntimeForContext(ctx, 'hookMemoPublishInvariant'),
+				b.id(names.cache),
+				hkNumLit(base),
+				entry.expression,
+			),
+		);
 	}
-	return {
-		name,
-		decl,
-		kind: stmt.kind,
-		fn,
-		deps,
-		immutableArrayFilter: callee._octaneImmutableArrayFilter ?? null,
-		generatedInvariant:
-			name === 'useCallback' &&
-			callee._octaneGenerated === true &&
-			callee._octaneLifetimeInvariant === true,
-	};
+	ctx.currentHookMemoOffset = base + entry.deps.length + 2;
+	const sequence = [];
+	const depNames = entry.deps.map((dependency, index) => {
+		const name = hookMemoExpressionTemp(ctx, `__hkd${index}`);
+		sequence.push(hkAssign(b.id(name), withoutInferredMemoName(dependency)));
+		return name;
+	});
+	sequence.push(
+		b.conditional(
+			hookMemoMissTest(entry, ctx, base, depNames),
+			b.call(
+				hookMemoPublishAlias(ctx, entry.deps.length),
+				b.id(names.cache),
+				hkNumLit(base),
+				entry.expression,
+				...depNames.map((name) => b.id(name)),
+			),
+			cell(base + entry.deps.length + 1),
+		),
+	);
+	return sequence.length === 1 ? sequence[0] : b.sequence(sequence);
 }
 
 // Compute statements writing the site's result into `target` (an expression
@@ -16034,12 +16123,20 @@ function authoredHookMemoOf(stmt) {
 // useCallback caches the factory itself.
 function hookMemoComputeStatements(entry, ctx, target) {
 	const { name, fn } = entry;
-	if (name === 'useCallback') return [hkExprStmt(hkAssign(target, fn))];
-	if (fn.body.type !== 'BlockStatement') return [hkExprStmt(hkAssign(target, fn.body))];
+	if (name === 'useCallback') return [hkExprStmt(hkAssign(target, withoutInferredMemoName(fn)))];
+	if (fn.body.type !== 'BlockStatement')
+		return [hkExprStmt(hkAssign(target, withoutInferredMemoName(fn.body)))];
 	const names = hookMemoNames(ctx);
+	const rewritten = replaceOwnReturns(fn.body, names);
 	return [
 		b.let(names.result, null),
-		b.labeled(names.label, replaceOwnReturns(fn.body, names)),
+		b.labeled(names.label, {
+			...rewritten,
+			// A finally clause can cancel a return with break/continue. Only a
+			// return that actually exits this label may retain its assigned value;
+			// ordinary function fallthrough must still produce undefined.
+			body: [...rewritten.body, hkExprStmt(hkAssign(b.id(names.result), b.void0))],
+		}),
 		hkExprStmt(hkAssign(target, b.id(names.result))),
 	];
 }
@@ -16074,7 +16171,7 @@ function lowerPuMemoDecl(stmt, ctx) {
 		body.push(
 			b.declaration(
 				'const',
-				deps.map((dep, i) => b.declarator(temp(i), dep)),
+				deps.map((dep, i) => b.declarator(temp(i), withoutInferredMemoName(dep))),
 			),
 		);
 	}
@@ -16101,42 +16198,30 @@ function lowerPuMemoDecl(stmt, ctx) {
 function lowerAuthoredHookMemo(stmt, ctx) {
 	const entry = authoredHookMemoOf(stmt);
 	if (entry === null) return null;
-	const { name, decl, kind, fn, deps, generatedInvariant } = entry;
-	// Explicit `null` deps: recompute every render — no cache at all. A
-	// useCallback degenerates to the factory itself; a useMemo evaluates
-	// inline (via the shared block machinery when the body is a block).
+	const { decl, deps } = entry;
+	const declarationWith = (init) => ({
+		...stmt,
+		declarations: [{ ...decl, init }],
+	});
+	if (entry.expression !== null) {
+		return [declarationWith(buildFlatHookMemoExpression(entry, ctx))];
+	}
+	// Multi-statement useMemo factories need a statement region, but the
+	// authored declaration stays after it with its original binding kind.
+	// Explicit null deps recompute every render and need no cache.
 	if (deps === null) {
-		if (name === 'useCallback' || fn.body.type !== 'BlockStatement') {
-			const init = name === 'useCallback' ? fn : fn.body;
-			return [{ ...stmt, declarations: [{ ...decl, init }] }];
-		}
+		const result = b.id(allocCompilerName(ctx, '__hkv'));
 		return [
-			b.let(decl.id, null),
-			b.block([...hookMemoComputeStatements(entry, ctx, { ...decl.id })]),
+			b.let(result, null),
+			b.block(hookMemoComputeStatements(entry, ctx, result)),
+			declarationWith(result),
 		];
 	}
 	const names = hookMemoNames(ctx);
 	const base = ctx.currentHookMemoOffset;
-	if (generatedInvariant) {
-		// A compiler-owned callback whose captures are lifetime-invariant cannot
-		// miss after its first render. Its function value doubles as the init flag,
-		// and publishing it immediately preserves identity across suspension.
-		ctx.currentHookMemoOffset = base + 1;
-		const valueCell = () => b.member(b.id(names.cache), hkNumLit(base), true);
-		return [
-			{
-				...stmt,
-				declarations: [
-					{
-						...decl,
-						init: b.logical('??', valueCell(), b.assignment('=', valueCell(), fn)),
-					},
-				],
-			},
-		];
-	}
 	const k = deps.length;
 	ctx.currentHookMemoOffset = base + k + 2;
+	const result = b.id(allocCompilerName(ctx, '__hkv'));
 	const cellRef = (i) => b.member(b.id(names.cache), hkNumLit(i), true);
 	const valueCell = () => cellRef(base + 1 + k);
 	const body = [];
@@ -16144,41 +16229,36 @@ function lowerAuthoredHookMemo(stmt, ctx) {
 		body.push(
 			b.declaration(
 				'const',
-				deps.map((dep, i) => b.declarator(b.id(hookMemoTemp(ctx, i)), dep)),
-			),
-		);
-	}
-	let missTest = b.binary('!==', cellRef(base), b.literal(true, 'true'));
-	for (let i = 0; i < k; i++) {
-		missTest = b.logical(
-			'||',
-			missTest,
-			b.unary('!', hkObjectIs(cellRef(base + 1 + i), b.id(hookMemoTemp(ctx, i)))),
-		);
-	}
-	if (entry.immutableArrayFilter !== null) {
-		const { receiver, property } = entry.immutableArrayFilter;
-		missTest = b.logical(
-			'||',
-			missTest,
-			b.unary(
-				'!',
-				b.call(
-					requireRuntimeForContext(ctx, 'compilerCacheImmutableArrayFilter'),
-					b.id(receiver),
-					b.literal(property),
+				deps.map((dep, i) =>
+					b.declarator(b.id(hookMemoTemp(ctx, i)), withoutInferredMemoName(dep)),
 				),
 			),
 		);
 	}
-	const missBody = [...hookMemoComputeStatements(entry, ctx, valueCell())];
-	for (let i = 0; i < k; i++) {
-		missBody.push(hkExprStmt(hkAssign(cellRef(base + 1 + i), b.id(hookMemoTemp(ctx, i)))));
-	}
-	missBody.push(hkExprStmt(hkAssign(cellRef(base), b.literal(true, 'true'))));
+	const missTest = hookMemoMissTest(
+		entry,
+		ctx,
+		base,
+		deps.map((_, index) => hookMemoTemp(ctx, index)),
+	);
+	// Keep the authored binding in its TDZ while the factory runs. Publishing
+	// only after a successful compute also leaves the previous entry intact if
+	// the factory throws, and gives held transitions a complete old/new record.
+	const missBody = [
+		...hookMemoComputeStatements(entry, ctx, result),
+		hkExprStmt(
+			b.call(
+				hookMemoPublishAlias(ctx, deps.length),
+				b.id(names.cache),
+				hkNumLit(base),
+				result,
+				...deps.map((_, i) => b.id(hookMemoTemp(ctx, i))),
+			),
+		),
+	];
 	body.push(b.if(missTest, b.block(missBody), null));
-	body.push(hkExprStmt(hkAssign({ ...decl.id }, valueCell())));
-	return [b.let(decl.id, null), b.block(body)];
+	body.push(hkExprStmt(hkAssign(result, valueCell())));
+	return [b.let(result, null), b.block(body), declarationWith(result)];
 }
 
 // The statement walker: recurses into conditional blocks (conditional hooks
@@ -16244,6 +16324,52 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 	};
 	return mapAst(node, rewrite);
 
+	function canLowerClientMemo(call, name) {
+		return (
+			ctx.inlineHookMemo &&
+			ctx.mode !== 'server' &&
+			ctx._universalRuntimeUnit == null &&
+			call._octaneHookRuntimeImportedHook === undefined &&
+			(name === 'useMemo' || name === 'useCallback')
+		);
+	}
+
+	function slotMemoCandidate(call, name) {
+		if (call._octaneInlineMemoHook !== undefined) {
+			if (call._octaneInlineMemoHook !== null) ctx.hasSlotMemoCandidates = true;
+			return call._octaneInlineMemoHook;
+		}
+		if (localSlotMarks.get(call) === true && !ctx.currentHookMemoOwnerSafe) return null;
+		// Slotting a custom hook turns its call into withSlot(...). Preserve the
+		// safety proof from BEFORE that rewrite; otherwise a factory containing a
+		// hook could incorrectly appear hook-free in the final module pass.
+		if (analyzeInlineMemoCall(call, { allowMissingSlot: true, allowUnbound: true }) === null) {
+			return null;
+		}
+		ctx.hasSlotMemoCandidates = true;
+		return name;
+	}
+
+	function lowerLocalMemoExpression(call, name) {
+		if (
+			!canLowerClientMemo(call, name) ||
+			localSlotMarks.get(call) !== true ||
+			!ctx.currentHookMemoOwnerSafe ||
+			ctx.currentHookMemoCacheProperty === null
+		) {
+			return null;
+		}
+		const entry = flatHookMemoOf(call);
+		if (entry === null || entry.expression === null) return null;
+		// Recurse before replacing the outer call: mapAst intentionally does not
+		// descend into a replacement. Nested callback/helper scopes retain their
+		// Symbol slots, while deps in this render scope keep their own sites.
+		const args = call.arguments.map((argument) =>
+			rewriteHookCalls(argument, ctx, componentName, localRoot),
+		);
+		return buildFlatHookMemoExpression(flatHookMemoOf({ ...call, arguments: args }), ctx);
+	}
+
 	function rewriteHookCallNode(n) {
 		// First-class subtemplates have their own compileFunctionBody pass. Leave
 		// their contents untouched here so hook sites are slotted exactly once and
@@ -16295,11 +16421,18 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 			const isCustom = !generated && !isBuiltin && /^use[A-Z]/.test(name) && name !== 'useContext';
 			const isServerUse = name === 'use' && ctx.mode === 'server';
 			if (isBuiltin || isCustom || isServerUse) {
+				if (isBuiltin) {
+					const inline = lowerLocalMemoExpression(n, name);
+					if (inline !== null) return inline;
+				}
 				// Keep a Symbol at custom-hook call boundaries: published bindings split
 				// that trailing value from optional user args and derive manual sub-slots
 				// from it. Proven render-scope base hooks can use the smaller numeric
 				// production ABI; arbitrary callable helpers cannot.
 				const hasSpread = n.arguments.some((arg) => arg.type === 'SpreadElement');
+				const memoRoute = isBuiltin && canLowerClientMemo(n, name);
+				const memoCandidate = memoRoute ? slotMemoCandidate(n, name) : null;
+				const explicitMemoSlot = memoRoute && n.arguments.length === 3 && !hasSpread;
 				const numericSlot =
 					!ctx.hmr &&
 					!ctx.profile &&
@@ -16323,7 +16456,12 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 					ctx.userRuntimeNames.add(localName === name ? 'use' : `use as ${localName}`);
 				let symVar = null;
 				let slot;
-				if (numericSlot) {
+				if (explicitMemoSlot) {
+					// The authored third argument is already the raw memo slot. A
+					// fourth compiler slot is ignored by the runtime and would also
+					// hide this site from the path-aware closure-free lowering.
+					slot = null;
+				} else if (numericSlot) {
 					const id = ctx.nextHookSymId++;
 					slot = b.literal(id, String(id));
 				} else {
@@ -16349,7 +16487,10 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 				// its own slot, e.g. `useStore(api, useShallow(sel))` or a hook in a deps
 				// array. (Allocating the outer slot first keeps its id stable; nested
 				// inner hooks just take the following ids.)
-				const args = n.arguments.map((a) => rewriteHookCalls(a, ctx, componentName, localRoot));
+				// Once a call is inside a callable/class scope, walking an argument
+				// separately must not re-promote its nested hooks to render-local.
+				const argsLocalRoot = localSlotMarks.get(n) === true;
+				const args = n.arguments.map((a) => rewriteHookCalls(a, ctx, componentName, argsLocalRoot));
 				// NB: base hooks are ALSO `use[A-Z]`, so the wrap is for custom hooks ONLY
 				// (`isCustom && !isBuiltin`) — base hooks keep the plain trailing-slot form.
 				if (isCustom && !isBuiltin) {
@@ -16362,7 +16503,9 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 					const withSlotAlias = requireRuntimeForContext(ctx, 'withSlot');
 					return b.call(withSlotAlias, b.id(symVar), n.callee, ...args, b.id(symVar));
 				}
-				const hookArgs = appendHookSlotArgument(name, args, slot, numericSlot, n);
+				const hookArgs = explicitMemoSlot
+					? args
+					: appendHookSlotArgument(name, args, slot, numericSlot, n);
 				if (isServerUse && n._octaneHydrationSite !== undefined) {
 					hookArgs.push(
 						inheritOriginLoc(
@@ -16373,6 +16516,7 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 				}
 				return {
 					...n,
+					...(memoRoute ? { _octaneInlineMemoHook: memoCandidate } : null),
 					callee:
 						getterHelper !== null
 							? b.id(runtimeAliasForContext(ctx, getterHelper))
@@ -16400,6 +16544,16 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 			const isBuiltin = HOOK_NAMES.has(name);
 			const isServerUse = name === 'use' && ctx.mode === 'server';
 			if (isBuiltin || isServerUse) {
+				if (isBuiltin) {
+					const inline = lowerLocalMemoExpression(n, name);
+					if (inline !== null) return inline;
+				}
+				const memoRoute = isBuiltin && canLowerClientMemo(n, name);
+				const memoCandidate = memoRoute ? slotMemoCandidate(n, name) : null;
+				const explicitMemoSlot =
+					memoRoute &&
+					n.arguments.length === 3 &&
+					!n.arguments.some((argument) => argument.type === 'SpreadElement');
 				const annotatedOwner = ctx.profile ? ctx.profileOwnerMarks?.get(n) : null;
 				const profileOwner = annotatedOwner?.name || componentName;
 				const getterHelper = stateGetterMarks.get(n) ? STATE_GETTER_HELPERS[name] : null;
@@ -16410,7 +16564,9 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 					localSlotMarks.get(n) === true &&
 					!n.arguments.some((arg) => arg.type === 'SpreadElement');
 				let slot;
-				if (numericSlot) {
+				if (explicitMemoSlot) {
+					slot = null;
+				} else if (numericSlot) {
 					const id = ctx.nextHookSymId++;
 					slot = b.literal(id, String(id));
 				} else {
@@ -16427,12 +16583,17 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 						true,
 					);
 				}
-				const args = n.arguments.map((a) => rewriteHookCalls(a, ctx, componentName, localRoot));
+				const args = n.arguments.map((a) =>
+					rewriteHookCalls(a, ctx, componentName, localSlotMarks.get(n) === true),
+				);
 				return {
 					...n,
+					...(memoRoute ? { _octaneInlineMemoHook: memoCandidate } : null),
 					callee:
 						getterHelper !== null ? b.id(runtimeAliasForContext(ctx, getterHelper)) : n.callee,
-					arguments: appendHookSlotArgument(name, args, slot, numericSlot, n),
+					arguments: explicitMemoSlot
+						? args
+						: appendHookSlotArgument(name, args, slot, numericSlot, n),
 				};
 			}
 		}
@@ -16469,8 +16630,9 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 				true,
 			);
 			const withSlotAlias = requireRuntimeForContext(ctx, 'withSlot');
-			const object = rewriteHookCalls(n.callee.object, ctx, componentName, localRoot);
-			const args = n.arguments.map((a) => rewriteHookCalls(a, ctx, componentName, localRoot));
+			const argsLocalRoot = localSlotMarks.get(n) === true;
+			const object = rewriteHookCalls(n.callee.object, ctx, componentName, argsLocalRoot);
+			const args = n.arguments.map((a) => rewriteHookCalls(a, ctx, componentName, argsLocalRoot));
 			return b.call(
 				withSlotAlias,
 				b.id(symVar),
@@ -16487,6 +16649,7 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 // descriptor type identity). No component gate, no signature rewrite to (scope,props).
 function compileReturnJsxFunction(node, ctx, options) {
 	const name = node.id.name;
+	const hookMemoOpaqueOwner = ctx.inlineHookMemo && hasInlineMemoOpaqueDirective(node);
 	recordProfileComponent(ctx, node, name);
 	const scoping = applyCssScoping(node, ctx);
 	node = scoping.node;
@@ -16631,16 +16794,19 @@ function compileReturnJsxFunction(node, ctx, options) {
 	// helper fns (compInlinedSubs — filled by the statement mapping above) are
 	// function DECLARATION nodes embedded at the top of the body, matching the
 	// historical after-the-`{` splice.
+	const emittedFunction = b.function_declaration(
+		node.id,
+		node.params,
+		b.block([
+			...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)),
+			...compInlinedSubs,
+			...newStatements,
+		]),
+	);
 	const fn = inheritOriginLoc(
-		b.function_declaration(
-			node.id,
-			node.params,
-			b.block([
-				...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)),
-				...compInlinedSubs,
-				...newStatements,
-			]),
-		),
+		hookMemoOpaqueOwner
+			? { ...emittedFunction, _octaneInlineMemoOpaqueOwner: true }
+			: emittedFunction,
 		node,
 	);
 	// M2 AST emit: return the function declaration NODE plus any HMR-rebind /

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -1366,13 +1366,17 @@ function cloneDependency(node) {
 	return { ...node };
 }
 
-/** @param {any} ast @param {{ onlyImported?: boolean, hookRuntimeModules?: readonly string[], filename?: string }} options */
+/** @param {any} ast @param {{ onlyImported?: boolean, hookRuntimeModules?: readonly string[], filename?: string, inferDependencies?: boolean }} options */
 function analyzeInternal(ast, options) {
 	const onlyImported = options.onlyImported === true;
 	const hookRuntimeModules = new Set(['octane', ...(options.hookRuntimeModules || [])]);
 	const analysis = buildScopes(ast, onlyImported, hookRuntimeModules);
-	markDependencyInvariantBindings(analysis);
 	const inferred = new Map();
+	// A hand-slotted module owns its authored dependency ABI. The production
+	// memo-only pass still needs lexical import provenance, but must not infer
+	// omitted lists or reject source the manual-slot path previously accepted.
+	if (options.inferDependencies === false) return { analysis, inferred };
+	markDependencyInvariantBindings(analysis);
 
 	for (const candidate of analysis.candidates) {
 		const rawCallback = candidate.call.arguments[candidate.config.callback];
@@ -1501,7 +1505,7 @@ function rebuildWithHookMetadata(ast, analysis, inferred, insertDeps) {
  * keyed by the rebuilt calls. Dependency arrays are NOT inserted — that pass
  * edits source text from the inference results instead of reprinting the tree.
  */
-/** @param {any} ast @param {{ onlyImported?: boolean, hookRuntimeModules?: readonly string[], filename?: string }} [options] */
+/** @param {any} ast @param {{ onlyImported?: boolean, hookRuntimeModules?: readonly string[], filename?: string, inferDependencies?: boolean }} [options] */
 export function annotateHookCalls(ast, options = {}) {
 	const { analysis, inferred } = analyzeInternal(ast, options);
 	return rebuildWithHookMetadata(ast, analysis, inferred, false);

--- a/packages/octane/src/compiler/inline-hook-memo.js
+++ b/packages/octane/src/compiler/inline-hook-memo.js
@@ -1,0 +1,654 @@
+// Shared, AST-only lowering for memo sites which must retain their ordinary
+// path-aware hook entry. The component compiler has a cheaper flat-cache tier;
+// plain custom hooks and authored explicit slots cannot use that tier because
+// their effective slot includes the caller's withSlot path.
+
+import { builders as b } from '@tsrx/core';
+
+const FUNCTION_TYPES = new Set([
+	'FunctionDeclaration',
+	'FunctionExpression',
+	'ArrowFunctionExpression',
+]);
+const VALUE_WRAPPERS = new Set([
+	'TSAsExpression',
+	'TSTypeAssertion',
+	'TSNonNullExpression',
+	'TSSatisfiesExpression',
+	'TSInstantiationExpression',
+	'ParenthesizedExpression',
+]);
+const META_KEYS = new Set([
+	'loc',
+	'start',
+	'end',
+	'range',
+	'metadata',
+	'parent',
+	'leadingComments',
+	'trailingComments',
+	'innerComments',
+	'comments',
+]);
+
+function unwrapValue(node) {
+	while (node && VALUE_WRAPPERS.has(node.type)) node = node.expression;
+	return node;
+}
+
+function walkEveryNode(root, visit) {
+	function walk(node) {
+		if (node === null || typeof node !== 'object') return true;
+		if (Array.isArray(node)) {
+			for (const child of node) if (!walk(child)) return false;
+			return true;
+		}
+		if (visit(node) === false) return false;
+		for (const key in node) {
+			if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+			if (!walk(node[key])) return false;
+		}
+		return true;
+	}
+	return walk(root);
+}
+
+function isHookShapedCall(node) {
+	if (node.type !== 'CallExpression') return false;
+	if (
+		typeof node._octaneImportedHook === 'string' ||
+		typeof node._octaneHookRuntimeImportedHook === 'string'
+	) {
+		return true;
+	}
+	const callee = unwrapValue(node.callee);
+	const name =
+		callee?.type === 'Identifier'
+			? callee.name
+			: callee?.type === 'MemberExpression' &&
+				  !callee.computed &&
+				  callee.property?.type === 'Identifier'
+				? callee.property.name
+				: null;
+	return name === 'use' || (name !== null && /^use[A-Z]/.test(name));
+}
+
+function hasOwnScopeDeclaration(root) {
+	function walk(node) {
+		if (node === null || typeof node !== 'object') return false;
+		if (Array.isArray(node)) return node.some(walk);
+		if (node.type === 'FunctionDeclaration') return true;
+		if (FUNCTION_TYPES.has(node.type)) return false;
+		if (node.type === 'VariableDeclaration' && node.kind === 'var') return true;
+		for (const key in node) {
+			if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+			if (walk(node[key])) return true;
+		}
+		return false;
+	}
+	return walk(root);
+}
+
+/**
+ * Whether invoking this useMemo factory can be replaced by its body. Ordinary
+ * functions deliberately keep their own this/arguments/new.target/name scope.
+ * A direct eval or an opaque function directive also needs the original scope.
+ * Hook-shaped calls cannot be moved behind a cache-hit branch.
+ */
+export function isInlineMemoFactorySafe(fn) {
+	if (
+		fn?.type !== 'ArrowFunctionExpression' ||
+		fn.async ||
+		fn.generator ||
+		(fn.params?.length ?? 0) !== 0
+	) {
+		return false;
+	}
+	if (fn.body?.type === 'BlockStatement') {
+		const first = fn.body.body?.[0];
+		const expression = first?.type === 'ExpressionStatement' ? unwrapValue(first.expression) : null;
+		if (typeof first?.directive === 'string' || typeof expression?.value === 'string') return false;
+		if (hasOwnScopeDeclaration(fn.body)) return false;
+	}
+	return walkEveryNode(fn.body, (node) => {
+		if (isHookShapedCall(node)) return false;
+		if (node.type !== 'CallExpression') return true;
+		const callee = unwrapValue(node.callee);
+		return callee?.type !== 'Identifier' || callee.name !== 'eval';
+	});
+}
+
+/** Attach origins only to generated scaffolding; authored subtrees stay shared. */
+export function inheritHookMemoOrigin(root, origin) {
+	if (origin?.loc == null) return root;
+	function inherit(node) {
+		if (node === null || typeof node !== 'object') return node;
+		if (Array.isArray(node)) return node.map(inherit);
+		if (typeof node.type !== 'string' || node.loc != null) return node;
+		const out = {
+			...node,
+			start: origin.start,
+			end: origin.end,
+			loc: origin.loc,
+		};
+		for (const key in node) {
+			if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+			out[key] = inherit(node[key]);
+		}
+		return out;
+	}
+	return inherit(root);
+}
+
+function factoryExpression(name, fn, original) {
+	if (name === 'useCallback') return original;
+	if (fn.body.type !== 'BlockStatement') return fn.body;
+	const statements = fn.body.body || [];
+	if (statements.length === 0) return b.void0;
+	if (statements.length === 1 && statements[0].type === 'ReturnStatement') {
+		return statements[0].argument ?? b.void0;
+	}
+	return null;
+}
+
+/**
+ * Recognize a memo with known dependencies and trustworthy hook provenance.
+ * The caller slots/inserts inferred deps first, or explicitly allows an absent
+ * raw slot for a manually composed custom-hook path. `expression === null`
+ * means the safe factory needs statement-position lowering, never an IIFE.
+ */
+export function analyzeInlineMemoCall(call, options = {}) {
+	call = unwrapValue(call);
+	if (call?.type !== 'CallExpression' || call.optional) return null;
+	const canonical = options.canonicalHookName?.(call);
+	if (canonical === null) return null;
+	const imported = canonical ?? call._octaneImportedHook ?? call._octaneHookRuntimeImportedHook;
+	const callee = unwrapValue(call.callee);
+	const name =
+		imported ??
+		(callee?.type === 'Identifier' &&
+		(callee._octaneGenerated === true ||
+			(options.allowUnbound === true && call._octaneUnboundCallee === true))
+			? callee.name
+			: null);
+	if (name !== 'useMemo' && name !== 'useCallback') return null;
+	if (
+		call.arguments.length !== 3 &&
+		!(options.allowMissingSlot === true && call.arguments.length === 2)
+	) {
+		return null;
+	}
+	if (call.arguments.some((argument) => argument.type === 'SpreadElement')) return null;
+	const original = call.arguments[0];
+	const fn = unwrapValue(original);
+	if (fn?.type !== 'ArrowFunctionExpression' && fn?.type !== 'FunctionExpression') return null;
+	if (name === 'useMemo' && !isInlineMemoFactorySafe(fn)) return null;
+	const dependency = unwrapValue(call.arguments[1]);
+	let deps;
+	if (dependency?.type === 'ArrayExpression') {
+		deps = dependency.elements || [];
+		if (deps.length > (options.maxDeps ?? 4)) return null;
+		if (deps.some((element) => element == null || element.type === 'SpreadElement')) return null;
+	} else if (dependency?.type === 'Literal' && dependency.value === null) {
+		deps = null;
+	} else {
+		return null;
+	}
+	return {
+		name,
+		fn,
+		deps,
+		slot: call.arguments[2],
+		expression: factoryExpression(name, fn, original),
+		call,
+	};
+}
+
+const assign = (left, right) => b.assignment('=', left, right);
+const id = (name) => b.id(name);
+
+// An anonymous function/class used as a return value or call argument has no
+// inferred name. Moving it onto an identifier assignment must not silently
+// give it the compiler's temporary name.
+export function withoutInferredMemoName(expression) {
+	const value = unwrapValue(expression);
+	return value?.type === 'ArrowFunctionExpression' ||
+		((value?.type === 'FunctionExpression' || value?.type === 'ClassExpression') && !value.id)
+		? b.sequence([b.literal(0), expression])
+		: expression;
+}
+
+function slotCall(entry, runtime) {
+	return b.call(runtime('memoSlot'), entry.slot ?? b.void0, b.literal(entry.name));
+}
+
+/**
+ * Build a closure-free sequence expression. `temp` allocates and registers a
+ * function-local mutable binding; `runtime` registers an import and returns its
+ * local name. Dependency expressions run exactly once, before the raw slot.
+ */
+export function buildSlotMemoExpression(entry, { temp, runtime }) {
+	if (entry.expression === null) return null;
+	const slot = temp('__hks');
+	const sequence = [];
+	const depNames = (entry.deps || []).map((dependency, index) => {
+		const name = temp(`__hkd${index}`);
+		sequence.push(assign(id(name), withoutInferredMemoName(dependency)));
+		return name;
+	});
+	sequence.push(assign(id(slot), slotCall(entry, runtime)));
+	if (entry.deps === null) {
+		sequence.push(b.call(runtime('memoPublishAlways'), id(slot), entry.expression));
+	} else {
+		const previous = temp('__hke');
+		sequence.push(
+			assign(
+				id(previous),
+				b.call(runtime(`memoTake${depNames.length}`), id(slot), ...depNames.map(id)),
+			),
+		);
+		sequence.push(
+			b.conditional(
+				b.binary('===', id(previous), b.null),
+				b.call(runtime('memoPublish'), id(slot), entry.expression, ...depNames.map(id)),
+				b.member(id(previous), 'value'),
+			),
+		);
+	}
+	return inheritHookMemoOrigin(b.sequence(sequence), entry.call);
+}
+
+function replaceOwnReturns(root, result, label) {
+	function rewrite(node) {
+		if (node === null || typeof node !== 'object') return node;
+		if (Array.isArray(node)) {
+			let out = null;
+			for (let i = 0; i < node.length; i++) {
+				const mapped = rewrite(node[i]);
+				if (out === null && mapped !== node[i]) out = node.slice(0, i);
+				if (out !== null) out.push(mapped);
+			}
+			return out ?? node;
+		}
+		if (FUNCTION_TYPES.has(node.type)) return node;
+		if (node.type === 'ReturnStatement') {
+			return inheritHookMemoOrigin(
+				b.block([
+					b.stmt(assign(id(result), withoutInferredMemoName(node.argument ?? b.void0))),
+					{ ...b.break, label: id(label) },
+				]),
+				node,
+			);
+		}
+		let out = null;
+		for (const key in node) {
+			if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+			const mapped = rewrite(node[key]);
+			if (mapped !== node[key]) {
+				if (out === null) out = { ...node };
+				out[key] = mapped;
+			}
+		}
+		return out ?? node;
+	}
+	return rewrite(root);
+}
+
+/**
+ * Statement-position counterpart for a multi-statement factory. The caller
+ * owns `target` and retains the authored declaration/return after this block,
+ * preserving its const/let binding and temporal dead zone.
+ */
+export function buildSlotMemoStatements(entry, { temp, runtime }, target) {
+	const slot = temp('__hks');
+	const statements = [];
+	const depNames = (entry.deps || []).map((dependency, index) => {
+		const name = temp(`__hkd${index}`);
+		statements.push(b.stmt(assign(id(name), withoutInferredMemoName(dependency))));
+		return name;
+	});
+	statements.push(b.stmt(assign(id(slot), slotCall(entry, runtime))));
+	const value = temp('__hkv');
+	let compute;
+	if (entry.expression !== null) {
+		compute = [b.stmt(assign(id(value), withoutInferredMemoName(entry.expression)))];
+	} else {
+		const label = temp('__hkl', true);
+		const body = replaceOwnReturns(entry.fn.body, value, label);
+		// A finally break/continue can cancel a pending return and let the
+		// original factory fall through. Clear its abandoned result only on
+		// normal completion; real returns break past this statement.
+		const fallthrough = inheritHookMemoOrigin(b.stmt(assign(id(value), b.void0)), entry.fn.body);
+		compute = [b.labeled(label, { ...body, body: [...body.body, fallthrough] })];
+	}
+	const publish = b.stmt(
+		assign(
+			target,
+			entry.deps === null
+				? b.call(runtime('memoPublishAlways'), id(slot), id(value))
+				: b.call(runtime('memoPublish'), id(slot), id(value), ...depNames.map(id)),
+		),
+	);
+	if (entry.deps === null) {
+		statements.push(...compute, publish);
+	} else {
+		const previous = temp('__hke');
+		statements.push(
+			b.stmt(
+				assign(
+					id(previous),
+					b.call(runtime(`memoTake${depNames.length}`), id(slot), ...depNames.map(id)),
+				),
+			),
+			b.if(
+				b.binary('===', id(previous), b.null),
+				b.block([...compute, publish]),
+				b.stmt(assign(target, b.member(id(previous), 'value'))),
+			),
+		);
+	}
+	return inheritHookMemoOrigin(b.block(statements), entry.call);
+}
+
+function mapChildren(node, visit) {
+	if (node === null || typeof node !== 'object') return node;
+	if (Array.isArray(node)) {
+		let out = null;
+		for (let i = 0; i < node.length; i++) {
+			const mapped = visit(node[i]);
+			if (out === null && mapped !== node[i]) out = node.slice(0, i);
+			if (out !== null) out.push(mapped);
+		}
+		return out ?? node;
+	}
+	let out = null;
+	for (const key in node) {
+		if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+		const value = node[key];
+		if (value === null || typeof value !== 'object') continue;
+		const mapped = visit(value);
+		if (mapped !== value) {
+			if (out === null) out = { ...node };
+			out[key] = mapped;
+		}
+	}
+	return out ?? node;
+}
+
+function walkNodes(root, visit) {
+	function walk(node) {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (visit(node) === false) return;
+		for (const key in node) {
+			if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+			walk(node[key]);
+		}
+	}
+	walk(root);
+}
+
+function replaceWrappedValue(node, replacement) {
+	return VALUE_WRAPPERS.has(node?.type)
+		? { ...node, expression: replaceWrappedValue(node.expression, replacement) }
+		: replacement;
+}
+
+/** New bindings and imports must be invisible to every lexical direct eval. */
+export function hasInlineMemoDirectEval(root) {
+	let found = false;
+	walkNodes(root, (node) => {
+		// A descendant function's direct eval can inspect this function's
+		// lexical environment too. New outer cache bindings must stay invisible
+		// to it, even when the descendant itself contains no lowered memo.
+		if (
+			node.type === 'CallExpression' &&
+			unwrapValue(node.callee)?.type === 'Identifier' &&
+			unwrapValue(node.callee).name === 'eval'
+		) {
+			found = true;
+		}
+		return !found;
+	});
+	return found;
+}
+
+function directiveEnd(statements) {
+	let index = 0;
+	while (index < statements.length) {
+		const statement = statements[index];
+		const expression =
+			statement?.type === 'ExpressionStatement' ? unwrapValue(statement.expression) : null;
+		if (typeof statement?.directive !== 'string' && typeof expression?.value !== 'string') break;
+		index++;
+	}
+	return index;
+}
+
+/** Whether an authored function belongs to an opaque execution transform. */
+export function hasInlineMemoOpaqueDirective(fn) {
+	if (fn.body?.type !== 'BlockStatement' && fn.body?.type !== 'JSXCodeBlock') return false;
+	const statements = fn.body.body || [];
+	const end = directiveEnd(statements);
+	for (let i = 0; i < end; i++) {
+		const value = statements[i].directive ?? unwrapValue(statements[i].expression)?.value;
+		if (value !== 'use strict' && value !== 'use strong') return true;
+	}
+	return false;
+}
+
+/** Adding body-local cache temporaries must not alter eval or opaque code. */
+export function isInlineMemoOwnerSafe(fn) {
+	return (
+		fn._octaneInlineMemoOpaqueOwner !== true &&
+		!hasInlineMemoDirectEval(fn.body) &&
+		!hasInlineMemoOpaqueDirective(fn)
+	);
+}
+
+/**
+ * Lower already-slotted memo calls throughout a Program. The owning compiler
+ * supplies collision-free names and runtime import registration; this pass
+ * creates only AST and leaves the owning Program print to that compiler.
+ */
+export function lowerSlotMemoFunctions(ast, options) {
+	const state = { lowered: 0 };
+	const analyze = (node) =>
+		analyzeInlineMemoCall(node, {
+			allowMissingSlot: options.allowMissingSlot === true,
+			allowUnbound: options.allowUnbound === true,
+			canonicalHookName: options.canonicalHookName,
+		});
+
+	function makeContext(fn) {
+		const locals = [];
+		return {
+			enabled: isInlineMemoOwnerSafe(fn),
+			locals,
+			temp(preferred, labelOnly = false) {
+				const name = options.allocateName(preferred);
+				if (!labelOnly) locals.push(name);
+				return name;
+			},
+			runtime(imported) {
+				return options.requireRuntime(imported);
+			},
+		};
+	}
+
+	function visitFunction(fn) {
+		const context = makeContext(fn);
+		// Opaque execution directives can serialize or otherwise reinterpret the
+		// entire function, including nested functions and classes. Do not add
+		// cache code anywhere inside an owner whose scope must remain intact.
+		if (!context.enabled) return fn;
+		// Parameter initializers execute before body-local lets are initialized.
+		// Only nested functions inside parameters may get their own lowering.
+		const params = mapChildren(fn.params || [], (node) => visit(node, null));
+		let body = visit(fn.body, context);
+		if (context.locals.length > 0) {
+			if (body.type !== 'BlockStatement') {
+				body = inheritHookMemoOrigin(b.block([b.return(body)]), fn.body);
+			}
+			const at = directiveEnd(body.body);
+			const declaration = inheritHookMemoOrigin(
+				b.declaration(
+					'let',
+					context.locals.map((name) => b.declarator(name, null)),
+				),
+				fn.body,
+			);
+			body = {
+				...body,
+				body: [...body.body.slice(0, at), declaration, ...body.body.slice(at)],
+			};
+		}
+		return params === fn.params && body === fn.body
+			? fn
+			: {
+					...fn,
+					params,
+					body,
+					...(fn.type === 'ArrowFunctionExpression'
+						? { expression: body.type !== 'BlockStatement' }
+						: null),
+				};
+	}
+
+	function blockMemoOf(value, context) {
+		if (!context?.enabled) return null;
+		const entry = analyze(unwrapValue(value));
+		return entry !== null && entry.expression === null ? entry : null;
+	}
+
+	function mappedEntry(entry, context) {
+		const call = mapChildren(entry.call, (node) => visit(node, context));
+		return analyze(call);
+	}
+
+	function lowerDirectValue(value, entry, context) {
+		const result = context.temp('__hkr');
+		const mapped = mappedEntry(entry, context);
+		const block = buildSlotMemoStatements(mapped, context, b.id(result));
+		state.lowered++;
+		return {
+			block,
+			value: replaceWrappedValue(value, b.id(result, entry.call)),
+		};
+	}
+
+	function visitStatementList(statements, context) {
+		const out = [];
+		let changed = false;
+		for (const statement of statements) {
+			if (statement.type === 'VariableDeclaration' && context?.enabled) {
+				let pending = [];
+				let split = false;
+				for (const declaration of statement.declarations) {
+					const entry = blockMemoOf(declaration.init, context);
+					if (entry === null) {
+						pending.push(visit(declaration, context));
+						continue;
+					}
+					if (pending.length > 0) {
+						out.push({ ...statement, declarations: pending });
+						pending = [];
+					}
+					const lowered = lowerDirectValue(declaration.init, entry, context);
+					out.push(lowered.block, {
+						...statement,
+						declarations: [{ ...declaration, init: lowered.value }],
+					});
+					split = true;
+				}
+				if (pending.length > 0) {
+					const same =
+						!split &&
+						pending.every((declaration, index) => declaration === statement.declarations[index]);
+					out.push(same ? statement : { ...statement, declarations: pending });
+					if (!same) changed = true;
+				}
+				if (split) changed = true;
+				continue;
+			}
+			const value =
+				statement.type === 'ReturnStatement'
+					? statement.argument
+					: statement.type === 'ExpressionStatement'
+						? statement.expression
+						: null;
+			const entry = blockMemoOf(value, context);
+			if (entry !== null) {
+				const lowered = lowerDirectValue(value, entry, context);
+				out.push(
+					lowered.block,
+					statement.type === 'ReturnStatement'
+						? { ...statement, argument: lowered.value }
+						: { ...statement, expression: lowered.value },
+				);
+				changed = true;
+				continue;
+			}
+			const mapped = visit(statement, context);
+			if (mapped !== statement) changed = true;
+			out.push(mapped);
+		}
+		return changed ? out : statements;
+	}
+
+	function visit(node, context) {
+		if (node === null || typeof node !== 'object') return node;
+		if (Array.isArray(node)) return mapChildren(node, (child) => visit(child, context));
+		if (FUNCTION_TYPES.has(node.type)) return visitFunction(node);
+		// Field initializers can execute after their enclosing function returns,
+		// and several instances can share that function's lexical environment.
+		// They cannot borrow its mutable cache temporaries. Methods still receive
+		// their own function context when visited below this boundary.
+		if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+			return mapChildren(node, (child) => visit(child, null));
+		}
+		if (node.type === 'BlockStatement') {
+			const body = visitStatementList(node.body, context);
+			return body === node.body ? node : { ...node, body };
+		}
+		if (node.type === 'SwitchCase') {
+			const test = visit(node.test, context);
+			const consequent = visitStatementList(node.consequent, context);
+			return test === node.test && consequent === node.consequent
+				? node
+				: { ...node, test, consequent };
+		}
+		// A braceless return/expression arm needs a block. Declarations are only
+		// expanded by their owning statement list so their lexical scope survives.
+		if (node.type === 'ReturnStatement' || node.type === 'ExpressionStatement') {
+			const key = node.type === 'ReturnStatement' ? 'argument' : 'expression';
+			const entry = blockMemoOf(node[key], context);
+			if (entry !== null) {
+				const lowered = lowerDirectValue(node[key], entry, context);
+				return inheritHookMemoOrigin(
+					b.block([lowered.block, { ...node, [key]: lowered.value }]),
+					node,
+				);
+			}
+		}
+		if (node.type === 'CallExpression' && context?.enabled) {
+			// Prove the original factory before visiting descendants. Otherwise an
+			// inner lowered hook could disappear and incorrectly make its enclosing
+			// memo factory look hook-free.
+			const entry = analyze(node);
+			const mapped = mapChildren(node, (child) => visit(child, context));
+			if (entry !== null && entry.expression !== null) {
+				const lowered = buildSlotMemoExpression(analyze(mapped), context);
+				state.lowered++;
+				return lowered;
+			}
+			return mapped;
+		}
+		return mapChildren(node, (child) => visit(child, context));
+	}
+
+	return { ast: visit(ast, null), lowered: state.lowered };
+}

--- a/packages/octane/src/compiler/plain-hook-memo.js
+++ b/packages/octane/src/compiler/plain-hook-memo.js
@@ -1,0 +1,274 @@
+// Production-only whole-Program path for plain TypeScript/JavaScript hooks.
+// Unlike slot-hooks' line-preserving fallback, every generated token here is
+// AST and esrap prints the completed TypeScript Program exactly once.
+
+import { builders as b, clone_ast_node as cloneAstNode } from '@tsrx/core';
+import { print as esrapPrint } from 'esrap';
+import esrapTsx from 'esrap/languages/tsx';
+import { METHOD_DEP_IMPORT } from './hook-deps.js';
+import {
+	hasInlineMemoDirectEval,
+	inheritHookMemoOrigin,
+	lowerSlotMemoFunctions,
+} from './inline-hook-memo.js';
+
+const META_KEYS = new Set([
+	'loc',
+	'start',
+	'end',
+	'range',
+	'metadata',
+	'parent',
+	'leadingComments',
+	'trailingComments',
+	'innerComments',
+	'comments',
+]);
+const PURE_COMMENTS = [{ type: 'Block', value: ' @__PURE__ ' }];
+
+function mapChildren(node, visit) {
+	if (node === null || typeof node !== 'object') return node;
+	if (Array.isArray(node)) {
+		let out = null;
+		for (let i = 0; i < node.length; i++) {
+			const mapped = visit(node[i]);
+			if (out === null && mapped !== node[i]) out = node.slice(0, i);
+			if (out !== null) out.push(mapped);
+		}
+		return out ?? node;
+	}
+	let out = null;
+	for (const key in node) {
+		if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+		const value = node[key];
+		if (value === null || typeof value !== 'object') continue;
+		const mapped = visit(value);
+		if (mapped !== value) {
+			if (out === null) out = { ...node };
+			out[key] = mapped;
+		}
+	}
+	return out ?? node;
+}
+
+function walkNodes(root, visit) {
+	function walk(node) {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (visit(node) === false) return;
+		for (const key in node) {
+			if (META_KEYS.has(key) || key.startsWith('_octane')) continue;
+			walk(node[key]);
+		}
+	}
+	walk(root);
+}
+
+function collectUsedNames(ast) {
+	const names = new Set();
+	walkNodes(ast, (node) => {
+		if (node.type === 'Identifier') names.add(node.name);
+	});
+	return names;
+}
+
+function allocName(state, preferred) {
+	let name = preferred;
+	while (state.usedNames.has(name)) name += '$';
+	state.usedNames.add(name);
+	return name;
+}
+
+function requireHelper(state, imported, request = 'octane/internal/client') {
+	const key = `${request}\0${imported}`;
+	let helper = state.helpers.get(key);
+	if (helper === undefined) {
+		helper = { imported, local: allocName(state, `_$${imported}`), request };
+		state.helpers.set(key, helper);
+	}
+	return helper.local;
+}
+
+function pure(node) {
+	return { ...node, __octanePure: true };
+}
+
+function allocateHookSlot(state, origin) {
+	const index = state.slotDeclarations.length;
+	if (state.slotBase === null) state.slotBase = allocName(state, '_hs$');
+	const name = allocName(state, `_h$${index}`);
+	const offset =
+		index === 0 ? b.id(state.slotBase) : b.binary('+', b.id(state.slotBase), b.literal(index));
+	state.slotDeclarations.push(
+		inheritHookMemoOrigin(b.const(name, pure(b.call('Symbol', offset))), origin),
+	);
+	return b.id(name, origin);
+}
+
+function inferredDependencyArray(inferred, state, origin) {
+	return inheritHookMemoOrigin(
+		b.array(
+			inferred.dependencies.map((dependency) =>
+				dependency.method
+					? b.call(
+							requireHelper(state, METHOD_DEP_IMPORT, 'octane'),
+							cloneAstNode(dependency.method.root),
+							b.literal(dependency.method.name),
+						)
+					: cloneAstNode(dependency.node),
+			),
+		),
+		origin,
+	);
+}
+
+// Match the surgical pass's BASE-hook-only policy. Custom hooks remain normal
+// calls; their compiled caller owns withSlot. Existing explicit memo slots are
+// already the effective third argument, so no unused fourth argument is added.
+function slotBaseHooks(ast, state, options) {
+	function visit(node) {
+		if (node === null || typeof node !== 'object') return node;
+		if (Array.isArray(node)) return mapChildren(node, visit);
+		const imported = node.type === 'CallExpression' ? node._octaneImportedHook : undefined;
+		if (imported === undefined || !options.hookNames.has(imported)) {
+			return mapChildren(node, visit);
+		}
+		const inferred = options.inferred.get(node);
+		const explicitMemoSlot =
+			(imported === 'useMemo' || imported === 'useCallback') &&
+			inferred === undefined &&
+			node.arguments.length === 3 &&
+			!node.arguments.some((argument) => argument.type === 'SpreadElement');
+		const slot = explicitMemoSlot ? null : allocateHookSlot(state, node);
+		const mapped = mapChildren(node, visit);
+		const args = mapped.arguments.slice();
+		if (inferred !== undefined) {
+			args.splice(inferred.depsIndex, 0, inferredDependencyArray(inferred, state, node));
+		}
+		if (slot !== null) args.push(slot);
+		let callee = mapped.callee;
+		if (options.getterCalls.has(node) && options.stateGetterHelpers[imported]) {
+			callee = b.id(requireHelper(state, options.stateGetterHelpers[imported], 'octane'), node);
+		}
+		return { ...mapped, callee, arguments: args };
+	}
+	return visit(ast);
+}
+
+function collectComments(ast) {
+	const comments = new Map();
+	const seen = new WeakSet();
+	function visit(node) {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child);
+			return;
+		}
+		if (
+			(node.type === 'Block' || node.type === 'Line') &&
+			typeof node.value === 'string' &&
+			node.loc
+		) {
+			comments.set(`${node.start}:${node.end}`, node);
+			return;
+		}
+		for (const key in node) {
+			if (key === 'loc' || key === 'metadata' || key === 'parent') continue;
+			visit(node[key]);
+		}
+	}
+	visit(ast);
+	return [...comments.values()].sort((left, right) => left.start - right.start);
+}
+
+function canPrintProgram(ast, visitors) {
+	let supported = true;
+	walkNodes(ast, (node) => {
+		if (typeof node.type === 'string' && typeof visitors[node.type] !== 'function') {
+			supported = false;
+			return false;
+		}
+		return supported;
+	});
+	return supported;
+}
+
+/**
+ * Try the whole-AST path using the already parsed, hook-annotated authored
+ * Program. Returning null asks the caller to retain its surgical behavior.
+ */
+export function inlinePlainHookMemos(ast, source, id, options) {
+	// Even a sibling function's eval can observe newly added module imports.
+	// Keep the entire rare-eval module on the unchanged surgical path.
+	if (source.startsWith('#!') || hasInlineMemoDirectEval(ast)) return null;
+	let hasMemo = false;
+	let hasUse = false;
+	walkNodes(ast, (node) => {
+		if (node.type !== 'CallExpression') return;
+		const imported = node._octaneImportedHook;
+		if (imported === 'useMemo' || imported === 'useCallback') hasMemo = true;
+		if (imported === 'use') hasUse = true;
+	});
+	// The existing parallel-use pass has its own grouping and warm behavior.
+	// Keep those modules entirely on that path until both transforms share AST.
+	if (!hasMemo || hasUse) return null;
+	const visitors = esrapTsx({
+		comments: collectComments(ast),
+		getLeadingComments: (node) => (node.__octanePure ? PURE_COMMENTS : undefined),
+	});
+	if (!canPrintProgram(ast, visitors)) return null;
+	const state = {
+		usedNames: collectUsedNames(ast),
+		helpers: new Map(),
+		slotBase: null,
+		slotDeclarations: [],
+	};
+	let transformed = options.manualSlots ? ast : slotBaseHooks(ast, state, options);
+	const lowered = lowerSlotMemoFunctions(transformed, {
+		allocateName: (preferred) => allocName(state, preferred),
+		requireRuntime: (imported) => requireHelper(state, imported),
+		allowMissingSlot: options.manualSlots === true,
+	});
+	if (lowered.lowered === 0) return null;
+	transformed = lowered.ast;
+	const origin = ast.body[0] ?? ast;
+	const trailing = [];
+	if (state.slotDeclarations.length > 0) {
+		const hookSlots = requireHelper(state, 'hookSlots', 'octane');
+		trailing.push(
+			inheritHookMemoOrigin(
+				b.const(state.slotBase, pure(b.call(hookSlots, b.literal(state.slotDeclarations.length)))),
+				origin,
+			),
+			...state.slotDeclarations,
+		);
+	}
+	const byRequest = new Map();
+	for (const helper of state.helpers.values()) {
+		let specifiers = byRequest.get(helper.request);
+		if (specifiers === undefined) byRequest.set(helper.request, (specifiers = []));
+		specifiers.push(b.import_specifier(helper.imported, helper.local));
+	}
+	const imports = [...byRequest].map(([request, specifiers]) =>
+		inheritHookMemoOrigin(b.import_declaration(specifiers, request), origin),
+	);
+	const program = { ...transformed, body: [...transformed.body, ...imports, ...trailing] };
+	// One TS-preserving print, with real mappings. Never feed this generated code
+	// back through the surgical pass or parse it into a second compiler pipeline.
+	try {
+		const printed = esrapPrint(program, visitors, {
+			sourceMapSource: id,
+			sourceMapContent: source,
+		});
+		return { code: printed.code, map: printed.map };
+	} catch {
+		// A parser can support a TypeScript shape before its esrap visitor does.
+		// Unsupported authored syntax must remain the host toolchain's input,
+		// rather than becoming a production-only compiler error.
+		return null;
+	}
+}

--- a/packages/octane/src/compiler/slot-hooks.js
+++ b/packages/octane/src/compiler/slot-hooks.js
@@ -1,10 +1,9 @@
 // Lightweight, surgical hook-slotting for plain `.ts`/`.js` modules.
 //
-// The full `compile()` path re-emits the whole module (esrap), which can't print
-// arbitrary TypeScript (index signatures, generic call signatures, type aliases) —
-// so it's reserved for `.tsrx`/`.tsx`. A custom hook can also live in a plain
-// module, though, and its base octane hooks still need a per-call-site slot key
-// or they throw "useState was called without a hook slot" at runtime.
+// A custom hook can live in a plain module, and its base octane hooks still
+// need per-call-site slots. The default path preserves arbitrary TypeScript
+// byte-for-byte. Production bundlers may additionally select the separate
+// whole-AST memo path, which preserves TypeScript and supplies a source map.
 //
 // This pass parses the module (for byte offsets), finds ONLY octane BASE hook
 // calls, and splices a trailing compiler slot into each — every other byte (all the
@@ -17,6 +16,7 @@
 import { parseModule } from '@tsrx/core';
 import { HOOK_NAMES, hookSlotHash } from './compile.js';
 import { METHOD_DEP_IMPORT, annotateHookCalls } from './hook-deps.js';
+import { inlinePlainHookMemos } from './plain-hook-memo.js';
 import { assertStrongMode } from './strong-mode.js';
 
 // Build a cheap import-presence gate. Precise call identity is annotated by the
@@ -1005,12 +1005,15 @@ function walk(node, owner, st) {
  *
  * @param {string} source raw module text
  * @param {string} id     module id (embedded in the stable Symbol.for key)
- * @param {{ environment?: 'client' | 'server', strong?: boolean, hmr?: boolean, profile?: boolean, profileFilename?: string, isVoidComponentImport?: (request: string, imported: string) => boolean }} [options] `hmr: true` (dev serve) emits
+ * @param {{ environment?: 'client' | 'server', strong?: boolean, hmr?: boolean, dev?: boolean, profile?: boolean, profileFilename?: string, inlineHookMemo?: boolean, manualSlots?: boolean, universalRuntime?: unknown, renderer?: { target?: string }, isVoidComponentImport?: (request: string, imported: string) => boolean }} [options] `hmr: true` (dev serve) emits
  *   `Symbol.for(stableKey)` so a re-imported module resolves the same hook
  *   slots (state survives HMR); off (ordinary prod builds and SSR) emits
  *   runtime-ranged Symbols. Profiling retains short described Symbols because
  *   hook metadata is keyed by Symbol identity.
- * @returns {{ code: string, map: null } | null}
+ *   `inlineHookMemo: true` enables the production-client whole-AST memo path;
+ *   the default remains surgical. `manualSlots: true` permits only that memo
+ *   rewrite and never injects or changes the module's authored slot policy.
+ * @returns {{ code: string, map: any } | null}
  */
 export function slotHooks(source, id, options) {
 	const environment = options?.environment ?? 'client';
@@ -1041,16 +1044,41 @@ export function slotHooks(source, id, options) {
 	// inference keyed by the rebuilt calls.
 	let inferred = new Map();
 	if (importInfo.importsHook) {
-		const annotated = annotateHookCalls(ast, { filename: id, onlyImported: true });
+		const annotated = annotateHookCalls(ast, {
+			filename: id,
+			onlyImported: true,
+			...(options?.manualSlots === true ? { inferDependencies: false } : null),
+		});
 		ast = annotated.ast;
 		inferred = annotated.inferred;
 	}
+	const getterCalls = importInfo.importsHook ? collectStateGetterCalls(ast) : new WeakSet();
+	if (
+		options?.inlineHookMemo === true &&
+		environment === 'client' &&
+		!options?.hmr &&
+		!options?.dev &&
+		!options?.profile &&
+		options?.universalRuntime == null &&
+		options?.renderer?.target !== 'universal' &&
+		!(canSpecializeRoot && collectVoidRootCandidates(ast).length > 0)
+	) {
+		const inlined = inlinePlainHookMemos(ast, source, id, {
+			manualSlots: options?.manualSlots === true,
+			hookNames: HOOK_NAMES,
+			inferred,
+			getterCalls,
+			stateGetterHelpers: STATE_GETTER_HELPERS,
+		});
+		if (inlined !== null) return inlined;
+	}
+	if (options?.manualSlots === true) return null;
 
 	const st = {
 		locals: importInfo.locals,
 		source,
 		inferred,
-		getterCalls: importInfo.importsHook ? collectStateGetterCalls(ast) : new WeakSet(),
+		getterCalls,
 		getterHelpers: new Map(),
 		filename: id,
 		profileFilename: (options && options.profileFilename) || id,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -5197,9 +5197,9 @@ export const useLayoutEffect = useEffect;
 export const useInsertionEffect = useEffect;
 export function useImperativeHandle(): void {}
 
-export function useMemo<T>(compute: () => T, deps?: readonly unknown[] | null, slot?: symbol): T;
-export function useMemo<T>(
-	compute: () => T,
+function memoHookValue<T>(
+	input: T | (() => T),
+	compute: boolean,
 	depsOrSlot?: readonly unknown[] | null | ServerHookSlot,
 	maybeSlot?: ServerHookSlot,
 ): T {
@@ -5208,18 +5208,27 @@ export function useMemo<T>(
 		maybeSlot ?? (Array.isArray(depsOrSlot) || depsOrSlot === null ? undefined : depsOrSlot);
 	// `null` means recompute every pass. Omitted dependency arrays reach the
 	// runtime as compiler-inferred arrays, preserving Octane's documented API.
-	if (deps === null) return compute();
+	if (deps === null) return compute ? (input as () => T)() : (input as T);
 	const position = hookPosition(slot);
-	if (position === null) return compute();
+	if (position === null) return compute ? (input as () => T)() : (input as T);
 	let rec = position.list[position.index] as MemoHookRec | undefined;
 	if (rec === undefined) {
-		rec = { value: compute(), deps: deps.slice() };
+		rec = { value: compute ? (input as () => T)() : input, deps: deps.slice() };
 		position.list[position.index] = rec;
 	} else if (!serverDepsEqual(rec.deps, deps)) {
-		rec.value = compute();
+		rec.value = compute ? (input as () => T)() : input;
 		rec.deps = deps.slice();
 	}
 	return rec.value as T;
+}
+
+export function useMemo<T>(compute: () => T, deps?: readonly unknown[] | null, slot?: symbol): T;
+export function useMemo<T>(
+	compute: () => T,
+	depsOrSlot?: readonly unknown[] | null | ServerHookSlot,
+	maybeSlot?: ServerHookSlot,
+): T {
+	return memoHookValue<T>(compute, true, depsOrSlot, maybeSlot);
 }
 
 export function useCallback<F>(fn: F, deps?: readonly unknown[] | null, slot?: symbol): F;
@@ -5228,7 +5237,7 @@ export function useCallback<F>(
 	depsOrSlot?: readonly unknown[] | null | ServerHookSlot,
 	maybeSlot?: ServerHookSlot,
 ): F {
-	return (useMemo as any)(() => fn, depsOrSlot, maybeSlot) as F;
+	return memoHookValue<F>(fn, false, depsOrSlot, maybeSlot);
 }
 
 export function useRef<T = undefined>(): { current: T | undefined };

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1163,7 +1163,7 @@ let deferringStagedRevealEffects = false;
 // same render patched on the way past. The attempt makes the render undoable:
 // journal window over the origin's whole render, live-queue checkpoints for the
 // work it enqueued, the flushed cells reverted to the recorded baseValues, and
-// the parallel-use entries it replaced swapped back.
+// the hook-map and inline memo entries it replaced swapped back.
 //
 // The pending cue needs no special treatment: `slotRef.isPending` was flipped
 // by the listener pass and survives the unwind. Re-rendering the origin at
@@ -1171,7 +1171,7 @@ let deferringStagedRevealEffects = false;
 // bindings — every other binding no-ops on its restored bag guard, and old
 // cells render previously committed (cached) content, so it cannot suspend.
 //
-// On settle the hold PROMOTES: parallel-use entries swap forward, cells write
+// On settle the hold PROMOTES: memo entries swap forward, cells write
 // forward, and an ordinary transition drain commits the whole screen in one
 // flush — or suspends on a later dependency and goes around again. Warm-walk
 // creations are carried on the hold as an episode-agnostic HARVEST, because
@@ -1184,6 +1184,10 @@ let deferringStagedRevealEffects = false;
 // store — falls back to today's per-boundary behavior untouched.
 // ─────────────────────────────────────────────────────────────────────────────
 
+type TransitionMemoSwap =
+	| [kind: 0, hooks: Map<HookSlot, unknown>, slot: HookSlot, previous: unknown, next: unknown]
+	| [kind: 1, cells: any[], base: number, previous: any[], next: any[]];
+
 interface TransitionAttempt {
 	origin: Block;
 	journalCheckpoint: number;
@@ -1195,8 +1199,8 @@ interface TransitionAttempt {
 	refDetach: number;
 	effectDeps: EffectDepsSnapshot;
 	heldSlots: Set<TrySlot> | null;
-	/** [hooksMap, slot, previousEntry, nextEntry] — undone on hold, redone on promotion. */
-	puSwaps: Array<[Map<HookSlot, unknown>, HookSlot, unknown, unknown]> | null;
+	/** Hook-map entries and inline memo-cell ranges: undone on hold, redone on promotion. */
+	memoSwaps: TransitionMemoSwap[] | null;
 }
 
 let ACTIVE_TRANSITION_ATTEMPT: TransitionAttempt | null = null;
@@ -1215,7 +1219,7 @@ interface WarmHarvestEntry {
 let HELD_SYNC_TRANSITION: {
 	origin: Block;
 	entries: Array<TransitionActionUpdate<any>>;
-	puSwaps: Array<[Map<HookSlot, unknown>, HookSlot, unknown, unknown]> | null;
+	memoSwaps: TransitionMemoSwap[] | null;
 	/** Values the attempt's warm walk created, adoptable in ANY later round's
 	 * episode. `taken` resets on each re-revert so every round can adopt. */
 	warmHarvest: WarmHarvestEntry[] | null;
@@ -1225,12 +1229,12 @@ let HELD_SYNC_TRANSITION: {
 /**
  * Swaps a promotion applied forward, pending the promoted round's outcome. A
  * held transition can take several rounds — each settle promotes, renders, and
- * may suspend on a LATER dependency. The next round's unwind must swap back
- * everything promoted so far, not just that round's own publishes, or the cue
- * re-render dep-misses the earlier slots and re-creates old-version requests.
+ * may suspend on a LATER dependency. Earlier publications remain available to
+ * the continuing rounds, which do not need another old-input cue render. This
+ * carrier both retains those values and identifies a continuing attempt.
  * Cleared when a promoted round commits or the transition is discarded.
  */
-let PROMOTED_PU_SWAPS: Array<[Map<HookSlot, unknown>, HookSlot, unknown, unknown]> | null = null;
+let PROMOTED_MEMO_SWAPS: TransitionMemoSwap[] | null = null;
 /** The harvest survives promotion the same way, for the round after next. */
 let PROMOTED_WARM_HARVEST: WarmHarvestEntry[] | null = null;
 
@@ -1254,7 +1258,7 @@ function beginTransitionAttempt(block: Block): TransitionAttempt | null {
 		refDetach: refDetachQueue.length,
 		effectDeps: snapshotSubtreeEffectDeps(block),
 		heldSlots: null,
-		puSwaps: null,
+		memoSwaps: null,
 	};
 	ACTIVE_TRANSITION_ATTEMPT = attempt;
 	return attempt;
@@ -1266,7 +1270,7 @@ function endTransitionAttempt(attempt: TransitionAttempt | null): void {
 	const held = attempt.heldSlots;
 	// A promoted round that ran to commit makes its forward state canon.
 	if (held === null || held.size === 0) {
-		PROMOTED_PU_SWAPS = null;
+		PROMOTED_MEMO_SWAPS = null;
 		PROMOTED_WARM_HARVEST = null;
 	}
 	// The unwind is only sound when the driving cells can be reverted with it:
@@ -1308,26 +1312,23 @@ function endTransitionAttempt(attempt: TransitionAttempt | null): void {
 		refAttachQueue.length = attempt.refAttach;
 		refDetachQueue.length = attempt.refDetach;
 		restoreSubtreeEffectDeps(attempt.origin, attempt.effectDeps);
-		// FIRST hold of a transition: swap the parallel-use entries back so the
+		// FIRST hold of a transition: swap the memo entries back so the
 		// cue re-render dep-hits the old creations instead of re-fetching them,
 		// and schedule that cue re-render below. A CONTINUING round (a promoted
 		// render suspending on a later dependency) needs neither: the old screen
 		// and the cue bindings were re-established in round one and the journal
-		// rollback above just restored them — so the parallel-use entries stay
+		// rollback above just restored them — so the memo entries stay
 		// monotonically FORWARD, and every later round dep-hits them outright.
-		const continuing = PROMOTED_PU_SWAPS !== null || PROMOTED_WARM_HARVEST !== null;
-		let puSwaps = attempt.puSwaps;
+		const continuing = PROMOTED_MEMO_SWAPS !== null || PROMOTED_WARM_HARVEST !== null;
+		let memoSwaps = attempt.memoSwaps;
 		if (continuing) {
-			if (PROMOTED_PU_SWAPS !== null) {
-				puSwaps = puSwaps === null ? PROMOTED_PU_SWAPS : PROMOTED_PU_SWAPS.concat(puSwaps);
-				PROMOTED_PU_SWAPS = null;
+			if (PROMOTED_MEMO_SWAPS !== null) {
+				memoSwaps =
+					memoSwaps === null ? PROMOTED_MEMO_SWAPS : PROMOTED_MEMO_SWAPS.concat(memoSwaps);
+				PROMOTED_MEMO_SWAPS = null;
 			}
-		} else if (puSwaps !== null) {
-			for (let i = puSwaps.length - 1; i >= 0; i--) {
-				const [hooks, slot, prev] = puSwaps[i];
-				if (prev === undefined) hooks.delete(slot);
-				else hooks.set(slot, prev);
-			}
+		} else if (memoSwaps !== null) {
+			for (let i = memoSwaps.length - 1; i >= 0; i--) applyTransitionMemoSwap(memoSwaps[i], false);
 		}
 		for (let i = 0; i < entries.length; i++) {
 			entries[i].slot.value = entries[i].baseValue;
@@ -1365,7 +1366,7 @@ function endTransitionAttempt(attempt: TransitionAttempt | null): void {
 		HELD_SYNC_TRANSITION = {
 			origin: attempt.origin,
 			entries,
-			puSwaps,
+			memoSwaps,
 			warmHarvest,
 			holders: new Set(held),
 		};
@@ -1383,7 +1384,7 @@ function endTransitionAttempt(attempt: TransitionAttempt | null): void {
 }
 
 /**
- * Record a parallel-use memo entry the attempt replaces, with both directions.
+ * Record a hook-map memo entry the attempt replaces, with both directions.
  * The cue re-render renders the OLD inputs and must dep-hit the old entries —
  * a miss would re-create old-version requests against data sources that have
  * moved on. The PROMOTED render renders the NEW inputs and must dep-hit the
@@ -1392,11 +1393,30 @@ function endTransitionAttempt(attempt: TransitionAttempt | null): void {
  * Attempt-owned: the per-boundary journal windows predate this and keep their
  * pinned replay behavior.
  */
-function journalPuEntry(scope: Scope, slot: HookSlot, next: unknown): void {
+function journalMemoEntry(scope: Scope, slot: HookSlot, next: unknown): void {
 	const attempt = ACTIVE_TRANSITION_ATTEMPT;
 	if (attempt === null) return;
 	const hooks = ensureHooks(scope);
-	(attempt.puSwaps ??= []).push([hooks, slot, hooks.get(slot), next]);
+	(attempt.memoSwaps ??= []).push([0, hooks, slot, hooks.get(slot), next]);
+}
+
+/** Inline memos publish immediately too, but hold/promotion must restore each
+ * complete entry rather than leaving its deps and value from different renders. */
+function journalHookMemoCells(cells: any[], base: number, next: any[]): void {
+	const attempt = ACTIVE_TRANSITION_ATTEMPT;
+	if (attempt === null) return;
+	(attempt.memoSwaps ??= []).push([1, cells, base, cells.slice(base, base + next.length), next]);
+}
+
+function applyTransitionMemoSwap(swap: TransitionMemoSwap, forward: boolean): void {
+	if (swap[0] === 0) {
+		const value = forward ? swap[4] : swap[3];
+		if (!forward && value === undefined) swap[1].delete(swap[2]);
+		else swap[1].set(swap[2], value);
+		return;
+	}
+	const values = forward ? swap[4] : swap[3];
+	for (let i = 0; i < values.length; i++) swap[1][swap[2] + i] = values[i];
 }
 
 /** True while the held cells are untouched — an in-place boundary success under
@@ -1416,15 +1436,13 @@ function promoteHeldSyncTransition(): boolean {
 	const held = HELD_SYNC_TRANSITION;
 	if (held === null) return false;
 	HELD_SYNC_TRANSITION = null;
-	// Swap the attempt's parallel-use creations forward BEFORE the renders run,
+	// Swap the attempt's memo entries forward BEFORE the renders run,
 	// so the promoted pass dep-hits everything the attempt already started.
-	const puSwaps = held.puSwaps;
-	if (puSwaps !== null) {
-		for (let i = 0; i < puSwaps.length; i++) {
-			const [hooks, slot, , next] = puSwaps[i];
-			hooks.set(slot, next);
-		}
-		PROMOTED_PU_SWAPS = PROMOTED_PU_SWAPS === null ? puSwaps : PROMOTED_PU_SWAPS.concat(puSwaps);
+	const memoSwaps = held.memoSwaps;
+	if (memoSwaps !== null) {
+		for (let i = 0; i < memoSwaps.length; i++) applyTransitionMemoSwap(memoSwaps[i], true);
+		PROMOTED_MEMO_SWAPS =
+			PROMOTED_MEMO_SWAPS === null ? memoSwaps : PROMOTED_MEMO_SWAPS.concat(memoSwaps);
 	}
 	// The harvest stays adoptable for this round's renders and, via the
 	// carrier, for the round after a re-suspend.
@@ -1459,7 +1477,7 @@ function discardHeldSyncTransition(state: TrySlot): void {
 	if (held === null || !held.holders.delete(state)) return;
 	if (held.holders.size === 0) {
 		HELD_SYNC_TRANSITION = null;
-		PROMOTED_PU_SWAPS = null;
+		PROMOTED_MEMO_SWAPS = null;
 		PROMOTED_WARM_HARVEST = null;
 	}
 }
@@ -6300,8 +6318,7 @@ function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, ph
 // normally supplies an inferred or explicit deps array before it. Keep the
 // trailing-symbol reinterpret for direct/uncompiled calls and normalize the
 // public `null` escape hatch to undefined; internally undefined means "run or
-// recompute on every commit/render". Shared by the effect hooks AND useMemo;
-// useCallback keeps its own reinterpret fork (it must forward the RAW slot).
+// recompute on every commit/render". Shared by the effect and memo hooks.
 function resolveHookArgs(
 	name: string,
 	deps: any[] | null | symbol | undefined,
@@ -6333,6 +6350,66 @@ export function useInsertionEffect(fn: EffectFn, deps?: any[] | null, slot?: Hoo
 	enqueueEffect(s, fn, d, INSERTION);
 }
 
+interface MemoHookEntry<T = any> {
+	deps: any[] | undefined;
+	value: T;
+	warmEpisode?: number;
+}
+
+function memoEntryHit<T>(slot: HookSlot, entry: MemoHookEntry<T>): MemoHookEntry<T> {
+	if (
+		entry.warmEpisode !== CURRENT_WARM_EPISODE &&
+		recordRealWarmMemo(slot, entry.deps as any[], entry)
+	) {
+		entry.warmEpisode = CURRENT_WARM_EPISODE;
+	}
+	return entry;
+}
+
+function adoptMemoEntry<T>(scope: Scope, slot: HookSlot, deps: any[]): MemoHookEntry<T> | null {
+	const adopted = adoptWarmValue(slot, deps);
+	if (adopted === WARM_MISS) return null;
+	const entry: MemoHookEntry<T> = {
+		deps,
+		value: adopted as T,
+		warmEpisode: CURRENT_WARM_EPISODE,
+	};
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalMemoEntry(scope, slot, entry);
+	ensureHooks(scope).set(slot, entry);
+	return entry;
+}
+
+function readMemoEntry<T>(
+	scope: Scope,
+	slot: HookSlot,
+	deps: any[] | undefined,
+): MemoHookEntry<T> | null {
+	const prev = scope.hooks?.get(slot) as MemoHookEntry<T> | undefined;
+	// deps === undefined → recompute every render (`null` at the public API;
+	// direct/uncompiled omitted calls also retain this runtime fallback).
+	if (prev && deps !== undefined && !depsChanged(prev.deps, deps)) {
+		return memoEntryHit(slot, prev);
+	}
+	// Parallel-use warming: before recomputing, adopt a prefetched creation for
+	// this slot (started by warmMemo during a suspended ancestor's warm walk) —
+	// the fetch is already in flight. Only compiler-warmed slots can hit;
+	// WARM_EVER keeps the ancestor walk off apps that never warm.
+	return WARM_EVER && deps !== undefined ? adoptMemoEntry(scope, slot, deps) : null;
+}
+
+function publishMemoEntry<T>(scope: Scope, slot: HookSlot, deps: any[] | undefined, value: T): T {
+	const entry: MemoHookEntry<T> = { deps, value };
+	// The attempt records the replacement both ways: the cue re-render must
+	// dep-hit the old entry (never re-create old-version requests), and the
+	// promoted render must dep-hit this one (never create twice).
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalMemoEntry(scope, slot, entry);
+	ensureHooks(scope).set(slot, entry);
+	if (deps !== undefined && recordRealWarmMemo(slot, deps, entry)) {
+		entry.warmEpisode = CURRENT_WARM_EPISODE;
+	}
+	return value;
+}
+
 export function useMemo<T>(compute: (...deps: any[]) => T, deps?: any[] | null, slot?: symbol): T;
 export function useMemo<T>(
 	compute: (...deps: any[]) => T,
@@ -6341,48 +6418,14 @@ export function useMemo<T>(
 ): T {
 	const [d, s] = resolveHookArgs('useMemo', deps, slot);
 	const scope = CURRENT_SCOPE!;
-	const prev = scope.hooks?.get(s) as
-		{ deps: any[] | undefined; value: T; warmEpisode?: number } | undefined;
-	// deps === undefined → recompute every render (`null` at the public API;
-	// direct/uncompiled omitted calls also retain this runtime fallback).
-	if (prev && d !== undefined && !depsChanged(prev.deps, d)) {
-		if (prev.warmEpisode !== CURRENT_WARM_EPISODE && recordRealWarmMemo(s, d, prev)) {
-			prev.warmEpisode = CURRENT_WARM_EPISODE;
-		}
-		return prev.value;
-	}
-	// Parallel-use warming: before recomputing, adopt a prefetched creation for
-	// this slot (started by warmMemo during a suspended ancestor's warm walk) —
-	// the fetch is already in flight. Only compiler-warmed slots can hit;
-	// WARM_EVER keeps the ancestor walk off apps that never warm.
-	if (WARM_EVER && d !== undefined) {
-		const adopted = adoptWarmValue(s, d);
-		if (adopted !== WARM_MISS) {
-			const adoptedEntry = {
-				deps: d,
-				value: adopted as T,
-				warmEpisode: CURRENT_WARM_EPISODE,
-			};
-			if (ACTIVE_TRANSITION_ATTEMPT !== null) journalPuEntry(scope, s, adoptedEntry);
-			ensureHooks(scope).set(s, adoptedEntry);
-			return adopted as T;
-		}
-	}
+	const entry = readMemoEntry<T>(scope, s, d);
+	if (entry !== null) return entry.value;
 	// Spread deps as positional args (superset of React — see PendingEffect.args):
 	// a factory written as a pure function of its deps is hoistable. Zero-arg
 	// React-style factories ignore the extra args.
 	// eslint-disable-next-line prefer-spread
 	const value = compute.apply(null, (d ?? []) as []);
-	const entry: { deps: any[] | undefined; value: T; warmEpisode?: number } = { deps: d, value };
-	// The attempt records the replacement both ways: the cue re-render must
-	// dep-hit the old entry (never re-create old-version requests), and the
-	// promoted render must dep-hit this one (never create twice).
-	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalPuEntry(scope, s, entry);
-	ensureHooks(scope).set(s, entry);
-	if (d !== undefined && recordRealWarmMemo(s, d, entry)) {
-		entry.warmEpisode = CURRENT_WARM_EPISODE;
-	}
-	return value;
+	return publishMemoEntry(scope, s, d, value);
 }
 
 export function useCallback<F extends (...args: any[]) => any>(
@@ -6395,21 +6438,106 @@ export function useCallback<F extends (...args: any[]) => any>(
 	deps?: any[] | null,
 	slot?: HookSlot,
 ): F {
-	// Trailing-symbol ABI (see resolveHookArgs): `useCallback(fn)` arrives as
-	// `useCallback(fn, slot)`. Reinterpret the omitted-deps case HERE so the slot Symbol
-	// can't leak into useMemo's `deps` array (it would in a custom-hook context, where
-	// resolveSlot turns the otherwise-undefined slot into the path prefix, defeating
-	// useMemo's own reinterpret guard). Forward the RAW slot — useMemo does the single
-	// resolveSlot; resolving here too and passing the result would double-combine the
-	// custom-hook path prefix into the wrong slot.
-	if (slot === undefined && typeof deps === 'symbol') {
-		slot = deps as unknown as symbol;
-		deps = undefined;
+	// Resolve the raw slot exactly once, including the omitted-deps Symbol ABI
+	// and a custom hook's path. The callback is a value: never invoke it or
+	// allocate another closure merely to return it on a cache miss.
+	const [d, s] = resolveHookArgs('useCallback', deps, slot);
+	const scope = CURRENT_SCOPE!;
+	const entry = readMemoEntry<F>(scope, s, d);
+	return entry === null ? publishMemoEntry(scope, s, d, fn) : entry.value;
+}
+
+/** Compiler-owned intrinsics cannot be shadowed by bindings in an authored body. */
+export const hookMemoEqual = Object.is;
+
+export function hookMemoCreate(size: number): any[] {
+	return new Array(size).fill(undefined);
+}
+
+/** Compiler ABI: publish a successful inline memo computation immediately.
+ * History is needed only while an attempt can hold the prior screen; ordinary
+ * suspend/replay continues to see the just-published cells. Fixed arities keep
+ * ordinary cache misses free of a rest-parameter dependency array. */
+export function hookMemoPublish0<T>(cells: any[], base: number, value: T): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalHookMemoCells(cells, base, [true, value]);
+	cells[base + 1] = value;
+	cells[base] = true;
+	return value;
+}
+
+export function hookMemoPublish1<T>(cells: any[], base: number, value: T, d0: any): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalHookMemoCells(cells, base, [true, d0, value]);
+	cells[base + 2] = value;
+	cells[base + 1] = d0;
+	cells[base] = true;
+	return value;
+}
+
+export function hookMemoPublish2<T>(cells: any[], base: number, value: T, d0: any, d1: any): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalHookMemoCells(cells, base, [true, d0, d1, value]);
+	cells[base + 3] = value;
+	cells[base + 1] = d0;
+	cells[base + 2] = d1;
+	cells[base] = true;
+	return value;
+}
+
+export function hookMemoPublish3<T>(
+	cells: any[],
+	base: number,
+	value: T,
+	d0: any,
+	d1: any,
+	d2: any,
+): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) {
+		journalHookMemoCells(cells, base, [true, d0, d1, d2, value]);
 	}
-	// Guard here (rather than letting useMemo throw) so the diagnostic names useCallback.
-	// resolveSlot is a read-only peek at the path stack, so this doesn't disturb useMemo's.
-	if (resolveSlot(slot) === undefined) missingSlot('useCallback');
-	return (useMemo as any)(() => fn, deps, slot) as F;
+	cells[base + 4] = value;
+	cells[base + 1] = d0;
+	cells[base + 2] = d1;
+	cells[base + 3] = d2;
+	cells[base] = true;
+	return value;
+}
+
+export function hookMemoPublish4<T>(
+	cells: any[],
+	base: number,
+	value: T,
+	d0: any,
+	d1: any,
+	d2: any,
+	d3: any,
+): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) {
+		journalHookMemoCells(cells, base, [true, d0, d1, d2, d3, value]);
+	}
+	cells[base + 5] = value;
+	cells[base + 1] = d0;
+	cells[base + 2] = d1;
+	cells[base + 3] = d2;
+	cells[base + 4] = d3;
+	cells[base] = true;
+	return value;
+}
+
+/** Larger dependency lists retain the compact variadic publication fallback. */
+export function hookMemoPublish<T>(cells: any[], base: number, value: T, ...deps: any[]): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) {
+		journalHookMemoCells(cells, base, [true, ...deps, value]);
+	}
+	cells[base + deps.length + 1] = value;
+	for (let i = 0; i < deps.length; i++) cells[base + i + 1] = deps[i];
+	cells[base] = true;
+	return value;
+}
+
+/** One-cell form for compiler-owned lifetime-invariant callback values. */
+export function hookMemoPublishInvariant<T>(cells: any[], base: number, value: T): T {
+	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalHookMemoCells(cells, base, [value]);
+	cells[base] = value;
+	return value;
 }
 
 export function useRef<T>(initial: T, slot?: symbol): { current: T };
@@ -9465,35 +9593,17 @@ function adoptWarmValue(slot: HookSlot, deps: any[]): any {
 
 export const puMiss: unique symbol = Symbol('octane.pu.miss');
 
-type PuMemoEntry = { deps: any[] | undefined; value: any; warmEpisode?: number };
-
-function puHit(slot: HookSlot, entry: PuMemoEntry): any {
-	if (
-		entry.warmEpisode !== CURRENT_WARM_EPISODE &&
-		recordRealWarmMemo(slot, entry.deps as any[], entry)
-	) {
-		entry.warmEpisode = CURRENT_WARM_EPISODE;
-	}
-	return entry.value;
-}
+type PuMemoEntry = MemoHookEntry;
 
 function puAdopt(slot: HookSlot, deps: any[]): any {
-	const adopted = adoptWarmValue(slot, deps);
-	if (adopted === WARM_MISS) return puMiss;
-	const adoptedEntry: PuMemoEntry = {
-		deps,
-		value: adopted,
-		warmEpisode: CURRENT_WARM_EPISODE,
-	};
-	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalPuEntry(CURRENT_SCOPE!, slot, adoptedEntry);
-	ensureHooks(CURRENT_SCOPE!).set(slot, adoptedEntry);
-	return adopted;
+	const entry = adoptMemoEntry(CURRENT_SCOPE!, slot, deps);
+	return entry === null ? puMiss : entry.value;
 }
 
 export function puTake0(slot: HookSlot): any {
 	const prev = CURRENT_SCOPE!.hooks?.get(slot) as PuMemoEntry | undefined;
 	if (prev !== undefined && prev.deps !== undefined && prev.deps.length === 0) {
-		return puHit(slot, prev);
+		return memoEntryHit(slot, prev).value;
 	}
 	if (WARM_EVER) return puAdopt(slot, []);
 	return puMiss;
@@ -9503,7 +9613,9 @@ export function puTake1(slot: HookSlot, d0: any): any {
 	const prev = CURRENT_SCOPE!.hooks?.get(slot) as PuMemoEntry | undefined;
 	if (prev !== undefined) {
 		const pd = prev.deps;
-		if (pd !== undefined && pd.length === 1 && Object.is(pd[0], d0)) return puHit(slot, prev);
+		if (pd !== undefined && pd.length === 1 && Object.is(pd[0], d0)) {
+			return memoEntryHit(slot, prev).value;
+		}
 	}
 	if (WARM_EVER) return puAdopt(slot, [d0]);
 	return puMiss;
@@ -9514,7 +9626,7 @@ export function puTake2(slot: HookSlot, d0: any, d1: any): any {
 	if (prev !== undefined) {
 		const pd = prev.deps;
 		if (pd !== undefined && pd.length === 2 && Object.is(pd[0], d0) && Object.is(pd[1], d1)) {
-			return puHit(slot, prev);
+			return memoEntryHit(slot, prev).value;
 		}
 	}
 	if (WARM_EVER) return puAdopt(slot, [d0, d1]);
@@ -9532,7 +9644,7 @@ export function puTake3(slot: HookSlot, d0: any, d1: any, d2: any): any {
 			Object.is(pd[1], d1) &&
 			Object.is(pd[2], d2)
 		) {
-			return puHit(slot, prev);
+			return memoEntryHit(slot, prev).value;
 		}
 	}
 	if (WARM_EVER) return puAdopt(slot, [d0, d1, d2]);
@@ -9551,7 +9663,7 @@ export function puTake4(slot: HookSlot, d0: any, d1: any, d2: any, d3: any): any
 			Object.is(pd[2], d2) &&
 			Object.is(pd[3], d3)
 		) {
-			return puHit(slot, prev);
+			return memoEntryHit(slot, prev).value;
 		}
 	}
 	if (WARM_EVER) return puAdopt(slot, [d0, d1, d2, d3]);
@@ -9559,11 +9671,102 @@ export function puTake4(slot: HookSlot, d0: any, d1: any, d2: any, d3: any): any
 }
 
 export function puPub(slot: HookSlot, value: any, ...deps: any[]): any {
-	const entry: PuMemoEntry = { deps, value };
-	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalPuEntry(CURRENT_SCOPE!, slot, entry);
-	ensureHooks(CURRENT_SCOPE!).set(slot, entry);
-	if (recordRealWarmMemo(slot, deps, entry)) entry.warmEpisode = CURRENT_WARM_EPISODE;
-	return value;
+	return publishMemoEntry(CURRENT_SCOPE!, slot, deps, value);
+}
+
+// General closure-free memo ABI for authored helpers/custom hooks. Resolve the
+// custom-hook path once, then retain the resolved slot through take + publish.
+// Unlike parallel-use's value sentinel, a nullable ENTRY handles every authored
+// memo value, including undefined, null, and puMiss itself. Dependency hits do
+// not construct a callback or dependency array.
+export function memoSlot(slot: HookSlot | undefined, name: 'useMemo' | 'useCallback'): HookSlot {
+	const resolved = resolveSlot(slot);
+	if (resolved === undefined) missingSlot(name);
+	return resolved;
+}
+
+export function memoTake0(slot: HookSlot): MemoHookEntry | null {
+	const scope = CURRENT_SCOPE!;
+	const prev = scope.hooks?.get(slot) as MemoHookEntry | undefined;
+	if (prev !== undefined && prev.deps !== undefined && prev.deps.length === 0) {
+		return memoEntryHit(slot, prev);
+	}
+	return WARM_EVER ? adoptMemoEntry(scope, slot, []) : null;
+}
+
+export function memoTake1(slot: HookSlot, d0: any): MemoHookEntry | null {
+	const scope = CURRENT_SCOPE!;
+	const prev = scope.hooks?.get(slot) as MemoHookEntry | undefined;
+	if (prev !== undefined) {
+		const pd = prev.deps;
+		if (pd !== undefined && pd.length === 1 && Object.is(pd[0], d0)) {
+			return memoEntryHit(slot, prev);
+		}
+	}
+	return WARM_EVER ? adoptMemoEntry(scope, slot, [d0]) : null;
+}
+
+export function memoTake2(slot: HookSlot, d0: any, d1: any): MemoHookEntry | null {
+	const scope = CURRENT_SCOPE!;
+	const prev = scope.hooks?.get(slot) as MemoHookEntry | undefined;
+	if (prev !== undefined) {
+		const pd = prev.deps;
+		if (pd !== undefined && pd.length === 2 && Object.is(pd[0], d0) && Object.is(pd[1], d1)) {
+			return memoEntryHit(slot, prev);
+		}
+	}
+	return WARM_EVER ? adoptMemoEntry(scope, slot, [d0, d1]) : null;
+}
+
+export function memoTake3(slot: HookSlot, d0: any, d1: any, d2: any): MemoHookEntry | null {
+	const scope = CURRENT_SCOPE!;
+	const prev = scope.hooks?.get(slot) as MemoHookEntry | undefined;
+	if (prev !== undefined) {
+		const pd = prev.deps;
+		if (
+			pd !== undefined &&
+			pd.length === 3 &&
+			Object.is(pd[0], d0) &&
+			Object.is(pd[1], d1) &&
+			Object.is(pd[2], d2)
+		) {
+			return memoEntryHit(slot, prev);
+		}
+	}
+	return WARM_EVER ? adoptMemoEntry(scope, slot, [d0, d1, d2]) : null;
+}
+
+export function memoTake4(
+	slot: HookSlot,
+	d0: any,
+	d1: any,
+	d2: any,
+	d3: any,
+): MemoHookEntry | null {
+	const scope = CURRENT_SCOPE!;
+	const prev = scope.hooks?.get(slot) as MemoHookEntry | undefined;
+	if (prev !== undefined) {
+		const pd = prev.deps;
+		if (
+			pd !== undefined &&
+			pd.length === 4 &&
+			Object.is(pd[0], d0) &&
+			Object.is(pd[1], d1) &&
+			Object.is(pd[2], d2) &&
+			Object.is(pd[3], d3)
+		) {
+			return memoEntryHit(slot, prev);
+		}
+	}
+	return WARM_EVER ? adoptMemoEntry(scope, slot, [d0, d1, d2, d3]) : null;
+}
+
+export function memoPublish<T>(slot: HookSlot, value: T, ...deps: any[]): T {
+	return publishMemoEntry(CURRENT_SCOPE!, slot, deps, value);
+}
+
+export function memoPublishAlways<T>(slot: HookSlot, value: T): T {
+	return publishMemoEntry(CURRENT_SCOPE!, slot, undefined, value);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -5608,7 +5608,12 @@ export function useEffect(
 	enqueueUniversalEffect('passive', create, deps, slot);
 }
 
-export function useMemo<T>(compute: () => T, deps?: readonly unknown[] | null, slot?: unknown): T {
+function memoHookValue<T>(
+	input: T | (() => T),
+	compute: boolean,
+	deps?: readonly unknown[] | null,
+	slot?: unknown,
+): T {
 	const owner = currentDraftOwner();
 	const resolved = resolveHookSlot(slot);
 	const previous = owner.hooks.get(resolved) as MemoHook<T> | undefined;
@@ -5628,11 +5633,17 @@ export function useMemo<T>(compute: () => T, deps?: readonly unknown[] | null, s
 	const warmed = takeUniversalWarmValue(owner.record.root, resolved, normalized);
 	const value =
 		warmed === NO_WARM_VALUE
-			? (compute as (...args: unknown[]) => T)(...(normalized ?? []))
+			? compute
+				? (input as (...args: unknown[]) => T)(...(normalized ?? []))
+				: (input as T)
 			: (warmed as T);
 	owner.hooks.set(resolved, { kind: 'memo', value, deps: normalized });
 	owner.clonedHooks.add(resolved);
 	return value;
+}
+
+export function useMemo<T>(compute: () => T, deps?: readonly unknown[] | null, slot?: unknown): T {
+	return memoHookValue<T>(compute, true, deps, slot);
 }
 
 export function useCallback<T extends (...args: any[]) => any>(
@@ -5640,7 +5651,7 @@ export function useCallback<T extends (...args: any[]) => any>(
 	deps?: readonly unknown[] | null,
 	slot?: unknown,
 ): T {
-	return useMemo(() => callback, deps, slot);
+	return memoHookValue<T>(callback, false, deps, slot);
 }
 
 export function useRef<T>(initial: T, slot?: unknown): { current: T } {

--- a/packages/octane/tests/_fixtures/hooks.tsrx
+++ b/packages/octane/tests/_fixtures/hooks.tsrx
@@ -108,6 +108,40 @@ export function CbTest(props) @{
 	<span>{props.label as string}</span>
 }
 
+function useForwardedCallback<T extends (...args: any[]) => any>(
+	callback: T,
+	dependencies: unknown[] | null,
+): T {
+	return useCallback(callback, dependencies);
+}
+
+export function ForwardedCallbackPair({
+	first,
+	second,
+	dependencies,
+	observe,
+	label,
+}: {
+	first: () => string;
+	second: () => string;
+	dependencies: unknown[] | null;
+	observe: (first: () => string, second: () => string) => void;
+	label: string;
+}) @{
+	const firstCallback = useForwardedCallback(first, dependencies);
+	const secondCallback = useForwardedCallback(second, dependencies);
+	observe(firstCallback, secondCallback);
+	<span>{label}</span>
+}
+
+export function CallbackRenderPass({ observe }: { observe: (callback: () => number) => void }) @{
+	const [step, setStep] = octaneUseState(0);
+	const callback = useForwardedCallback(() => step, []);
+	observe(callback);
+	if (step === 0) setStep(1);
+	<span>{'step=' + step + ' callback=' + callback()}</span>
+}
+
 // useRef — survives across renders, mutations don't trigger re-render.
 export function RefTest() @{
 	const ref = octaneUseRef(0);

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -1,7 +1,9 @@
 import {
 	use,
+	useCallback,
 	useEffect,
 	useLayoutEffect,
+	useMemo,
 	useReducer,
 	useState,
 	useTransition,
@@ -700,6 +702,146 @@ export function TransitionOutsideBoundary(props) @{
 			<ControlledValue load={props.load} step={step} />
 		} @pending {
 			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
+type MemoTransitionProps = {
+	load: (step: number) => PromiseLike<string>;
+	observe: (step: number, request: PromiseLike<string>, callback: () => number) => void;
+};
+
+function MemoTransitionValue({ load, observe, step }: MemoTransitionProps & { step: number }) @{
+	const request = useMemo(() => load(step), [load, step]);
+	const callback = useCallback(() => step, [step]);
+	observe(step, request, callback);
+	const value = use(request);
+	<span id="memo-value">{value as string}</span>
+}
+
+export function TransitionAuthoredMemo(props: MemoTransitionProps) @{
+	const [step, setStep] = useState(0);
+	const [tick, setTick] = useState(0);
+	<div>
+		<button id="memo-next" onClick={() => startTransition(() => setStep(1))}>{'next'}</button>
+		<button id="memo-urgent" onClick={() => setStep(2)}>{'urgent'}</button>
+		<button id="memo-refresh" onClick={() => setTick(tick + 1)}>{'refresh'}</button>
+		<h1 id="memo-shell">{'shell-' + step + ':' + tick}</h1>
+		@try {
+			<MemoTransitionValue load={props.load} observe={props.observe} step={step} />
+		} @pending {
+			<span id="memo-fallback">{'loading'}</span>
+		}
+	</div>
+}
+
+type MemoTransitionStagesProps = {
+	load: (step: number, stage: string) => PromiseLike<string>;
+};
+
+function MemoTransitionStagesValue({ load, step }: MemoTransitionStagesProps & { step: number }) @{
+	const firstRequest = useMemo(() => load(step, 'first'), [load, step]);
+	const first = use(firstRequest);
+	const secondRequest = useMemo(() => load(step, 'second'), [load, step]);
+	const second = use(secondRequest);
+	<span id="memo-stages-value">{first + '/' + second}</span>
+}
+
+export function TransitionAuthoredMemoStages(props: MemoTransitionStagesProps) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button
+			id="memo-stages-next"
+			onClick={() => startTransition(() => setStep(1))}
+		>{'next'}</button>
+		<h1 id="memo-stages-shell">{'shell-' + step}</h1>
+		@try {
+			<MemoTransitionStagesValue load={props.load} step={step} />
+		} @pending {
+			<span id="memo-stages-fallback">{'loading'}</span>
+		}
+	</div>
+}
+
+type InvariantMemoTransitionProps = {
+	promise: Promise<string>;
+	observe: (step: number, callback: () => void) => void;
+};
+
+function InvariantMemoTransitionValue({ step, promise, observe }: InvariantMemoTransitionProps & {
+	step: number;
+}) @{
+	const [count, setCount] = useState(0);
+	if (step === 0) return <span id="memo-invariant-value">{'zero'}</span>;
+	const increment = () => setCount((current) => current + 1);
+	observe(step, increment);
+	const value =
+		step === 1 ? use(promise) : 'urgent';
+	<button id="memo-invariant-value" onClick={increment}>{value + ':' + count}</button>
+}
+
+export function TransitionInvariantMemo(props: InvariantMemoTransitionProps) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button
+			id="memo-invariant-next"
+			onClick={() => startTransition(() => setStep(1))}
+		>{'next'}</button>
+		<button id="memo-invariant-urgent" onClick={() => setStep(2)}>{'urgent'}</button>
+		<h1 id="memo-invariant-shell">{'shell-' + step}</h1>
+		@try {
+			<InvariantMemoTransitionValue step={step} promise={props.promise} observe={props.observe} />
+		} @pending {
+			<span id="memo-invariant-fallback">{'loading'}</span>
+		}
+	</div>
+}
+
+type MemoArityValue = { step: number };
+type MemoArityTransitionProps = {
+	promise: Promise<string>;
+	observe: (step: number, values: MemoArityValue[], late: MemoArityValue | null) => void;
+};
+
+function MemoArityTransitionValue({ step, promise, observe }: MemoArityTransitionProps & {
+	step: number;
+}) @{
+	const zero = useMemo(() => ({ step }), []);
+	const one = useMemo(() => ({ step }), [step]);
+	const two = useMemo(() => ({ step }), [step, 'a']);
+	const three = useMemo(() => ({ step }), [step, 'a', 'b']);
+	const four = useMemo(() => ({ step }), [step, 'a', 'b', 'c']);
+	const five = useMemo(() => ({ step }), [step, 'a', 'b', 'c', 'd']);
+	let late: MemoArityValue | null = null;
+	if (step !== 0) {
+		const reached = useMemo(() => ({ step }), []);
+		late = reached;
+	}
+	observe(step, [zero, one, two, three, four, five], late);
+	const value =
+		step === 1
+			? use(promise)
+			: step === 0
+				? 'zero'
+				: 'urgent';
+	<span id="memo-arities-value">
+		{value + ':' + [zero.step, one.step, two.step, three.step, four.step, five.step].join(',')}
+	</span>
+}
+
+export function TransitionMemoArities(props: MemoArityTransitionProps) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button
+			id="memo-arities-next"
+			onClick={() => startTransition(() => setStep(1))}
+		>{'next'}</button>
+		<button id="memo-arities-urgent" onClick={() => setStep(2)}>{'urgent'}</button>
+		<h1 id="memo-arities-shell">{'shell-' + step}</h1>
+		@try {
+			<MemoArityTransitionValue step={step} promise={props.promise} observe={props.observe} />
+		} @pending {
+			<span id="memo-arities-fallback">{'loading'}</span>
 		}
 	</div>
 }

--- a/packages/octane/tests/_server-fixture.ts
+++ b/packages/octane/tests/_server-fixture.ts
@@ -8,9 +8,13 @@
  */
 import { readFileSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
+import ts from 'typescript';
 import { compile } from 'octane/compiler';
+import { slotHooks } from '../src/compiler/slot-hooks.js';
 import * as ServerRuntime from 'octane/server';
 import * as HydrationRuntime from 'octane/hydration';
+import * as InternalClientRuntime from 'octane/internal/client';
+import * as InternalServerRuntime from 'octane/internal/server';
 import * as ClientRuntime from '../src/index.js';
 
 export type CompiledFixtureModule = Record<string, any>;
@@ -30,19 +34,73 @@ export interface CompiledFixtureSourceOptions {
 	compileOptions?: Record<string, unknown>;
 }
 
+export interface PlainHookFixtureSourceOptions {
+	id: string;
+	inlineHookMemo: boolean;
+	manualSlots?: boolean;
+}
+
 export function loadCompiledFixtureSource<T extends CompiledFixtureModule = CompiledFixtureModule>(
 	source: string,
 	options: CompiledFixtureSourceOptions,
 ): T {
 	const { id, mode } = options;
-	let { code } = compile(source, id, {
+	const { code } = compile(source, id, {
 		...options.compileOptions,
 		mode,
 	});
+	return evaluateCompiledFixtureCode<T>(code, id, mode);
+}
 
+/** Execute the public plain-module transform through the shared module loader. */
+export function loadPlainHookFixtureSource<T extends CompiledFixtureModule = CompiledFixtureModule>(
+	source: string,
+	options: PlainHookFixtureSourceOptions,
+): T {
+	const out = slotHooks(source, options.id, {
+		environment: 'client',
+		hmr: false,
+		dev: false,
+		profile: false,
+		inlineHookMemo: options.inlineHookMemo,
+		manualSlots: options.manualSlots,
+	});
+	// The plain path deliberately leaves TypeScript to its host toolchain.
+	// Strip it here exactly once, then use the same evaluation boundary as the
+	// component compiler fixtures. No generated module is recompiled by Octane.
+	const { outputText } = ts.transpileModule(out?.code ?? source, {
+		fileName: options.id,
+		compilerOptions: {
+			target: ts.ScriptTarget.ESNext,
+			module: ts.ModuleKind.ESNext,
+			verbatimModuleSyntax: true,
+		},
+	});
+	return evaluateCompiledFixtureCode<T>(outputText, options.id, 'client');
+}
+
+function evaluateCompiledFixtureCode<T extends CompiledFixtureModule>(
+	code: string,
+	id: string,
+	mode: 'client' | 'server',
+): T {
 	const runtime = mode === 'server' ? ServerRuntime : ClientRuntime;
+	const internalRuntime = mode === 'server' ? InternalServerRuntime : InternalClientRuntime;
 	code = code.replace(
-		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/(?:server|internal\/(?:client|server)))?['"];?/g,
+		/import\s*\*\s*as\s+([\w$]+)\s*from\s*['"]octane\/internal\/(?:client|server)['"];?/g,
+		(_match: string, name: string) => `const ${name} = __internalRuntime;`,
+	);
+	code = code.replace(
+		/import\s*\*\s*as\s+([\w$]+)\s*from\s*['"]octane(?:\/server)?['"];?/g,
+		(_match: string, name: string) => `const ${name} = __runtime;`,
+	);
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/internal\/(?:client|server)['"];?/g,
+		(_match: string, names: string) =>
+			`const {${names.replace(/\s+as\s+/g, ': ')}} = __internalRuntime;`,
+	);
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
 		(_match: string, names: string) => `const {${names.replace(/\s+as\s+/g, ': ')}} = __runtime;`,
 	);
 	code = code.replace(
@@ -84,11 +142,12 @@ export function loadCompiledFixtureSource<T extends CompiledFixtureModule = Comp
 
 	const evaluate = new Function(
 		'__runtime',
+		'__internalRuntime',
 		'__hydrationRuntime',
 		'__exports',
 		`'use strict';\n${code}\n//# sourceURL=${id}?${mode}-fixture\nreturn __exports;`,
 	);
-	return evaluate(runtime, HydrationRuntime, {}) as T;
+	return evaluate(runtime, internalRuntime, HydrationRuntime, {}) as T;
 }
 
 export function loadServerFixture<T extends CompiledFixtureModule = CompiledFixtureModule>(

--- a/packages/octane/tests/compiler/compiler-ast-emit-audit.test.ts
+++ b/packages/octane/tests/compiler/compiler-ast-emit-audit.test.ts
@@ -35,7 +35,7 @@ const sources = collectCompilerFiles().map((path) => ({
 }));
 
 describe('compiler AST emit architecture', () => {
-	it('keeps final JavaScript printing at the two owning emit boundaries', () => {
+	it('keeps final Program printing at the owning emit boundaries', () => {
 		const printSites: string[] = [];
 		for (const { code, path } of sources) {
 			for (const _match of code.matchAll(/\besrapPrint\s*\(/g)) {
@@ -44,9 +44,13 @@ describe('compiler AST emit architecture', () => {
 		}
 
 		// Volar delegates its one Program print to @tsrx/core's transform() with
-		// boundaryTokens enabled. The main compiler and client-only stub are the
-		// only compiler-owned Program printers.
-		expect(printSites.sort()).toEqual(['client-only-server.js', 'compile.js']);
+		// boundaryTokens enabled. Plain-hook memo lowering owns a TS-preserving
+		// whole-Program print; its surgical fallback never prints fragments.
+		expect(printSites.sort()).toEqual([
+			'client-only-server.js',
+			'compile.js',
+			'plain-hook-memo.js',
+		]);
 	});
 
 	it('only parses authored module inputs', () => {

--- a/packages/octane/tests/compiler/data-callback-hooks.test.ts
+++ b/packages/octane/tests/compiler/data-callback-hooks.test.ts
@@ -11,7 +11,10 @@ import { compile } from 'octane/compiler';
 // stale closure rather than a loud error, which is why nothing is inferred here
 // and why the transform is inert until something opts in.
 
-const PROD = { hmr: false as const, dev: false };
+// Keep the inferred public hook call visible in this option/inference suite.
+// The runtime suite executes the declared form with inline lowering both on
+// and off; its cache identity and freshness must not depend on this artifact.
+const PROD = { hmr: false as const, dev: false, inlineHookMemo: false };
 const DECLARED = ['@octanejs/tanstack-store#useSelector'];
 
 const SOURCE = `

--- a/packages/octane/tests/compiler/inline-hook-memo-codegen.test.ts
+++ b/packages/octane/tests/compiler/inline-hook-memo-codegen.test.ts
@@ -30,7 +30,8 @@ describe('inline hook-memo tier — compile-mode and shape routing', () => {
 		// semantics (React parity for NaN/±0).
 		expect(code).not.toMatch(/useMemo\(/);
 		expect(code).not.toMatch(/useCallback\(/);
-		expect(code).toMatch(/Object\.is\(/);
+		expect(code).toMatch(/hookMemoEqual/);
+		expect(code).not.toMatch(/Object\.is\(/);
 	});
 
 	it('keeps the runtime path for shapes the inline tier declines', () => {
@@ -49,6 +50,127 @@ describe('inline hook-memo tier — compile-mode and shape routing', () => {
 		// Deps that aren't a literal array, and factories containing
 		// hook-shaped calls, stay on the runtime hook.
 		expect(code.match(/useMemo\(/g)?.length).toBe(2);
+	});
+
+	it('removes closures from expression, custom-hook return, and explicit-slot sites', () => {
+		const code = compile(
+			`
+				import { useMemo as memoValue, useCallback } from 'octane';
+				const SLOT = Symbol('authored');
+				function identity(value) { return value; }
+				function useReturned(value) { return memoValue(() => value + 1, [value]); }
+				function useBlock(value) {
+					return memoValue(() => { if (value < 0) return 0; const next = value + 1; return next; }, [value]);
+				}
+				export function App({ value }) @{
+					const [first] = memoValue(() => [value], [value]);
+					const callback = identity(useCallback(() => value, [value]));
+					const explicit = memoValue(() => value + 2, [value], SLOT);
+					const returned = useReturned(value);
+					const block = useBlock(value);
+					<p>{String(first + callback() + explicit + returned + block)}</p>
+				}
+			`,
+			'inline-memo-shapes.tsrx',
+			{ ...PROD, autoMemo: false },
+		).code;
+		expect(code).not.toMatch(/\b(?:memoValue|useCallback)\(/);
+		// Render-local sites avoid the hooks map; callable/custom-slot sites
+		// preserve their composable entry while removing the factory closure.
+		expect(code).toMatch(/hookMemoPublish1/);
+		expect(code).toMatch(/memoTake1/);
+		expect(code).toMatch(/memoSlot\(SLOT,/);
+	});
+
+	it('removes memo closures inside returned JSX without changing its callable ABI', () => {
+		const code = compile(
+			`/** @jsxImportSource octane */
+			import * as Octane from 'octane';
+			export function App({ value }) {
+				return <button onClick={Octane.useCallback(() => value, [value])}>
+					{Octane.useMemo(() => value + 1, [value])}
+				</button>;
+			}`,
+			'inline-memo-returned.tsx',
+			{ ...PROD, autoMemo: false },
+		).code;
+		expect(code).not.toMatch(/Octane\.use(?:Memo|Callback)\(/);
+		expect(code).toMatch(/export function App\(/);
+		expect(code).toMatch(/memoTake1/);
+	});
+
+	it('declines factory scopes and unsafe expression hoisting independently', () => {
+		for (const expression of [
+			`useMemo(function named() { return arguments[0]; }, [value])`,
+			`useMemo((dependency) => dependency, [value])`,
+			`useMemo(async () => value, [value])`,
+			`useMemo(() => { var local = value; return local; }, [value])`,
+			`useMemo(() => eval('value'), [value])`,
+			`String(useMemo(() => { const local = value; return local; }, [value]))`,
+		]) {
+			const code = compile(
+				`import { useMemo } from 'octane';
+				export function App({ value }) @{
+					const result = ${expression};
+					<p>{String(result)}</p>
+				}`,
+				'inline-memo-safety.tsrx',
+				{ ...PROD, autoMemo: false },
+			).code;
+			expect(code.match(/\buseMemo\(/g)?.length, expression).toBe(1);
+			expect(code, expression).not.toMatch(/\b(?:memoTake\d|hookMemoPublish\d?)\(/);
+		}
+	});
+
+	it('keeps opaque function subtrees opaque while lowering an ordinary sibling', () => {
+		const code = compile(
+			`import { useMemo } from 'octane';
+			function useOrdinary(value) { return useMemo(() => value, [value]); }
+			export function App({ value }) @{
+				'worklet';
+				function useInner(next) { return useMemo(() => next, [next]); }
+				const result = useMemo(() => value, [value]);
+				<><p>{String(result)}</p><span>tail</span></>
+			}`,
+			'inline-memo-opaque-owner.tsrx',
+			{ ...PROD, autoMemo: false },
+		).code;
+		expect(code.match(/\buseMemo\(/g)?.length).toBe(2);
+		expect(code).toMatch(/memoTake1/);
+	});
+
+	it('keeps the diagnostic off switch on the runtime path', () => {
+		const code = compile(
+			`import { useMemo } from 'octane';
+			function useValue(value) { return useMemo(() => value, [value]); }
+			export function App({ value }) @{
+				const result = useMemo(() => value + 1, [value]);
+				<p>{String(result + useValue(value))}</p>
+			}`,
+			'inline-memo-disabled.tsrx',
+			{ ...PROD, autoMemo: false, inlineHookMemo: false },
+		).code;
+		expect(code.match(/\buseMemo\(/g)?.length).toBe(2);
+		expect(code).not.toMatch(/octane\/internal\/client/);
+	});
+
+	it('does not lend render-local cache bindings to a later class initializer', () => {
+		const code = compile(
+			`import { useMemo } from 'octane';
+			export function App({ value, observe }) @{
+				class Later {
+					field = useMemo(() => value, [value]);
+					useValue(next) { return useMemo(() => next, [next]); }
+				}
+				observe(Later);
+				return null;
+			}`,
+			'inline-memo-class-scope.tsrx',
+			{ ...PROD, autoMemo: false },
+		).code;
+		expect(code.match(/\buseMemo\(/g)?.length).toBe(1);
+		expect(code).toMatch(/memoTake1/);
+		expect(code).not.toMatch(/hookMemoPublish\d?\(/);
 	});
 
 	it('keeps the runtime path in dev/HMR compiles', () => {

--- a/packages/octane/tests/compiler/plain-hook-memo-codegen.test.ts
+++ b/packages/octane/tests/compiler/plain-hook-memo-codegen.test.ts
@@ -1,0 +1,228 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { createOctaneCompiler } from '../../src/compiler/bundler.js';
+import { slotHooks } from '../../src/compiler/slot-hooks.js';
+import { decodeMappings } from '../_source-map.js';
+
+const SOURCE = `import { useMemo } from 'octane';
+export function useValue(value) { return useMemo(() => ({ value }), [value]); }`;
+
+describe('plain-module memo compilation', () => {
+	it('preserves the TypeScript module surface and emits an authored source map', () => {
+		const source = `/** @jsxImportSource octane */
+import { useMemo } from 'octane';
+export interface Bag { [key: string]: number; }
+export type Pair<A, B> = { a: A; b: B };
+export enum Choice { First, Second = 4 }
+class Box<T> { constructor(readonly value: T) {} }
+export const widen = <T>(value: T): T => value;
+export const useArrow = <T>(value: T) => useMemo(() => value, [value]);
+export function useValue<T>(value: T) {
+  return useMemo(() => new Box(value), [value]);
+}`;
+		const out = slotHooks(source, 'typed-hook.ts', { inlineHookMemo: true });
+		expect(out).not.toBeNull();
+		expect(out!.map).toMatchObject({
+			version: 3,
+			sources: ['typed-hook.ts'],
+			sourcesContent: [source],
+		});
+		expect(out!.code).toContain('/** @jsxImportSource octane */');
+		const ast = ts.createSourceFile('typed-hook.ts', out!.code, ts.ScriptTarget.Latest, true);
+		expect(ast.statements.some(ts.isInterfaceDeclaration)).toBe(true);
+		expect(ast.statements.some(ts.isTypeAliasDeclaration)).toBe(true);
+		expect(ast.statements.some(ts.isEnumDeclaration)).toBe(true);
+		const useValue = ast.statements.find(
+			(statement): statement is ts.FunctionDeclaration =>
+				ts.isFunctionDeclaration(statement) && statement.name?.text === 'useValue',
+		);
+		expect(useValue?.typeParameters?.[0].name.text).toBe('T');
+		const originalLine = source.split('\n').findIndex((line) => line.includes('new Box(value)'));
+		expect(
+			decodeMappings(out!.map.mappings)
+				.flat()
+				.some((segment) => segment[2] === originalLine),
+		).toBe(true);
+	});
+
+	it('keeps the direct slot pass surgical unless memo lowering is requested', () => {
+		expect(slotHooks(SOURCE, 'use-value.ts')).toEqual(
+			slotHooks(SOURCE, 'use-value.ts', { inlineHookMemo: false }),
+		);
+		expect(slotHooks(SOURCE, 'use-value.ts')?.map).toBeNull();
+	});
+
+	it('keeps development, server, profiling, and universal modules on their existing paths', () => {
+		for (const mode of [
+			{ hmr: true },
+			{ dev: true },
+			{ profile: true },
+			{ environment: 'server' as const },
+			{ renderer: { target: 'universal' } },
+			{ universalRuntime: 'universal' },
+		]) {
+			expect(slotHooks(SOURCE, 'use-value.ts', { ...mode, inlineHookMemo: true })).toEqual(
+				slotHooks(SOURCE, 'use-value.ts', { ...mode, inlineHookMemo: false }),
+			);
+		}
+	});
+
+	it('retains parallel use and disposable-root specialization', () => {
+		const sources = [
+			{
+				source: `import { use, useMemo } from 'octane';
+					export function useValue(load, id) {
+						const key = useMemo(() => id, [id]);
+						const first = use(load(key));
+						const second = use(load(key + 1));
+						return [first, second];
+					}`,
+				options: {},
+			},
+			{
+				source: `import { createRoot, useMemo } from 'octane';
+					import App from './App.tsrx';
+					export function useValue(value) { return useMemo(() => value, [value]); }
+					createRoot(document.body).render(App);`,
+				options: { isVoidComponentImport: () => true },
+			},
+		];
+		for (const { source, options } of sources) {
+			expect(slotHooks(source, 'preserved.ts', { ...options, inlineHookMemo: true })).toEqual(
+				slotHooks(source, 'preserved.ts', { ...options, inlineHookMemo: false }),
+			);
+		}
+	});
+
+	it('does not infer dependencies in a manually slotted module', () => {
+		const source = `import { useMemo } from 'octane';
+const slot = Symbol('value');
+function makeFactory(value) { return () => value; }
+export function useValue(value) {
+  const always = useMemo(makeFactory(value));
+  return useMemo(() => always, [always], slot);
+}`;
+		expect(slotHooks(source, 'manual.ts', { manualSlots: true, inlineHookMemo: false })).toBeNull();
+		const out = slotHooks(source, 'manual.ts', { manualSlots: true, inlineHookMemo: true });
+		expect(out?.map).not.toBeNull();
+		const ast = ts.createSourceFile('manual.ts', out!.code, ts.ScriptTarget.Latest, true);
+		const omitted: ts.CallExpression[] = [];
+		function visit(node: ts.Node) {
+			if (
+				ts.isCallExpression(node) &&
+				ts.isIdentifier(node.expression) &&
+				node.expression.text === 'useMemo' &&
+				node.arguments.length === 1
+			) {
+				omitted.push(node);
+			}
+			ts.forEachChild(node, visit);
+		}
+		visit(ast);
+		expect(omitted).toHaveLength(1);
+	});
+
+	it('retains factories and owners whose execution scope cannot be inlined', () => {
+		for (const body of [
+			`return useMemo(function named() { return [this, arguments, named]; }, [value]);`,
+			`eval('value'); return useMemo(() => value, [value]);`,
+			`'worklet'; return useMemo(() => value, [value]);`,
+			`return consume(useMemo(() => { const next = value + 1; return next; }, [value]));`,
+			`return useMemo((input) => input, [value]);`,
+			`return useMemo(async () => value, [value]);`,
+			`return class { value = useMemo(() => value, [value]); };`,
+		]) {
+			const source = `import { useMemo } from 'octane'; export function useValue(value) { ${body} }`;
+			expect(slotHooks(source, 'scope.ts', { inlineHookMemo: true })).toEqual(
+				slotHooks(source, 'scope.ts', { inlineHookMemo: false }),
+			);
+		}
+		const parameter = `import { useMemo } from 'octane';
+			export function useValue(value = useMemo(() => 1, [])) { return value; }`;
+		expect(slotHooks(parameter, 'parameter.ts', { inlineHookMemo: true })).toEqual(
+			slotHooks(parameter, 'parameter.ts', { inlineHookMemo: false }),
+		);
+	});
+
+	it("preserves memo calls throughout an opaque execution directive's subtree", () => {
+		const source = `import { useMemo } from 'octane';
+export function makeWorklet(value) {
+  'worklet';
+  function inner() { return useMemo(() => value, [value]); }
+  class Nested { read() { return useMemo(() => value, [value]); } }
+  return [inner, Nested];
+}
+export function useValue(value) { return useMemo(() => value, [value]); }`;
+		const out = slotHooks(source, 'worklet.ts', { inlineHookMemo: true });
+		expect(out?.map).not.toBeNull();
+		const ast = ts.createSourceFile('worklet.ts', out!.code, ts.ScriptTarget.Latest, true);
+		const functions = ast.statements.filter(ts.isFunctionDeclaration);
+		const worklet = functions.find((node) => node.name?.text === 'makeWorklet');
+		const ordinary = functions.find((node) => node.name?.text === 'useValue');
+		function memoCalls(root: ts.Node | undefined) {
+			let count = 0;
+			function visit(node: ts.Node) {
+				if (
+					ts.isCallExpression(node) &&
+					ts.isIdentifier(node.expression) &&
+					node.expression.text === 'useMemo'
+				) {
+					count++;
+				}
+				ts.forEachChild(node, visit);
+			}
+			if (root) visit(root);
+			return count;
+		}
+		const directive = worklet?.body?.statements[0];
+		expect(
+			directive && ts.isExpressionStatement(directive) && ts.isStringLiteral(directive.expression)
+				? directive.expression.text
+				: null,
+		).toBe('worklet');
+		expect(memoCalls(worklet)).toBe(2);
+		expect(memoCalls(ordinary)).toBe(0);
+	});
+
+	it('runs memo-only optimization for manual source packages and honors the hard opt-out', () => {
+		const root = mkdtempSync(join(tmpdir(), 'octane-manual-memo-'));
+		try {
+			writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app', private: true }));
+			const packageRoot = join(root, 'packages', 'manual-binding');
+			const sourceRoot = join(packageRoot, 'src');
+			mkdirSync(sourceRoot, { recursive: true });
+			writeFileSync(
+				join(packageRoot, 'package.json'),
+				JSON.stringify({
+					name: '@example/manual-binding',
+					dependencies: { octane: '*' },
+					octane: { hookSlots: { manual: ['src'] } },
+				}),
+			);
+			const source = `import { useMemo, useState } from 'octane';
+				const stateSlot = Symbol('state');
+				const memoSlot = Symbol('memo');
+				export function useValue(value) {
+					const [state] = useState(value, stateSlot);
+					return useMemo(() => state, [state], memoSlot);
+				}`;
+			const id = join(sourceRoot, 'use-value.ts');
+			const compiler = createOctaneCompiler({ root });
+			const enabled = compiler.transform(source, id);
+			expect(enabled?.map).not.toBeNull();
+			expect(compiler.transform(source, id, { inlineHookMemo: false })?.code ?? source).toBe(
+				source,
+			);
+			const optedOut = `// octane-no-slot\n${source}`;
+			expect(compiler.transform(optedOut, id)?.code ?? optedOut).toBe(optedOut);
+			for (const mode of [{ dev: true }, { hmr: true }, { environment: 'server' as const }]) {
+				expect(compiler.transform(source, id, mode)?.code ?? source).toBe(source);
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/octane/tests/data-callback-hooks-behavior.test.ts
+++ b/packages/octane/tests/data-callback-hooks-behavior.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { act, mount } from './_helpers';
 import { OffsetReader, OffsetReaderKeyed } from './_fixtures/data-callback-hooks.tsrx';
+import { loadCompiledFixtureSource } from './_server-fixture';
 
 // Dep-keying a callback changes when its identity moves, never what it computes.
 // These run in BOTH vitest projects, so the dev compile (which never keys) and
@@ -51,5 +52,57 @@ describe.each([
 		await act(() => store.set(30));
 		expect(r.find('#total').textContent).toBe('35');
 		r.unmount();
+	});
+});
+
+describe.each([false, true])('declared data callbacks (inline=%s)', (inlineHookMemo) => {
+	it('preserves a selection while its source and captured member stay equal', () => {
+		const { App } = loadCompiledFixtureSource(
+			`import { useMemo } from 'octane';
+			function useLocalSelector(source, selector) {
+				return useMemo(() => selector(source), [source, selector]);
+			}
+			export function App(props) @{
+				const selected = useLocalSelector(props.source, (s) => ({ total: s.base + props.offset }));
+				props.observe(selected);
+				<p>{String(selected.total)}</p>
+			}`,
+			{
+				id: 'declared-data-callback.tsrx',
+				mode: 'client',
+				compileOptions: {
+					hmr: false,
+					dev: false,
+					inlineHookMemo,
+					dataCallbackHooks: ['useLocalSelector'],
+				},
+			},
+		);
+		let selected!: { total: number };
+		const observe = (value: { total: number }) => {
+			selected = value;
+		};
+		const firstSource = { base: 10 };
+		const root = mount(App, { source: firstSource, offset: 1, tick: 0, observe });
+		const first = selected;
+		expect(root.html()).toBe('<p>11</p>');
+
+		root.update(App, { source: firstSource, offset: 1, tick: 1, observe });
+		expect(selected).toBe(first);
+		expect(root.html()).toBe('<p>11</p>');
+
+		const secondSource = { base: 20 };
+		root.update(App, { source: secondSource, offset: 1, tick: 1, observe });
+		const second = selected;
+		expect(second).not.toBe(first);
+		expect(root.html()).toBe('<p>21</p>');
+
+		root.update(App, { source: secondSource, offset: 5, tick: 1, observe });
+		const third = selected;
+		expect(third).not.toBe(second);
+		expect(root.html()).toBe('<p>25</p>');
+		root.update(App, { source: secondSource, offset: 5, tick: 2, observe });
+		expect(selected).toBe(third);
+		root.unmount();
 	});
 });

--- a/packages/octane/tests/hooks.test.ts
+++ b/packages/octane/tests/hooks.test.ts
@@ -12,6 +12,8 @@ import {
 	StableResultLookalikes,
 	CustomSelectorCallback,
 	CbTest,
+	ForwardedCallbackPair,
+	CallbackRenderPass,
 	RefTest,
 	EffectMount,
 	EffectDeps,
@@ -133,6 +135,78 @@ describe('useCallback', () => {
 		r.update(CbTest, { label: 'bye' });
 		expect(r.find('span').textContent).toBe('bye');
 		r.unmount();
+	});
+
+	it('preserves each custom-hook callback value without invoking it while comparing dependencies', () => {
+		const first = vi.fn(() => 'first');
+		const second = vi.fn(() => 'second');
+		const nextFirst = vi.fn(() => 'next-first');
+		const nextSecond = vi.fn(() => 'next-second');
+		const observed: Array<[() => string, () => string]> = [];
+		const observe = (left: () => string, right: () => string) => {
+			observed.push([left, right]);
+		};
+		const root = mount(ForwardedCallbackPair, {
+			first,
+			second,
+			dependencies: [NaN, 0],
+			observe,
+			label: 'initial',
+		});
+		expect(observed.at(-1)).toEqual([first, second]);
+		expect(first).not.toHaveBeenCalled();
+		expect(second).not.toHaveBeenCalled();
+
+		root.update(ForwardedCallbackPair, {
+			first: nextFirst,
+			second: nextSecond,
+			dependencies: [NaN, 0],
+			observe,
+			label: 'same',
+		});
+		expect(root.find('span').textContent).toBe('same');
+		expect(observed.at(-1)).toEqual([first, second]);
+		expect(nextFirst).not.toHaveBeenCalled();
+		expect(nextSecond).not.toHaveBeenCalled();
+
+		root.update(ForwardedCallbackPair, {
+			first: nextFirst,
+			second: nextSecond,
+			dependencies: [NaN, -0],
+			observe,
+			label: 'changed',
+		});
+		expect(observed.at(-1)).toEqual([nextFirst, nextSecond]);
+		expect(observed.at(-1)?.[0]()).toBe('next-first');
+		expect(observed.at(-1)?.[1]()).toBe('next-second');
+
+		root.update(ForwardedCallbackPair, {
+			first,
+			second,
+			dependencies: null,
+			observe,
+			label: 'always',
+		});
+		expect(observed.at(-1)).toEqual([first, second]);
+		root.update(ForwardedCallbackPair, {
+			first: nextFirst,
+			second: nextSecond,
+			dependencies: null,
+			observe,
+			label: 'always-again',
+		});
+		expect(observed.at(-1)).toEqual([nextFirst, nextSecond]);
+		root.unmount();
+	});
+
+	it('keeps a custom-hook callback across a render-phase state retry', () => {
+		const observed: Array<() => number> = [];
+		const root = mount(CallbackRenderPass, {
+			observe: (callback: () => number) => observed.push(callback),
+		});
+		expect(root.find('span').textContent).toBe('step=1 callback=0');
+		expect(observed.at(-1)).toBe(observed[0]);
+		root.unmount();
 	});
 });
 

--- a/packages/octane/tests/inline-hook-memo.test.ts
+++ b/packages/octane/tests/inline-hook-memo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { act, createLog, mount } from './_helpers';
+import { loadCompiledFixtureSource } from './_server-fixture';
 import {
 	CallbackIdentity,
 	ComputeCount,
@@ -18,6 +19,433 @@ import {
 // expectations in both is the tier's semantic-equivalence proof.
 
 describe('inline hook-memo behavior', () => {
+	for (const inlineHookMemo of [false, true]) {
+		const compileOptions = { hmr: false, dev: false, autoMemo: false, inlineHookMemo };
+
+		it(`preserves an ordinary factory's invocation scope (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				export function App({ value }) @{
+					const result = useMemo(function named() {
+						return [this === null, arguments[0] === value, typeof named].join(':');
+					}, [value]);
+					<p>{result as string}</p>
+				}`,
+				{ id: 'memo-function-scope.tsrx', mode: 'client', compileOptions },
+			);
+			const root = mount(App, { value: 42 });
+			expect(root.html()).toBe('<p>true:true:function</p>');
+			root.update(App, { value: 43 });
+			expect(root.html()).toBe('<p>true:true:function</p>');
+			root.unmount();
+		});
+
+		it(`keeps the declared value uninitialized while its factory runs (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				export function App() @{
+					const value = useMemo(() => value, []);
+					<p>{String(value)}</p>
+				}`,
+				{ id: 'memo-declaration-tdz.tsrx', mode: 'client', compileOptions },
+			);
+			expect(() => mount(App)).toThrow(ReferenceError);
+		});
+
+		it(`preserves anonymous returned function names (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useCallback, useMemo } from 'octane';
+				export function App() @{
+					const callback = useCallback(() => 1, null);
+					const expression = useMemo(() => () => 2, []);
+					const block = useMemo(() => { const value = 3; return () => value; }, []);
+					<p>{[callback.name, expression.name, block.name].join(':')}</p>
+				}`,
+				{ id: 'memo-anonymous-names.tsrx', mode: 'client', compileOptions },
+			);
+			const root = mount(App);
+			expect(root.html()).toBe('<p>::</p>');
+			root.unmount();
+		});
+
+		it(`preserves returns canceled or replaced by finally (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				export function App({ value }) @{
+					const canceledBreak = useMemo(() => {
+						done: { try { return 'canceled'; } finally { break done; } }
+					}, [value]);
+					const canceledContinue = useMemo(() => {
+						for (let i = 0; i < 1; i++) {
+							try { return 'canceled'; } finally { continue; }
+						}
+					}, [value]);
+					const replaced = useMemo(() => {
+						try { return 'canceled'; } finally { return 'replacement'; }
+					}, [value]);
+					<p>{String(canceledBreak) + ':' + String(canceledContinue) + ':' + replaced}</p>
+				}`,
+				{ id: 'memo-finally-completion.tsrx', mode: 'client', compileOptions },
+			);
+			const root = mount(App, { value: 1 });
+			expect(root.html()).toBe('<p>undefined:undefined:replacement</p>');
+			root.update(App, { value: 2 });
+			expect(root.html()).toBe('<p>undefined:undefined:replacement</p>');
+			root.unmount();
+		});
+
+		it(`does not expose private memo imports to a sibling direct eval (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				function read() { return eval('typeof _$hookMemoCreate'); }
+				export function App({ value }) @{
+					const result = useMemo(() => value, [value]);
+					<p>{read() + ':' + result}</p>
+				}`,
+				{ id: 'memo-module-eval.tsrx', mode: 'client', compileOptions },
+			);
+			const root = mount(App, { value: 1 });
+			expect(root.html()).toBe('<p>undefined:1</p>');
+			root.update(App, { value: 2 });
+			expect(root.html()).toBe('<p>undefined:2</p>');
+			root.unmount();
+		});
+
+		it(`keeps nested expression order, short-circuiting, and stale callbacks (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo, useCallback } from 'octane';
+				function identity(value) { return value; }
+				export function App({ value, salt, enabled, tick, mark, observe }) @{
+					const [first] = useMemo(() => (mark('pair-compute', value), [value]), [mark('pair-dep', value)]),
+						second = useMemo(() => (mark('second-compute', salt), salt), [mark('second-dep', salt)]);
+					const nested = enabled && identity(useMemo(
+						() => (mark('outer-compute', value), value + salt),
+						[mark('outer-a', value), useMemo(() => (mark('inner-compute', salt), salt), [mark('inner-dep', salt)])],
+					));
+					const callback = identity(useCallback(() => value + salt, [mark('callback-dep', value)]));
+					observe({ first, second, nested, callback });
+					<p>{tick + ':' + first + ':' + second + ':' + String(nested)}</p>
+				}`,
+				{ id: 'memo-expression-order.tsrx', mode: 'client', compileOptions },
+			);
+			const log = createLog();
+			const observed: Array<{
+				first: number;
+				second: number;
+				nested: number | false;
+				callback: () => number;
+			}> = [];
+			const shared = {
+				mark: (name: string, value: number) => {
+					log.push(`${name}:${value}`);
+					return value;
+				},
+				observe: (value: (typeof observed)[number]) => observed.push(value),
+			};
+			const root = mount(App, { ...shared, value: 1, salt: 10, enabled: false, tick: 0 });
+			const callback = observed[0].callback;
+			expect(log.drain()).toEqual([
+				'pair-dep:1',
+				'pair-compute:1',
+				'second-dep:10',
+				'second-compute:10',
+				'callback-dep:1',
+			]);
+			root.update(App, { ...shared, value: 1, salt: 10, enabled: true, tick: 1 });
+			expect(log.drain()).toEqual([
+				'pair-dep:1',
+				'second-dep:10',
+				'outer-a:1',
+				'inner-dep:10',
+				'inner-compute:10',
+				'outer-compute:1',
+				'callback-dep:1',
+			]);
+			root.update(App, { ...shared, value: 1, salt: 10, enabled: true, tick: 2 });
+			expect(log.drain()).toEqual([
+				'pair-dep:1',
+				'second-dep:10',
+				'outer-a:1',
+				'inner-dep:10',
+				'callback-dep:1',
+			]);
+			root.update(App, { ...shared, value: 1, salt: 11, enabled: true, tick: 3 });
+			expect(log.drain()).toEqual([
+				'pair-dep:1',
+				'second-dep:11',
+				'second-compute:11',
+				'outer-a:1',
+				'inner-dep:11',
+				'inner-compute:11',
+				'outer-compute:1',
+				'callback-dep:1',
+			]);
+			expect(observed.at(-1)).toMatchObject({ first: 1, second: 11, nested: 12 });
+			expect(observed.at(-1)!.callback).toBe(callback);
+			expect(callback()).toBe(11);
+			root.update(App, { ...shared, value: 2, salt: 11, enabled: true, tick: 4 });
+			expect(log.drain()).toEqual([
+				'pair-dep:2',
+				'pair-compute:2',
+				'second-dep:11',
+				'outer-a:2',
+				'inner-dep:11',
+				'outer-compute:2',
+				'callback-dep:2',
+			]);
+			expect(observed.at(-1)!.callback).not.toBe(callback);
+			expect(observed.at(-1)!.callback()).toBe(13);
+			expect(root.html()).toBe('<p>4:2:11:13</p>');
+			root.unmount();
+		});
+
+		it(`keeps custom-hook paths distinct and explicit slots authoritative (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				const SHARED = Symbol('shared-memo');
+				function useBox(value, mark) {
+					return useMemo(() => (mark('box:' + value), { value }), [value]);
+				}
+				function useBlock(value, mark) {
+					return useMemo(() => {
+						mark('block:' + value);
+						if (value < 0) return { value: -1 };
+						const doubled = value * 2;
+						return { value: doubled };
+					}, [value]);
+				}
+				export function App({ left, right, tick, mark, observe }) @{
+					const a = useBox(left, mark);
+					const b = useBox(right, mark);
+					const c = useBlock(left, mark);
+					const explicitA = useMemo(() => { mark('explicit:first'); return { value: left }; }, [left], SHARED);
+					const explicitB = useMemo(() => { mark('explicit:second'); return { value: 999 }; }, [left], SHARED);
+					observe({ a, b, c, explicitA, explicitB });
+					<p>{tick + ':' + a.value + ':' + b.value + ':' + c.value}</p>
+				}`,
+				{ id: 'memo-custom-explicit-slots.tsrx', mode: 'client', compileOptions },
+			);
+			const log = createLog();
+			type Box = { value: number };
+			const seen: Array<{ a: Box; b: Box; c: Box; explicitA: Box; explicitB: Box }> = [];
+			const shared = {
+				mark: log.push,
+				observe: (value: (typeof seen)[number]) => seen.push(value),
+			};
+			const root = mount(App, { ...shared, left: 1, right: 1, tick: 0 });
+			expect(log.drain()).toEqual(['box:1', 'box:1', 'block:1', 'explicit:first']);
+			expect(seen[0].a).not.toBe(seen[0].b);
+			expect(seen[0].explicitA).toBe(seen[0].explicitB);
+			root.update(App, { ...shared, left: 1, right: 1, tick: 1 });
+			expect(log.drain()).toEqual([]);
+			for (const key of ['a', 'b', 'c', 'explicitA', 'explicitB'] as const) {
+				expect(seen[1][key]).toBe(seen[0][key]);
+			}
+			root.update(App, { ...shared, left: 1, right: 2, tick: 2 });
+			expect(log.drain()).toEqual(['box:2']);
+			expect(seen[2].a).toBe(seen[0].a);
+			expect(seen[2].b).not.toBe(seen[0].b);
+			root.update(App, { ...shared, left: -1, right: 2, tick: 3 });
+			expect(log.drain()).toEqual(['box:-1', 'block:-1', 'explicit:first']);
+			expect(seen[3].explicitA).toBe(seen[3].explicitB);
+			expect(seen[3].explicitA).not.toBe(seen[0].explicitA);
+			expect(root.html()).toBe('<p>3:-1:2:-1</p>');
+			root.unmount();
+		});
+
+		it(`keeps nested dependency hooks in their callable scope (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo, useCallback } from 'octane';
+				export function App({ left, right, tick, observe }) @{
+					const useNested = useCallback((value) =>
+						useMemo(() => ({ value }), [useMemo(() => ({ value }), [value])]),
+					[]);
+					const a = useNested(left);
+					const b = useNested(right);
+					observe(a, b);
+					<p>{tick + ':' + a.value + ':' + b.value}</p>
+				}`,
+				{ id: 'memo-nested-callable-scope.tsrx', mode: 'client', compileOptions },
+			);
+			const seen: Array<[{ value: number }, { value: number }]> = [];
+			const observe = (a: (typeof seen)[number][0], b: (typeof seen)[number][1]) =>
+				seen.push([a, b]);
+			const root = mount(App, { left: 1, right: 2, tick: 0, observe });
+			root.update(App, { left: 1, right: 2, tick: 1, observe });
+			expect(seen[1][0]).toBe(seen[0][0]);
+			expect(seen[1][1]).toBe(seen[0][1]);
+			expect(seen[1][0]).not.toBe(seen[1][1]);
+			root.update(App, { left: 3, right: 2, tick: 2, observe });
+			expect(seen[2][0]).not.toBe(seen[0][0]);
+			expect(seen[2][1]).toBe(seen[0][1]);
+			expect(root.html()).toBe('<p>2:3:2</p>');
+			root.unmount();
+		});
+
+		it(`uses unshadowed cache intrinsics and compiler bindings (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				export function App({ value, read, observe, Object, Array, undefined, _$hookMemoCreate, _$hookMemoEqual, _$hookMemoPublish1 }) @{
+					const result = useMemo(() => read(value), [value]);
+					observe(result);
+					return null;
+				}`,
+				{ id: 'memo-shadowed-intrinsics.tsrx', mode: 'client', compileOptions },
+			);
+			const computed: number[] = [];
+			const observed: number[] = [];
+			const fail = () => {
+				throw new Error('authored shadow was invoked');
+			};
+			const shared = {
+				read: (value: number) => (computed.push(value), value),
+				observe: (value: number) => observed.push(value),
+				Object: { is: fail },
+				Array: fail,
+				undefined: 123,
+				_$hookMemoCreate: fail,
+				_$hookMemoEqual: fail,
+				_$hookMemoPublish1: fail,
+			};
+			const root = mount(App, { ...shared, value: NaN });
+			root.update(App, { ...shared, value: NaN });
+			root.update(App, { ...shared, value: 0 });
+			root.update(App, { ...shared, value: -0 });
+			expect(computed).toEqual([NaN, 0, -0]);
+			expect(observed).toEqual([NaN, NaN, 0, -0]);
+			root.unmount();
+		});
+
+		it(`preserves anonymous dependency names during class initialization (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				const SLOT = Symbol('dependency-name');
+				export function App({ value, observe }) @{
+					const first = useMemo(() => value, [class { static observed = observe(this.name); }]);
+					const second = useMemo(() => { const next = value + 1; return next; }, [class { static observed = observe(this.name); }], SLOT);
+					<p>{first + ':' + second}</p>
+				}`,
+				{ id: 'memo-dependency-names.tsrx', mode: 'client', compileOptions },
+			);
+			const names: string[] = [];
+			const observe = (name: string) => names.push(name);
+			const root = mount(App, { value: 1, observe });
+			root.update(App, { value: 2, observe });
+			expect(names).toEqual(['', '', '', '']);
+			expect(root.html()).toBe('<p>2:3</p>');
+			root.unmount();
+		});
+
+		it(`keeps returned-JSX memo values and event callbacks stable (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`/** @jsxImportSource octane */
+				import { useMemo, useCallback } from 'octane';
+				function View({ box, callback, tick, observe }) {
+					observe(box, callback);
+					return <button onClick={callback}>{tick + ':' + box.value}</button>;
+				}
+				export function App({ value, tick, observe, fire }) {
+					return <View
+						box={useMemo(() => ({ value, tick }), [value])}
+						callback={useCallback(() => fire(value + ':' + tick), [value])}
+						tick={tick}
+						observe={observe}
+					/>;
+				}`,
+				{ id: 'memo-returned-jsx.tsx', mode: 'client', compileOptions },
+			);
+			const log = createLog();
+			const seen: Array<[{ value: number; tick: number }, () => void]> = [];
+			const shared = {
+				fire: log.push,
+				observe: (box: (typeof seen)[number][0], callback: () => void) =>
+					seen.push([box, callback]),
+			};
+			const root = mount(App, { ...shared, value: 1, tick: 0 });
+			root.update(App, { ...shared, value: 1, tick: 1 });
+			expect(seen.at(-1)![0]).toBe(seen[0][0]);
+			expect(seen.at(-1)![1]).toBe(seen[0][1]);
+			root.click('button');
+			expect(log.drain()).toEqual(['1:0']);
+			root.update(App, { ...shared, value: 2, tick: 2 });
+			expect(seen.at(-1)![0]).not.toBe(seen[0][0]);
+			expect(seen.at(-1)![1]).not.toBe(seen[0][1]);
+			root.click('button');
+			expect(log.drain()).toEqual(['2:2']);
+			expect(root.html()).toBe('<button>2:2</button>');
+			root.unmount();
+		});
+
+		it(`retains the prior custom-hook entry when a factory throws (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useMemo } from 'octane';
+				function useBox(value, fail, mark) {
+					return useMemo(() => {
+						mark(value);
+						if (fail) throw new Error('expected');
+						return { value };
+					}, [value]);
+				}
+				export function App({ value, fail, tick, mark, observe }) @{
+					let result = null;
+					try { result = useBox(value, fail, mark); } catch {}
+					observe(result);
+					<p>{tick + ':' + (result === null ? 'caught' : result.value)}</p>
+				}`,
+				{ id: 'memo-throw-preserves-entry.tsrx', mode: 'client', compileOptions },
+			);
+			const calls: number[] = [];
+			const seen: Array<{ value: number } | null> = [];
+			const shared = {
+				mark: (value: number) => calls.push(value),
+				observe: (value: (typeof seen)[number]) => seen.push(value),
+			};
+			const root = mount(App, { ...shared, value: 1, fail: false, tick: 0 });
+			root.update(App, { ...shared, value: 2, fail: true, tick: 1 });
+			expect(root.html()).toBe('<p>1:caught</p>');
+			root.update(App, { ...shared, value: 1, fail: false, tick: 2 });
+			expect(seen.at(-1)).toBe(seen[0]);
+			expect(calls).toEqual([1, 2]);
+			root.update(App, { ...shared, value: 2, fail: false, tick: 3 });
+			expect(calls).toEqual([1, 2, 2]);
+			expect(seen.at(-1)).not.toBe(seen[0]);
+			expect(root.html()).toBe('<p>3:2</p>');
+			root.unmount();
+		});
+
+		it(`caches arbitrary values without a value-sentinel collision (inline=${inlineHookMemo})`, () => {
+			const { App, sentinel } = loadCompiledFixtureSource(
+				`import { useMemo, puMiss } from 'octane';
+				export const sentinel = puMiss;
+				function useValue(value, mark) {
+					return useMemo(() => (mark(), value), [value]);
+				}
+				export function App({ tick, mark, observe }) @{
+					const a = useValue(undefined, mark);
+					const b = useValue(null, mark);
+					const c = useValue(puMiss, mark);
+					observe(a, b, c);
+					<p>{tick as string}</p>
+				}`,
+				{ id: 'memo-arbitrary-values.tsrx', mode: 'client', compileOptions },
+			);
+			let calls = 0;
+			const seen: unknown[][] = [];
+			const shared = {
+				mark: () => calls++,
+				observe: (...values: unknown[]) => seen.push(values),
+			};
+			const root = mount(App, { ...shared, tick: 0 });
+			root.update(App, { ...shared, tick: 1 });
+			expect(calls).toBe(3);
+			expect(seen).toEqual([
+				[undefined, null, sentinel],
+				[undefined, null, sentinel],
+			]);
+			root.unmount();
+		});
+	}
+
 	it('recomputes only when deps change, not on unrelated re-renders', () => {
 		const log = createLog();
 		const r = mount(ComputeCount, { log: log.push });

--- a/packages/octane/tests/plain-hook-memo.test.ts
+++ b/packages/octane/tests/plain-hook-memo.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from './_helpers';
+import { loadPlainHookFixtureSource } from './_server-fixture';
+
+describe('memo hooks in plain modules', () => {
+	for (const inlineHookMemo of [false, true]) {
+		const load = (source: string, manualSlots = false) =>
+			loadPlainHookFixtureSource(source, {
+				id: 'plain-hook-memo.ts',
+				inlineHookMemo,
+				manualSlots,
+			});
+
+		it(`keeps repeated custom-hook calls independent and their getters live (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useCallback, useMemo, useState, withSlot } from 'octane';
+				const leftSlot = Symbol('left');
+				const rightSlot = Symbol('right');
+				interface Counter { value: number; }
+				function useCounter(start: number, report: (value: number) => void) {
+					const [value, setValue, getValue] = useState(start);
+					const result = useMemo(() => ({ value } as Counter), [value]);
+					const callback = useCallback(() => report(value), [report, value]);
+					const label = useMemo(() => value.toFixed(1));
+					return { result, callback, label, increment: () => setValue(getValue() + 1) };
+				}
+				export function App(props) {
+					const left = withSlot(leftSlot, useCounter, 1, props.report);
+					const right = withSlot(rightSlot, useCounter, 10, props.report);
+					props.observe(left, right);
+					return createElement('div', null,
+						createElement('button', { id: 'left', onClick: left.increment }, left.label),
+						createElement('button', { id: 'right', onClick: right.increment }, right.label));
+				}
+			`);
+			const observations: any[][] = [];
+			const reported: number[] = [];
+			const props = {
+				observe: (...values: any[]) => observations.push(values),
+				report: (value: number) => reported.push(value),
+			};
+			const root = mount(App, props);
+			const [firstLeft, firstRight] = observations.at(-1)!;
+			expect(root.find('#left').textContent).toBe('1.0');
+			expect(root.find('#right').textContent).toBe('10.0');
+			root.update(App, props);
+			expect(observations.at(-1)![0].result).toBe(firstLeft.result);
+			expect(observations.at(-1)![1].callback).toBe(firstRight.callback);
+			root.click('#left');
+			expect(root.find('#left').textContent).toBe('2.0');
+			expect(root.find('#right').textContent).toBe('10.0');
+			firstLeft.callback();
+			observations.at(-1)![0].callback();
+			expect(reported).toEqual([1, 2]);
+			root.click('#right');
+			expect(root.find('#right').textContent).toBe('11.0');
+			root.unmount();
+		});
+
+		it(`preserves short-circuit and nested argument evaluation order (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				export function App(props) {
+					const mark = (name: string) => { props.log(name); return name; };
+					const value = props.enabled && [
+						mark('before'),
+						useMemo(() => mark('outer'), [
+							useMemo(() => mark('inner'), []),
+							mark('dependency'),
+						]),
+						mark('after'),
+					].join(':');
+					return createElement('p', null, String(value));
+				}
+			`);
+			const log: string[] = [];
+			const props = { enabled: false, log: (value: string) => log.push(value) };
+			const root = mount(App, props);
+			expect(log).toEqual([]);
+			expect(root.html()).toBe('<p>false</p>');
+			root.update(App, { ...props, enabled: true });
+			expect(log.splice(0)).toEqual(['before', 'inner', 'dependency', 'outer', 'after']);
+			expect(root.html()).toBe('<p>before:outer:after</p>');
+			root.update(App, { ...props, enabled: true });
+			expect(log).toEqual(['before', 'dependency', 'after']);
+			root.unmount();
+		});
+
+		it(`keeps block returns, finally, and multi-declarator order (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				export function App(props) {
+					const first = props.log('first'), value = useMemo(() => {
+						try {
+							props.log('compute');
+							if (props.value < 0) return 'negative';
+							return 'value:' + props.value;
+						} finally { props.log('finally'); }
+					}, [props.value, props.log('dependency')]), last = props.log('last');
+					return createElement('p', null, value);
+				}
+			`);
+			const log: string[] = [];
+			const record = (value: string) => {
+				log.push(value);
+				return value;
+			};
+			const root = mount(App, { value: 1, log: record });
+			expect(log.splice(0)).toEqual(['first', 'dependency', 'compute', 'finally', 'last']);
+			expect(root.html()).toBe('<p>value:1</p>');
+			root.update(App, { value: 1, log: record });
+			expect(log.splice(0)).toEqual(['first', 'dependency', 'last']);
+			root.update(App, { value: -1, log: record });
+			expect(log).toEqual(['first', 'dependency', 'compute', 'finally', 'last']);
+			expect(root.html()).toBe('<p>negative</p>');
+			root.unmount();
+		});
+
+		it(`keeps the authored declaration in its temporal dead zone (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				export function App() {
+					const value = useMemo(() => { const read = true; if (read) return value; }, []);
+					return createElement('p', null, String(value));
+				}
+			`);
+			expect(() => mount(App)).toThrow(ReferenceError);
+		});
+
+		it(`discards returns canceled by finally control flow (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				export function App() {
+					const broken = useMemo(() => {
+						done: { try { return 'canceled'; } finally { break done; } }
+					}, []);
+					const continued = useMemo(() => {
+						for (let index = 0; index < 1; index++) {
+							try { return 'canceled'; } finally { continue; }
+						}
+					}, []);
+					const replaced = useMemo(() => {
+						try { return 'canceled'; } finally { return 'replacement'; }
+					}, []);
+					return createElement('p', null, [String(broken), String(continued), replaced].join(':'));
+				}
+			`);
+			const root = mount(App);
+			expect(root.html()).toBe('<p>undefined:undefined:replacement</p>');
+			root.update(App);
+			expect(root.html()).toBe('<p>undefined:undefined:replacement</p>');
+			root.unmount();
+		});
+
+		it(`preserves ordinary factory scope and anonymous result names (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useCallback, useMemo } from 'octane';
+				export function App({ value }) {
+					const scope = useMemo(function named() {
+						return [this === null, arguments[0] === value, typeof named].join(':');
+					}, [value]);
+					const callback = useCallback(() => 1, null);
+					const expression = useMemo(() => () => 2, []);
+					const block = useMemo(() => { const captured = 3; return () => captured; }, []);
+					const klass = useMemo(() => { const captured = 4; return class { get() { return captured; } }; }, []);
+					return createElement('p', null, [scope, callback.name, expression.name, block.name, klass.name].join('|'));
+				}
+			`);
+			const root = mount(App, { value: 42 });
+			expect(root.html()).toBe('<p>true:true:function||||</p>');
+			root.update(App, { value: 43 });
+			expect(root.html()).toBe('<p>true:true:function||||</p>');
+			root.unmount();
+		});
+
+		it(`does not invent names for anonymous dependency values (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				export function App() {
+					let expressionName = 'unset', blockName = 'unset';
+					const expression = useMemo(() => 1, [class { static observed = (expressionName = this.name); }]);
+					const block = useMemo(() => { const value = 2; return value; }, [class { static observed = (blockName = this.name); }]);
+					return createElement('p', null, [expressionName, blockName, expression + block].join('|'));
+				}
+			`);
+			const root = mount(App);
+			expect(root.html()).toBe('<p>||3</p>');
+			root.unmount();
+		});
+
+		it(`keeps generated bindings invisible to descendant direct eval (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				export function App({ value }) {
+					const read = () => eval('typeof __hks');
+					const memo = useMemo(() => value, [value]);
+					return createElement('p', null, read() + ':' + memo);
+				}
+			`);
+			const root = mount(App, { value: 1 });
+			expect(root.html()).toBe('<p>undefined:1</p>');
+			root.update(App, { value: 2 });
+			expect(root.html()).toBe('<p>undefined:2</p>');
+			root.unmount();
+		});
+
+		it(`keeps new runtime imports invisible to sibling direct eval (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import { createElement, useMemo } from 'octane';
+				function read() { return eval('typeof _$memoSlot'); }
+				export function App({ value }) {
+					const memo = useMemo(() => value, [value]);
+					return createElement('p', null, read() + ':' + memo);
+				}
+			`);
+			const root = mount(App, { value: 1 });
+			expect(root.html()).toBe('<p>undefined:1</p>');
+			root.update(App, { value: 2 });
+			expect(root.html()).toBe('<p>undefined:2</p>');
+			root.unmount();
+		});
+
+		it(`respects namespace import shadowing (inline=${inlineHookMemo})`, () => {
+			const { App } = load(`
+				import * as Octane from 'octane';
+				function local(Octane, value) {
+					return Octane.useMemo(() => value, [value]);
+				}
+				export function App(props) {
+					const localValue = local({ useMemo(compute) { return 'local:' + compute(); } }, props.value);
+					const realValue = Octane.useMemo(() => props.value * 2, [props.value]);
+					return Octane.createElement('p', null, localValue + ':' + realValue);
+				}
+			`);
+			const root = mount(App, { value: 2 });
+			expect(root.html()).toBe('<p>local:2:4</p>');
+			root.update(App, { value: 3 });
+			expect(root.html()).toBe('<p>local:3:6</p>');
+			root.unmount();
+		});
+
+		it(`retains manual slots and the omitted-dependency runtime behavior (inline=${inlineHookMemo})`, () => {
+			const { App } = load(
+				`
+				import { createElement, useCallback, useMemo, withSlot } from 'octane';
+				const leftSlot = Symbol('left');
+				const rightSlot = Symbol('right');
+				const valueSlot = Symbol('value');
+				const callbackSlot = Symbol('callback');
+				function makeFactory(value) { return () => ({ value }); }
+				function useValue(value) {
+					const stable = useMemo(() => ({ value }), [value], valueSlot);
+					const always = useMemo(makeFactory(value));
+					return { stable, always, callback: useCallback(() => value, [value], callbackSlot) };
+				}
+				export function App(props) {
+					const left = withSlot(leftSlot, useValue, props.left);
+					const right = withSlot(rightSlot, useValue, props.right);
+					props.observe(left, right);
+					return createElement('p', null, left.callback() + ':' + right.callback());
+				}
+			`,
+				true,
+			);
+			const observations: any[][] = [];
+			const props = {
+				left: 1,
+				right: 10,
+				observe: (...values: any[]) => observations.push(values),
+			};
+			const root = mount(App, props);
+			const [left, right] = observations.at(-1)!;
+			expect(root.html()).toBe('<p>1:10</p>');
+			root.update(App, props);
+			expect(observations.at(-1)![0].stable).toBe(left.stable);
+			expect(observations.at(-1)![1].callback).toBe(right.callback);
+			expect(observations.at(-1)![0].always).not.toBe(left.always);
+			root.update(App, { ...props, left: 2 });
+			expect(root.html()).toBe('<p>2:10</p>');
+			expect(left.callback()).toBe(1);
+			expect(observations.at(-1)![1].stable).toBe(right.stable);
+			root.unmount();
+		});
+
+		it(`retains a previous manual memo when a replacement throws (inline=${inlineHookMemo})`, () => {
+			const { App } = load(
+				`
+				import { createElement, useMemo, withSlot } from 'octane';
+				const caller = Symbol('caller');
+				const valueSlot = Symbol('value');
+				function useValue(value) {
+					try {
+						return useMemo(() => { if (value === 2) throw new Error('retry'); return value; }, [value], valueSlot);
+					} catch {
+						return useMemo(() => 'lost previous value', [1], valueSlot);
+					}
+				}
+				export function App(props) {
+					return createElement('p', null, withSlot(caller, useValue, props.value));
+				}
+			`,
+				true,
+			);
+			const root = mount(App, { value: 1 });
+			root.update(App, { value: 2 });
+			expect(root.html()).toBe('<p>1</p>');
+			root.update(App, { value: 3 });
+			expect(root.html()).toBe('<p>3</p>');
+			root.unmount();
+		});
+
+		it(`caches every return value with Object.is dependency semantics (inline=${inlineHookMemo})`, () => {
+			const { App, missValue } = load(
+				`
+				import { createElement, puMiss, useMemo, withSlot } from 'octane';
+				const caller = Symbol('caller');
+				const valueSlot = Symbol('value');
+				function useValue(dep, value, record) {
+					return useMemo(() => { record(value); return value; }, [dep], valueSlot);
+				}
+				export function missValue() { return puMiss; }
+				export function App(props) {
+					const value = withSlot(caller, useValue, props.dep, props.value, props.record);
+					props.observe(value);
+					return createElement('p', null, value === puMiss ? 'miss' : String(value));
+				}
+			`,
+				true,
+			);
+			const computed: unknown[] = [];
+			const observed: unknown[] = [];
+			const props = {
+				record: (value: unknown) => computed.push(value),
+				observe: (value: unknown) => observed.push(value),
+			};
+			const miss = missValue();
+			const root = mount(App, { ...props, dep: NaN, value: undefined });
+			root.update(App, { ...props, dep: NaN, value: null });
+			expect(root.html()).toBe('<p>undefined</p>');
+			root.update(App, { ...props, dep: 0, value: null });
+			expect(root.html()).toBe('<p>null</p>');
+			root.update(App, { ...props, dep: -0, value: miss });
+			root.update(App, { ...props, dep: -0, value: 'changed' });
+			expect(root.html()).toBe('<p>miss</p>');
+			expect(observed.at(-1)).toBe(miss);
+			expect(computed).toEqual([undefined, null, miss]);
+			root.unmount();
+		});
+	}
+});

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -321,6 +321,46 @@ describe.each([
 });
 
 describe('SSR Phase 1 — semantics', () => {
+	it('preserves callback values and custom-hook identity across server render retries', () => {
+		const callbacks = evalServer(
+			`
+				import { useCallback, useState } from 'octane';
+				function useForwarded(callback, dependencies) {
+					return useCallback(callback, dependencies);
+				}
+				export function Callbacks(props) @{
+					const [updated, setUpdated] = useState(false);
+					const first = useForwarded(updated ? props.nextFirst : props.first, []);
+					const second = useForwarded(updated ? props.nextSecond : props.second, []);
+					props.observe(first, second);
+					if (!updated) setUpdated(true);
+					<output>{updated ? 'ready' : 'initial'}</output>
+				}
+			`,
+			'server-callback-value.tsrx',
+		);
+		const first = vi.fn(() => 'first');
+		const second = vi.fn(() => 'second');
+		const nextFirst = vi.fn(() => 'next-first');
+		const nextSecond = vi.fn(() => 'next-second');
+		const observed: Array<[() => string, () => string]> = [];
+		expect(
+			RT.renderToString(callbacks.Callbacks, {
+				first,
+				second,
+				nextFirst,
+				nextSecond,
+				observe(left: () => string, right: () => string) {
+					observed.push([left, right]);
+				},
+			}).html,
+		).toBe('<output>ready</output>');
+		expect(observed.at(-1)).toEqual([first, second]);
+		for (const callback of [first, second, nextFirst, nextSecond]) {
+			expect(callback).not.toHaveBeenCalled();
+		}
+	});
+
 	it('compares server memo dependencies with Object.is across render-phase retries', () => {
 		const memo = evalServer(
 			`

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { mount, act, createLog } from './_helpers';
 import { flushSync } from '../src/index.js';
 import {
@@ -27,6 +27,10 @@ import {
 	TransitionKeyedEmptyFill,
 	TransitionArrayModeExit,
 	TransitionOutsideBoundary,
+	TransitionAuthoredMemo,
+	TransitionAuthoredMemoStages,
+	TransitionInvariantMemo,
+	TransitionMemoArities,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -42,6 +46,252 @@ function deferred<T>(): Deferred<T> {
 	});
 	return { promise, resolve, reject };
 }
+
+function fulfilledMemoValue(value: string): Promise<string> {
+	return {
+		status: 'fulfilled',
+		value,
+		then: (resolve: (value: string) => void) => void resolve(value),
+	} as unknown as Promise<string>;
+}
+
+interface MemoObservation {
+	step: number;
+	request: PromiseLike<string>;
+	callback: () => number;
+}
+
+function observeMemos() {
+	const entries: MemoObservation[] = [];
+	return {
+		entries,
+		observe(step: number, request: PromiseLike<string>, callback: () => number) {
+			entries.push({ step, request, callback });
+		},
+	};
+}
+
+describe('memoized values across suspended transitions', () => {
+	let activeMemoRoot: ReturnType<typeof mount> | null = null;
+	afterEach(async () => {
+		activeMemoRoot?.unmount();
+		activeMemoRoot = null;
+		await act(() => {});
+	});
+
+	it('reuses a request and callback created before an initial suspension', async () => {
+		const pending = deferred<string>();
+		const load = vi.fn(() => pending.promise);
+		const observations = observeMemos();
+		const root = mount(TransitionAuthoredMemo, { load, observe: observations.observe });
+		activeMemoRoot = root;
+		expect(root.find('#memo-fallback').textContent).toBe('loading');
+		const first = observations.entries[0];
+		expect(first.request).toBe(pending.promise);
+		expect(first.callback()).toBe(0);
+
+		await act(() => pending.resolve('zero'));
+		expect(root.find('#memo-value').textContent).toBe('zero');
+		expect(observations.entries.at(-1)?.request).toBe(first.request);
+		expect(observations.entries.at(-1)?.callback).toBe(first.callback);
+		expect(load.mock.calls).toEqual([[0]]);
+	});
+
+	it('keeps both committed and pending memo identities while a transition is held', async () => {
+		const pending = deferred<string>();
+		const initial = fulfilledMemoValue('zero');
+		const load = vi.fn((step: number) => (step === 0 ? initial : pending.promise));
+		const observations = observeMemos();
+		const root = mount(TransitionAuthoredMemo, { load, observe: observations.observe });
+		activeMemoRoot = root;
+		const first = observations.entries[0];
+
+		root.click('#memo-next');
+		const attempted = observations.entries.find((entry) => entry.step === 1)!;
+		expect(root.find('#memo-shell').textContent).toBe('shell-0:0');
+		expect(root.find('#memo-value').textContent).toBe('zero');
+		expect(root.findAll('#memo-fallback')).toHaveLength(0);
+		expect(observations.entries.at(-1)?.callback).toBe(first.callback);
+		expect(attempted.request).toBe(pending.promise);
+		expect(attempted.callback()).toBe(1);
+		expect(load.mock.calls).toEqual([[0], [1]]);
+
+		await act(() => pending.resolve('one'));
+		expect(root.find('#memo-shell').textContent).toBe('shell-1:0');
+		expect(root.find('#memo-value').textContent).toBe('one');
+		expect(observations.entries.at(-1)?.request).toBe(attempted.request);
+		expect(observations.entries.at(-1)?.callback).toBe(attempted.callback);
+		expect(load.mock.calls).toEqual([[0], [1]]);
+	});
+
+	it('does not restore an abandoned pending memo over an urgent update', async () => {
+		const pending = deferred<string>();
+		const initial = fulfilledMemoValue('zero');
+		const urgent = fulfilledMemoValue('two');
+		const load = vi.fn((step: number) =>
+			step === 0 ? initial : step === 1 ? pending.promise : urgent,
+		);
+		const observations = observeMemos();
+		const root = mount(TransitionAuthoredMemo, { load, observe: observations.observe });
+		activeMemoRoot = root;
+
+		root.click('#memo-next');
+		expect(root.find('#memo-value').textContent).toBe('zero');
+		root.click('#memo-urgent');
+		const committed = observations.entries.at(-1)!;
+		expect(committed.step).toBe(2);
+		expect(committed.callback()).toBe(2);
+		expect(root.find('#memo-shell').textContent).toBe('shell-2:0');
+		expect(root.find('#memo-value').textContent).toBe('two');
+
+		await act(() => pending.resolve('one'));
+		root.click('#memo-refresh');
+		expect(root.find('#memo-shell').textContent).toBe('shell-2:1');
+		expect(root.find('#memo-value').textContent).toBe('two');
+		expect(observations.entries.at(-1)?.request).toBe(committed.request);
+		expect(observations.entries.at(-1)?.callback).toBe(committed.callback);
+		expect(load.mock.calls).toEqual([[0], [1], [2]]);
+	});
+
+	it('retains already-started requests when promotion suspends on a later dependency', async () => {
+		const first = deferred<string>();
+		const second = deferred<string>();
+		const initialFirst = fulfilledMemoValue('old-first');
+		const initialSecond = fulfilledMemoValue('old-second');
+		const load = vi.fn((step: number, stage: string) => {
+			if (step === 0) return stage === 'first' ? initialFirst : initialSecond;
+			return stage === 'first' ? first.promise : second.promise;
+		});
+		const root = mount(TransitionAuthoredMemoStages, { load });
+		activeMemoRoot = root;
+		expect(root.find('#memo-stages-value').textContent).toBe('old-first/old-second');
+
+		root.click('#memo-stages-next');
+		expect(root.find('#memo-stages-shell').textContent).toBe('shell-0');
+		expect(root.find('#memo-stages-value').textContent).toBe('old-first/old-second');
+		expect(load.mock.calls).toEqual([
+			[0, 'first'],
+			[0, 'second'],
+			[1, 'first'],
+		]);
+
+		await act(() => first.resolve('new-first'));
+		expect(root.find('#memo-stages-shell').textContent).toBe('shell-0');
+		expect(root.find('#memo-stages-value').textContent).toBe('old-first/old-second');
+		expect(load.mock.calls).toEqual([
+			[0, 'first'],
+			[0, 'second'],
+			[1, 'first'],
+			[1, 'second'],
+		]);
+
+		await act(() => second.resolve('new-second'));
+		expect(root.find('#memo-stages-shell').textContent).toBe('shell-1');
+		expect(root.find('#memo-stages-value').textContent).toBe('new-first/new-second');
+		expect(load.mock.calls).toEqual([
+			[0, 'first'],
+			[0, 'second'],
+			[1, 'first'],
+			[1, 'second'],
+		]);
+	});
+
+	it('promotes an invariant callback first reached by the suspended attempt', async () => {
+		const pending = deferred<string>();
+		const observed: Array<{ step: number; callback: () => void }> = [];
+		const root = mount(TransitionInvariantMemo, {
+			promise: pending.promise,
+			observe: (step: number, callback: () => void) => observed.push({ step, callback }),
+		});
+		activeMemoRoot = root;
+		root.click('#memo-invariant-next');
+		const attempted = observed[0].callback;
+		expect(root.find('#memo-invariant-shell').textContent).toBe('shell-0');
+		expect(root.find('#memo-invariant-value').textContent).toBe('zero');
+
+		await act(() => pending.resolve('one'));
+		expect(root.find('#memo-invariant-shell').textContent).toBe('shell-1');
+		expect(root.find('#memo-invariant-value').textContent).toBe('one:0');
+		expect(observed.at(-1)?.callback).toBe(attempted);
+		root.click('#memo-invariant-value');
+		expect(root.find('#memo-invariant-value').textContent).toBe('one:1');
+		expect(observed.at(-1)?.callback).toBe(attempted);
+	});
+
+	it('discards a newly reached invariant callback when an urgent render supersedes its hold', async () => {
+		const pending = deferred<string>();
+		const observed: Array<{ step: number; callback: () => void }> = [];
+		const root = mount(TransitionInvariantMemo, {
+			promise: pending.promise,
+			observe: (step: number, callback: () => void) => observed.push({ step, callback }),
+		});
+		activeMemoRoot = root;
+		root.click('#memo-invariant-next');
+		const attempted = observed[0].callback;
+		root.click('#memo-invariant-urgent');
+		const committed = observed.at(-1)!.callback;
+		expect(committed).not.toBe(attempted);
+		expect(root.find('#memo-invariant-shell').textContent).toBe('shell-2');
+		expect(root.find('#memo-invariant-value').textContent).toBe('urgent:0');
+
+		await act(() => pending.resolve('one'));
+		root.click('#memo-invariant-value');
+		expect(root.find('#memo-invariant-value').textContent).toBe('urgent:1');
+		expect(observed.at(-1)?.callback).toBe(committed);
+	});
+
+	for (const supersede of [false, true]) {
+		it(`preserves memo entries with zero through five dependencies across ${supersede ? 'urgent superseding' : 'promotion'}`, async () => {
+			const pending = deferred<string>();
+			const observed: Array<{
+				step: number;
+				values: Array<{ step: number }>;
+				late: { step: number } | null;
+			}> = [];
+			const root = mount(TransitionMemoArities, {
+				promise: pending.promise,
+				observe: (step: number, values: Array<{ step: number }>, late: { step: number } | null) =>
+					observed.push({ step, values, late }),
+			});
+			activeMemoRoot = root;
+			const initial = observed[0];
+			expect(initial.late).toBeNull();
+			root.click('#memo-arities-next');
+			const attempted = observed.find((entry) => entry.step === 1)!;
+			const held = observed.at(-1)!;
+			expect(root.find('#memo-arities-shell').textContent).toBe('shell-0');
+			expect(root.find('#memo-arities-value').textContent).toBe('zero:0,0,0,0,0,0');
+			for (let index = 0; index < initial.values.length; index++) {
+				expect(held.values[index]).toBe(initial.values[index]);
+				if (index === 0) expect(attempted.values[index]).toBe(initial.values[index]);
+				else expect(attempted.values[index]).not.toBe(initial.values[index]);
+			}
+			expect(held.late).toBeNull();
+			expect(attempted.late?.step).toBe(1);
+
+			if (supersede) root.click('#memo-arities-urgent');
+			await act(() => pending.resolve('one'));
+			const committed = observed.at(-1)!;
+			expect(root.find('#memo-arities-shell').textContent).toBe(supersede ? 'shell-2' : 'shell-1');
+			expect(root.find('#memo-arities-value').textContent).toBe(
+				supersede ? 'urgent:0,2,2,2,2,2' : 'one:0,1,1,1,1,1',
+			);
+			for (let index = 0; index < attempted.values.length; index++) {
+				if (supersede && index !== 0) {
+					expect(committed.values[index]).not.toBe(attempted.values[index]);
+				} else {
+					expect(committed.values[index]).toBe(attempted.values[index]);
+				}
+			}
+			if (supersede) {
+				expect(committed.late).not.toBe(attempted.late);
+				expect(committed.late?.step).toBe(2);
+			} else {
+				expect(committed.late).toBe(attempted.late);
+			}
+		});
+	}
+});
 
 describe('useTransition — basics', () => {
 	it('returns [isPending=false, start]; start runs fn and tags renders as transition', async () => {

--- a/packages/octane/tests/universal-scheduling.test.ts
+++ b/packages/octane/tests/universal-scheduling.test.ts
@@ -15,6 +15,7 @@ import {
 	universalTry,
 	universalValue,
 	use,
+	useCallback,
 	useContext,
 	useDeferredValue,
 	useEffect,
@@ -950,6 +951,36 @@ describe('universal transition scheduling', () => {
 		flushAll();
 		expect(values(container)).toEqual({ pending: false, content: 'third' });
 		expect(container.commits).toHaveLength(acceptedCommits);
+		root.unmount();
+	});
+
+	it('keeps callback values isolated from suspended drafts and compares their dependencies', () => {
+		const resource = deferred<string>();
+		const initialResource = fulfilled('initial');
+		const first = () => 'first';
+		const next = () => 'next';
+		const observed: Array<() => string> = [];
+		const Scene = defineUniversalComponent(
+			'object',
+			(props: { callback: () => string; dependency: number; resource: Promise<string> }) => {
+				const callback = useCallback(props.callback, [props.dependency], 'callback');
+				observed.push(callback);
+				return node('content', use(props.resource));
+			},
+		);
+		const { container, root } = objectRoot();
+
+		root.render(Scene, { callback: first, dependency: 0, resource: initialResource });
+		expect(observed.at(-1)).toBe(first);
+		root.render(Scene, { callback: next, dependency: 0, resource: initialResource });
+		expect(observed.at(-1)).toBe(first);
+		root.render(Scene, { callback: next, dependency: -0, resource: resource.promise });
+		expect(observed.at(-1)).toBe(next);
+		expect(values(container)).toEqual({ content: 'initial' });
+
+		root.render(Scene, { callback: next, dependency: 0, resource: initialResource });
+		expect(observed.at(-1)).toBe(first);
+		expect(values(container)).toEqual({ content: 'initial' });
 		root.unmount();
 	});
 

--- a/website/playground-runtime.ts
+++ b/website/playground-runtime.ts
@@ -1,0 +1,117 @@
+import type { Plugin } from 'vite';
+import { createRequire } from 'node:module';
+import { build as esbuildBuild } from 'esbuild';
+import type { RuntimeManifest } from './src/lib/playground-sandbox.ts';
+
+// The playground executes user code in a sandboxed iframe with an OPAQUE
+// origin (src/lib/playground-sandbox.ts). That iframe can't import the site's
+// bundled octane (blob URLs are origin-bound and cross-origin module fetches
+// need CORS), so the parent hands it the runtime as TEXT and the iframe turns
+// it into blob modules on its own side of the boundary.
+//
+// The runtime ships as a JSON MANIFEST of esbuild code-split chunks rather
+// than one file: `octane`, its compiler-only client ABI, and `octane/react`
+// are separate entries sharing the core through common chunks. Bundling any
+// entry standalone would duplicate the runtime's hook/context singletons. React
+// itself stays EXTERNAL: the sandbox's import map resolves the react family to
+// esm.sh, so react is only ever fetched when user code actually imports
+// `octane/react` — pure-octane sessions never touch the network.
+export async function buildPlaygroundRuntimeManifest(): Promise<RuntimeManifest> {
+	const require = createRequire(import.meta.url);
+	const out = await esbuildBuild({
+		// Workspace link: website/node_modules/octane → packages/octane, whose
+		// exports map points entries at raw TS sources — esbuild handles them.
+		entryPoints: {
+			octane: require.resolve('octane'),
+			'octane-internal-client': require.resolve('octane/internal/client'),
+			'octane-react': require.resolve('octane/react'),
+		},
+		bundle: true,
+		splitting: true,
+		format: 'esm',
+		target: ['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4'],
+		minify: true,
+		write: false,
+		outdir: 'playground-runtime',
+		entryNames: '[name]',
+		chunkNames: 'chunk-[hash]',
+		outExtension: { '.js': '.mjs' },
+		external: [
+			'react',
+			'react-dom',
+			'react-dom/client',
+			'react/jsx-runtime',
+			'react/jsx-dev-runtime',
+		],
+		define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+	});
+
+	const files: Record<string, string> = {};
+	for (const file of out.outputFiles) {
+		files[file.path.replace(/^.*[/\\]/, '')] = file.text;
+	}
+
+	// The sandbox creates a blob URL per file and splices it into the files
+	// that import it, so files must arrive dependencies-first. Topo-sort the
+	// chunk graph (esbuild inter-chunk specifiers are exactly `./<name>.mjs`).
+	const deps = new Map<string, string[]>();
+	for (const [name, code] of Object.entries(files)) {
+		const imported: string[] = [];
+		for (const match of code.matchAll(/(["'])\.\/([\w.-]+\.mjs)\1/g)) {
+			if (files[match[2]] && !imported.includes(match[2])) imported.push(match[2]);
+		}
+		deps.set(name, imported);
+	}
+	const order: string[] = [];
+	const state = new Map<string, 'visiting' | 'done'>();
+	const visit = (name: string, chain: string[]) => {
+		if (state.get(name) === 'done') return;
+		if (state.get(name) === 'visiting') {
+			throw new Error(
+				`playground runtime chunks import each other cyclically (${[...chain, name].join(' → ')}) — the sandbox's dependencies-first blob ordering cannot represent that`,
+			);
+		}
+		state.set(name, 'visiting');
+		for (const dep of deps.get(name) ?? []) visit(dep, [...chain, name]);
+		state.set(name, 'done');
+		order.push(name);
+	};
+	for (const name of deps.keys()) visit(name, []);
+
+	return {
+		entries: {
+			octane: 'octane.mjs',
+			'octane/internal/client': 'octane-internal-client.mjs',
+			'octane/react': 'octane-react.mjs',
+		},
+		order,
+		files,
+	};
+}
+
+export function playgroundRuntime(): Plugin {
+	const MANIFEST_PATH = '/playground-runtime.json'; // = RUNTIME_MANIFEST_PATH in playground-sandbox.ts
+	const bundle = async () => JSON.stringify(await buildPlaygroundRuntimeManifest());
+
+	return {
+		name: 'octane-playground-runtime',
+		configureServer(server) {
+			server.middlewares.use(MANIFEST_PATH, (_req, res, next) => {
+				// Rebuilt per request — esbuild bundles the runtime in ~15ms, and
+				// this way dev never serves a stale runtime after octane edits.
+				bundle().then((code) => {
+					res.setHeader('Content-Type', 'application/json; charset=utf-8');
+					res.end(code);
+				}, next);
+			});
+		},
+		async generateBundle() {
+			if (this.environment.name !== 'client') return;
+			this.emitFile({
+				type: 'asset',
+				fileName: MANIFEST_PATH.slice(1),
+				source: await bundle(),
+			});
+		},
+	};
+}

--- a/website/src/lib/playground-modules.ts
+++ b/website/src/lib/playground-modules.ts
@@ -8,8 +8,9 @@
 // see playground-sandbox.ts for the CSP that backs it):
 //   ./File[.ext]        → sibling file, rewritten to a `__pg_module:<name>__`
 //                         token the sandbox swaps for a blob URL
-//   octane, octane/react, react family → left bare; the sandbox import map
-//                         resolves them (octane → local runtime blobs)
+//   octane, octane/react, octane/internal/client, react family → left bare;
+//                         the sandbox import map resolves them (Octane's
+//                         public and compiler-only APIs share local blobs)
 //   other octane/*      → error (not available in the playground)
 //   https://esm.sh/*    → allowed verbatim; any other URL → error
 //   any other bare id   → https://esm.sh/<id>?external=octane — `external`
@@ -42,6 +43,7 @@ export interface ModuleGraphFailure {
 /** Import specifiers the sandbox import map resolves — leave them bare. */
 const IMPORT_MAP_SPECIFIERS = new Set([
 	'octane',
+	'octane/internal/client',
 	'octane/react',
 	'react',
 	'react/jsx-runtime',
@@ -193,7 +195,7 @@ export async function buildModuleGraph(
 			} else if (specifier.startsWith('octane/')) {
 				return {
 					ok: false,
-					error: `${file.name}: "${specifier}" is not available in the playground (only "octane" and "octane/react" are).`,
+					error: `${file.name}: "${specifier}" is not available in the playground (only bundled client runtime entry points are supported).`,
 				};
 			} else if (specifier.startsWith('https://esm.sh/')) {
 				// Already an esm.sh URL — allowed verbatim.

--- a/website/src/lib/playground-sandbox.ts
+++ b/website/src/lib/playground-sandbox.ts
@@ -40,7 +40,8 @@
 // chunks dependencies-first, then installs a SINGLE import map — as a classic
 // (non-module) script it runs before any module load, which is baseline
 // import-map behavior in every supporting browser; no late-map mutation
-// anywhere — wiring bare `octane` / `octane/react` to those blobs and the
+// anywhere — wiring bare `octane`, its compiler-only client ABI, and
+// `octane/react` to those blobs and the
 // react family to esm.sh (react is only fetched if something imports it).
 // User modules keep those specifiers bare; sibling-file imports arrive as
 // `__pg_module:<name>__` tokens the bootstrap swaps for blob URLs.
@@ -66,7 +67,7 @@ export const PLAYGROUND_REACT_VERSION = '19.2.0';
 
 /** Shape of the runtime manifest built by the playgroundRuntime() vite plugin. */
 export interface RuntimeManifest {
-	entries: { octane: string; 'octane/react': string };
+	entries: { octane: string; 'octane/internal/client': string; 'octane/react': string };
 	order: string[];
 	files: Record<string, string>;
 }
@@ -142,6 +143,7 @@ window.addEventListener('message', async (event) => {
 			map.textContent = JSON.stringify({
 				imports: {
 					octane: blobs[entries['octane']],
+					'octane/internal/client': blobs[entries['octane/internal/client']],
 					'octane/react': blobs[entries['octane/react']],
 					react: esm('react@' + REACT_VERSION),
 					'react/jsx-runtime': esm('react@' + REACT_VERSION + '/jsx-runtime'),

--- a/website/tests/playground-modules.test.ts
+++ b/website/tests/playground-modules.test.ts
@@ -122,6 +122,27 @@ describe('third-party import policy', () => {
 		expect(graph.modules[0].code).not.toContain('esm.sh/octane');
 	});
 
+	it('keeps compiler-only client helpers on the shared runtime import map', async () => {
+		const graph = await buildModuleGraph(
+			[
+				app(
+					"import { useMemo } from 'octane';\nexport default function App({ value }) @{\n\tconst doubled = useMemo(() => value * 2, [value]);\n\t<b>{doubled as string}</b>\n}",
+				),
+			],
+			APP,
+		);
+		expect(graph.ok).toBe(true);
+		if (!graph.ok) return;
+		const { init, parse } = await import('es-module-lexer');
+		await init;
+		const [imports] = parse(graph.modules[0].code);
+		const specifiers = imports.map((entry) => entry.n);
+		expect(specifiers).toContain('octane/internal/client');
+		expect(specifiers.some((specifier) => specifier?.startsWith('https://esm.sh/octane'))).toBe(
+			false,
+		);
+	});
+
 	it('allows verbatim esm.sh URLs but no other URL imports', async () => {
 		const ok = await buildModuleGraph(
 			[app("import x from 'https://esm.sh/canvas-confetti';\nexport const y = x;")],
@@ -136,9 +157,14 @@ describe('third-party import policy', () => {
 	});
 
 	it('rejects octane subpaths the sandbox does not provide', async () => {
-		const graph = await buildModuleGraph([app("import { compile } from 'octane/compiler';")], APP);
-		expect(graph.ok).toBe(false);
-		if (!graph.ok) expect(graph.error).toContain('octane/compiler');
+		for (const specifier of ['octane/compiler', 'octane/internal/server', 'octane/not-provided']) {
+			const graph = await buildModuleGraph(
+				[app(`import * as unavailable from '${specifier}'; export const value = unavailable;`)],
+				APP,
+			);
+			expect(graph.ok).toBe(false);
+			if (!graph.ok) expect(graph.error).toContain(specifier);
+		}
 	});
 });
 

--- a/website/tests/playground-runtime.test.ts
+++ b/website/tests/playground-runtime.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment node
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { build as esbuildBuild } from 'esbuild';
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+import { buildPlaygroundRuntimeManifest } from '../playground-runtime.ts';
+import { PROTOCOL_KEY, sandboxSrcdoc } from '../src/lib/playground-sandbox.ts';
+
+type TestWindow = Window & typeof globalThis;
+const require = createRequire(import.meta.url);
+const { JSDOM } = require('jsdom') as {
+	JSDOM: new (
+		html: string,
+		options: {
+			runScripts: 'outside-only' | 'dangerously';
+			beforeParse?: (window: TestWindow) => void;
+		},
+	) => { window: TestWindow };
+};
+
+describe('playground runtime manifest', () => {
+	it('links compiler-only memo helpers to the sandbox runtime singleton', async () => {
+		const manifest = await buildPlaygroundRuntimeManifest();
+		const privateEntry = manifest.entries['octane/internal/client'];
+		expect(privateEntry).toBeTypeOf('string');
+		expect(manifest.order).toContain(privateEntry);
+		expect(manifest.files[privateEntry]).toBeTypeOf('string');
+
+		const directory = mkdtempSync(join(tmpdir(), 'octane-playground-runtime-'));
+		try {
+			for (const [name, code] of Object.entries(manifest.files)) {
+				writeFileSync(join(directory, name), code);
+			}
+			// Load the actual code-split artifacts. Independent bundles could
+			// expose the same names while silently creating two hook runtimes.
+			const publicRuntime = require(join(directory, manifest.entries.octane));
+			const privateRuntime = require(join(directory, privateEntry));
+			expect(privateRuntime.useMemo).toBe(publicRuntime.useMemo);
+			expect(privateRuntime.createRoot).toBe(publicRuntime.createRoot);
+
+			// Link a real compiled custom hook against these exact emitted entry
+			// files. Its path-aware memo needs the same active scope as createRoot;
+			// merely exposing matching export names from two runtimes is not enough.
+			const compiled = compile(
+				`import { useMemo } from 'octane';
+function useDoubled(value, record) {
+	return useMemo(() => { record(value); return value * 2; }, [value]);
+}
+export function MemoApp({ value, record }) @{
+	const doubled = useDoubled(value, record);
+	<p>{doubled as string}</p>
+}`,
+				'playground-memo.tsrx',
+				{ hmr: false, dev: false },
+			).code;
+			const linked = await esbuildBuild({
+				stdin: {
+					contents:
+						compiled +
+						`
+import { createRoot, flushSync } from 'octane';
+const computed = [];
+const record = value => computed.push(value);
+const root = createRoot(document.getElementById('app'));
+const render = value => flushSync(() => root.render(MemoApp, { value, record }));
+render(1);
+globalThis.__playgroundMemo = { render, computed, dispose: () => root.unmount() };
+`,
+					loader: 'js',
+					resolveDir: directory,
+					sourcefile: 'playground-memo.js',
+				},
+				bundle: true,
+				format: 'iife',
+				platform: 'browser',
+				target: 'esnext',
+				logLevel: 'silent',
+				write: false,
+				plugins: [
+					{
+						name: 'playground-manifest-entries',
+						setup(build) {
+							build.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path }) => {
+								const entry = manifest.entries[path as keyof typeof manifest.entries];
+								return entry === undefined
+									? { errors: [{ text: 'Missing playground runtime entry: ' + path }] }
+									: { path: join(directory, entry) };
+							});
+						},
+					},
+				],
+			});
+			const rendered = new JSDOM('<!doctype html><div id="app"></div>', {
+				runScripts: 'outside-only',
+			});
+			try {
+				rendered.window.eval(linked.outputFiles[0].text);
+				const probe = (
+					rendered.window as unknown as {
+						__playgroundMemo: { render(value: number): void; computed: number[]; dispose(): void };
+					}
+				).__playgroundMemo;
+				expect(rendered.window.document.querySelector('#app')!.innerHTML).toBe('<p>2</p>');
+				probe.render(1);
+				probe.render(2);
+				expect(rendered.window.document.querySelector('#app')!.innerHTML).toBe('<p>4</p>');
+				expect(Array.from(probe.computed)).toEqual([1, 2]);
+				probe.dispose();
+			} finally {
+				rendered.window.close();
+			}
+
+			const blobs: string[] = [];
+			const dom = new JSDOM(sandboxSrcdoc(), {
+				runScripts: 'dangerously',
+				beforeParse(window: TestWindow) {
+					window.URL.createObjectURL = () => {
+						const url = 'blob:playground-runtime-' + blobs.length;
+						blobs.push(url);
+						return url;
+					};
+				},
+			});
+			try {
+				const ready = new Promise<void>((resolve) => {
+					dom.window.addEventListener('message', (event: MessageEvent) => {
+						if (event.data?.[PROTOCOL_KEY] === true && event.data.type === 'ready') resolve();
+					});
+				});
+				dom.window.dispatchEvent(
+					new dom.window.MessageEvent('message', {
+						source: dom.window.parent,
+						data: { [PROTOCOL_KEY]: true, type: 'init', manifest },
+					}),
+				);
+				const map = JSON.parse(
+					dom.window.document.querySelector('script[type="importmap"]')!.textContent!,
+				);
+				expect(map.imports['octane/internal/client']).toBe(
+					blobs[manifest.order.indexOf(privateEntry)],
+				);
+				expect(map.imports.octane).toBe(blobs[manifest.order.indexOf(manifest.entries.octane)]);
+				expect(map.imports['octane/compiler']).toBeUndefined();
+				expect(map.imports['octane/internal/server']).toBeUndefined();
+				// jsdom cannot execute blob ESM; the bootstrap still reports that
+				// import failure after installing the real import map.
+				await ready;
+			} finally {
+				dom.window.close();
+			}
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig, type Plugin } from 'vite';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { build as esbuildBuild } from 'esbuild';
 import { octaneMdx } from '@octanejs/mdx/vite';
 import { threeRenderers } from '@octanejs/three/config';
 import { tanstackStart } from '@octanejs/tanstack-start/plugin/vite';
 import { nitro } from 'nitro/vite';
 import { websiteMdxOptions } from './mdx-options.ts';
+import { playgroundRuntime } from './playground-runtime.ts';
 
 // Does any pre-bundled dependency resolve to a checkout OUTSIDE node_modules —
 // a `link:` override in pnpm-workspace.yaml pointing at a sibling repo?
@@ -54,113 +54,6 @@ function isDeclarable(specifier: string): boolean {
 		? specifier.split('/').slice(0, 2).join('/')
 		: specifier.split('/')[0];
 	return existsSync(new URL(`./node_modules/${name}`, import.meta.url));
-}
-
-// The playground executes user code in a sandboxed iframe with an OPAQUE
-// origin (src/lib/playground-sandbox.ts). That iframe can't import the site's
-// bundled octane (blob URLs are origin-bound and cross-origin module fetches
-// need CORS), so the parent hands it the runtime as TEXT and the iframe turns
-// it into blob modules on its own side of the boundary.
-//
-// The runtime ships as a JSON MANIFEST of esbuild code-split chunks rather
-// than one file: `octane` and `octane/react` are separate entries sharing the
-// octane core through common chunks (bundling `octane/react` standalone would
-// duplicate the core — two runtimes, broken hook/context singletons). React
-// itself stays EXTERNAL: the sandbox's import map resolves the react family to
-// esm.sh, so react is only ever fetched when user code actually imports
-// `octane/react` — pure-octane sessions never touch the network.
-function playgroundRuntime(): Plugin {
-	const MANIFEST_PATH = '/playground-runtime.json'; // = RUNTIME_MANIFEST_PATH in playground-sandbox.ts
-
-	async function bundle(): Promise<string> {
-		const require = createRequire(import.meta.url);
-		const out = await esbuildBuild({
-			// Workspace link: website/node_modules/octane → packages/octane, whose
-			// exports map points entries at raw TS sources — esbuild handles them.
-			entryPoints: {
-				octane: require.resolve('octane'),
-				'octane-react': require.resolve('octane/react'),
-			},
-			bundle: true,
-			splitting: true,
-			format: 'esm',
-			target: ['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4'],
-			minify: true,
-			write: false,
-			outdir: 'playground-runtime',
-			entryNames: '[name]',
-			chunkNames: 'chunk-[hash]',
-			outExtension: { '.js': '.mjs' },
-			external: [
-				'react',
-				'react-dom',
-				'react-dom/client',
-				'react/jsx-runtime',
-				'react/jsx-dev-runtime',
-			],
-			define: { 'process.env.NODE_ENV': JSON.stringify('production') },
-		});
-
-		const files: Record<string, string> = {};
-		for (const file of out.outputFiles) {
-			files[file.path.replace(/^.*[/\\]/, '')] = file.text;
-		}
-
-		// The sandbox creates a blob URL per file and splices it into the files
-		// that import it, so files must arrive dependencies-first. Topo-sort the
-		// chunk graph (esbuild inter-chunk specifiers are exactly `./<name>.mjs`).
-		const deps = new Map<string, string[]>();
-		for (const [name, code] of Object.entries(files)) {
-			const imported: string[] = [];
-			for (const match of code.matchAll(/(["'])\.\/([\w.-]+\.mjs)\1/g)) {
-				if (files[match[2]] && !imported.includes(match[2])) imported.push(match[2]);
-			}
-			deps.set(name, imported);
-		}
-		const order: string[] = [];
-		const state = new Map<string, 'visiting' | 'done'>();
-		const visit = (name: string, chain: string[]) => {
-			if (state.get(name) === 'done') return;
-			if (state.get(name) === 'visiting') {
-				throw new Error(
-					`playground runtime chunks import each other cyclically (${[...chain, name].join(' → ')}) — the sandbox's dependencies-first blob ordering cannot represent that`,
-				);
-			}
-			state.set(name, 'visiting');
-			for (const dep of deps.get(name) ?? []) visit(dep, [...chain, name]);
-			state.set(name, 'done');
-			order.push(name);
-		};
-		for (const name of deps.keys()) visit(name, []);
-
-		return JSON.stringify({
-			entries: { octane: 'octane.mjs', 'octane/react': 'octane-react.mjs' },
-			order,
-			files,
-		});
-	}
-
-	return {
-		name: 'octane-playground-runtime',
-		configureServer(server) {
-			server.middlewares.use(MANIFEST_PATH, (_req, res, next) => {
-				// Rebuilt per request — esbuild bundles the runtime in ~15ms, and
-				// this way dev never serves a stale runtime after octane edits.
-				bundle().then((code) => {
-					res.setHeader('Content-Type', 'application/json; charset=utf-8');
-					res.end(code);
-				}, next);
-			});
-		},
-		async generateBundle() {
-			if (this.environment.name !== 'client') return;
-			this.emitFile({
-				type: 'asset',
-				fileName: MANIFEST_PATH.slice(1),
-				source: await bundle(),
-			});
-		},
-	};
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extend production-client memo lowering to safe nested expressions, returned JSX, custom hooks, plain TypeScript modules, and explicit hook slots. Cache hits do not evaluate a factory or callback function expression or dependency-array literal; unsupported cases keep the runtime hook path.
- Preserve dependency evaluation order, explicit slot sharing, factory scope, TDZ, anonymous function/class names, abrupt completion, and suspension semantics. Flat cache publication now participates in the existing two-way held-transition memo journal.
- Remove the extra runtime `() => callback` allocation on client, server, and universal paths. Keep the new compiler/runtime ABI private, with fixed-arity flat publishers to avoid adding ordinary miss-side rest arrays.
- Add behavioral regressions, a patch changeset, and a deterministic production A/B allocation-and-size benchmark with 12 guards.

### Performance evidence

Fresh paired runs against upstream base `922b2d46e` reproduce the original pinned-baseline results:

| Eligible scenarios | Before | After |
| --- | ---: | ---: |
| Cache-hit function-expression creations | 1,088 | 0 |
| Cache-hit application array literals | 736 | 0 |
| Cache-hit total array creations | 1,824 | 352 |
| Cache-miss function-expression creations | 1,184 | 448 |
| Compiled fixture gzip bytes | 2,169 | 2,654 |
| Tree-shaken bundle gzip bytes | 44,139 | 44,603 |

The candidate passes all 12 guards; the base breaches seven. These are source-creation counts, not V8 heap bytes or a browser-latency claim. Bundle cost is +464 gzip bytes (+1.05%) for this corpus. The recorded hookless compiler-throughput control emitted 18 byte-identical outputs; its timing spread includes parity.

[Benchmark methodology and source hashes](https://github.com/openai-oss-forks/octane/blob/e5645d5d4e1d87c9b539c87261b7cbefadaddaaa/benchmarks/hook-memo/README.md) · [Design and safety boundaries](https://github.com/openai-oss-forks/octane/blob/e5645d5d4e1d87c9b539c87261b7cbefadaddaaa/docs/decallback-memo.md)

## Validation

- [x] `pnpm sync` — completed on the rebased tree; no generated changes remained. Used the available cached dependencies with `pnpm_config_verify_deps_before_run=warn`.
- [ ] `pnpm format:check` — repo-wide check not run; scoped Prettier check passed for all 33 non-ignored changed files, and `git diff --check` passed.
- [ ] `pnpm typecheck` — repo-wide check not run; `tsgo --noEmit -p packages/octane/tsconfig.json` and `tsgo --noEmit -p packages/octane/typetests/tsconfig.json` passed. The added hooks/transition fixtures introduce zero diagnostics relative to their baseline.
- [ ] `pnpm test` — normal locked-toolchain run remains unavailable because dependency installation returned registry 403.
- [x] Targeted tests: actual Vitest with the checked-in JavaScript parser, frozen AST/location assertions, and real Octane plugin/runtime. Rebased dev/HMR matrix: **305 passed across 14 files**. Rebased production core run: **7,164 passed**, with the same ten baseline/dependency failures and three suite-load failures described below.
- [x] `node benchmarks/bench.mjs --ratios hook-memo` with the same documented fallback loader for both sides — **12/12 pass**; baseline negative control fails seven. Observer tests: **2/2 pass**.

Fallback toolchain: Node 26.4.0, `@tsrx/core` 0.1.56, esrap 2.3.0, esbuild 0.28.1. The ten remaining test failures are four known Volar/core-version mismatches, three installed-binding discovery failures, and three native compiler-registration failures. The imperative-DOM differential fixture, production-profile bundle, and React-hosted web3 suites cannot load because the fallback setup lacks their generated fixture/native parser/workspace dependencies. These are not claimed green.

## Risk / follow-ups

- Rerun the normal locked native-parser and full workspace checks before marking this ready. This PR intentionally remains a draft.
- Generated code grows; the committed ratio guards cover the paired fixture and bundle costs. A representative production-browser workload is still needed for any latency or GC claim.
- A pre-existing continuing-transition limitation remains: after promotion suspends again, an urgent render can retain an empty-dependency callback from the attempt. Both ordinary and lowered memo paths reproduce it; the separate scheduler fix is documented, not folded into this optimization.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729339&installation_model_id=432790&pr_number=788&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F788&signature=8bc57a1e6369402b79cbce760f5e76fa6983edefc0e41344d482ea043802a78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core compiler output, client hook runtime, and transition memo journaling; incorrect lowering could change identities, TDZ, or held-transition behavior despite broad tests and benchmarks.
> 
> **Overview**
> Production client compilation now **lowers more `useMemo` / `useCallback` sites to closure-free inline caches** instead of per-render factory arrows and dependency arrays. Eligible cache hits skip evaluating the factory and skip creating dependency-array literals; `useCallback` only materializes its function on a miss. Coverage expands beyond flat declarations to **nested expressions, returned JSX, custom hooks, plain `.ts`/`.js` hook modules, and explicit third-slot calls**, with unsafe shapes still on the runtime hook path.
> 
> The compiler adds a **path-aware post-slot pass** (`inline-hook-memo.js`, `plain-hook-memo.js`) for helpers and explicit slots, plus **flat per-body `_k$N` caches** for render-local sites. Runtime gains private helpers (`hookMemoPublish*`, `memoTake*` / `memoPublish*`, `hookMemoCreate`, `hookMemoEqual`) and **stores callback values directly**—no extra `() => fn` wrapper. **Held-transition rollback/promotion** journals inline memo cell ranges alongside hook-map entries.
> 
> A new **`hook-memo` benchmark** (fixtures, post-tree-shake allocation observer, 12 ratio guards) and MCP **`octane_benchmark`** listing document the allocation and gzip tradeoffs (~+1% bundle gzip in the recorded corpus).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee05bb4ebb45ba067267d69c6d1d83c5120afe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->