### PR TITLE
fix(website): publish shadcn registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ packages/intersection-observer/.pristine-upstream-*/
 website/public/lynx-examples
 website/public/lynx-runtime
 
+# Copied from packages/shadcn/registry by the website Vite config.
+website/public/r
+
 # React-parity pristine suite scratch copies
 packages/*/.pristine-upstream-*/
 # Vitest timing/results cache for the TanStack Store pristine upstream suite.

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -57,6 +57,23 @@ describe('built Start server', () => {
 		expect(fs.existsSync(path.join(staticRoot, 'playground-runtime.json'))).toBe(true);
 	});
 
+	it('serves the documented shadcn registry paths', async () => {
+		for (const registryPath of [
+			'/r/button.json',
+			'/r/styles/base-nova/button.json',
+			'/r/styles/radix-nova/button.json',
+			'/r/styles/aria-nova/button.json',
+		]) {
+			const { response, html } = await get(registryPath);
+			expect(response.status, registryPath).toBe(200);
+			expect(response.headers.get('content-type'), registryPath).toMatch(/^application\/json\b/);
+			expect(JSON.parse(html), registryPath).toMatchObject({
+				name: 'button',
+				type: 'registry:ui',
+			});
+		}
+	});
+
 	it('server-renders the home page with the hydration payload', async () => {
 		const { response, html } = await get('/');
 		expect(response.status).toBe(200);

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,12 +1,31 @@
 import { defineConfig, type Plugin } from 'vite';
-import { existsSync } from 'node:fs';
+import { cpSync, existsSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { octaneMdx } from '@octanejs/mdx/vite';
 import { threeRenderers } from '@octanejs/three/config';
 import { tanstackStart } from '@octanejs/tanstack-start/plugin/vite';
 import { nitro } from 'nitro/vite';
 import { websiteMdxOptions } from './mdx-options.ts';
 import { playgroundRuntime } from './playground-runtime.ts';
+
+// The upstream shadcn CLI fetches registry items directly from /r. Keep the
+// deployed tree derived from the package's checked generated output so website
+// builds cannot publish a second, independently drifting registry copy.
+function prepareShadcnRegistry(): void {
+	const sourceUrl = new URL('../packages/shadcn/registry/', import.meta.url);
+	const source = fileURLToPath(sourceUrl);
+	const destination = fileURLToPath(new URL('./public/r', import.meta.url));
+	if (!existsSync(new URL('registry.json', sourceUrl))) {
+		throw new Error(
+			'shadcn registry is missing; run `pnpm shadcn:registry` from the repository root',
+		);
+	}
+	rmSync(destination, { recursive: true, force: true });
+	cpSync(source, destination, { recursive: true });
+}
+
+prepareShadcnRegistry();
 
 // Does any pre-bundled dependency resolve to a checkout OUTSIDE node_modules —
 // a `link:` override in pnpm-workspace.yaml pointing at a sibling repo?


### PR DESCRIPTION
## Summary

- publish the canonical `packages/shadcn/registry` tree at the website's documented `/r` path
- keep the staged `website/public/r` copy generated and ignored so registry content has one source of truth
- cover the default and all three documented style endpoints in the production Vercel smoke test

## Why

The shadcn README documents `https://octanejs.dev/r/styles/{style}/{name}.json`, but the website build did not include the registry and returned 404 for every CLI request.

Fixes #787.

## Changes

- stage the checked registry output before Vite consumes the website public directory
- fail the website build with an actionable message if the canonical registry is missing
- assert that `/r/button.json` and the Base UI, Radix, and React Aria style URLs return valid registry items

## Validation

- [ ] `pnpm format:check` (not run; scoped formatting check passed)
- [ ] `pnpm typecheck` (not run; website typecheck passed)
- [ ] `pnpm test` (not run; targeted production integration test passed)
- [x] targeted tests: `pnpm exec vitest run --project website-integration website/tests/ssr-smoke.test.ts --reporter=verbose`
- [x] `pnpm --dir website typecheck`
- [x] `pnpm shadcn:registry:check`
- [x] `pnpm format:files:check website/vite.config.ts website/tests/ssr-smoke.test.ts`
- [x] `pnpm sync`

## Risk / follow-ups

- The deployment adds the existing 174-file, approximately 1 MB registry tree as static assets; it does not add registry content to the application bundle.
- No changeset is needed because no published package changes.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ebd4fbf870282cfe051bd49961a93cc3a52ab9d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789818989&installation_model_id=432790&pr_number=804&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F804&signature=26887003ea2a4d4c9f801f4b02828e8eba82555e5a68453cd63bb29372d00fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->