### PR TITLE
perf(octane): skip empty scheduled flushes

### DIFF
--- a/.changeset/empty-scheduled-flush.md
+++ b/.changeset/empty-scheduled-flush.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip already-drained scheduled flushes after synchronous native-event commits. Preserve commit-only effects, refs, Fragment bindings, transition finalization, profiling notifications, and microtask ordering.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3020,6 +3020,23 @@ function flush(): void {
 		}
 		return;
 	}
+	// A discrete event can synchronously drain work after its microtask was
+	// armed. An empty render queue alone is not enough: first mounts/hydration
+	// still need their commit, and refs/Fragment bindings are intentionally not
+	// included in hasPendingWork(). Retained Actions and ViewTransition also
+	// carry flush-finalization work outside those queues.
+	if (
+		!hasPendingWork() &&
+		refDetachQueue.length === 0 &&
+		refAttachQueue.length === 0 &&
+		activeFragments.size === 0 &&
+		FLUSHED_TRANSITION_UPDATES.length === 0 &&
+		VIEW_TRANSITION_DRIVER === null
+	) {
+		if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
+			__devtoolsNotifyFlush();
+		return;
+	}
 	// The optional driver owns all concrete ViewTransition state/implementation.
 	// A client that never retains the feature sees only this null check.
 	if (VIEW_TRANSITION_DRIVER?.routeFlush() === true) return;

--- a/packages/octane/tests/devtools-runtime.test.tsrx
+++ b/packages/octane/tests/devtools-runtime.test.tsrx
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { useState } from 'octane';
+import { createRoot, useState } from 'octane';
 import { act, mount } from './_helpers';
 import type { OctaneDevtoolsHook } from '../src/devtools-hook';
 
@@ -50,4 +50,59 @@ describe('runtime devtools instrumentation (profile build)', () => {
 		off();
 		unmount();
 	});
+
+	it(
+		'notifies subscribers when an effect-free first render reaches its deferred commit',
+		async () => {
+			await Promise.resolve();
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			const root = createRoot(container);
+			let off = () => {};
+			try {
+				root.render(CounterApp);
+				const observedTrees: string[][] = [];
+				off = hook().subscribe(() => {
+					observedTrees.push(hook().getTree().map((entry) => entry.name));
+				});
+				expect(container.querySelector('span')?.textContent).toBe('0');
+				expect(observedTrees).toEqual([]);
+
+				await Promise.resolve();
+
+				expect(observedTrees.some((names) => names.includes('CounterApp'))).toBe(true);
+			} finally {
+				off();
+				root.unmount();
+				container.remove();
+			}
+		},
+	);
+
+	it(
+		'notifies subscribers when a synchronous click reaches its already-queued commit',
+		async () => {
+			const rendered = mount(<CounterApp />);
+			let off = () => {};
+			try {
+				await Promise.resolve();
+				const button = rendered.find('button') as HTMLButtonElement;
+				button.click();
+				expect(rendered.find('span').textContent).toBe('1');
+
+				const observedTrees: string[][] = [];
+				off = hook().subscribe(() => {
+					observedTrees.push(hook().getTree().map((entry) => entry.name));
+				});
+				expect(observedTrees).toEqual([]);
+				await Promise.resolve();
+
+				expect(observedTrees.some((names) => names.includes('CounterApp'))).toBe(true);
+				expect(rendered.find('span').textContent).toBe('1');
+			} finally {
+				off();
+				rendered.unmount();
+			}
+		},
+	);
 });

--- a/packages/octane/tests/scheduler-commit.test.ts
+++ b/packages/octane/tests/scheduler-commit.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRoot, hydrateRoot, type Root } from '../src/index.js';
+import * as ServerRuntime from 'octane/server';
+import { flushEffects, mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture.js';
+import { ConnectedRef } from './_fixtures/ref-timing.tsrx';
+import { ManyPassiveEffects, PhaseOrder } from './_fixtures/effect-timing.tsrx';
+import { BatchChild } from './conformance/_fixtures/event-listener.tsrx';
+
+function makeContainer(): HTMLDivElement {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	return container;
+}
+
+describe('scheduled commits after synchronous DOM work', () => {
+	it('attaches a first-render ref when no component update is queued', async () => {
+		await Promise.resolve();
+		const container = makeContainer();
+		const root = createRoot(container);
+		const seen: Array<HTMLElement | null> = [];
+		try {
+			root.render(ConnectedRef, {
+				observe: (element: HTMLElement | null) => {
+					seen.push(element);
+				},
+			});
+			const host = container.querySelector<HTMLElement>('#host');
+			expect(host?.textContent).toBe('x');
+			expect(seen).toEqual([]);
+
+			await Promise.resolve();
+
+			expect(seen).toEqual([host]);
+			expect(host?.isConnected).toBe(true);
+			root.unmount();
+			expect(seen).toEqual([host, null]);
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	});
+
+	it('commits a hydration ref to the adopted element without another render', async () => {
+		await Promise.resolve();
+		const server = loadServerFixture('packages/octane/tests/_fixtures/ref-timing.tsrx');
+		const container = makeContainer();
+		const seen: Array<HTMLElement | null> = [];
+		let root: Root | undefined;
+		try {
+			container.innerHTML = ServerRuntime.renderToString(server.ConnectedRef, {
+				observe: () => {},
+			}).html;
+			const host = container.querySelector<HTMLElement>('#host');
+			root = hydrateRoot(container, ConnectedRef, {
+				observe: (element: HTMLElement | null) => {
+					seen.push(element);
+				},
+			});
+			expect(container.querySelector('#host')).toBe(host);
+			expect(seen).toEqual([]);
+
+			await Promise.resolve();
+
+			expect(seen).toEqual([host]);
+			expect(host?.isConnected).toBe(true);
+			root.unmount();
+			expect(seen).toEqual([host, null]);
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
+	for (const mode of ['render', 'hydrate'] as const) {
+		it(`commits ${mode} effects in order while keeping passive work deferred`, async () => {
+			await Promise.resolve();
+			const container = makeContainer();
+			const log: string[] = [];
+			let root: Root | undefined;
+			try {
+				const props = { tick: 0, log };
+				if (mode === 'hydrate') {
+					const server = loadServerFixture('packages/octane/tests/_fixtures/effect-timing.tsrx');
+					container.innerHTML = ServerRuntime.renderToString(server.PhaseOrder, props).html;
+					root = hydrateRoot(container, PhaseOrder, props);
+				} else {
+					root = createRoot(container);
+					root.render(PhaseOrder, props);
+				}
+				expect(container.textContent).toBe('x');
+				expect(log).toEqual([]);
+
+				await Promise.resolve();
+
+				expect(log).toEqual(['ins:body', 'lay:body']);
+				flushEffects();
+				expect(log).toEqual(['ins:body', 'lay:body', 'eff:body']);
+			} finally {
+				root?.unmount();
+				container.remove();
+				flushEffects();
+			}
+		});
+
+		it(`schedules passive-only ${mode} effects without an additional update`, async () => {
+			await Promise.resolve();
+			vi.useFakeTimers();
+			vi.stubGlobal('requestAnimationFrame', () => 0);
+			const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+			const container = makeContainer();
+			const log: string[] = [];
+			let root: Root | undefined;
+			try {
+				if (mode === 'hydrate') {
+					const server = loadServerFixture('packages/octane/tests/_fixtures/effect-timing.tsrx');
+					container.innerHTML = ServerRuntime.renderToString(server.ManyPassiveEffects, {
+						log,
+					}).html;
+					root = hydrateRoot(container, ManyPassiveEffects, { log });
+				} else {
+					root = createRoot(container);
+					root.render(ManyPassiveEffects, { log });
+				}
+				expect(container.textContent).toBe('multi');
+				expect(log).toEqual([]);
+
+				await Promise.resolve();
+				expect(log).toEqual([]);
+				await vi.advanceTimersByTimeAsync(1_000);
+
+				expect(log).toEqual(['A:body', 'B:body', 'C:body']);
+				root.unmount();
+				expect(log).toEqual(['A:body', 'B:body', 'C:body']);
+				flushEffects();
+				expect(log).toEqual(['A:body', 'B:body', 'C:body', 'A:cleanup', 'B:cleanup', 'C:cleanup']);
+			} finally {
+				root?.unmount();
+				container.remove();
+				flushEffects();
+				visibility.mockRestore();
+				vi.unstubAllGlobals();
+				vi.useRealTimers();
+			}
+		});
+	}
+
+	it('keeps an already-armed batch ahead of a later user microtask after a click', async () => {
+		let setValue!: (value: string) => void;
+		const observed: string[] = [];
+		const rendered = mount(BatchChild, {
+			register: (setter: (value: string) => void) => {
+				setValue = setter;
+			},
+			onEvent: () => {
+				setValue('clicked');
+				observed.push(rendered.find('.child-span').textContent ?? '');
+			},
+		});
+		try {
+			// Settle the mount's own scheduled commit before dispatching a native
+			// click. The mount helper's click() would wrap it in flushSync.
+			await Promise.resolve();
+			const span = rendered.find('.child-span') as HTMLElement;
+			span.click();
+			expect(observed).toEqual(['Child']);
+			expect(span.textContent).toBe('clicked');
+
+			queueMicrotask(() => observed.push(span.textContent ?? ''));
+			setValue('queued');
+			expect(span.textContent).toBe('clicked');
+			await Promise.resolve();
+
+			expect(observed).toEqual(['Child', 'queued']);
+			expect(span.textContent).toBe('queued');
+			setValue('later');
+			expect(span.textContent).toBe('queued');
+			await Promise.resolve();
+			expect(span.textContent).toBe('later');
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('starts a later non-event batch after a click and its queued commit have settled', async () => {
+		let setValue!: (value: string) => void;
+		const observed: string[] = [];
+		const rendered = mount(BatchChild, {
+			register: (setter: (value: string) => void) => {
+				setValue = setter;
+			},
+			onEvent: () => setValue('clicked'),
+		});
+		try {
+			await Promise.resolve();
+			const span = rendered.find('.child-span') as HTMLElement;
+			span.click();
+			expect(span.textContent).toBe('clicked');
+			await Promise.resolve();
+
+			queueMicrotask(() => observed.push(span.textContent ?? ''));
+			setValue('later');
+			expect(span.textContent).toBe('clicked');
+			await Promise.resolve();
+
+			expect(observed).toEqual(['clicked']);
+			expect(span.textContent).toBe('later');
+		} finally {
+			rendered.unmount();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Skip an already-drained scheduled flush after a synchronous native-event commit. This is a runtime-only optimization with regression tests and an `octane` patch changeset; no benchmark infrastructure or compiler changes are included.

## Why

A native discrete event can queue a microtask and then synchronously commit the same update. The queued callback must remain in place to preserve ordering with later user microtasks and updates, but it need not enter the render/effect pipeline when every relevant queue is empty.

The local, pinned canonical `04_select1k` comparison on main `231e2485` improved from **3.829 to 3.548 ms total** (7.35% lower) and **0.737 to 0.559 ms scripting** (24.23% lower). All three independent rounds improved.

## Changes

- Return early only after the existing scheduler/reentry handling and only when render, effect, controlled-form, ref, Fragment, retained-Action, and ViewTransition obligations are absent.
- Preserve profiling flush notifications and the existing microtask schedule.
- Cover first mount, hydration, ref/effect timing, native-click ordering, later asynchronous updates, and profiling subscribers.

## Validation

- [ ] `pnpm format:check` — repo-wide check not run.
- [ ] `pnpm typecheck` — repo-wide check not run.
- [ ] `pnpm test` — repo-wide command not run.
- [x] Targeted development, production, and profiling suites: **893 tests passed**.
- [x] Octane package typecheck; runtime and regression-test formatting.
- [x] Production Chromium A/B probe: real selection work and DOM identity are unchanged; the candidate omits only the trailing empty render/effect drain.
- [x] Unchanged canonical HTML/keyedness gate and nine accepted 25-sample benchmark runs. One load-rejected Pyreon attempt and its traces were preserved and excluded by the predeclared policy.
- [x] Ordinary nonempty asynchronous-flush control: four fresh A–B–B–A production-browser runs; overall candidate/main ratio **1.0022**, with both paired comparisons and the predeclared 5% regression/noise screens passing. The earlier too-short sample protocol was stopped as invalid and preserved separately.
- [x] Changeset validation, final `pnpm sync`, and whitespace checks; sync generated no additional changes.

Local compiler/build checks used the disclosed supported JavaScript-parser fallback with cached, repository-patched `@tsrx/core` 0.1.56; the Pyreon control used archive-verified 0.51.0 PR-head workspace source. Full exact-lockfile repository checks were not rerun.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

Published through the GitHub MCP. GitHub reports commit `d6149a882de2d1653ed23c3c0e4221b2dc8857bb` as unsigned; local SSH-signing settings were not changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789813610&installation_model_id=432790&pr_number=803&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F803&signature=197da56f8bb82865d4ba0426e27f953fcf2d14ab09e2a2a3d53df643cae06813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d6149a882de2d1653ed23c3c0e4221b2dc8857bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->