### PR TITLE
perf(octane): reduce class-only keyed selection work

### DIFF
--- a/.changeset/keyed-row-selection-work.md
+++ b/.changeset/keyed-row-selection-work.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reduce keyed-row selection work for compiler-proven class-only updates. Preserve full row reconciliation for live renderable children and use the correct class setter for statically known HTML, SVG, and MathML templates. Also avoid unnecessary state-update allocations and focus traversal when a document has no focused control.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -186,6 +186,7 @@ internally, get their own baseline and guard namespace.
 | manifest name | dir | servers | notes |
 | --- | --- | --- | --- |
 | `js-framework` | js-framework | Octane + reference frameworks | krausest ops incl. `add` |
+| `js-framework-selection-work` | js-framework | none (builds) | deterministic unrelated-label-read guard for compiler-proven class-only keyed selection |
 | `js-framework-reorder` | js-framework | same fixtures | keyed reorder matrix (LIS vs lastPlacedIndex) |
 | `todomvc` | todomvc | Octane + reference frameworks | Speedometer-style TodoMVC interactions |
 | `weather-app` | weather-app | octane-tsrx, react, preact, solid, svelte, vue | upstream weather UI: cold ready, keyed forecast churn, async search/error/recovery |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -520,6 +520,22 @@
     "note": "Same-run production Chromium controlled-input hydration under real 6x CPU throttling: Octane measured about 0.4x React and must preserve the complete pre-hydration draft, focus, and caret."
   },
   {
+    "suite": "js-framework-selection-work",
+    "op": "selection_label_reads_10",
+    "target": "literal-class-work",
+    "reference": "dynamic-class-work",
+    "maxRatio": 0,
+    "note": "Compiler-proven literal-class selection must not re-read unrelated row labels. The same-run dynamic-class arm performs ordinary row work and supplies a validated nonzero denominator. Both production browser arms verify classes, labels, keyed identity, reset/reselect/alternate operations, data changes, reorder, and clear/refill. Ten rows also exercise the small-list path."
+  },
+  {
+    "suite": "js-framework-selection-work",
+    "op": "selection_label_reads_1000",
+    "target": "literal-class-work",
+    "reference": "dynamic-class-work",
+    "maxRatio": 0,
+    "note": "The PR2985-shaped 1,000-row table must update only its selected classes, with zero unrelated label reads. Benign label getters are installed by the external browser driver after compilation; the semantically identical dynamic-class control prevents a missing observer from making this zero-work guard pass."
+  },
+  {
     "suite": "js-framework",
     "op": "run",
     "target": "octane-tsrx",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -85,6 +85,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Untimed compiler-proven keyed selection against an ordinary-row control.
+		// The harness production-bundles its own tiny fixture and drives Chromium.
+		name: 'js-framework-selection-work',
+		cwd: 'js-framework',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'selection-work.mjs', args: () => [] }],
+	},
+	{
 		name: 'js-framework-reorder',
 		cwd: 'js-framework',
 		servers: [

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -24,6 +24,8 @@ benchmarks/js-framework/
 ├── preact/         # Vite app, dev server on :5260 — native Preact hooks
 ├── svelte/         # Vite app, dev server on :5271 — Svelte 5 runes + keyed #each
 ├── run.mjs             # Playwright harness — the canonical krausest ops
+├── selection-work.mjs  # deterministic class-only keyed-selection work guard
+├── selection-work/     # production fixture + external label-read observer
 ├── run-reorder.mjs     # Playwright harness — the keyed-reorder matrix (see below)
 ├── package.json        # umbrella; depends on playwright
 ├── results/            # output / scratch
@@ -124,6 +126,35 @@ count, insertion position and order, survivor DOM identity, connectivity,
 delegated events, and selection, then uses precise production call coverage in
 a separate `--jitless` browser to guard reduced per-row framework work without
 depending on minified helper names or contaminating wall-clock measurements.
+
+### Class-only selection work
+
+```bash
+node benchmarks/bench.mjs --ratios js-framework-selection-work
+BENCH_JSON=/tmp/selection-work.json node benchmarks/js-framework/selection-work.mjs
+```
+
+This separate, untimed Chromium suite production-compiles the small table from
+[Pyreon PR 2985](https://github.com/pyreon/pyreon/pull/2985), including its two
+`useState` cells and raw `{row.id}` / `{row.label}` holes. A literal selected
+class is compared with the same class supplied through a dynamic prop, which
+keeps the ordinary row-body path as a same-run control. The external browser
+driver installs benign label getters only after compilation, so observation
+does not alter the compiler's purity proof. Clean data-property rows and
+observed rows must produce identical semantic snapshots.
+
+Both arms verify every visible class and label, keyed DOM identity, first
+selection, equal-value reselection, alternating selection, reset, a label
+replacement, reorder, and clear/refill. The 10-row and 1,000-row count guards
+require zero unrelated label reads from literal-class selection and validate a
+nonzero ordinary-row control. They make no absolute-time or allocation claim.
+
+`OCTANE_SELECTION_ROOT` can select another source checkout, and
+`OCTANE_SELECTION_EXTERNAL_ROOT` can select the checkout supplying installed
+dependencies. Keep the fixture, driver, parser, printer, and bundler identical
+for before/after evidence; source and toolchain hashes are recorded in the JSON.
+`--build-only` checks the production bundle without launching Chromium. Disclose
+any nonstandard parser loader alongside the result.
 
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 

--- a/benchmarks/js-framework/package.json
+++ b/benchmarks/js-framework/package.json
@@ -6,6 +6,7 @@
   "description": "js-framework-benchmark umbrella that drives Octane and reference framework fixtures via Playwright.",
   "scripts": {
     "bench": "node run.mjs",
+    "bench:selection-work": "node selection-work.mjs",
     "bench:style-work": "node style-work.mjs",
     "bench:long": "node run.mjs 16",
     "bench:reorder": "node run-reorder.mjs",

--- a/benchmarks/js-framework/selection-work.mjs
+++ b/benchmarks/js-framework/selection-work.mjs
@@ -1,0 +1,205 @@
+// Deterministic production work, not a timing benchmark. The two components
+// render identical tables; only the compiler's literal-class proof differs.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { runSelectionScenario } from './selection-work/driver.mjs';
+
+const ROOT = import.meta.dirname;
+const REPO = path.resolve(process.env.OCTANE_SELECTION_ROOT || path.join(ROOT, '../..'));
+const DEPENDENCY_REPO = path.resolve(process.env.OCTANE_SELECTION_EXTERNAL_ROOT || REPO);
+const OCTANE_ROOT = path.join(REPO, 'packages/octane');
+const SOURCE_ROOT = path.join(OCTANE_ROOT, 'src');
+const requireDependencies = createRequire(
+	path.join(DEPENDENCY_REPO, 'packages/octane/package.json'),
+);
+const { build, version: esbuildVersion } = requireDependencies('esbuild');
+const { chromium } = requireDependencies('playwright');
+const { compile } = await import(pathToFileURL(path.join(SOURCE_ROOT, 'compiler/index.js')).href);
+const exportsMap = JSON.parse(
+	fs.readFileSync(path.join(OCTANE_ROOT, 'package.json'), 'utf8'),
+).exports;
+const FIXTURE = path.join(ROOT, 'selection-work/rows.tsrx');
+const ENTRY = path.join(ROOT, 'selection-work/entry.mjs');
+const ROW_COUNTS = [10, 1000];
+const TARGETS = [
+	{ name: 'literal-class-work', component: 'LiteralClassRows' },
+	{ name: 'dynamic-class-work', component: 'DynamicClassRows' },
+];
+const SELECTION_OPS = [
+	'select_first',
+	'reselect',
+	'select_another',
+	'reset',
+	'reset_again',
+	'alternate_cycle',
+	'select_after_reorder',
+	'reset_after_reorder',
+	'select_after_refill',
+	'reset_after_refill',
+];
+const stat = (value) => ({ score: value, median: value, min: value, samples: 1 });
+const sha256 = (file) => createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+
+function dependencyVersion(name) {
+	let directory = path.dirname(requireDependencies.resolve(name));
+	while (directory !== path.dirname(directory)) {
+		const manifest = path.join(directory, 'package.json');
+		if (fs.existsSync(manifest)) {
+			const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+			if (pkg.name === name) return pkg.version;
+		}
+		directory = path.dirname(directory);
+	}
+	return null;
+}
+
+function octaneRequest(request) {
+	const key = request === 'octane' ? '.' : './' + request.slice('octane/'.length);
+	const entry = exportsMap[key];
+	const target = typeof entry === 'string' ? entry : entry?.import || entry?.default;
+	if (typeof target !== 'string') throw new Error(`Unmapped runtime import ${request}`);
+	return path.resolve(OCTANE_ROOT, target);
+}
+
+async function bundleApplication() {
+	const compiled = compile(fs.readFileSync(FIXTURE, 'utf8'), FIXTURE, {
+		mode: 'client',
+		hmr: false,
+		dev: false,
+	});
+	assert.equal(compiled.diagnostics.length, 0, 'selection fixture emitted compiler diagnostics');
+	const result = await build({
+		entryPoints: [ENTRY],
+		absWorkingDir: REPO,
+		bundle: true,
+		write: false,
+		format: 'iife',
+		globalName: '__octaneSelectionWork',
+		platform: 'browser',
+		target: 'es2022',
+		minify: true,
+		logLevel: 'silent',
+		define: {
+			'process.env.NODE_ENV': '"production"',
+			__OCTANE_PROFILE_ENABLED__: 'false',
+		},
+		nodePaths: [
+			path.join(DEPENDENCY_REPO, 'packages/octane/node_modules'),
+			path.join(DEPENDENCY_REPO, 'node_modules'),
+		],
+		plugins: [
+			{
+				name: 'keyed-selection-work',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => ({
+						path: octaneRequest(request),
+					}));
+					plugin.onLoad({ filter: /\.tsrx$/ }, ({ path: filename }) =>
+						filename === FIXTURE
+							? { contents: compiled.code, loader: 'js', resolveDir: path.dirname(filename) }
+							: null,
+					);
+				},
+			},
+		],
+	});
+	assert.equal(result.outputFiles.length, 1, 'expected one self-contained selection bundle');
+	return result.outputFiles[0].text;
+}
+
+const metadata = {
+	node: process.version,
+	esbuild: esbuildVersion,
+	tsrxCore: dependencyVersion('@tsrx/core'),
+	esrap: dependencyVersion('esrap'),
+	sourceRoot: REPO,
+	runtimeSha256: sha256(path.join(SOURCE_ROOT, 'runtime.ts')),
+	compilerSha256: sha256(path.join(SOURCE_ROOT, 'compiler/compile.js')),
+	fixtureSha256: sha256(FIXTURE),
+	entrySha256: sha256(ENTRY),
+	driverSha256: sha256(path.join(ROOT, 'selection-work/driver.mjs')),
+	measurement: 'label-property reads; no timing or heap-allocation claim',
+};
+
+const results = [];
+let browser;
+let failed;
+try {
+	const bundle = await bundleApplication();
+	if (process.argv.includes('--build-only')) {
+		console.log(`Production selection-work bundle: ${Buffer.byteLength(bundle)} bytes.`);
+	} else {
+		browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+		const page = await browser.newPage();
+		const errors = [];
+		page.on('pageerror', (error) => errors.push(String(error)));
+		page.on('console', (message) => {
+			if (message.type() === 'error') errors.push(message.text());
+		});
+		await page.addScriptTag({ content: bundle });
+		const expectedSemantics = new Map();
+		for (const target of TARGETS) {
+			const ops = {};
+			const measurements = {};
+			for (const rowCount of ROW_COUNTS) {
+				const input = { component: target.component, rowCount };
+				const clean = await page.evaluate(runSelectionScenario, { ...input, observed: false });
+				const observed = await page.evaluate(runSelectionScenario, { ...input, observed: true });
+				assert.deepEqual(observed.semantics, clean.semantics, 'label observer changed semantics');
+				if (!expectedSemantics.has(rowCount)) expectedSemantics.set(rowCount, clean.semantics);
+				else
+					assert.deepEqual(
+						clean.semantics,
+						expectedSemantics.get(rowCount),
+						'literal and dynamic class arms changed semantics',
+					);
+				assert.ok(observed.counts.mount > 0, 'label observer did not see mounted labels');
+				assert.ok(observed.counts.label_replacement > 0, 'label replacement skipped row work');
+				assert.equal(observed.counts.reselect, 0, 'equal-value selection repeated row work');
+				assert.equal(observed.counts.reset_again, 0, 'equal-value reset repeated row work');
+				const reads = SELECTION_OPS.reduce((sum, name) => sum + observed.counts[name], 0);
+				if (target.name === 'dynamic-class-work') {
+					for (const name of SELECTION_OPS) {
+						if (name === 'reselect' || name === 'reset_again') continue;
+						assert.ok(observed.counts[name] > 0, `ordinary-row control lost ${name} reads`);
+					}
+					assert.ok(reads > 0, 'selection ratio denominator must be nonzero');
+				}
+				ops[`selection_label_reads_${rowCount}`] = stat(reads);
+				for (const [name, count] of Object.entries(observed.counts)) {
+					ops[`${name}_label_reads_${rowCount}`] = stat(count);
+				}
+				measurements[rowCount] = observed;
+				console.log(`${target.name}, ${rowCount} rows: ${reads} selection label reads`);
+			}
+			results.push({ name: target.name, ops, meta: { run: metadata, measurements } });
+		}
+		assert.deepEqual(errors, [], 'selection-work browser errors');
+		console.log('Selection class, label, identity, reset, and observer controls passed.');
+	}
+} catch (error) {
+	failed = error instanceof Error ? error.message : String(error);
+	console.error(error);
+} finally {
+	await browser?.close();
+}
+
+if (!process.argv.includes('--build-only')) {
+	const payload = {
+		suite: 'js-framework-selection-work',
+		iterations: 1,
+		targets: results,
+		meta: metadata,
+		...(failed ? { failed } : {}),
+	};
+	if (process.env.BENCH_JSON) {
+		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');
+	}
+}
+if (failed) process.exitCode = 1;

--- a/benchmarks/js-framework/selection-work/driver.mjs
+++ b/benchmarks/js-framework/selection-work/driver.mjs
@@ -1,0 +1,143 @@
+// Passed directly to page.evaluate. All observation lives outside the authored
+// component, so counting label reads cannot change the compiler's purity proof.
+export function runSelectionScenario({ component, rowCount, observed }) {
+	const api = globalThis.__octaneSelectionWork;
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	const root = api.createRoot(container);
+	const counts = {};
+	const semantics = [];
+	let setters;
+	let labelReads = 0;
+	let identities = new Map();
+	let expected = Array.from({ length: rowCount }, (_, index) => ({
+		id: index + 1,
+		label: `row ${index + 1}`,
+	}));
+	let selected = null;
+
+	function check(condition, message) {
+		if (!condition) throw new Error(`${component}/${rowCount}: ${message}`);
+	}
+
+	function makeRow(row) {
+		if (!observed) return { id: row.id, label: row.label };
+		const label = row.label;
+		return {
+			id: row.id,
+			get label() {
+				labelReads++;
+				return label;
+			},
+		};
+	}
+
+	function verify(name) {
+		const actual = Array.from(container.querySelectorAll('tbody tr'));
+		check(actual.length === expected.length, `${name}: incorrect row count`);
+		let checksum = 2166136261;
+		const selectedIds = [];
+		for (let index = 0; index < actual.length; index++) {
+			const node = actual[index];
+			const row = expected[index];
+			const cells = node.querySelectorAll('td');
+			const className = row.id === selected ? 'selected' : '';
+			check(cells.length === 2, `${name}: row ${row.id} lost a cell`);
+			check(cells[0].textContent === String(row.id), `${name}: incorrect id at ${index}`);
+			check(cells[1].textContent === row.label, `${name}: incorrect label for ${row.id}`);
+			check(node.className === className, `${name}: incorrect selected class for ${row.id}`);
+			if (identities.has(row.id)) {
+				check(identities.get(row.id) === node, `${name}: row ${row.id} lost DOM identity`);
+			}
+			if (className !== '') selectedIds.push(row.id);
+			const text = `${row.id}\0${row.label}\0${className}\0`;
+			for (let i = 0; i < text.length; i++) {
+				checksum = Math.imul(checksum ^ text.charCodeAt(i), 16777619);
+			}
+		}
+		semantics.push({ name, rows: actual.length, selectedIds, checksum: checksum >>> 0 });
+		return actual;
+	}
+
+	function commit(name, update) {
+		labelReads = 0;
+		api.flushSync(update);
+		counts[name] = labelReads;
+		return verify(name);
+	}
+
+	function select(name, id) {
+		selected = id;
+		return commit(name, () => setters.setSelected(id));
+	}
+
+	try {
+		api.flushSync(() => {
+			root.render(api[component], {
+				selectedClass: 'selected',
+				onMounted(value) {
+					setters = value;
+				},
+			});
+		});
+		api.drainPassiveEffects();
+		check(setters !== undefined, 'mount did not expose its state setters');
+
+		let rows = expected.map(makeRow);
+		const mounted = commit('mount', () => setters.setRows(rows));
+		identities = new Map(expected.map((row, index) => [row.id, mounted[index]]));
+		const first = expected[Math.floor(rowCount / 2)].id;
+		const second = expected[(Math.floor(rowCount / 2) + 1) % rowCount].id;
+		select('select_first', first);
+		select('reselect', first);
+		select('select_another', second);
+		select('reset', null);
+		select('reset_again', null);
+
+		labelReads = 0;
+		for (let i = 0; i < 16; i++) {
+			selected = i % 2 === 0 ? first : second;
+			api.flushSync(() => setters.setSelected(selected));
+			verify(`alternate_${i}`);
+		}
+		counts.alternate_cycle = labelReads;
+
+		// A real data change must still run ordinary reconciliation. The selected
+		// row survives by key, updates its label, then survives a full reorder.
+		expected = expected.map((row) =>
+			row.id === second ? { id: row.id, label: row.label + ' updated' } : row,
+		);
+		rows = rows.map((row, index) => (row.id === second ? makeRow(expected[index]) : row));
+		commit('label_replacement', () => setters.setRows(rows));
+		expected = expected.toReversed();
+		rows = rows.toReversed();
+		commit('reorder', () => setters.setRows(rows));
+		select('select_after_reorder', first);
+		select('reset_after_reorder', null);
+
+		const removed = Array.from(identities.values());
+		expected = [];
+		commit('clear', () => setters.setRows([]));
+		check(
+			removed.every((node) => !node.isConnected),
+			'clear left an old row connected',
+		);
+		identities = new Map();
+		expected = Array.from({ length: rowCount }, (_, index) => ({
+			id: index + 1,
+			label: `refilled row ${index + 1}`,
+		}));
+		rows = expected.map(makeRow);
+		const refilled = commit('refill', () => setters.setRows(rows));
+		identities = new Map(expected.map((row, index) => [row.id, refilled[index]]));
+		select('select_after_refill', second);
+		select('reset_after_refill', null);
+	} finally {
+		root.unmount();
+		api.drainPassiveEffects();
+		check(container.childNodes.length === 0, 'unmount left managed DOM behind');
+		container.remove();
+	}
+
+	return { counts, semantics };
+}

--- a/benchmarks/js-framework/selection-work/entry.mjs
+++ b/benchmarks/js-framework/selection-work/entry.mjs
@@ -1,0 +1,2 @@
+export { createRoot, flushSync, drainPassiveEffects } from 'octane';
+export { LiteralClassRows, DynamicClassRows } from './rows.tsrx';

--- a/benchmarks/js-framework/selection-work/rows.tsrx
+++ b/benchmarks/js-framework/selection-work/rows.tsrx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'octane';
+
+interface Row {
+	id: number;
+	label: string;
+}
+
+interface Setters {
+	setRows: (rows: Row[]) => void;
+	setSelected: (id: number | null) => void;
+}
+
+interface Props {
+	onMounted: (setters: Setters) => void;
+	selectedClass: string;
+}
+
+// Keep the raw primitive holes from Pyreon PR 2985. A call such as String(row.id)
+// changes the compiler's row-purity proof, and would measure a different path.
+export function LiteralClassRows(props: Props) @{
+	const [rows, setRows] = useState<Row[]>([]);
+	const [selectedId, setSelected] = useState<number | null>(null);
+
+	useEffect(() => {
+		props.onMounted({ setRows, setSelected });
+	}, []);
+
+	<table>
+		<tbody>
+			@for (const row of rows; key row.id) {
+				<tr class={row.id === selectedId ? 'selected' : ''}>
+					<td>{row.id}</td>
+					<td>{row.label}</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+// The browser supplies the same class string, but this authored dynamic arm
+// cannot use the literal-class proof. It remains the same-run ordinary-row
+// control even when production bundling can see its eventual prop value.
+export function DynamicClassRows(props: Props) @{
+	const [rows, setRows] = useState<Row[]>([]);
+	const [selectedId, setSelected] = useState<number | null>(null);
+
+	useEffect(() => {
+		props.onMounted({ setRows, setSelected });
+	}, []);
+
+	<table>
+		<tbody>
+			@for (const row of rows; key row.id) {
+				<tr class={row.id === selectedId ? props.selectedClass : ''}>
+					<td>{row.id}</td>
+					<td>{row.label}</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -13481,7 +13481,16 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			cssHash,
 		);
 	} else {
-		plan = planJsx(jsxNodes, ctx, name, inlinedSubs, parentNs, cssHash, mountCallbackSinks);
+		plan = planJsx(
+			jsxNodes,
+			ctx,
+			name,
+			inlinedSubs,
+			parentNs,
+			cssHash,
+			mountCallbackSinks,
+			options?.keyedSelection ?? null,
+		);
 	}
 	ctx.currentInvariantLocals = prevInvariantLocals;
 	ctx.currentEventInvariantLocals = prevEventInvariantLocals;
@@ -17422,6 +17431,11 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				const bodyHole = `h${holeProps.length}`;
 				holeProps.push(objectProp(bodyHole, b.id(rec.bodyHelper)));
 				rec.bodyHelper = `props.${bodyHole}`;
+				if (rec.selectionHelper != null) {
+					const selectionHole = `h${holeProps.length}`;
+					holeProps.push(objectProp(selectionHole, b.id(rec.selectionHelper)));
+					rec.selectionHelper = `props.${selectionHole}`;
+				}
 			}
 			if (mapCall) {
 				const methodHole = `h${holeProps.length}`;
@@ -20440,6 +20454,7 @@ function planJsx(
 	parentNs = 'html',
 	cssHash = null,
 	mountCallbackSinks = null,
+	keyedSelection = null,
 ) {
 	// DEV ONLY: per-element source-location map for THIS body (path-key → [line, col]),
 	// populated at the top of emitElementHtml and read in the binding mount loop to emit
@@ -20711,6 +20726,15 @@ function planJsx(
 				}
 				tplNs = resolved === null ? 'html' : resolved;
 				resolvedFrag = tplNs !== 'opaque';
+			}
+		}
+		// Binding planning precedes the final template namespace. An inherited
+		// opaque namespace can now use the same concrete namespace as clone(),
+		// including HTML's faster className property. Preserve explicit foreign
+		// content and leave genuinely opaque/mixed templates destination-aware.
+		if (tplNs !== 'opaque') {
+			for (const binding of elementBindings) {
+				if (binding.ns === 'opaque') binding.ns = tplNs;
 			}
 		}
 		const flag = nsFlag(tplNs);
@@ -21235,6 +21259,24 @@ function planJsx(
 		if (b.deferred) everyRenderLines.push(updateEmit);
 		else updateLines.push(updateEmit);
 	}
+	if (keyedSelection !== null && single && !noTemplate) {
+		// Reuse the ordinary root-class write and its exact bag fields. Updating
+		// only the DOM would leave the normal row diff's previous value stale.
+		const classes = elementBindings.filter(
+			(binding) => binding.kind === 'class' && binding.path.length === 0,
+		);
+		if (
+			classes.length === 1 &&
+			!classes[0].fresh &&
+			!classes[0].mountOnly &&
+			collectFreeIdentifiers(classes[0].expr, [
+				keyedSelection.itemName,
+				keyedSelection.selectedName,
+			]).size === 0
+		) {
+			keyedSelection.update = emitBindingUpdate(classes[0], bag);
+		}
+	}
 
 	// After (forBlock + ifBlock calls run on every render — they reconcile).
 	//
@@ -21343,6 +21385,7 @@ function planJsx(
 			rtAlias(forHelper),
 			fc.keyHelper,
 			fc.bodyHelper,
+			fc.selectionHelper,
 			fc.emptyHelper,
 		]);
 		registerClauseOrigin(ctx, fc.emptyKeyword, [fc.emptyHelper]);
@@ -21367,7 +21410,8 @@ function planJsx(
 			(fc.requiresScope ? 32 : 0) |
 			(fc.keyedSelectionIndex >= 0 ? fc.keyedSelectionIndex << 6 : 0);
 		// Arg layout: forBlock(__s, slot, host, items, keyFn, body, flags?, deps?,
-		// emptyBody?, anchor?, ownEnd?).
+		// emptyBody?, anchor?, ownEnd?, selectionBody?). The final argument is
+		// emitted only for a certified keyed-selection call.
 		// Optional args backfill positionally: `flags`/`deps` placeholders
 		// (`0`/`undefined`) when only `emptyHelper` (`null` when no `@empty`
 		// branch) or the anchor is present, and a `null` empty-body placeholder
@@ -21419,6 +21463,12 @@ function planJsx(
 		// list's trailing boundary. Let forBlock reuse it as its end marker instead
 		// of retaining it beside a newly-created `/for` comment.
 		if (fc.anchorVar) tailArgs.push(b.literal(true));
+		if (fc.selectionHelper != null) {
+			// tailArgs starts at argument 5; preserve the optional positions through
+			// ownEnd before supplying the selection updater as argument 12.
+			while (tailArgs.length < 7) tailArgs.push(undefinedNode());
+			tailArgs.push(helperRefNode(fc.selectionHelper));
+		}
 		if (isMappedList) {
 			const nativeName = allocCompilerName(ctx, '__mapNative');
 			if (fc.autoMemoDeps !== null) {
@@ -25000,6 +25050,7 @@ function hoistBodyHelper(
 	cssHash,
 	envNames,
 	idOrigin = null,
+	keyedSelection = null,
 ) {
 	const helperName = `${prefix}$${ctx.nextHelperId++}`;
 	const ownEnvNames = envNames === null ? null : helperCaptures(ctx, stmts, params);
@@ -25067,7 +25118,14 @@ function hoistBodyHelper(
 	);
 	let helperFn;
 	try {
-		helperFn = compileFunctionBody(fake, ctx, helperName, parentNs, cssHash);
+		helperFn = compileFunctionBody(
+			fake,
+			ctx,
+			helperName,
+			parentNs,
+			cssHash,
+			keyedSelection === null ? null : { keyedSelection },
+		);
 	} finally {
 		ctx.currentComponentLocals = prevLocals;
 		ctx.currentInvariantLocals = prevInvariantLocals;
@@ -25076,6 +25134,35 @@ function hoistBodyHelper(
 	// Module-scope placement: the compiled helper joins the module AST as a
 	// hoisted statement node (M2 AST emit).
 	ctx.hoistedHelpers.push(helperFn);
+	if (keyedSelection?.update != null) {
+		const selectionName = allocCompilerName(ctx, `__select$${ctx.nextHelperId++}`);
+		const origin = keyedSelection.update;
+		const selectionBody = [
+			inheritOriginLoc(
+				b.const(
+					keyedSelection.selectedName,
+					b.member(b.id('__extra'), b.literal(keyedSelection.selectedIndex), true),
+				),
+				origin,
+			),
+			inheritOriginLoc(
+				b.const('_b', b.member(b.member(b.id('__s'), 'slots'), b.literal(0), true)),
+				origin,
+			),
+			keyedSelection.update,
+		];
+		ctx.hoistedHelpers.push(
+			inheritOriginLoc(
+				b.function_declaration(
+					b.id(selectionName, idOrigin ?? fakeOrigin ?? undefined),
+					[...params, b.id('__s'), b.id('__extra')],
+					b.block(selectionBody),
+				),
+				fakeOrigin,
+			),
+		);
+		keyedSelection.helper = selectionName;
+	}
 	return helperName;
 }
 
@@ -26494,18 +26581,6 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			node.emptyKeyword ?? null,
 		);
 	}
-	const itemHelperName = hoistBodyHelper(
-		ctx,
-		inlinedSubs,
-		'__item',
-		itemAllStmts,
-		itemParams,
-		parentNs,
-		cssHash,
-		envNames,
-		directiveKeywordOrigin(ctx, node),
-	);
-
 	// Single-root detection: when the body emits exactly one Element root and
 	// no other JSX siblings (no Fragment, no Component, no top-level if/for/try),
 	// the runtime can skip per-item Comment markers and use the row element
@@ -26577,6 +26652,31 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		!containsRenderCall(subStmts) &&
 		!containsAutoMemoUnsafeStructure(subStmts) &&
 		isHostMountSafeTree(subStmts[0]);
+	// Class-only updates need the stricter host-lifecycle proof as well as the
+	// existing equality proof. The item planner fills this compiler-owned result
+	// only when the root class survives as one ordinary cached binding.
+	const keyedSelection =
+		hostMountSafe && keyedSelectionIndex >= 0 && envNames !== null
+			? {
+					itemName,
+					selectedName: runtimeDepNames[keyedSelectionIndex],
+					selectedIndex: keyedSelectionIndex,
+					update: null,
+					helper: null,
+				}
+			: null;
+	const itemHelperName = hoistBodyHelper(
+		ctx,
+		inlinedSubs,
+		'__item',
+		itemAllStmts,
+		itemParams,
+		parentNs,
+		cssHash,
+		envNames,
+		directiveKeywordOrigin(ctx, node),
+		keyedSelection,
+	);
 
 	const mapCall = node.nativeArrayMap || null;
 	return {
@@ -26607,6 +26707,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		keyHelper,
 		inlineKey: inlineKey ? keyFn : null,
 		bodyHelper: itemHelperName,
+		selectionHelper: keyedSelection?.helper ?? null,
 		hasPerItemEventClosure,
 		pure,
 		singleRoot,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1040,24 +1040,27 @@ function stagedTransitionValue<T>(slot: TransitionActionSlot<T>): T {
 function stageTransitionValue<T>(
 	slot: TransitionActionSlot<T>,
 	block: Block,
-	operation: (value: T) => T,
+	operation: T | ((value: T) => T),
 	value: T,
 	forceRender = false,
 ): boolean {
 	const batch = transitionActionBatchForUpdate();
 	if (batch === null) return false;
+	// Replacement values need a replay closure only when an Action actually
+	// stages the update. Ordinary useState setters stay allocation-free here.
+	const replay = typeof operation === 'function' ? (operation as (value: T) => T) : () => operation;
 	const current = batch.updates.get(slot) as TransitionActionUpdate<T> | undefined;
 	if (current === undefined) {
 		batch.updates.set(slot, {
 			slot,
 			block,
-			operations: [operation],
+			operations: [replay],
 			baseValue: slot.value,
 			value,
 			forceRender,
 		});
 	} else {
-		current.operations.push(operation);
+		current.operations.push(replay);
 		current.value = value;
 		current.forceRender ||= forceRender;
 	}
@@ -3034,6 +3037,12 @@ interface FocusSelectionSnapshot {
 function activeElementForDocument(doc: Document): Element | null {
 	try {
 		let focused = doc.activeElement;
+		// Unfocused documents usually report body. It can itself host an open
+		// shadow tree, so only skip the descent when that tree has no focus.
+		if (focused === doc.body) {
+			focused = focused?.shadowRoot?.activeElement ?? null;
+			if (focused === null) return null;
+		}
 		while (focused !== null) {
 			if (focused.localName === 'iframe') {
 				let nested: Document | null;
@@ -5679,10 +5688,9 @@ export function useState<T>(initial?: T | (() => T), slot?: HookSlot): StateTupl
 			value: initVal,
 			setter: (next) => {
 				const previous = stagedTransitionValue(s!);
-				const operation = typeof next === 'function' ? (next as (p: T) => T) : () => next;
-				const computed = operation(previous);
+				const computed = typeof next === 'function' ? (next as (p: T) => T)(previous) : next;
 				if (Object.is(computed, previous)) return;
-				if (stageTransitionValue(s!, block, operation, computed)) {
+				if (stageTransitionValue(s!, block, next, computed)) {
 					if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__) {
 						const update = s!.pendingActionBatch?.updates.get(s!) as
 							TransitionActionUpdate<T> | undefined;
@@ -25536,6 +25544,7 @@ export function keyedForBlock<T>(
 	emptyBody?: ComponentBody | null,
 	anchor?: Node | null,
 	ownEnd?: boolean,
+	selectionBody?: ComponentBody<T, any[]>,
 ): void {
 	const state = parentScope.slots[slotKey] as ForSlot | undefined;
 	if (TRANSITION_JOURNAL !== null) {
@@ -25552,7 +25561,15 @@ export function keyedForBlock<T>(
 		state !== undefined &&
 		activeHydration() === null &&
 		state.cachedDeps !== null &&
-		tryUpdateKeyedSelection(state, items, itemBody, state.cachedDeps, deps, flags >>> 6)
+		tryUpdateKeyedSelection(
+			state,
+			items,
+			itemBody,
+			state.cachedDeps,
+			deps,
+			flags >>> 6,
+			selectionBody,
+		)
 	) {
 		return;
 	}
@@ -25742,6 +25759,7 @@ export function fastKeyedForBlock<T>(
 	emptyBody?: ComponentBody | null,
 	anchor?: Node | null,
 	ownEnd?: boolean,
+	selectionBody?: ComponentBody<T, any[]>,
 ): void {
 	const state = parentScope.slots[slotKey] as ForSlot | undefined;
 	const parent = fastHostListParent(state, items, flags);
@@ -25758,6 +25776,7 @@ export function fastKeyedForBlock<T>(
 			emptyBody,
 			anchor,
 			ownEnd,
+			selectionBody,
 		);
 		return;
 	}
@@ -25883,6 +25902,7 @@ function tryUpdateKeyedSelection<T>(
 	previousDeps: any[],
 	deps: any[],
 	selectionIndex: number,
+	selectionBody: ComponentBody<T, any[]> | undefined,
 ): boolean {
 	if (
 		state.selectionItems !== items ||
@@ -25915,12 +25935,24 @@ function tryUpdateKeyedSelection<T>(
 	if (first !== undefined) {
 		first.body = itemBody as ComponentBody;
 		first.extra = deps;
-		(itemBody as any)(first.props, first, deps);
+		// A separately certified host row can update just its class binding. Raw
+		// object/function children register child slots, however, and must still
+		// reconcile on the ordinary body path even when their identity is stable.
+		// Primitive-only child holes retain no slots, so they pay no extra cache.
+		if (selectionBody !== undefined && first._slots === null) {
+			selectionBody(first.props, first, deps);
+		} else {
+			(itemBody as any)(first.props, first, deps);
+		}
 	}
 	if (second !== undefined) {
 		second.body = itemBody as ComponentBody;
 		second.extra = deps;
-		(itemBody as any)(second.props, second, deps);
+		if (selectionBody !== undefined && second._slots === null) {
+			selectionBody(second.props, second, deps);
+		} else {
+			(itemBody as any)(second.props, second, deps);
+		}
 	}
 	return true;
 }

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -274,6 +274,32 @@ export function KeyedSelectionList(props: {
 	</ul>
 }
 
+export function KeyedSelectionControlledList(props: {
+	items: SelectionRow[];
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul id="keyed-selection-controlled-list">
+		@for (const row of props.items; key row.id) {
+			<li class={selected === row.id ? 'selected' : ''}>
+				<input value={row.label} readOnly={true} />
+			</li>
+		}
+	</ul>
+}
+
+export function KeyedSelectionRenderableList(props: {
+	items: Array<{ id: number; content: OctaneNode }>;
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul id="keyed-selection-renderable-list">
+		@for (const row of props.items; key row.id) {
+			<li class={selected === row.id ? 'selected' : ''}>{row.content}</li>
+		}
+	</ul>
+}
+
 export function KeyedSelectionUuidList(props: {
 	items: Array<{ uuid: string; label: string }>;
 	selected: string | null;

--- a/packages/octane/tests/_fixtures/hooks.tsrx
+++ b/packages/octane/tests/_fixtures/hooks.tsrx
@@ -25,6 +25,12 @@ export function TwoStates() @{
 	</div>
 }
 
+export function StateValueProbe(props) @{
+	const [value, setValue, getValue] = octaneUseState(() => props.initial);
+	props.expose(setValue, getValue);
+	<span>{props.display(value) as string}</span>
+}
+
 // useReducer
 export function Tally() @{
 	const [n, dispatch] = useReducer((s, a) => s + a, 0);

--- a/packages/octane/tests/_fixtures/svg-deopt.tsrx
+++ b/packages/octane/tests/_fixtures/svg-deopt.tsrx
@@ -1,4 +1,5 @@
 import { createElement, Suspense, use } from 'octane';
+import type { ClassValue } from 'octane/jsx-runtime';
 
 // Returns an SVG tree via createElement (VALUE position) so it renders through the
 // runtime de-opt reconciler — exercising SVG-namespace creation outside the compiled
@@ -82,6 +83,59 @@ function ReturnedAmbiguousAnchorRoot(props) {
 
 function ReturnedAmbiguousMathRowRoot(props) {
 	return <mrow id={props.id}>{props.label as string}</mrow>;
+}
+
+function ClassAnchorRoot(props: { id: string; value: ClassValue }) @{
+	<a id={props.id} class={props.value} />
+}
+
+function ClassHtmlFragment(props: { value: ClassValue }) @{
+	<>
+		<div id="class-html-fragment-first" class={props.value} />
+		<span id="class-html-fragment-second" className={props.value} />
+	</>
+}
+
+function ClassMixedFragment(props: { anchorId: string; groupId: string; value: ClassValue }) @{
+	<>
+		<a id={props.anchorId} class={props.value} />
+		<g id={props.groupId} className={props.value} />
+	</>
+}
+
+function ClassMathRoot(props: { value: ClassValue }) @{
+	<mrow id="class-math-fixed" className={props.value} />
+}
+
+export function TemplateClassNamespaces(props: { value: ClassValue }) @{
+	<section id="class-html-root" class={props.value}>
+		<a id="class-html-nested" className={props.value} />
+		<ClassHtmlFragment value={props.value} />
+		<TemplateHtmlDestination id="class-html-destination">
+			<ClassAnchorRoot id="class-html-ambiguous" value={props.value} />
+		</TemplateHtmlDestination>
+		<TemplateSvgDestination id="class-svg-destination">
+			<ClassAnchorRoot id="class-svg-ambiguous" value={props.value} />
+			<ClassMixedFragment
+				anchorId="class-svg-mixed-anchor"
+				groupId="class-svg-mixed-group"
+				value={props.value}
+			/>
+			<g id="class-svg-fixed" class={props.value} />
+			<foreignObject>
+				<span id="class-foreign-html" className={props.value} />
+			</foreignObject>
+		</TemplateSvgDestination>
+		<TemplateMathDestination id="class-math-destination">
+			<ClassAnchorRoot id="class-math-ambiguous" value={props.value} />
+			<ClassMathRoot value={props.value} />
+			<ClassMixedFragment
+				anchorId="class-math-mixed-anchor"
+				groupId="class-math-mixed-group"
+				value={props.value}
+			/>
+		</TemplateMathDestination>
+	</section>
 }
 
 // Template-form children cross an opaque component boundary before their

--- a/packages/octane/tests/focus-restoration.test.ts
+++ b/packages/octane/tests/focus-restoration.test.ts
@@ -344,6 +344,62 @@ describe('focus and text selection survive DOM updates', () => {
 		}
 	});
 
+	it('restores focus and selection when the document body hosts an open shadow tree', () => {
+		// A shadow root cannot be detached from its host. Give this case its own
+		// document so the suite's body remains available to subsequent tests.
+		const frame = document.createElement('iframe');
+		document.body.appendChild(frame);
+		const owner = frame.contentDocument!;
+		const bodyShadow = owner.body.attachShadow({ mode: 'open' });
+		const nestedHost = owner.createElement('section');
+		bodyShadow.appendChild(nestedHost);
+		const shadow = nestedHost.attachShadow({ mode: 'open' });
+		const container = owner.createElement('div');
+		shadow.appendChild(container);
+		const root = createRoot(container);
+		try {
+			root.render(FastHostControlledList, { items: rows });
+			flushSync(() => {});
+			const input = container.querySelectorAll('input')[1]!;
+			input.focus();
+			input.setSelectionRange(2, 9);
+			expect(owner.activeElement).toBe(owner.body);
+			expect(bodyShadow.activeElement).toBe(nestedHost);
+			expect(shadow.activeElement).toBe(input);
+
+			const parent = container.querySelector('#fast-host-controlled-list')!;
+			const originalInsert = parent.insertBefore;
+			let lostFocus = false;
+			const move = vi.spyOn(parent, 'insertBefore').mockImplementation(function <T extends Node>(
+				node: T,
+				anchor: Node | null,
+			): T {
+				const result = originalInsert.call(this, node, anchor) as T;
+				if (!lostFocus) {
+					input.blur();
+					input.setSelectionRange(0, 0);
+					lostFocus = shadow.activeElement !== input;
+				}
+				return result;
+			});
+			try {
+				flushSync(() => root.render(FastHostControlledList, { items: rows.toReversed() }));
+
+				expect(lostFocus).toBe(true);
+				expect(container.querySelectorAll('input')[2]).toBe(input);
+				expect(owner.activeElement).toBe(owner.body);
+				expect(bodyShadow.activeElement).toBe(nestedHost);
+				expect(shadow.activeElement).toBe(input);
+				expect([input.selectionStart, input.selectionEnd]).toEqual([2, 9]);
+			} finally {
+				move.mockRestore();
+			}
+		} finally {
+			root.unmount();
+			frame.remove();
+		}
+	});
+
 	it('restores focus to a moved content-editable host with an active selection', () => {
 		const rendered = mount(EditableRows, { items: rows });
 		try {

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -16,6 +16,8 @@ import {
 	NestedConditionalTransition,
 	PlainCalleeList,
 	KeyedSelectionList,
+	KeyedSelectionControlledList,
+	KeyedSelectionRenderableList,
 	KeyedSelectionTransition,
 	KeyedSelectionUuidList,
 	MismatchedKeyedSelectionList,
@@ -488,6 +490,34 @@ describe('keyed list selection', () => {
 		r.unmount();
 	});
 
+	it('uses strict equality for NaN and signed-zero selection keys', () => {
+		const items = [
+			{ id: Number.NaN, label: 'not a number' },
+			{ id: -0, label: 'zero' },
+			{ id: 1, label: 'one' },
+		];
+		const r = mount(KeyedSelectionList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+
+		r.update(KeyedSelectionList, { items, selected: Number.NaN });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+
+		r.update(KeyedSelectionList, { items, selected: -0 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		r.update(KeyedSelectionList, { items, selected: 0 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		r.update(KeyedSelectionList, { items, selected: 99 });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+
+		const reordered = [items[2]!, items[0]!, items[1]!];
+		r.update(KeyedSelectionList, { items: reordered, selected: Number.NaN });
+		expect(r.findAll('li')).toEqual([originalRows[2], originalRows[0], originalRows[1]]);
+		expect(r.findAll('li.selected')).toHaveLength(0);
+		r.update(KeyedSelectionList, { items: reordered, selected: 0 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		r.unmount();
+	});
+
 	it('matches selection against the authored custom key property', () => {
 		const items = [
 			{ uuid: 'a-1', label: 'first' },
@@ -550,24 +580,83 @@ describe('keyed list selection', () => {
 		r.unmount();
 	});
 
-	it('preserves immutable keyed-row updates when the selection changes together', () => {
+	it('preserves immutable row updates when returning to an earlier selected key', () => {
 		const initialItems = makeRows();
 		const r = mount(KeyedSelectionList, { items: initialItems, selected: 1 });
 		const originalRows = r.findAll('li');
+
+		r.update(KeyedSelectionList, { items: initialItems, selected: 2 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+
 		const updatedItems = [
 			initialItems[0]!,
 			{ ...initialItems[1]!, label: 'updated second' },
 			initialItems[2]!,
 		];
 
-		r.update(KeyedSelectionList, { items: updatedItems, selected: 2 });
+		r.update(KeyedSelectionList, { items: updatedItems, selected: 1 });
 		expect(labels(r)).toEqual(['first', 'updated second', 'third']);
-		expect(r.find('.selected').textContent).toBe('updated second');
+		expect(r.findAll('li.selected')).toEqual([originalRows[0]]);
 		expect(r.findAll('li')).toEqual(originalRows);
 
-		r.update(KeyedSelectionList, { items: updatedItems, selected: 3 });
-		expect(r.find('.selected').textContent).toBe('third');
+		r.update(KeyedSelectionList, { items: updatedItems, selected: 2 });
+		expect(r.find('.selected').textContent).toBe('updated second');
 		expect(labels(r)).toEqual(['first', 'updated second', 'third']);
+		r.unmount();
+	});
+
+	it('reasserts controlled values in rows whose selection changes', () => {
+		const items = makeRows();
+		const r = mount(KeyedSelectionControlledList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+		const controls = r.findAll('input') as HTMLInputElement[];
+		controls[0]!.focus();
+		controls[0]!.value = 'changed outside render';
+		controls[1]!.value = 'changed before selection';
+
+		r.update(KeyedSelectionControlledList, { items, selected: 2 });
+		expect(controls.map((control) => control.value)).toEqual(items.map((row) => row.label));
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		expect(r.findAll('li')).toEqual(originalRows);
+		expect(r.findAll('input')).toEqual(controls);
+		expect(document.activeElement).toBe(controls[0]);
+		r.unmount();
+	});
+
+	it('keeps stable render-function children live when their rows are selected', () => {
+		let first = 'first';
+		let second = 'second';
+		const items = [
+			{
+				id: 1,
+				content: () =>
+					createElement('span', { className: 'keyed-selection-readable-child' }, first),
+			},
+			{
+				id: 2,
+				content: () =>
+					createElement('span', { className: 'keyed-selection-readable-child' }, second),
+			},
+			{ id: 3, content: 'third' },
+		];
+		const r = mount(KeyedSelectionRenderableList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+		const originalChildren = r.findAll('.keyed-selection-readable-child');
+		expect(labels(r)).toEqual(['first', 'second', 'third']);
+
+		first = 'updated first';
+		second = 'updated second';
+		r.update(KeyedSelectionRenderableList, { items, selected: 2 });
+		expect(labels(r)).toEqual(['updated first', 'updated second', 'third']);
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		expect(r.findAll('li')).toEqual(originalRows);
+		expect(r.findAll('.keyed-selection-readable-child')).toEqual(originalChildren);
+
+		first = 'selected first again';
+		r.update(KeyedSelectionRenderableList, { items, selected: 1 });
+		expect(labels(r)).toEqual(['selected first again', 'updated second', 'third']);
+		expect(r.findAll('li.selected')).toEqual([originalRows[0]]);
+		expect(r.findAll('.keyed-selection-readable-child')).toEqual(originalChildren);
 		r.unmount();
 	});
 

--- a/packages/octane/tests/hooks.test.ts
+++ b/packages/octane/tests/hooks.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mount, nextPaint } from './_helpers';
+import { act, mount, nextPaint } from './_helpers';
+import { flushSync, startTransition } from '../src/index.js';
 import {
 	LazyInit,
 	TwoStates,
+	StateValueProbe,
 	Tally,
 	MemoTest,
 	CustomMemoDeps,
@@ -41,6 +43,94 @@ describe('useState', () => {
 		expect(r.find('#a').textContent).toBe('2');
 		expect(r.find('#b').textContent).toBe('14');
 		r.unmount();
+	});
+
+	it('rebases functional Action updates while retaining later replacement values', async () => {
+		let setValue!: (next: number | ((previous: number) => number)) => void;
+		let getValue!: () => number;
+		let releaseFirst!: () => void;
+		let releaseFinal!: () => void;
+		const first = new Promise<void>((resolve) => (releaseFirst = resolve));
+		const final = new Promise<void>((resolve) => (releaseFinal = resolve));
+		const r = mount(StateValueProbe, {
+			initial: 1,
+			display: String,
+			expose: (set: typeof setValue, get: typeof getValue) => {
+				setValue = set;
+				getValue = get;
+			},
+		});
+		try {
+			flushSync(() =>
+				startTransition(async () => {
+					setValue((value) => value + 10);
+					await first;
+					setValue(40);
+					setValue((value) => value + 2);
+					await final;
+				}),
+			);
+			expect(r.find('span').textContent).toBe('1');
+			expect(getValue()).toBe(11);
+			flushSync(() => setValue(5));
+			expect(r.find('span').textContent).toBe('5');
+			expect(getValue()).toBe(15);
+
+			await act(() => releaseFirst());
+			expect(r.find('span').textContent).toBe('5');
+			expect(getValue()).toBe(42);
+			flushSync(() => setValue(9));
+			expect(r.find('span').textContent).toBe('9');
+			expect(getValue()).toBe(42);
+
+			await act(() => releaseFinal());
+			expect(r.find('span').textContent).toBe('42');
+			expect(getValue()).toBe(42);
+		} finally {
+			releaseFirst();
+			releaseFinal();
+			await act(() => {});
+			r.unmount();
+		}
+	});
+
+	it('retains function-valued state through urgent and staged replacements', async () => {
+		type Value = () => string;
+		let setValue!: (next: Value | ((previous: Value) => Value)) => void;
+		let getValue!: () => Value;
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		const initial = () => 'initial';
+		const staged = () => 'staged';
+		const urgent = () => 'urgent';
+		const r = mount(StateValueProbe, {
+			initial,
+			display: (value: Value) => value(),
+			expose: (set: typeof setValue, get: typeof getValue) => {
+				setValue = set;
+				getValue = get;
+			},
+		});
+		try {
+			flushSync(() =>
+				startTransition(async () => {
+					setValue(() => staged);
+					await gate;
+				}),
+			);
+			expect(r.find('span').textContent).toBe('initial');
+			expect(getValue()).toBe(staged);
+			flushSync(() => setValue(() => urgent));
+			expect(r.find('span').textContent).toBe('urgent');
+			expect(getValue()).toBe(staged);
+			await act(() => release());
+			expect(r.find('span').textContent).toBe('staged');
+			expect(getValue()).toBe(staged);
+		} finally {
+			release();
+			await act(() => {});
+			r.unmount();
+		}
 	});
 });
 

--- a/packages/octane/tests/svg-deopt.test.ts
+++ b/packages/octane/tests/svg-deopt.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as ServerRuntime from 'octane/server';
+import type { ClassValue } from 'octane/jsx-runtime';
 import { flushSync, hydrateRoot } from '../src/index.js';
 import { mount } from './_helpers';
 import {
 	DeoptNamespaceSlots,
 	DescriptorNamespaceDocument,
 	SvgViaCreateElement,
+	TemplateClassNamespaces,
 	TemplateNamespaceDestinations,
 } from './_fixtures/svg-deopt.tsrx';
 import { loadServerFixture } from './_server-fixture.js';
@@ -98,6 +100,51 @@ function captureTemplateNodes(root: ParentNode): Map<string, Element> {
 function expectTemplateNodeIdentity(root: ParentNode, before: Map<string, Element>): void {
 	for (const [selector, node] of before) {
 		expect(root.querySelector(selector), selector).toBe(node);
+	}
+}
+
+const CLASS_NAMESPACE_CASES: Array<[string, string]> = [
+	['#class-html-root', HTML_NS],
+	['#class-html-nested', HTML_NS],
+	['#class-html-fragment-first', HTML_NS],
+	['#class-html-fragment-second', HTML_NS],
+	['#class-html-ambiguous', HTML_NS],
+	['#class-foreign-html', HTML_NS],
+	['#class-svg-ambiguous', SVG_NS],
+	['#class-svg-mixed-anchor', SVG_NS],
+	['#class-svg-mixed-group', SVG_NS],
+	['#class-svg-fixed', SVG_NS],
+	['#class-math-ambiguous', MATHML_NS],
+	['#class-math-fixed', MATHML_NS],
+	['#class-math-mixed-anchor', MATHML_NS],
+	['#class-math-mixed-group', MATHML_NS],
+];
+
+const INITIAL_CLASS: ClassValue = ['first', { active: true, absent: false }];
+const CLASS_UPDATES: Array<[ClassValue, string | null]> = [
+	[['next', { active: false, visible: true }], 'next visible'],
+	[false, null],
+	['', ''],
+	[null, null],
+	[INITIAL_CLASS, 'first active'],
+];
+
+function captureClassNodes(root: ParentNode): Map<string, Element> {
+	return new Map(
+		CLASS_NAMESPACE_CASES.map(([selector]) => [selector, root.querySelector(selector)!]),
+	);
+}
+
+function expectNamespaceClasses(
+	root: ParentNode,
+	value: string | null,
+	before?: Map<string, Element>,
+): void {
+	for (const [selector, namespace] of CLASS_NAMESPACE_CASES) {
+		const node = root.querySelector(selector);
+		expect(node?.namespaceURI, selector).toBe(namespace);
+		expect(node?.getAttribute('class'), selector).toBe(value);
+		if (before !== undefined) expect(node, selector).toBe(before.get(selector));
 	}
 }
 
@@ -214,9 +261,50 @@ describe('component template namespace inheritance', () => {
 
 		mounted.unmount();
 	});
+
+	it('composes and removes classes in fixed and destination-selected namespaces', () => {
+		const mounted = mount(TemplateClassNamespaces, { value: INITIAL_CLASS });
+		try {
+			expectNamespaceClasses(mounted.container, 'first active');
+			const before = captureClassNodes(mounted.container);
+			for (const [value, expected] of CLASS_UPDATES) {
+				mounted.update(TemplateClassNamespaces, { value });
+				expectNamespaceClasses(mounted.container, expected, before);
+			}
+		} finally {
+			mounted.unmount();
+		}
+	});
 });
 
 describe('namespace inheritance across server rendering', () => {
+	it('adopts namespace-specific classes and updates them without replacing server elements', async () => {
+		const props = { value: INITIAL_CLASS };
+		const { html } = await ServerRuntime.renderToString(server.TemplateClassNamespaces, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const recoveries: unknown[] = [];
+		let root: ReturnType<typeof hydrateRoot> | null = null;
+		try {
+			container.innerHTML = html;
+			expectNamespaceClasses(container, 'first active');
+			const before = captureClassNodes(container);
+			root = hydrateRoot(container, TemplateClassNamespaces, props, {
+				onRecoverableError: (error) => recoveries.push(error),
+			});
+			flushSync(() => {});
+			expectNamespaceClasses(container, 'first active', before);
+			for (const [value, expected] of CLASS_UPDATES) {
+				flushSync(() => root!.render(TemplateClassNamespaces, { value }));
+				expectNamespaceClasses(container, expected, before);
+			}
+			expect(recoveries).toEqual([]);
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
 	it('hydrates component-selected template namespaces in place with live updates', async () => {
 		const props = { label: 'server label' };
 		const { html } = await ServerRuntime.renderToString(


### PR DESCRIPTION
## Summary

- Reduce work in the existing O(1) keyed-selection path by emitting a narrowly certified class-only row updater.
- Reuse the ordinary class binding's cache, preserve full reconciliation for live renderable children, and keep controlled/lifecycle-sensitive rows on their existing paths.
- Use the resolved template namespace for class bindings, avoid unnecessary urgent-state replay closures, and stop focus traversal early when a document genuinely has no focused control.
- Add a production Chromium work-count guard, behavioral regressions, and an Octane patch changeset. No public API or benchmark-application change is required.

## Why

[Pyreon PR #2985](https://github.com/pyreon/pyreon/pull/2985) highlighted a constant-cost gap in row selection. Octane already selects keyed rows in O(1), but still ran the complete helpers for the affected rows. Pyreon's selector can update the keyed class binding directly. This patch removes unrelated row work while preserving Octane's existing state, scheduling, focus, hydration, and child-reconciliation contracts.

## Performance evidence

Local production Chromium measurements at 1,000 rows, using Pyreon source pinned to `72500eb7c2b27f1dfebd0b88fb79685ee5ab8a94` and Octane investigation baseline `1ac62305379c6ee735580ce34886142dd806d29c`:

| Measurement | Octane before | Retained candidate | Reduction | Pyreon before / candidate control |
| --- | ---: | ---: | ---: | ---: |
| PR reset/select harness | 537.0 ns/op | 491.7 ns/op | 8.4% | 335.2 / 342.4 ns/op |
| Synchronous null ↔ selected | 255.6 ns/change | 221.7 ns/change | 13.2% | 93.3 / 89.9 ns/change |
| Synchronous row A ↔ row B | 335.5 ns/change | 271.4 ns/change | 19.1% | 172.0 / 157.8 ns/change |

These are investigation measurements, **not the official js-framework-benchmark score or a claim of Pyreon parity**. The PR harness includes await, layout-read, and DOM-probe overhead. The synchronous companion excludes those from its timed loop. The crossover retained 5 baseline passes/60 batch samples and 3 candidate passes/36 samples; the other 2 candidate passes exceeded the load ceiling. The synchronous runs used 15 samples of 300,000 changes after 100,000 warmup changes. Separate checks verified the minimum one/two class writes per change and surviving row/cell identity. Machine: Apple M5 Max, Chromium 151.0.7922.34.

The checked-in, untimed guard is reproducible with:

```sh
node benchmarks/bench.mjs --ratios js-framework-selection-work
```

The old source fails both guards with **40 unrelated label reads** at both 10 and 1,000 rows; this patch performs **zero**. Same-run ordinary-row controls perform 230 and 23,000 reads. Both arms also check class/label output, keyed identity, reselect/reset, data replacement, reorder, and clear/refill.

The timings predate transplantation onto upstream `be97666d0854bb69378422574dbd2df4d8cf433e`. The final runtime is byte-identical to the measured candidate (`ef92a5d7a2bd1289df7d8c6859d52d9d52ac2cf48dab8b8f4941472f47971b94`), and production compiler output is byte-identical for the exact PR fixture, the real js-framework `Main.tsrx`, and the new work guard. The transplant retains upstream's separate universal-renderer memo fix.

## Validation

- [ ] `pnpm format:check` — repository-wide command not run; explicit Prettier checks pass for every changed file.
- [ ] `pnpm typecheck` — repository-wide command not run; the complete Octane package passes `tsgo --noEmit -p packages/octane/tsconfig.json`.
- [ ] `pnpm test` — root wrapper not run; direct scoped Vitest results are below.
- [x] `pnpm sync` with dependency auto-install disabled; no additional tracked generated changes. Changeset validation and `git diff --check` pass.
- [x] Targeted development/production/profiling and compiler-safety tests: **426 passed across 20 files** on the rebased PR source.
- [x] Baseline and deliberate-break evidence for stale class caches, live render-function children, controlled inputs, BODY shadow-root focus, Action rebasing, and HTML/SVG/MathML class semantics; restored implementations pass.
- [x] Fresh production Chromium selection-work comparison against clean upstream `be97666d0`: upstream fails both guards at 40/40 label reads; this PR passes both at 0/0, with identical nonzero controls and all semantic checks passing.
- [x] Real clickable js-framework fixture: selection/identity/direct-mount correctness gates pass. Its selection timings hit the 0.1 ms clock floor, so no click-latency improvement is claimed.

The registry denied the exact locked parser packages. Both timing arms and the scoped tests used Octane's supported pure-JavaScript parser path with repository-patched `@tsrx/core` 0.1.56 and esrap 2.3.2. The local formatter used cached TSRX Prettier 0.3.118. These are disclosed recovery-toolchain results, not a claim that the complete exact-lockfile workspace or CI has passed.

## Risk / follow-ups

- Pyreon remains about 1.44× faster in the candidate's same-run crossover control. Further transparent runtime work is a separate investigation.
- The fast row updater is restricted to the existing strict-equality/literal-class proof plus the stronger host-safety proof; rows with live child slots fall back to their full body. The ordinary class cache, authored `===` semantics, namespace behavior, transitions, hydration, and focus restoration remain intact.
- The real benchmark bundle grew by about 0.28 kB raw / 0.08 kB gzip. No broad mount/reorder/paint speedup is claimed.
- Larger owner-render bypass and lazy-initializer experiments were removed because they did not show a robust additional gain. Diagnostic shortcuts that weakened render-frame or focus semantics are not included.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches keyed-list compiler proofs, runtime selection fast paths, and class binding across HTML/SVG/MathML; mitigated by narrow certification, slot-based fallbacks, and production work-count guards.
> 
> **Overview**
> **Compiler-certified keyed lists** can now update **only the selected row’s class** when the `@for` body is a single host root with a literal, item-independent class binding. The compiler hoists a dedicated `selectionBody` that reuses the normal class-binding cache and wires it through `keyedForBlock` / `fastKeyedForBlock`; opaque inherited namespaces are resolved before planning so HTML can use `className` and SVG/MathML keep the right setter.
> 
> **Runtime** keeps full row reconciliation when rows have child slots (controlled inputs, render-function children) or when the fast path’s preconditions fail. Smaller fixes: urgent `useState` skips replay closures unless a transition stages the update; focus traversal no longer treats an unfocused `document.body` as the active element when it has an open shadow root.
> 
> **Benchmarks and tests:** new untimed `js-framework-selection-work` suite (literal vs dynamic class, label-read guards at 10 and 1,000 rows), plus regressions for namespace class updates, selection semantics, transition rebasing, and body shadow focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b527d7b50ad352791b1eef0d54c124a86345056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755921&installation_model_id=432790&pr_number=798&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F798&signature=97cdf938fbeb2aadfd40b9384f2f00ac9cfec0d4c4d382342e780ba836d76aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->