### PR TITLE
perf(octane): recognize keyed selection aliases

### DIFF
--- a/.changeset/keyed-selection-row-alias.md
+++ b/.changeset/keyed-selection-row-alias.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep keyed row selection updates bounded when a row declares a constant alias for its key before rendering. Preserve the full affected-row bodies, event captures, strict-equality behavior, and transition replay.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -25985,14 +25985,17 @@ function makeSwitchCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = nul
  * snapshot remain unchanged.
  *
  * This recognizes `selected === item.id` (or its reverse) under `key item.id`,
- * and the same proof for any other explicit, noncomputed item property.
+ * optionally through one preceding `const id = item.id`, and the same proof
+ * for any other explicit, noncomputed item property. The authored declaration
+ * stays in the full item body, preserving its read position and event captures.
  * Dynamic ternary arms, extra references to
  * `selected` anywhere in the row (including deferred event callbacks), spreads,
  * and anything other than one direct host root all fail closed.
  */
 function keyedSelectionDepIndex(itemName, keyBody, subStmts, runtimeDepNames, ctx) {
-	if (subStmts.length !== 1 || !isPlainHostRoot(subStmts[0])) return -1;
-	const root = subStmts[0];
+	if (subStmts.length !== 1 && subStmts.length !== 2) return -1;
+	const root = subStmts[subStmts.length - 1];
+	if (!isPlainHostRoot(root)) return -1;
 	const attrs = root.attributes || root.openingElement?.attributes || [];
 	if (attrs.some((attr) => attr.type !== 'Attribute' && attr.type !== 'JSXAttribute')) {
 		return -1;
@@ -26044,12 +26047,33 @@ function keyedSelectionDepIndex(itemName, keyBody, subStmts, runtimeDepNames, ct
 			member.property.name === keyProperty
 		);
 	};
+	let keyAlias = null;
+	if (subStmts.length === 2) {
+		const declaration = subStmts[0];
+		const binding = declaration.declarations?.[0];
+		if (
+			declaration.type !== 'VariableDeclaration' ||
+			declaration.kind !== 'const' ||
+			declaration.declare === true ||
+			declaration.declarations?.length !== 1 ||
+			binding?.id?.type !== 'Identifier' ||
+			binding.id.name === itemName ||
+			!isItemKey(binding.init)
+		) {
+			return -1;
+		}
+		keyAlias = binding.id.name;
+	}
+	const isComparedKey = (expression) =>
+		isItemKey(expression) ||
+		(keyAlias !== null && expression?.type === 'Identifier' && expression.name === keyAlias);
 	const left = unwrapTsExpr(test.left);
 	const right = unwrapTsExpr(test.right);
-	const selected = isItemKey(left) ? right : isItemKey(right) ? left : null;
+	const selected = isComparedKey(left) ? right : isComparedKey(right) ? left : null;
 	if (
 		selected?.type !== 'Identifier' ||
 		selected.name === itemName ||
+		selected.name === keyAlias ||
 		!ctx.currentComponentLocals?.has(selected.name)
 	) {
 		return -1;

--- a/packages/octane/tests/_fixtures/keyed-selection-alias.tsrx
+++ b/packages/octane/tests/_fixtures/keyed-selection-alias.tsrx
@@ -1,0 +1,211 @@
+import { use, useEffect, useState, type OctaneNode } from 'octane';
+
+export interface AliasRow {
+	id: number;
+	label: string;
+}
+
+export interface AliasSelectionProps {
+	items: ArrayLike<AliasRow>;
+	selected: number | null;
+	onPick: (id: number) => void;
+	onRemove: (id: number) => void;
+}
+
+export function KeyAliasTable(props: AliasSelectionProps) @{
+	const items = props.items;
+	const selected = props.selected;
+	const onPick = props.onPick;
+	const onRemove = props.onRemove;
+	<table class="key-alias-table">
+		<tbody>
+			@for (const row of items; key row.id) {
+				const id = row.id;
+				<tr class={selected === id ? 'selected' : ''} data-id={id}>
+					<td>{id}</td>
+					<td>
+						<a class="pick" onClick={() => onPick(id)}>{row.label}</a>
+					</td>
+					<td>
+						<button class="remove" onClick={() => onRemove(id)}>Remove</button>
+					</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+interface NamedAliasRow {
+	uuid: string;
+	id: string;
+	label: string;
+}
+
+interface NamedAliasProps {
+	items: NamedAliasRow[];
+	selected: string | null;
+}
+
+export function ReverseKeyAliasList(props: NamedAliasProps) @{
+	const selected = props.selected;
+	<ul>
+		@for (const row of props.items; key row.uuid) {
+			const id = row.uuid;
+			<li class={id === selected ? 'selected' : ''}>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function MismatchedKeyAliasList(props: NamedAliasProps) @{
+	const selected = props.selected;
+	<ul>
+		@for (const row of props.items; key row.uuid) {
+			const id = row.id;
+			<li class={selected === id ? 'selected' : ''}>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function OverriddenKeyAliasList(props: NamedAliasProps) @{
+	const selected = props.selected;
+	<ul>
+		@for (const row of props.items; key row.id) {
+			const id = row.id;
+			<li key={row.uuid} class={selected === id ? 'selected' : ''}>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function CapturedSelectionAliasList(props: {
+	items: AliasRow[];
+	selected: number | null;
+	onObserve: (id: number, selected: number | null) => void;
+}) @{
+	const selected = props.selected;
+	const onObserve = props.onObserve;
+	<ul>
+		@for (const row of props.items; key row.id) {
+			const id = row.id;
+			<li
+				class={selected === id ? 'selected' : ''}
+				data-id={id}
+				onClick={() => onObserve(id, selected)}
+			>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function ShadowedSelectionAliasList(props: {
+	items: AliasRow[];
+	selected: number | null;
+	onObserve: (id: number, eventType: string) => void;
+}) @{
+	const selected = props.selected;
+	const onObserve = props.onObserve;
+	<ul>
+		@for (const row of props.items; key row.id) {
+			const id = row.id;
+			<li
+				class={selected === id ? 'selected' : ''}
+				data-id={id}
+				onClick={(selected: MouseEvent) => onObserve(id, selected.type)}
+			>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function ControlledKeyAliasList(props: {
+	items: AliasRow[];
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul>
+		@for (const row of props.items; key row.id) {
+			const id = row.id;
+			<li class={selected === id ? 'selected' : ''}>
+				<input value={row.label} readOnly={true} />
+			</li>
+		}
+	</ul>
+}
+
+export function RenderableKeyAliasList(props: {
+	items: Array<{ id: number; content: OctaneNode }>;
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul>
+		@for (const row of props.items; key row.id) {
+			const id = row.id;
+			<li class={selected === id ? 'selected' : ''}>{row.content}</li>
+		}
+	</ul>
+}
+
+export interface ReplayAliasProps {
+	items: ArrayLike<AliasRow>;
+	selected: number | null;
+	before: () => void;
+	tail: OctaneNode;
+}
+
+export function ReplayKeyAliasList(props: ReplayAliasProps) @{
+	const items = props.items;
+	const selected = props.selected;
+	props.before();
+	<section>
+		<ul>
+			@for (const row of items; key row.id) {
+				const id = row.id;
+				<li class={selected === id ? 'selected' : ''}>{row.label as string}</li>
+			}
+		</ul>
+		{props.tail}
+	</section>
+}
+
+type Setter<T> = (next: T | ((previous: T) => T)) => void;
+
+export interface AliasTransitionApi {
+	setSelected: Setter<number | null>;
+	setResource: Setter<Promise<string>>;
+}
+
+function AliasResource(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<p class="alias-resource">{value as string}</p>
+}
+
+export function SuspenseKeyAliasTable(props: {
+	items: AliasRow[];
+	initialResource: Promise<string>;
+	onMounted: (api: AliasTransitionApi) => void;
+}) @{
+	const [selected, setSelected] = useState<number | null>(1);
+	const [resource, setResource] = useState(props.initialResource);
+	useEffect(() => {
+		props.onMounted({ setSelected, setResource });
+	}, []);
+	<section>
+		@try {
+			<div>
+				<table class="key-alias-table">
+					<tbody>
+						@for (const row of props.items; key row.id) {
+							const id = row.id;
+							<tr class={selected === id ? 'selected' : ''}>
+								<td>{id}</td>
+								<td>
+									<a class="pick" onClick={() => setSelected(id)}>{row.label}</a>
+								</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+				<AliasResource promise={resource} />
+			</div>
+		} @pending {
+			<p role="status">Loading selection</p>
+		}
+	</section>
+}

--- a/packages/octane/tests/keyed-selection-alias.test.ts
+++ b/packages/octane/tests/keyed-selection-alias.test.ts
@@ -1,0 +1,495 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import {
+	createElement,
+	flushSync,
+	hydrateRoot,
+	startTransition,
+	type ComponentBody,
+} from '../src/index.js';
+import { act, mount } from './_helpers';
+import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
+import {
+	CapturedSelectionAliasList,
+	ControlledKeyAliasList,
+	KeyAliasTable,
+	MismatchedKeyAliasList,
+	OverriddenKeyAliasList,
+	RenderableKeyAliasList,
+	ReplayKeyAliasList,
+	ReverseKeyAliasList,
+	ShadowedSelectionAliasList,
+	SuspenseKeyAliasTable,
+	type AliasRow,
+	type AliasSelectionProps,
+	type AliasTransitionApi,
+	type ReplayAliasProps,
+} from './_fixtures/keyed-selection-alias.tsrx';
+
+const fixturePath = 'packages/octane/tests/_fixtures/keyed-selection-alias.tsrx';
+const noop = () => {};
+
+function makeRows(): AliasRow[] {
+	return [
+		{ id: 1, label: 'Alpha' },
+		{ id: 2, label: 'Beta' },
+		{ id: 3, label: 'Gamma' },
+	];
+}
+
+function tableRows(container: ParentNode): HTMLTableRowElement[] {
+	return Array.from(container.querySelectorAll<HTMLTableRowElement>('tbody > tr'));
+}
+
+function selectedLabels(container: ParentNode): Array<string | null> {
+	return Array.from(container.querySelectorAll('.selected'), (row) => {
+		return row.querySelector('.pick')?.textContent ?? row.textContent;
+	});
+}
+
+function productionFixture() {
+	return loadCompiledFixtureSource<typeof import('./_fixtures/keyed-selection-alias.tsrx')>(
+		readFileSync(fixturePath, 'utf8'),
+		{ id: fixturePath, mode: 'client', compileOptions: { hmr: false, dev: false } },
+	);
+}
+
+function catchingBody<P>(body: ComponentBody<P>, errors: unknown[]): ComponentBody<P> {
+	return (props, scope, extra) => {
+		try {
+			body(props, scope, extra);
+		} catch (error) {
+			errors.push(error);
+		}
+	};
+}
+
+describe('keyed selection with an authored row-key local', () => {
+	it('keeps selection, event captures, and keyed nodes current', () => {
+		const items = makeRows();
+		const picked: number[] = [];
+		const removed: number[] = [];
+		const props: AliasSelectionProps = {
+			items,
+			selected: 1,
+			onPick: (id) => picked.push(id),
+			onRemove: (id) => removed.push(id),
+		};
+		const rendered = mount(KeyAliasTable, props);
+		try {
+			const original = tableRows(rendered.container);
+			rendered.click('[data-id="3"] .pick');
+			expect(picked).toEqual([3]);
+			rendered.update(KeyAliasTable, { ...props, selected: 3 });
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+			rendered.update(KeyAliasTable, { ...props, selected: 2 });
+			expect(selectedLabels(rendered.container)).toEqual(['Beta']);
+			expect(tableRows(rendered.container)).toEqual(original);
+			rendered.click('[data-id="1"] .remove');
+			expect(removed).toEqual([1]);
+
+			const nextPicked: number[] = [];
+			rendered.update(KeyAliasTable, {
+				...props,
+				selected: 2,
+				onPick: (id) => nextPicked.push(id),
+			});
+			rendered.click('[data-id="3"] .pick');
+			expect(picked).toEqual([3]);
+			expect(nextPicked).toEqual([3]);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('preserves selection and survivor identity through source replacement and empty lists', () => {
+		const items = makeRows();
+		const props: AliasSelectionProps = { items, selected: 1, onPick: noop, onRemove: noop };
+		const rendered = mount(KeyAliasTable, props);
+		try {
+			const original = tableRows(rendered.container);
+			rendered.update(KeyAliasTable, { ...props, selected: 2 });
+			const updated = [items[2]!, { ...items[1]!, label: 'Beta updated' }, items[0]!];
+			rendered.update(KeyAliasTable, { ...props, items: updated, selected: 1 });
+			expect(tableRows(rendered.container)).toEqual(original.toReversed());
+			expect(rendered.findAll('.pick').map((node) => node.textContent)).toEqual([
+				'Gamma',
+				'Beta updated',
+				'Alpha',
+			]);
+			expect(selectedLabels(rendered.container)).toEqual(['Alpha']);
+
+			rendered.update(KeyAliasTable, { ...props, items: updated, selected: 2 });
+			expect(selectedLabels(rendered.container)).toEqual(['Beta updated']);
+			rendered.update(KeyAliasTable, {
+				...props,
+				items: [updated[0]!, updated[2]!],
+				selected: 2,
+			});
+			expect(tableRows(rendered.container)).toEqual([original[2], original[0]]);
+			expect(selectedLabels(rendered.container)).toEqual([]);
+			rendered.update(KeyAliasTable, { ...props, items: [], selected: null });
+			expect(tableRows(rendered.container)).toEqual([]);
+			rendered.update(KeyAliasTable, { ...props, selected: 3 });
+			expect(rendered.findAll('.pick').map((node) => node.textContent)).toEqual([
+				'Alpha',
+				'Beta',
+				'Gamma',
+			]);
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('uses strict equality for missing, NaN, and signed-zero keys', () => {
+		const items = [
+			{ id: Number.NaN, label: 'Not a number' },
+			{ id: -0, label: 'Zero' },
+			{ id: 1, label: 'One' },
+		];
+		const props: AliasSelectionProps = { items, selected: 1, onPick: noop, onRemove: noop };
+		const rendered = mount(KeyAliasTable, props);
+		try {
+			const original = tableRows(rendered.container);
+			for (const selected of [Number.NaN, 99, null]) {
+				rendered.update(KeyAliasTable, { ...props, selected });
+				expect(selectedLabels(rendered.container)).toEqual([]);
+			}
+			for (const selected of [-0, +0]) {
+				rendered.update(KeyAliasTable, { ...props, selected });
+				expect(selectedLabels(rendered.container)).toEqual(['Zero']);
+				expect(tableRows(rendered.container)).toEqual(original);
+			}
+			rendered.update(KeyAliasTable, {
+				...props,
+				items: [items[2]!, items[0]!, items[1]!],
+				selected: Number.NaN,
+			});
+			expect(tableRows(rendered.container)).toEqual([original[2], original[0], original[1]]);
+			expect(selectedLabels(rendered.container)).toEqual([]);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('does not reread a production list when only the sign of zero changes', () => {
+		const Body = productionFixture().KeyAliasTable;
+		let armed = false;
+		const failure = new Error('unchanged zero key was read');
+		const items = [
+			{
+				get id() {
+					if (armed) throw failure;
+					return 0;
+				},
+				label: 'Zero',
+			},
+			{ id: 1, label: 'One' },
+		];
+		const props: AliasSelectionProps = { items, selected: -0, onPick: noop, onRemove: noop };
+		const rendered = mount(Body, props);
+		try {
+			const original = tableRows(rendered.container);
+			armed = true;
+			expect(() => rendered.update(Body, { ...props, selected: +0 })).not.toThrow();
+			expect(tableRows(rendered.container)).toEqual(original);
+			expect(selectedLabels(rendered.container)).toEqual(['Zero']);
+			armed = false;
+			rendered.update(Body, { ...props, selected: 1 });
+			expect(selectedLabels(rendered.container)).toEqual(['One']);
+		} finally {
+			armed = false;
+			rendered.unmount();
+		}
+	});
+
+	it('matches either comparison operand against the authored custom key', () => {
+		const items = [
+			{ uuid: 'a', id: 'shared', label: 'Alpha' },
+			{ uuid: 'b', id: 'other', label: 'Beta' },
+			{ uuid: 'c', id: 'shared', label: 'Gamma' },
+		];
+		const rendered = mount(ReverseKeyAliasList, { items, selected: 'a' });
+		try {
+			const original = rendered.findAll('li');
+			rendered.update(ReverseKeyAliasList, { items, selected: 'c' });
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+			expect(rendered.findAll('li')).toEqual(original);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	for (const [name, Body] of [
+		['a different header key', MismatchedKeyAliasList],
+		['an overriding element key', OverriddenKeyAliasList],
+	] as const) {
+		it(`updates every match when the row local uses ${name}`, () => {
+			const items = [
+				{ uuid: 'a', id: 'shared', label: 'Alpha' },
+				{ uuid: 'b', id: 'other', label: 'Beta' },
+				{ uuid: 'c', id: 'shared', label: 'Gamma' },
+			];
+			const rendered = mount(Body, { items, selected: 'other' });
+			try {
+				const original = rendered.findAll('li');
+				rendered.update(Body, { items, selected: 'shared' });
+				expect(selectedLabels(rendered.container)).toEqual(['Alpha', 'Gamma']);
+				expect(rendered.findAll('li')).toEqual(original);
+			} finally {
+				rendered.unmount();
+			}
+		});
+	}
+
+	it('refreshes untouched-row handlers that also capture the selected value', () => {
+		const items = makeRows();
+		const observed: Array<[number, number | null]> = [];
+		const onObserve = (id: number, selected: number | null) => observed.push([id, selected]);
+		const rendered = mount(CapturedSelectionAliasList, { items, selected: 1, onObserve });
+		try {
+			rendered.update(CapturedSelectionAliasList, { items, selected: 2, onObserve });
+			rendered.click('[data-id="3"]');
+			expect(observed).toEqual([[3, 2]]);
+			expect(selectedLabels(rendered.container)).toEqual(['Beta']);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('keeps callback parameters distinct from an outer selection with the same name', () => {
+		const items = makeRows();
+		const observed: Array<[number, string]> = [];
+		const onObserve = (id: number, eventType: string) => observed.push([id, eventType]);
+		const rendered = mount(ShadowedSelectionAliasList, { items, selected: 1, onObserve });
+		try {
+			rendered.update(ShadowedSelectionAliasList, { items, selected: 2, onObserve });
+			rendered.click('[data-id="3"]');
+			expect(observed).toEqual([[3, 'click']]);
+			expect(selectedLabels(rendered.container)).toEqual(['Beta']);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('reasserts controlled values in both rows whose selection changes', () => {
+		const items = makeRows();
+		const rendered = mount(ControlledKeyAliasList, { items, selected: 1 });
+		try {
+			const original = rendered.findAll('li');
+			const inputs = rendered.findAll('input') as HTMLInputElement[];
+			inputs[0]!.focus();
+			inputs[0]!.value = 'external edit';
+			inputs[1]!.value = 'next external edit';
+			rendered.update(ControlledKeyAliasList, { items, selected: 2 });
+			expect(inputs.map((input) => input.value)).toEqual(items.map((row) => row.label));
+			expect(rendered.findAll('li.selected')).toEqual([original[1]]);
+			expect(rendered.findAll('li')).toEqual(original);
+			expect(rendered.findAll('input')).toEqual(inputs);
+			expect(document.activeElement).toBe(inputs[0]);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('keeps stable render-function children live during selection', () => {
+		let first = 'Alpha';
+		let second = 'Beta';
+		const items = [
+			{ id: 1, content: () => createElement('span', { className: 'live-alias-child' }, first) },
+			{ id: 2, content: () => createElement('span', { className: 'live-alias-child' }, second) },
+			{ id: 3, content: 'Gamma' },
+		];
+		const rendered = mount(RenderableKeyAliasList, { items, selected: 1 });
+		try {
+			const original = rendered.findAll('li');
+			const children = rendered.findAll('.live-alias-child');
+			first = 'Alpha updated';
+			second = 'Beta updated';
+			rendered.update(RenderableKeyAliasList, { items, selected: 2 });
+			expect(rendered.findAll('li').map((row) => row.textContent)).toEqual([
+				'Alpha updated',
+				'Beta updated',
+				'Gamma',
+			]);
+			expect(rendered.findAll('li.selected')).toEqual([original[1]]);
+			expect(rendered.findAll('li')).toEqual(original);
+			expect(rendered.findAll('.live-alias-child')).toEqual(children);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('retains the entered production snapshot across synchronous setup reentry', () => {
+		const Body = productionFixture().ReplayKeyAliasList as ComponentBody<ReplayAliasProps>;
+		let reenter!: (props: ReplayAliasProps) => void;
+		const List: ComponentBody<ReplayAliasProps> = (props, scope, extra) => {
+			reenter = (next) => Body(next, scope, extra);
+			Body(props, scope, extra);
+		};
+		const props: ReplayAliasProps = { items: makeRows(), selected: 1, before: noop, tail: null };
+		const rendered = mount(List, props);
+		try {
+			const original = rendered.findAll('li');
+			rendered.update(List, {
+				...props,
+				before: () => reenter({ ...props, selected: 2 }),
+			});
+			expect(rendered.findAll('li')).toEqual(original);
+			expect(selectedLabels(rendered.container)).toEqual(['Beta']);
+			rendered.update(List, { ...props, selected: 3 });
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('reports an authored key-read error and recovers on an immutable replacement', () => {
+		let armed = false;
+		const failure = new Error('row key failed');
+		const errors: unknown[] = [];
+		const Body = catchingBody(ReplayKeyAliasList, errors);
+		const items = makeRows();
+		items[1] = {
+			get id() {
+				if (armed) throw failure;
+				return 2;
+			},
+			label: 'Beta',
+		};
+		const props: ReplayAliasProps = { items, selected: 1, before: noop, tail: null };
+		const rendered = mount(Body, props);
+		try {
+			const original = rendered.findAll('li');
+			armed = true;
+			rendered.update(Body, { ...props, selected: 2 });
+			expect(errors).toEqual([failure]);
+			armed = false;
+			rendered.update(Body, { ...props, items: makeRows(), selected: 3 });
+			expect(rendered.findAll('li')).toEqual(original);
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+		} finally {
+			armed = false;
+			rendered.unmount();
+		}
+	});
+
+	it('retries an incomplete list after a later renderable throws', () => {
+		const errors: unknown[] = [];
+		const Body = catchingBody(ReplayKeyAliasList, errors);
+		const tailFailure = new Error('later renderable failed');
+		const retryFailure = new Error('incomplete list was retried');
+		let failTail = false;
+		let failLength = false;
+		const items = new Proxy(makeRows(), {
+			get(target, property, receiver) {
+				if (property === 'length' && failLength) throw retryFailure;
+				return Reflect.get(target, property, receiver);
+			},
+		});
+		const props: ReplayAliasProps = {
+			items,
+			selected: 1,
+			before: noop,
+			tail: () => {
+				if (failTail) throw tailFailure;
+				return 'Ready';
+			},
+		};
+		const rendered = mount(Body, props);
+		try {
+			const original = rendered.findAll('li');
+			failTail = true;
+			rendered.update(Body, { ...props, selected: 2 });
+			expect(errors).toEqual([tailFailure]);
+			failTail = false;
+			failLength = true;
+			rendered.update(Body, { ...props, selected: 2 });
+			expect(errors).toEqual([tailFailure, retryFailure]);
+			failLength = false;
+			rendered.update(Body, { ...props, selected: 3 });
+			expect(rendered.findAll('li')).toEqual(original);
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+			expect(rendered.container.textContent).toContain('Ready');
+		} finally {
+			failTail = false;
+			failLength = false;
+			rendered.unmount();
+		}
+	});
+
+	it('keeps committed rows visible while a later transition sibling suspends', async () => {
+		let resolveNext!: (value: string) => void;
+		const next = new Promise<string>((resolve) => {
+			resolveNext = resolve;
+		});
+		let api!: AliasTransitionApi;
+		const rendered = mount(SuspenseKeyAliasTable, {
+			items: makeRows(),
+			initialResource: Promise.resolve('Ready'),
+			onMounted: (value: AliasTransitionApi) => {
+				api = value;
+			},
+		});
+		try {
+			await act(() => {});
+			const original = tableRows(rendered.container);
+			flushSync(() => {
+				startTransition(() => {
+					api.setSelected(2);
+					api.setResource(next);
+				});
+			});
+			expect(selectedLabels(rendered.container)).toEqual(['Alpha']);
+			expect(rendered.find('.alias-resource').textContent).toBe('Ready');
+			expect(rendered.findAll('[role="status"]')).toEqual([]);
+			await act(() => resolveNext('Resolved'));
+			expect(tableRows(rendered.container)).toEqual(original);
+			expect(selectedLabels(rendered.container)).toEqual(['Beta']);
+			expect(rendered.find('.alias-resource').textContent).toBe('Resolved');
+			flushSync(() => api.setSelected(3));
+			expect(selectedLabels(rendered.container)).toEqual(['Gamma']);
+		} finally {
+			resolveNext('Resolved');
+			await act(() => {});
+			rendered.unmount();
+		}
+	});
+
+	it('adopts server rows and preserves their events and identity after selection', () => {
+		const server = loadServerFixture(fixturePath, {
+			compileOptions: { hmr: false, dev: false },
+		});
+		const picked: number[] = [];
+		const props: AliasSelectionProps = {
+			items: makeRows(),
+			selected: 1,
+			onPick: (id) => picked.push(id),
+			onRemove: noop,
+		};
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.KeyAliasTable, props).html;
+		const original = tableRows(container);
+		const recoveries: unknown[] = [];
+		const root = hydrateRoot(container, KeyAliasTable, props, {
+			onRecoverableError: (error) => recoveries.push(error),
+		});
+		try {
+			flushSync(() => {});
+			expect(tableRows(container)).toEqual(original);
+			expect(selectedLabels(container)).toEqual(['Alpha']);
+			flushSync(() => root.render(KeyAliasTable, { ...props, selected: 3 }));
+			expect(tableRows(container)).toEqual(original);
+			expect(selectedLabels(container)).toEqual(['Gamma']);
+			flushSync(() => container.querySelector<HTMLAnchorElement>('[data-id="2"] .pick')!.click());
+			expect(picked).toEqual([2]);
+			expect(recoveries).toEqual([]);
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Recognize a constant row-key alias in the existing keyed-selection proof. This is a standalone compiler fix; it does not include the runtime changes from #799 or any benchmark infrastructure.

## Why

The [canonical js-framework-benchmark Octane app](https://github.com/krausest/js-framework-benchmark/blob/afe7c118dd217ccae4c10813613ac0d7566b1ef1/frameworks/keyed/octane/src/App.tsrx) declares `const id = row.id` before its row JSX. That extra statement prevented the compiler from selecting the existing old/new-row update path, so selection revisited the whole list.

The same missed proof also leaves an aliased-key list on its previous selection after a held transition resolves in production. The regression fails on the unchanged upstream base and passes with this patch.

## Changes

- Accept one `const` identifier initialized from the actual explicit row-key property.
- Preserve the authored full row body, key-read order, event captures, strict equality, and all existing dependency/selection-use guards.
- Keep mismatched keys, extra selection captures, unknown aliases, and fast-host mounting on their existing paths.
- Add behavioral coverage and an `octane` patch changeset. No runtime ABI or public API changes.

## Validation

- [ ] `pnpm format:check` (repo-wide not run)
- [ ] `pnpm typecheck` (repo-wide not run)
- [ ] `pnpm test` (repo-wide not run)
- [x] Targeted dev/prod/profile/compiler suites: 861 tests passed.
- [x] Exact-base production transition regression: red before, green after.
- [x] Package typecheck, four-file Prettier check, changeset check, `pnpm sync`, and `git diff --check`.
- [x] Production Chromium bounded-work check: the 1,000-row selection sequence drops from 23,000 label reads to 40; the ordinary-list control remains at 23,000. Class, label, event, reset, and survivor-identity controls pass.
- [x] Unchanged official benchmark HTML/keyedness checks for the exact base, candidate, and pinned Pyreon source.

Local compiler checks used Octane's supported JavaScript parser with cached, repository-patched `@tsrx/core` 0.1.56 because the locked native parser dependencies were unavailable. Full repository CI remains to run.

## Risk / follow-ups

The proof is deliberately narrow and calls the existing full affected-row renderer. The final official latency matrix is incomplete because host load exceeded the fixed ceiling; its accepted and rejected runs are preserved locally. This PR claims bounded selection work, not a final wall-clock percentage or Pyreon parity. Context: https://github.com/pyreon/pyreon/pull/2985.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769165&installation_model_id=432790&pr_number=801&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F801&signature=6897a2c9ff72c41a804bbc4da14f105941c1f873e3948c12814a5354c0d465b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compile-time proof and production render paths for keyed `@for` rows; guards are narrow and heavily tested, but incorrect proof could cause stale UI without a runtime API change.
> 
> **Overview**
> Extends the Octane compiler’s **keyed selection** proof so a row can start with **`const id = row.id`** (or the keyed property) and still use the **old/new-row-only** update path when `class` compares `selected === id`.
> 
> **`keyedSelectionDepIndex`** now accepts a two-statement row body (one `const` alias initialized from the real key property, then a plain host root), treats the alias like a direct key read in the `===` test, and keeps the authored declaration in the emitted row body so key reads, handlers, and strict equality stay unchanged. Mismatched keys, extra `selected` captures, and invalid aliases still **fail closed** to the full-list path.
> 
> Adds a **patch changeset** and broad fixture/tests (events, hydration, suspense transitions, production compile checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffd9e7e59b75eb04568f67cf8ffcf5ca7a607e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->