### PR TITLE
ci: split React parity across four shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
           --exclude "$ASTRO_E2E_SPEC"
 
   react_parity_shard:
-    name: React parity shard (${{ matrix.shard }}/3)
+    name: React parity shard (${{ matrix.shard }}/4)
     needs: release_change
     # The complete package suite is intentionally Node 24-only. Like the
     # general shards, an authenticated release or lightweight change inherits
@@ -464,7 +464,7 @@ jobs:
       matrix:
         # Vitest hashes parity file paths across these workers. Non-Vitest
         # manifests remain whole and use the same generic shard coordinates.
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout code
@@ -494,7 +494,7 @@ jobs:
       - name: Check React parity inventories and execute required lanes
         env:
           REACT_PARITY_VITEST_REPORT: ${{ runner.temp }}/react-parity-vitest/shard-${{ matrix.shard }}.json
-        run: pnpm react-parity:check --shard ${{ matrix.shard }}/3
+        run: pnpm react-parity:check --shard ${{ matrix.shard }}/4
 
       - name: Upload React parity Vitest shard report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -534,7 +534,7 @@ jobs:
         run: >-
           node scripts/react-parity/verify-vitest-shards.mjs
           --reports-directory "${{ runner.temp }}/react-parity-vitest"
-          --expected-shards 3
+          --expected-shards 4
 
   # Keep the Node 24 aggregate check name while the work happens in parallel
   # above. `always()` makes a failed shard produce a failed required check and

--- a/docs/react-parity-testing.md
+++ b/docs/react-parity-testing.md
@@ -226,12 +226,13 @@ identity uniqueness. It does not collect or execute Vitest, Jest, or type-test
 lanes.
 
 The generic React parity workers run the complete package suites on Node 24. CI
-currently requests three native Vitest file shards:
+currently requests four native Vitest file shards:
 
 ```bash
-pnpm react-parity:check --shard 1/3
-pnpm react-parity:check --shard 2/3
-pnpm react-parity:check --shard 3/3
+pnpm react-parity:check --shard 1/4
+pnpm react-parity:check --shard 2/4
+pnpm react-parity:check --shard 3/4
+pnpm react-parity:check --shard 4/4
 ```
 
 `pnpm react-parity:check` without `--shard` retains the complete single-runner

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -313,15 +313,15 @@ describe('CI workflow aggregation', () => {
 		const parity = jobSource('react_parity_shard');
 		const parityAggregate = jobSource('react_parity_checks');
 		const lint = jobSource('lint_checks');
-		assert.match(parity, /name: React parity shard \(\$\{\{ matrix\.shard \}\}\/3\)/);
+		assert.match(parity, /name: React parity shard \(\$\{\{ matrix\.shard \}\}\/4\)/);
 		assert.match(parity, /node-version: 24/);
 		assert.doesNotMatch(parity, /node-version: \[22, 24\]/);
-		assert.match(parity, /shard: \[1, 2, 3\]/);
+		assert.match(parity, /shard: \[1, 2, 3, 4\]/);
 		assert.match(
 			parity,
 			/pnpm --filter website exec playwright install --with-deps chromium(?:\n|$)/,
 		);
-		assert.match(parity, /pnpm react-parity:check --shard \$\{\{ matrix\.shard \}\}\/3/);
+		assert.match(parity, /pnpm react-parity:check --shard \$\{\{ matrix\.shard \}\}\/4/);
 		assert.match(
 			parity,
 			/REACT_PARITY_VITEST_REPORT: \$\{\{ runner\.temp \}\}\/react-parity-vitest\/shard-\$\{\{ matrix\.shard \}\}\.json/,
@@ -340,7 +340,7 @@ describe('CI workflow aggregation', () => {
 			parityAggregate,
 			/node scripts\/react-parity\/verify-vitest-shards\.mjs\s+--reports-directory/,
 		);
-		assert.match(parityAggregate, /--expected-shards 3/);
+		assert.match(parityAggregate, /--expected-shards 4/);
 		assert.doesNotMatch(parityAggregate, /pnpm install|playwright install/);
 		assert.match(lint, /pnpm react-parity:test/);
 		assert.match(lint, /pnpm react-parity:validate/);


### PR DESCRIPTION
## Summary

- Run React parity across four generic CI workers instead of three.

## Why

- Shard 3 has been the parity bottleneck. In the [recent upstream run](https://github.com/octanejs/octane/actions/runs/32246963343), the three parity steps took 5m33s, 5m43s, and 6m08s. The existing runner already supports arbitrary shard counts, so another worker can redistribute the Vitest file workload without introducing package-specific CI configuration.

## Changes

- Expand the matrix and shard coordinates to `1/4` through `4/4`.
- Require four uploaded reports in the existing exact-coverage aggregate. Keep its stable check name, unique artifacts, and missing/duplicate identity checks.
- Update the CI workflow contract and documented local commands. No package changes or changeset are needed.

## Validation

- [ ] `pnpm format:check` — repository-wide check not run; changed-file check passed.
- [ ] `pnpm typecheck` — not run; CI configuration and documentation only.
- [ ] `pnpm test` — not run; no runtime changes.
- [x] Targeted tests: `node --test scripts/react-parity/check-lib.test.mjs scripts/react-parity/shard-lib.test.mjs scripts/react-parity/vitest-batch-lib.test.mjs scripts/react-parity/vitest-contract.test.mjs` — 28 passed.
- [x] Confirmed the old workflow fails the four-worker assertion, and the updated matrix, command denominator, and required report count agree.
- [x] Exercised the real four-way non-Vitest plan: all 44 manifests appear exactly once, with 11 per worker and estimated weights 247, 249, 249, and 246.
- [x] `pnpm_config_verify_deps_before_run=warn pnpm format:files:check .github/workflows/ci.yml docs/react-parity-testing.md scripts/ci-workflow.test.mjs`.
- [x] `pnpm_config_verify_deps_before_run=warn pnpm sync` — completed with no generated changes.
- [ ] Full CI workflow test and parity execution — the clean frozen install was blocked by the configured registry returning HTTP 403 for `@tsrx/prettier-plugin@0.3.120`. Current TSRX parser dependencies are also unavailable locally. Focused tests used cached Vitest 4.1.10; formatting/sync used cached Prettier 3.9.6 and the older TSRX formatting plugin 0.3.118, without changing the lockfile or registry configuration.

## Risk / follow-ups

- Measure actual four-way wall-clock time after CI runs. Whole non-Vitest manifests remain indivisible; Vaul still contributes a roughly 100-second tail on its assigned worker.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix and documentation only; the existing parity runner already supports arbitrary shard counts with no runtime or package changes.
> 
> **Overview**
> **React parity CI** now runs on **four parallel workers** instead of three, to ease the shard-3 bottleneck without package-specific workflow changes.
> 
> The `react_parity_shard` matrix adds a fourth worker; each job invokes `pnpm react-parity:check` with `--shard N/4`. The **`React parity checks`** aggregate still merges Vitest shard reports but now requires **`--expected-shards 4`**.
> 
> **Docs** (`react-parity-testing.md`) and **`scripts/ci-workflow.test.mjs`** assertions are updated to match the new shard count and coordinates. No application or parity harness logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b925ce870b2b45f51de7ff33103daf9f0802f107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789733562&installation_model_id=432790&pr_number=789&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F789&signature=07766059325af5882ad60081271c8212b2405ff68b1e955018ff92522eda8942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->