### PR TITLE
perf(octane): specialize class-only keyed row updates

### DIFF
--- a/.changeset/keyed-row-selection-work.md
+++ b/.changeset/keyed-row-selection-work.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reduce keyed-row selection work for compiler-proven class-only updates. Preserve full row reconciliation for live renderable children and use the correct class setter for statically known HTML, SVG, and MathML templates. Also avoid unnecessary state-update allocations and focus traversal when a document has no focused control.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -13481,7 +13481,16 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			cssHash,
 		);
 	} else {
-		plan = planJsx(jsxNodes, ctx, name, inlinedSubs, parentNs, cssHash, mountCallbackSinks);
+		plan = planJsx(
+			jsxNodes,
+			ctx,
+			name,
+			inlinedSubs,
+			parentNs,
+			cssHash,
+			mountCallbackSinks,
+			options?.keyedSelection ?? null,
+		);
 	}
 	ctx.currentInvariantLocals = prevInvariantLocals;
 	ctx.currentEventInvariantLocals = prevEventInvariantLocals;
@@ -17422,6 +17431,11 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				const bodyHole = `h${holeProps.length}`;
 				holeProps.push(objectProp(bodyHole, b.id(rec.bodyHelper)));
 				rec.bodyHelper = `props.${bodyHole}`;
+				if (rec.selectionHelper != null) {
+					const selectionHole = `h${holeProps.length}`;
+					holeProps.push(objectProp(selectionHole, b.id(rec.selectionHelper)));
+					rec.selectionHelper = `props.${selectionHole}`;
+				}
 			}
 			if (mapCall) {
 				const methodHole = `h${holeProps.length}`;
@@ -20440,6 +20454,7 @@ function planJsx(
 	parentNs = 'html',
 	cssHash = null,
 	mountCallbackSinks = null,
+	keyedSelection = null,
 ) {
 	// DEV ONLY: per-element source-location map for THIS body (path-key → [line, col]),
 	// populated at the top of emitElementHtml and read in the binding mount loop to emit
@@ -20711,6 +20726,15 @@ function planJsx(
 				}
 				tplNs = resolved === null ? 'html' : resolved;
 				resolvedFrag = tplNs !== 'opaque';
+			}
+		}
+		// Binding planning precedes the final template namespace. An inherited
+		// opaque namespace can now use the same concrete namespace as clone(),
+		// including HTML's faster className property. Preserve explicit foreign
+		// content and leave genuinely opaque/mixed templates destination-aware.
+		if (tplNs !== 'opaque') {
+			for (const binding of elementBindings) {
+				if (binding.ns === 'opaque') binding.ns = tplNs;
 			}
 		}
 		const flag = nsFlag(tplNs);
@@ -21235,6 +21259,24 @@ function planJsx(
 		if (b.deferred) everyRenderLines.push(updateEmit);
 		else updateLines.push(updateEmit);
 	}
+	if (keyedSelection !== null && single && !noTemplate) {
+		// Reuse the ordinary root-class write and its exact bag fields. Updating
+		// only the DOM would leave the normal row diff's previous value stale.
+		const classes = elementBindings.filter(
+			(binding) => binding.kind === 'class' && binding.path.length === 0,
+		);
+		if (
+			classes.length === 1 &&
+			!classes[0].fresh &&
+			!classes[0].mountOnly &&
+			collectFreeIdentifiers(classes[0].expr, [
+				keyedSelection.itemName,
+				keyedSelection.selectedName,
+			]).size === 0
+		) {
+			keyedSelection.update = emitBindingUpdate(classes[0], bag);
+		}
+	}
 
 	// After (forBlock + ifBlock calls run on every render — they reconcile).
 	//
@@ -21343,6 +21385,7 @@ function planJsx(
 			rtAlias(forHelper),
 			fc.keyHelper,
 			fc.bodyHelper,
+			fc.selectionHelper,
 			fc.emptyHelper,
 		]);
 		registerClauseOrigin(ctx, fc.emptyKeyword, [fc.emptyHelper]);
@@ -21367,7 +21410,8 @@ function planJsx(
 			(fc.requiresScope ? 32 : 0) |
 			(fc.keyedSelectionIndex >= 0 ? fc.keyedSelectionIndex << 6 : 0);
 		// Arg layout: forBlock(__s, slot, host, items, keyFn, body, flags?, deps?,
-		// emptyBody?, anchor?, ownEnd?).
+		// emptyBody?, anchor?, ownEnd?, selectionBody?). The final argument is
+		// emitted only for a certified keyed-selection call.
 		// Optional args backfill positionally: `flags`/`deps` placeholders
 		// (`0`/`undefined`) when only `emptyHelper` (`null` when no `@empty`
 		// branch) or the anchor is present, and a `null` empty-body placeholder
@@ -21419,6 +21463,12 @@ function planJsx(
 		// list's trailing boundary. Let forBlock reuse it as its end marker instead
 		// of retaining it beside a newly-created `/for` comment.
 		if (fc.anchorVar) tailArgs.push(b.literal(true));
+		if (fc.selectionHelper != null) {
+			// tailArgs starts at argument 5; preserve the optional positions through
+			// ownEnd before supplying the selection updater as argument 12.
+			while (tailArgs.length < 7) tailArgs.push(undefinedNode());
+			tailArgs.push(helperRefNode(fc.selectionHelper));
+		}
 		if (isMappedList) {
 			const nativeName = allocCompilerName(ctx, '__mapNative');
 			if (fc.autoMemoDeps !== null) {
@@ -25000,6 +25050,7 @@ function hoistBodyHelper(
 	cssHash,
 	envNames,
 	idOrigin = null,
+	keyedSelection = null,
 ) {
 	const helperName = `${prefix}$${ctx.nextHelperId++}`;
 	const ownEnvNames = envNames === null ? null : helperCaptures(ctx, stmts, params);
@@ -25067,7 +25118,14 @@ function hoistBodyHelper(
 	);
 	let helperFn;
 	try {
-		helperFn = compileFunctionBody(fake, ctx, helperName, parentNs, cssHash);
+		helperFn = compileFunctionBody(
+			fake,
+			ctx,
+			helperName,
+			parentNs,
+			cssHash,
+			keyedSelection === null ? null : { keyedSelection },
+		);
 	} finally {
 		ctx.currentComponentLocals = prevLocals;
 		ctx.currentInvariantLocals = prevInvariantLocals;
@@ -25076,6 +25134,35 @@ function hoistBodyHelper(
 	// Module-scope placement: the compiled helper joins the module AST as a
 	// hoisted statement node (M2 AST emit).
 	ctx.hoistedHelpers.push(helperFn);
+	if (keyedSelection?.update != null) {
+		const selectionName = allocCompilerName(ctx, `__select$${ctx.nextHelperId++}`);
+		const origin = keyedSelection.update;
+		const selectionBody = [
+			inheritOriginLoc(
+				b.const(
+					keyedSelection.selectedName,
+					b.member(b.id('__extra'), b.literal(keyedSelection.selectedIndex), true),
+				),
+				origin,
+			),
+			inheritOriginLoc(
+				b.const('_b', b.member(b.member(b.id('__s'), 'slots'), b.literal(0), true)),
+				origin,
+			),
+			keyedSelection.update,
+		];
+		ctx.hoistedHelpers.push(
+			inheritOriginLoc(
+				b.function_declaration(
+					b.id(selectionName, idOrigin ?? fakeOrigin ?? undefined),
+					[...params, b.id('__s'), b.id('__extra')],
+					b.block(selectionBody),
+				),
+				fakeOrigin,
+			),
+		);
+		keyedSelection.helper = selectionName;
+	}
 	return helperName;
 }
 
@@ -26494,18 +26581,6 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			node.emptyKeyword ?? null,
 		);
 	}
-	const itemHelperName = hoistBodyHelper(
-		ctx,
-		inlinedSubs,
-		'__item',
-		itemAllStmts,
-		itemParams,
-		parentNs,
-		cssHash,
-		envNames,
-		directiveKeywordOrigin(ctx, node),
-	);
-
 	// Single-root detection: when the body emits exactly one Element root and
 	// no other JSX siblings (no Fragment, no Component, no top-level if/for/try),
 	// the runtime can skip per-item Comment markers and use the row element
@@ -26577,6 +26652,31 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		!containsRenderCall(subStmts) &&
 		!containsAutoMemoUnsafeStructure(subStmts) &&
 		isHostMountSafeTree(subStmts[0]);
+	// Class-only updates need the stricter host-lifecycle proof as well as the
+	// existing equality proof. The item planner fills this compiler-owned result
+	// only when the root class survives as one ordinary cached binding.
+	const keyedSelection =
+		hostMountSafe && keyedSelectionIndex >= 0 && envNames !== null
+			? {
+					itemName,
+					selectedName: runtimeDepNames[keyedSelectionIndex],
+					selectedIndex: keyedSelectionIndex,
+					update: null,
+					helper: null,
+				}
+			: null;
+	const itemHelperName = hoistBodyHelper(
+		ctx,
+		inlinedSubs,
+		'__item',
+		itemAllStmts,
+		itemParams,
+		parentNs,
+		cssHash,
+		envNames,
+		directiveKeywordOrigin(ctx, node),
+		keyedSelection,
+	);
 
 	const mapCall = node.nativeArrayMap || null;
 	return {
@@ -26607,6 +26707,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		keyHelper,
 		inlineKey: inlineKey ? keyFn : null,
 		bodyHelper: itemHelperName,
+		selectionHelper: keyedSelection?.helper ?? null,
 		hasPerItemEventClosure,
 		pure,
 		singleRoot,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1040,24 +1040,27 @@ function stagedTransitionValue<T>(slot: TransitionActionSlot<T>): T {
 function stageTransitionValue<T>(
 	slot: TransitionActionSlot<T>,
 	block: Block,
-	operation: (value: T) => T,
+	operation: T | ((value: T) => T),
 	value: T,
 	forceRender = false,
 ): boolean {
 	const batch = transitionActionBatchForUpdate();
 	if (batch === null) return false;
+	// Replacement values need a replay closure only when an Action actually
+	// stages the update. Ordinary useState setters stay allocation-free here.
+	const replay = typeof operation === 'function' ? (operation as (value: T) => T) : () => operation;
 	const current = batch.updates.get(slot) as TransitionActionUpdate<T> | undefined;
 	if (current === undefined) {
 		batch.updates.set(slot, {
 			slot,
 			block,
-			operations: [operation],
+			operations: [replay],
 			baseValue: slot.value,
 			value,
 			forceRender,
 		});
 	} else {
-		current.operations.push(operation);
+		current.operations.push(replay);
 		current.value = value;
 		current.forceRender ||= forceRender;
 	}
@@ -3034,6 +3037,12 @@ interface FocusSelectionSnapshot {
 function activeElementForDocument(doc: Document): Element | null {
 	try {
 		let focused = doc.activeElement;
+		// Unfocused documents usually report body. It can itself host an open
+		// shadow tree, so only skip the descent when that tree has no focus.
+		if (focused === doc.body) {
+			focused = focused?.shadowRoot?.activeElement ?? null;
+			if (focused === null) return null;
+		}
 		while (focused !== null) {
 			if (focused.localName === 'iframe') {
 				let nested: Document | null;
@@ -5679,10 +5688,9 @@ export function useState<T>(initial?: T | (() => T), slot?: HookSlot): StateTupl
 			value: initVal,
 			setter: (next) => {
 				const previous = stagedTransitionValue(s!);
-				const operation = typeof next === 'function' ? (next as (p: T) => T) : () => next;
-				const computed = operation(previous);
+				const computed = typeof next === 'function' ? (next as (p: T) => T)(previous) : next;
 				if (Object.is(computed, previous)) return;
-				if (stageTransitionValue(s!, block, operation, computed)) {
+				if (stageTransitionValue(s!, block, next, computed)) {
 					if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__) {
 						const update = s!.pendingActionBatch?.updates.get(s!) as
 							TransitionActionUpdate<T> | undefined;
@@ -25536,6 +25544,7 @@ export function keyedForBlock<T>(
 	emptyBody?: ComponentBody | null,
 	anchor?: Node | null,
 	ownEnd?: boolean,
+	selectionBody?: ComponentBody<T, any[]>,
 ): void {
 	const state = parentScope.slots[slotKey] as ForSlot | undefined;
 	if (TRANSITION_JOURNAL !== null) {
@@ -25552,7 +25561,15 @@ export function keyedForBlock<T>(
 		state !== undefined &&
 		activeHydration() === null &&
 		state.cachedDeps !== null &&
-		tryUpdateKeyedSelection(state, items, itemBody, state.cachedDeps, deps, flags >>> 6)
+		tryUpdateKeyedSelection(
+			state,
+			items,
+			itemBody,
+			state.cachedDeps,
+			deps,
+			flags >>> 6,
+			selectionBody,
+		)
 	) {
 		return;
 	}
@@ -25742,6 +25759,7 @@ export function fastKeyedForBlock<T>(
 	emptyBody?: ComponentBody | null,
 	anchor?: Node | null,
 	ownEnd?: boolean,
+	selectionBody?: ComponentBody<T, any[]>,
 ): void {
 	const state = parentScope.slots[slotKey] as ForSlot | undefined;
 	const parent = fastHostListParent(state, items, flags);
@@ -25758,6 +25776,7 @@ export function fastKeyedForBlock<T>(
 			emptyBody,
 			anchor,
 			ownEnd,
+			selectionBody,
 		);
 		return;
 	}
@@ -25883,6 +25902,7 @@ function tryUpdateKeyedSelection<T>(
 	previousDeps: any[],
 	deps: any[],
 	selectionIndex: number,
+	selectionBody: ComponentBody<T, any[]> | undefined,
 ): boolean {
 	if (
 		state.selectionItems !== items ||
@@ -25915,12 +25935,24 @@ function tryUpdateKeyedSelection<T>(
 	if (first !== undefined) {
 		first.body = itemBody as ComponentBody;
 		first.extra = deps;
-		(itemBody as any)(first.props, first, deps);
+		// A separately certified host row can update just its class binding. Raw
+		// object/function children register child slots, however, and must still
+		// reconcile on the ordinary body path even when their identity is stable.
+		// Primitive-only child holes retain no slots, so they pay no extra cache.
+		if (selectionBody !== undefined && first._slots === null) {
+			selectionBody(first.props, first, deps);
+		} else {
+			(itemBody as any)(first.props, first, deps);
+		}
 	}
 	if (second !== undefined) {
 		second.body = itemBody as ComponentBody;
 		second.extra = deps;
-		(itemBody as any)(second.props, second, deps);
+		if (selectionBody !== undefined && second._slots === null) {
+			selectionBody(second.props, second, deps);
+		} else {
+			(itemBody as any)(second.props, second, deps);
+		}
 	}
 	return true;
 }

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -274,6 +274,32 @@ export function KeyedSelectionList(props: {
 	</ul>
 }
 
+export function KeyedSelectionControlledList(props: {
+	items: SelectionRow[];
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul id="keyed-selection-controlled-list">
+		@for (const row of props.items; key row.id) {
+			<li class={selected === row.id ? 'selected' : ''}>
+				<input value={row.label} readOnly={true} />
+			</li>
+		}
+	</ul>
+}
+
+export function KeyedSelectionRenderableList(props: {
+	items: Array<{ id: number; content: OctaneNode }>;
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul id="keyed-selection-renderable-list">
+		@for (const row of props.items; key row.id) {
+			<li class={selected === row.id ? 'selected' : ''}>{row.content}</li>
+		}
+	</ul>
+}
+
 export function KeyedSelectionUuidList(props: {
 	items: Array<{ uuid: string; label: string }>;
 	selected: string | null;

--- a/packages/octane/tests/_fixtures/hooks.tsrx
+++ b/packages/octane/tests/_fixtures/hooks.tsrx
@@ -25,6 +25,12 @@ export function TwoStates() @{
 	</div>
 }
 
+export function StateValueProbe(props) @{
+	const [value, setValue, getValue] = octaneUseState(() => props.initial);
+	props.expose(setValue, getValue);
+	<span>{props.display(value) as string}</span>
+}
+
 // useReducer
 export function Tally() @{
 	const [n, dispatch] = useReducer((s, a) => s + a, 0);

--- a/packages/octane/tests/_fixtures/svg-deopt.tsrx
+++ b/packages/octane/tests/_fixtures/svg-deopt.tsrx
@@ -1,4 +1,5 @@
 import { createElement, Suspense, use } from 'octane';
+import type { ClassValue } from 'octane/jsx-runtime';
 
 // Returns an SVG tree via createElement (VALUE position) so it renders through the
 // runtime de-opt reconciler — exercising SVG-namespace creation outside the compiled
@@ -82,6 +83,59 @@ function ReturnedAmbiguousAnchorRoot(props) {
 
 function ReturnedAmbiguousMathRowRoot(props) {
 	return <mrow id={props.id}>{props.label as string}</mrow>;
+}
+
+function ClassAnchorRoot(props: { id: string; value: ClassValue }) @{
+	<a id={props.id} class={props.value} />
+}
+
+function ClassHtmlFragment(props: { value: ClassValue }) @{
+	<>
+		<div id="class-html-fragment-first" class={props.value} />
+		<span id="class-html-fragment-second" className={props.value} />
+	</>
+}
+
+function ClassMixedFragment(props: { anchorId: string; groupId: string; value: ClassValue }) @{
+	<>
+		<a id={props.anchorId} class={props.value} />
+		<g id={props.groupId} className={props.value} />
+	</>
+}
+
+function ClassMathRoot(props: { value: ClassValue }) @{
+	<mrow id="class-math-fixed" className={props.value} />
+}
+
+export function TemplateClassNamespaces(props: { value: ClassValue }) @{
+	<section id="class-html-root" class={props.value}>
+		<a id="class-html-nested" className={props.value} />
+		<ClassHtmlFragment value={props.value} />
+		<TemplateHtmlDestination id="class-html-destination">
+			<ClassAnchorRoot id="class-html-ambiguous" value={props.value} />
+		</TemplateHtmlDestination>
+		<TemplateSvgDestination id="class-svg-destination">
+			<ClassAnchorRoot id="class-svg-ambiguous" value={props.value} />
+			<ClassMixedFragment
+				anchorId="class-svg-mixed-anchor"
+				groupId="class-svg-mixed-group"
+				value={props.value}
+			/>
+			<g id="class-svg-fixed" class={props.value} />
+			<foreignObject>
+				<span id="class-foreign-html" className={props.value} />
+			</foreignObject>
+		</TemplateSvgDestination>
+		<TemplateMathDestination id="class-math-destination">
+			<ClassAnchorRoot id="class-math-ambiguous" value={props.value} />
+			<ClassMathRoot value={props.value} />
+			<ClassMixedFragment
+				anchorId="class-math-mixed-anchor"
+				groupId="class-math-mixed-group"
+				value={props.value}
+			/>
+		</TemplateMathDestination>
+	</section>
 }
 
 // Template-form children cross an opaque component boundary before their

--- a/packages/octane/tests/focus-restoration.test.ts
+++ b/packages/octane/tests/focus-restoration.test.ts
@@ -344,6 +344,62 @@ describe('focus and text selection survive DOM updates', () => {
 		}
 	});
 
+	it('restores focus and selection when the document body hosts an open shadow tree', () => {
+		// A shadow root cannot be detached from its host. Give this case its own
+		// document so the suite's body remains available to subsequent tests.
+		const frame = document.createElement('iframe');
+		document.body.appendChild(frame);
+		const owner = frame.contentDocument!;
+		const bodyShadow = owner.body.attachShadow({ mode: 'open' });
+		const nestedHost = owner.createElement('section');
+		bodyShadow.appendChild(nestedHost);
+		const shadow = nestedHost.attachShadow({ mode: 'open' });
+		const container = owner.createElement('div');
+		shadow.appendChild(container);
+		const root = createRoot(container);
+		try {
+			root.render(FastHostControlledList, { items: rows });
+			flushSync(() => {});
+			const input = container.querySelectorAll('input')[1]!;
+			input.focus();
+			input.setSelectionRange(2, 9);
+			expect(owner.activeElement).toBe(owner.body);
+			expect(bodyShadow.activeElement).toBe(nestedHost);
+			expect(shadow.activeElement).toBe(input);
+
+			const parent = container.querySelector('#fast-host-controlled-list')!;
+			const originalInsert = parent.insertBefore;
+			let lostFocus = false;
+			const move = vi.spyOn(parent, 'insertBefore').mockImplementation(function <T extends Node>(
+				node: T,
+				anchor: Node | null,
+			): T {
+				const result = originalInsert.call(this, node, anchor) as T;
+				if (!lostFocus) {
+					input.blur();
+					input.setSelectionRange(0, 0);
+					lostFocus = shadow.activeElement !== input;
+				}
+				return result;
+			});
+			try {
+				flushSync(() => root.render(FastHostControlledList, { items: rows.toReversed() }));
+
+				expect(lostFocus).toBe(true);
+				expect(container.querySelectorAll('input')[2]).toBe(input);
+				expect(owner.activeElement).toBe(owner.body);
+				expect(bodyShadow.activeElement).toBe(nestedHost);
+				expect(shadow.activeElement).toBe(input);
+				expect([input.selectionStart, input.selectionEnd]).toEqual([2, 9]);
+			} finally {
+				move.mockRestore();
+			}
+		} finally {
+			root.unmount();
+			frame.remove();
+		}
+	});
+
 	it('restores focus to a moved content-editable host with an active selection', () => {
 		const rendered = mount(EditableRows, { items: rows });
 		try {

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -16,6 +16,8 @@ import {
 	NestedConditionalTransition,
 	PlainCalleeList,
 	KeyedSelectionList,
+	KeyedSelectionControlledList,
+	KeyedSelectionRenderableList,
 	KeyedSelectionTransition,
 	KeyedSelectionUuidList,
 	MismatchedKeyedSelectionList,
@@ -488,6 +490,34 @@ describe('keyed list selection', () => {
 		r.unmount();
 	});
 
+	it('uses strict equality for NaN and signed-zero selection keys', () => {
+		const items = [
+			{ id: Number.NaN, label: 'not a number' },
+			{ id: -0, label: 'zero' },
+			{ id: 1, label: 'one' },
+		];
+		const r = mount(KeyedSelectionList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+
+		r.update(KeyedSelectionList, { items, selected: Number.NaN });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+
+		r.update(KeyedSelectionList, { items, selected: -0 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		r.update(KeyedSelectionList, { items, selected: 0 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		r.update(KeyedSelectionList, { items, selected: 99 });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+
+		const reordered = [items[2]!, items[0]!, items[1]!];
+		r.update(KeyedSelectionList, { items: reordered, selected: Number.NaN });
+		expect(r.findAll('li')).toEqual([originalRows[2], originalRows[0], originalRows[1]]);
+		expect(r.findAll('li.selected')).toHaveLength(0);
+		r.update(KeyedSelectionList, { items: reordered, selected: 0 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		r.unmount();
+	});
+
 	it('matches selection against the authored custom key property', () => {
 		const items = [
 			{ uuid: 'a-1', label: 'first' },
@@ -550,24 +580,83 @@ describe('keyed list selection', () => {
 		r.unmount();
 	});
 
-	it('preserves immutable keyed-row updates when the selection changes together', () => {
+	it('preserves immutable row updates when returning to an earlier selected key', () => {
 		const initialItems = makeRows();
 		const r = mount(KeyedSelectionList, { items: initialItems, selected: 1 });
 		const originalRows = r.findAll('li');
+
+		r.update(KeyedSelectionList, { items: initialItems, selected: 2 });
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+
 		const updatedItems = [
 			initialItems[0]!,
 			{ ...initialItems[1]!, label: 'updated second' },
 			initialItems[2]!,
 		];
 
-		r.update(KeyedSelectionList, { items: updatedItems, selected: 2 });
+		r.update(KeyedSelectionList, { items: updatedItems, selected: 1 });
 		expect(labels(r)).toEqual(['first', 'updated second', 'third']);
-		expect(r.find('.selected').textContent).toBe('updated second');
+		expect(r.findAll('li.selected')).toEqual([originalRows[0]]);
 		expect(r.findAll('li')).toEqual(originalRows);
 
-		r.update(KeyedSelectionList, { items: updatedItems, selected: 3 });
-		expect(r.find('.selected').textContent).toBe('third');
+		r.update(KeyedSelectionList, { items: updatedItems, selected: 2 });
+		expect(r.find('.selected').textContent).toBe('updated second');
 		expect(labels(r)).toEqual(['first', 'updated second', 'third']);
+		r.unmount();
+	});
+
+	it('reasserts controlled values in rows whose selection changes', () => {
+		const items = makeRows();
+		const r = mount(KeyedSelectionControlledList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+		const controls = r.findAll('input') as HTMLInputElement[];
+		controls[0]!.focus();
+		controls[0]!.value = 'changed outside render';
+		controls[1]!.value = 'changed before selection';
+
+		r.update(KeyedSelectionControlledList, { items, selected: 2 });
+		expect(controls.map((control) => control.value)).toEqual(items.map((row) => row.label));
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		expect(r.findAll('li')).toEqual(originalRows);
+		expect(r.findAll('input')).toEqual(controls);
+		expect(document.activeElement).toBe(controls[0]);
+		r.unmount();
+	});
+
+	it('keeps stable render-function children live when their rows are selected', () => {
+		let first = 'first';
+		let second = 'second';
+		const items = [
+			{
+				id: 1,
+				content: () =>
+					createElement('span', { className: 'keyed-selection-readable-child' }, first),
+			},
+			{
+				id: 2,
+				content: () =>
+					createElement('span', { className: 'keyed-selection-readable-child' }, second),
+			},
+			{ id: 3, content: 'third' },
+		];
+		const r = mount(KeyedSelectionRenderableList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+		const originalChildren = r.findAll('.keyed-selection-readable-child');
+		expect(labels(r)).toEqual(['first', 'second', 'third']);
+
+		first = 'updated first';
+		second = 'updated second';
+		r.update(KeyedSelectionRenderableList, { items, selected: 2 });
+		expect(labels(r)).toEqual(['updated first', 'updated second', 'third']);
+		expect(r.findAll('li.selected')).toEqual([originalRows[1]]);
+		expect(r.findAll('li')).toEqual(originalRows);
+		expect(r.findAll('.keyed-selection-readable-child')).toEqual(originalChildren);
+
+		first = 'selected first again';
+		r.update(KeyedSelectionRenderableList, { items, selected: 1 });
+		expect(labels(r)).toEqual(['selected first again', 'updated second', 'third']);
+		expect(r.findAll('li.selected')).toEqual([originalRows[0]]);
+		expect(r.findAll('.keyed-selection-readable-child')).toEqual(originalChildren);
 		r.unmount();
 	});
 

--- a/packages/octane/tests/hooks.test.ts
+++ b/packages/octane/tests/hooks.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mount, nextPaint } from './_helpers';
+import { act, mount, nextPaint } from './_helpers';
+import { flushSync, startTransition } from '../src/index.js';
 import {
 	LazyInit,
 	TwoStates,
+	StateValueProbe,
 	Tally,
 	MemoTest,
 	CustomMemoDeps,
@@ -41,6 +43,94 @@ describe('useState', () => {
 		expect(r.find('#a').textContent).toBe('2');
 		expect(r.find('#b').textContent).toBe('14');
 		r.unmount();
+	});
+
+	it('rebases functional Action updates while retaining later replacement values', async () => {
+		let setValue!: (next: number | ((previous: number) => number)) => void;
+		let getValue!: () => number;
+		let releaseFirst!: () => void;
+		let releaseFinal!: () => void;
+		const first = new Promise<void>((resolve) => (releaseFirst = resolve));
+		const final = new Promise<void>((resolve) => (releaseFinal = resolve));
+		const r = mount(StateValueProbe, {
+			initial: 1,
+			display: String,
+			expose: (set: typeof setValue, get: typeof getValue) => {
+				setValue = set;
+				getValue = get;
+			},
+		});
+		try {
+			flushSync(() =>
+				startTransition(async () => {
+					setValue((value) => value + 10);
+					await first;
+					setValue(40);
+					setValue((value) => value + 2);
+					await final;
+				}),
+			);
+			expect(r.find('span').textContent).toBe('1');
+			expect(getValue()).toBe(11);
+			flushSync(() => setValue(5));
+			expect(r.find('span').textContent).toBe('5');
+			expect(getValue()).toBe(15);
+
+			await act(() => releaseFirst());
+			expect(r.find('span').textContent).toBe('5');
+			expect(getValue()).toBe(42);
+			flushSync(() => setValue(9));
+			expect(r.find('span').textContent).toBe('9');
+			expect(getValue()).toBe(42);
+
+			await act(() => releaseFinal());
+			expect(r.find('span').textContent).toBe('42');
+			expect(getValue()).toBe(42);
+		} finally {
+			releaseFirst();
+			releaseFinal();
+			await act(() => {});
+			r.unmount();
+		}
+	});
+
+	it('retains function-valued state through urgent and staged replacements', async () => {
+		type Value = () => string;
+		let setValue!: (next: Value | ((previous: Value) => Value)) => void;
+		let getValue!: () => Value;
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		const initial = () => 'initial';
+		const staged = () => 'staged';
+		const urgent = () => 'urgent';
+		const r = mount(StateValueProbe, {
+			initial,
+			display: (value: Value) => value(),
+			expose: (set: typeof setValue, get: typeof getValue) => {
+				setValue = set;
+				getValue = get;
+			},
+		});
+		try {
+			flushSync(() =>
+				startTransition(async () => {
+					setValue(() => staged);
+					await gate;
+				}),
+			);
+			expect(r.find('span').textContent).toBe('initial');
+			expect(getValue()).toBe(staged);
+			flushSync(() => setValue(() => urgent));
+			expect(r.find('span').textContent).toBe('urgent');
+			expect(getValue()).toBe(staged);
+			await act(() => release());
+			expect(r.find('span').textContent).toBe('staged');
+			expect(getValue()).toBe(staged);
+		} finally {
+			release();
+			await act(() => {});
+			r.unmount();
+		}
 	});
 });
 

--- a/packages/octane/tests/svg-deopt.test.ts
+++ b/packages/octane/tests/svg-deopt.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as ServerRuntime from 'octane/server';
+import type { ClassValue } from 'octane/jsx-runtime';
 import { flushSync, hydrateRoot } from '../src/index.js';
 import { mount } from './_helpers';
 import {
 	DeoptNamespaceSlots,
 	DescriptorNamespaceDocument,
 	SvgViaCreateElement,
+	TemplateClassNamespaces,
 	TemplateNamespaceDestinations,
 } from './_fixtures/svg-deopt.tsrx';
 import { loadServerFixture } from './_server-fixture.js';
@@ -98,6 +100,51 @@ function captureTemplateNodes(root: ParentNode): Map<string, Element> {
 function expectTemplateNodeIdentity(root: ParentNode, before: Map<string, Element>): void {
 	for (const [selector, node] of before) {
 		expect(root.querySelector(selector), selector).toBe(node);
+	}
+}
+
+const CLASS_NAMESPACE_CASES: Array<[string, string]> = [
+	['#class-html-root', HTML_NS],
+	['#class-html-nested', HTML_NS],
+	['#class-html-fragment-first', HTML_NS],
+	['#class-html-fragment-second', HTML_NS],
+	['#class-html-ambiguous', HTML_NS],
+	['#class-foreign-html', HTML_NS],
+	['#class-svg-ambiguous', SVG_NS],
+	['#class-svg-mixed-anchor', SVG_NS],
+	['#class-svg-mixed-group', SVG_NS],
+	['#class-svg-fixed', SVG_NS],
+	['#class-math-ambiguous', MATHML_NS],
+	['#class-math-fixed', MATHML_NS],
+	['#class-math-mixed-anchor', MATHML_NS],
+	['#class-math-mixed-group', MATHML_NS],
+];
+
+const INITIAL_CLASS: ClassValue = ['first', { active: true, absent: false }];
+const CLASS_UPDATES: Array<[ClassValue, string | null]> = [
+	[['next', { active: false, visible: true }], 'next visible'],
+	[false, null],
+	['', ''],
+	[null, null],
+	[INITIAL_CLASS, 'first active'],
+];
+
+function captureClassNodes(root: ParentNode): Map<string, Element> {
+	return new Map(
+		CLASS_NAMESPACE_CASES.map(([selector]) => [selector, root.querySelector(selector)!]),
+	);
+}
+
+function expectNamespaceClasses(
+	root: ParentNode,
+	value: string | null,
+	before?: Map<string, Element>,
+): void {
+	for (const [selector, namespace] of CLASS_NAMESPACE_CASES) {
+		const node = root.querySelector(selector);
+		expect(node?.namespaceURI, selector).toBe(namespace);
+		expect(node?.getAttribute('class'), selector).toBe(value);
+		if (before !== undefined) expect(node, selector).toBe(before.get(selector));
 	}
 }
 
@@ -214,9 +261,50 @@ describe('component template namespace inheritance', () => {
 
 		mounted.unmount();
 	});
+
+	it('composes and removes classes in fixed and destination-selected namespaces', () => {
+		const mounted = mount(TemplateClassNamespaces, { value: INITIAL_CLASS });
+		try {
+			expectNamespaceClasses(mounted.container, 'first active');
+			const before = captureClassNodes(mounted.container);
+			for (const [value, expected] of CLASS_UPDATES) {
+				mounted.update(TemplateClassNamespaces, { value });
+				expectNamespaceClasses(mounted.container, expected, before);
+			}
+		} finally {
+			mounted.unmount();
+		}
+	});
 });
 
 describe('namespace inheritance across server rendering', () => {
+	it('adopts namespace-specific classes and updates them without replacing server elements', async () => {
+		const props = { value: INITIAL_CLASS };
+		const { html } = await ServerRuntime.renderToString(server.TemplateClassNamespaces, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const recoveries: unknown[] = [];
+		let root: ReturnType<typeof hydrateRoot> | null = null;
+		try {
+			container.innerHTML = html;
+			expectNamespaceClasses(container, 'first active');
+			const before = captureClassNodes(container);
+			root = hydrateRoot(container, TemplateClassNamespaces, props, {
+				onRecoverableError: (error) => recoveries.push(error),
+			});
+			flushSync(() => {});
+			expectNamespaceClasses(container, 'first active', before);
+			for (const [value, expected] of CLASS_UPDATES) {
+				flushSync(() => root!.render(TemplateClassNamespaces, { value }));
+				expectNamespaceClasses(container, expected, before);
+			}
+			expect(recoveries).toEqual([]);
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
 	it('hydrates component-selected template namespaces in place with live updates', async () => {
 		const props = { label: 'server label' };
 		const { html } = await ServerRuntime.renderToString(


### PR DESCRIPTION
## Summary

- Emit a class-only updater for compiler-proven keyed selection and reuse the normal class-binding cache. Rows with live children or other sensitive bindings retain full reconciliation.
- Resolve the template namespace before choosing the class setter, so known HTML uses `className` while SVG and MathML keep the correct behavior.
- Avoid unused urgent-state replay closures and stop focus traversal early when the document has no focused control, including the BODY shadow-root case.

## Why

Octane's keyed selection was already O(1), but it still ran the full helpers for the affected rows. These changes remove that constant work without changing the public state API or benchmark application. This replaces #798 with a core-only diff.

The local production Chromium comparison at 1,000 rows improved from **537 to 492 ns/op** (8.4% lower). Pyreon was about 342 ns/op in the candidate run, so this is progress toward parity, not a parity or official benchmark-score claim. See [Pyreon PR #2985](https://github.com/pyreon/pyreon/pull/2985) for the original comparison.

## Validation

- [ ] `pnpm format:check` — repo-wide check not run.
- [ ] `pnpm typecheck` — repo-wide check not run.
- [ ] `pnpm test` — repo-wide command not run.
- [x] Targeted Octane development, production, profiling, and compiler-safety tests: **451 passed**.
- [x] Octane package typecheck and changed-file formatting.
- [x] Changeset validation, `pnpm sync`, and whitespace checks.

Local tests used the supported JavaScript parser fallback; the full exact-lockfile workspace checks were not rerun.

## Risk / follow-ups

The fast path keeps the existing strict-equality proof, adds host-safety checks, and falls back for live child slots. Targeted regressions cover cache coherence, renderable children, controlled inputs, namespace/hydration behavior, focus, and Action rebasing. Further runtime/compiler optimizations remain separate.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789758909&installation_model_id=432790&pr_number=799&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F799&signature=e225e0e65465fc2182d87e552dc3e49e6584a2e5dbe34bef34c91b8989d18e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyed `@for` fast paths and transition state staging in the runtime plus compiler certification for `selectionBody`; fallbacks and new tests limit regressions but list reconciliation and Actions remain sensitive areas.
> 
> **Overview**
> Speeds up **keyed list selection** when only the selected row’s root **class** can change: the compiler may emit a dedicated **`selectionBody`** that reuses the normal class-binding update path, and the runtime calls it from **`tryUpdateKeyedSelection`** instead of the full item body for rows with **no child slots**. Rows with controlled inputs, render-function children, or other live bindings still take the full reconciliation path.
> 
> **Template class bindings** now resolve an inherited opaque namespace to the concrete HTML/SVG/MathML template namespace before planning updates, so static templates pick the right setter (e.g. HTML **`className`**).
> 
> Smaller runtime tweaks: **`stageTransitionValue` / `useState`** avoid allocating replay closures for plain replacement values while preserving functional Action rebasing; **`activeElementForDocument`** still descends into an open shadow tree on **`body`** when nothing is focused, skipping unnecessary focus work otherwise.
> 
> Tests cover NaN/±0 selection keys, controlled rows, renderable children, namespace class updates (client + hydrate), body-hosted shadow focus, and staged transition state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dea92d583da2189d817dd509b03ed26d8f7fdaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->