### PR TITLE
fix: preserve deferred hydration DOM and styles

### DIFF
--- a/.changeset/hydrate-composed-route-assets.md
+++ b/.changeset/hydrate-composed-route-assets.md
@@ -1,0 +1,7 @@
+---
+'@octanejs/app-core': patch
+---
+
+Keep stylesheets for route layouts, root fallbacks, and their deferred Hydrate
+children available before client activation without eagerly preloading their
+JavaScript.

--- a/.changeset/hydrate-preserved-descriptor-range.md
+++ b/.changeset/hydrate-preserved-descriptor-range.md
@@ -3,5 +3,6 @@
 ---
 
 Preserve server-rendered descriptor components when a suspended Hydrate boundary
-resumes. Avoid false hydration mismatch reports while continuing to remove
-genuinely unmatched server content.
+resumes. Claim fallback cleanup ranges only after adoption completes, avoiding
+false hydration mismatch reports while preserving template-owned checks and
+removing genuinely unmatched content added during suspension.

--- a/.changeset/hydrate-preserved-descriptor-range.md
+++ b/.changeset/hydrate-preserved-descriptor-range.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Preserve server-rendered descriptor components when a suspended Hydrate boundary
+resumes. Avoid false hydration mismatch reports while continuing to remove
+genuinely unmatched server content.

--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -116,11 +116,12 @@ Available strategies:
 | `condition(booleanOrGetter)` | Hydrates once the condition is truthy. |
 | `never()` | Keeps initial server HTML permanently static. |
 
-`interaction()` listens for `pointerenter`, `focusin`, `pointerdown`, and
-`click` by default. Supported custom events are `auxclick`, `click`,
-`contextmenu`, `dblclick`, `focusin`, `keydown`, `keyup`, `mousedown`,
-`mouseenter`, `mouseover`, `mouseup`, `pointerdown`, `pointerenter`,
-`pointerover`, and `pointerup`.
+`interaction()` listens for `pointerenter`, `focusin`, `pointerdown`,
+`touchstart`, `touchend`, `beforeinput`, `input`, `compositionstart`,
+`compositionupdate`, `compositionend`, and `click` by default. Supported custom
+events also include `auxclick`, `contextmenu`, `dblclick`, `keydown`, `keyup`,
+`mousedown`, `mouseenter`, `mouseover`, `mouseup`, `pointerover`, and
+`pointerup`.
 
 #### Capture interactions before `hydrateRoot()`
 
@@ -178,10 +179,10 @@ Generated Hydrate chunks are not eagerly module-preloaded. Lazy-module discovery
 for independently suspended siblings never enters a dormant Hydrate boundary,
 so its child code remains deferred until activation or an explicit prefetch
 strategy. The Vite and Rsbuild app integrations still link CSS reachable from a
-route's deferred chunks, because that route's server HTML needs its styling
-before the child JavaScript loads. This eager CSS collection follows the route
-entry's asset graph; it does not turn deferred JavaScript into an eager
-dependency.
+route's deferred chunks, including its layout and configured root fallbacks,
+because that route's server HTML needs its styling before the child JavaScript
+loads. This eager CSS collection follows the composed route's asset graphs; it
+does not turn deferred JavaScript into an eager dependency.
 
 ### `prefetch`
 
@@ -379,8 +380,10 @@ static-HTML exception.
 Nested boundaries hydrate parent-first. Interaction intent can wake an
 unresolved ancestor chain, after which Octane replays a same-type event for the
 target boundary. A `never()` ancestor keeps every deferred descendant inert.
-Native event payload details such as pointer coordinates are not guaranteed to
-survive replay.
+Replay preserves supported platform event classes and their captured keyboard,
+pointer, mouse, touch, input, composition, and focus data where the browser can
+construct that event. A replayed event is still programmatic: it cannot restore
+the original event's trusted status or expired transient user activation.
 
 If activation races a pending renderer-owned streamed Suspense reveal, the
 boundary waits for that reveal or its client-render degradation before adopting
@@ -392,3 +395,7 @@ wrapper in layout and HTML nesting; direct placement inside SVG or MathML is
 unsupported because an HTML parser moves a `<div>` out of foreign content before
 hydration. The exact permanent-static form described above is wrapper-free and
 inherits its HTML, SVG, or MathML parser namespace.
+
+For the proposed next step—omitting an inert page shell while independently
+hydrating its live islands—see [Static shells and independently hydrated islands](./hydration-islands-plan.md).
+That design is not a shipped hydration mode.

--- a/docs/hydration-islands-plan.md
+++ b/docs/hydration-islands-plan.md
@@ -209,6 +209,31 @@ The immutable shell remains server-owned. A future live-context bridge or SPA
 promotion mechanism needs its own design and tests; it is not implied by this
 entry mode.
 
+## Deferred Hydrate recovery follow-up
+
+Completed descriptor adoption and divergent fragment recovery are separate
+contracts. Runtime-only, compiler-shaped probes against the existing runtime
+show that a mismatched multi-root fragment inside Hydrate can report a
+recoverable mismatch, remove its own insertion anchor, and then throw
+`NotFoundError` while rebuilding. Both immediate and suspended cases reproduce
+on the pre-change base. This is an existing limitation, not fixed by deferring
+the descriptor cleanup claim; native compiler coverage is still required.
+
+A recovery design must validate and replace only a proven owner range. Use the
+actual current scope's insertion owner, including adopted lite-scope ranges,
+and retain the live end anchor and unaffected siblings. A fresh fragment may
+contain component, conditional, list, or Suspense holes: those children must
+client-build without adopting a following owner's server range. Suppressing DOM
+adoption must not leave the recovered subtree's serialized `use()` values for a
+later sibling to consume. Replaying setup or restarting the whole island is not
+a safe shortcut around seed, ID, ref, effect, and browser-state ownership.
+
+Before shipping this recovery, add public compiler regressions in development
+and production for immediate and suspended mismatches, nested and lite owners,
+mixed directive holes, later sibling identity/events, cancellation, repeated
+suspension, and seeds before and after the replaced range. The independent-island
+protocol must not assume this stronger recovery contract already exists.
+
 ## Vite, Rspack, and app integration
 
 Keep proof rules, reference IDs, manifest validation/versioning, and diagnostics

--- a/docs/hydration-islands-plan.md
+++ b/docs/hydration-islands-plan.md
@@ -1,0 +1,295 @@
+# Static shells and independently hydrated islands
+
+Status: proposed. Source investigation began at `1ac623053` on 2026-08-20.
+The proposed modes and protocol are not shipped APIs. The isolated export-retention
+experiment below has measurements; no static-shell performance result exists.
+The existing public contract remains [deferred hydration](./deferred-hydration.md).
+
+## Goal
+
+An SSR page may have a root-to-`Hydrate` component chain that produces useful
+HTML but has no client work of its own. Let an application omit that shell's
+hydration and, when nothing else needs its exports or module effects, omit its
+JavaScript too. Interactive islands must still adopt their server DOM, receive
+the right inputs, and preserve normal Octane behavior.
+
+These are three separate proofs:
+
+1. The shell has no required client render, commit, or cleanup behavior.
+2. The shell is immutable for this entry's lifetime, or a supported update path
+   remains available.
+3. Removing its client graph does not remove another consumer's exports,
+   singleton identity, module effects, or styles.
+
+Having no local state or event handlers proves none of these on its own. Start
+with an explicitly opted-in, immutable SSR/SSG document route. Do not change
+ordinary `hydrateRoot`, `root.render`, or client navigation semantics.
+
+## What exists today
+
+| Existing mechanism                                                                                                                                                                                | Consequence for this work                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [Compiler-owned Hydrate extraction](../packages/octane/src/compiler/hydrate-boundaries.js) creates stable `?octane-hydrate=0` / `0.0` requests from the original source.                          | Reuse this independently reproducible entry mechanism; do not require an adapter-owned virtual-module cache.                              |
+| Exclusive private declarations can move into a child chunk. Shared/eager declarations, public exports, and declarations containing another Hydrate site are retained.                             | Better declaration ownership can improve splitting independently of static shells. Preserve shared identity and initialization behavior.  |
+| A split child receives arbitrary live lexical values through a client capture array and inherits its parent's runtime scope.                                                                      | The current capture protocol is not a server serializer or a standalone island entry.                                                     |
+| The exact `split={false} when={never()}` form removes its whole client subtree, preserves its server range, and reserves skipped IDs.                                                             | It cannot represent a shell with live holes: nested Hydrate boundaries also become inert, and a client-only mount renders no descendants. |
+| [The app bootstrap](../packages/app-core/src/codegen.js) reconstructs page/layout/root boundaries and hydrates the complete root.                                                                 | A new entry mode must discover islands without first importing and executing that shell.                                                  |
+| [Vite](../packages/vite-plugin-octane/src/client-assets.js) and [Rsbuild](../packages/rsbuild-plugin-octane/src/client-assets-plugin.js) collect CSS reachable through deferred Hydrate branches. | Preserve eager styling without turning deferred JavaScript into an eager preload. Include the complete rendered route composition.        |
+| [Astro's adapter](../packages/astro/src/client.js) supports independent roots, identifier prefixes, opaque static slots, refresh, and disposal.                                                   | Reuse these ownership precedents and the existing hydration-range bridge; do not invent unrelated DOM-ownership rules.                    |
+
+The compiler's existing hookless, single-root, auto-memo, and warm-plan metadata
+is not an inertness proof. Memoization still performs an initial render, and its
+pure-render contract can admit imported helpers or descendants whose client
+behavior is unknown to this module.
+
+## Proposed entry modes
+
+The following names are design labels, not configuration options yet:
+
+| Mode      | Behavior                                                                               |
+| --------- | -------------------------------------------------------------------------------------- |
+| `full`    | Current whole-root hydration; default and fallback for unproven entries.               |
+| `none`    | Proven immutable document with no live island frontier; no Octane hydration bootstrap. |
+| `islands` | Immutable server-owned shell plus independently addressable Hydrate frontiers.         |
+
+Choose modes per route **and selected export**, not per file. One module can
+export both an immutable document and a component used by a client-rendered
+route. Planned export-aware loading and complete composed-route CSS coverage
+are separate opportunities; neither proves an entry is safe for `islands`.
+Export-aware loading is not shipped and remains blocked by the continuation
+semantics described below.
+
+Build-time uncertainty selects `full`. A request-time serialization failure
+must be detected before the specialized response/bootstrap commits. It can use
+an explicitly emitted full-hydration recovery entry, or reject a strict
+island-only render. A route retaining a recovery entry may save initial bytes
+without removing the shell from the total client graph. Never silently fall
+back to overlapping full-root hydration after individual islands have started.
+
+## Parked investigation: export-aware route loading
+
+The current bootstrap imports a route's complete module namespace and selects
+an export using a runtime name or the default/first-PascalCase fallback. That
+namespace can keep unrelated exported components and their dependencies in a
+production bundle, even when configuration explicitly names one component.
+
+A synthetic production fixture at `1ac623053` made an unused export reference a
+32,809-byte deterministic payload. Replacing namespace loading with a real
+`export { Page as default }` facade removed that payload. Total emitted raw JS
+changed from 36,405 to 3,547 bytes in Vite 8.1.5, and from 36,130 to 3,271 bytes
+in Rspack 2.1.4. The selected Page returned the same value, and the route's
+top-level effect still ran once. Both unchanged runs produced the same sizes.
+The harness used Node 26.4.0, Vite's esbuild production minifier with `esnext`,
+and Rspack's native production minimizer with ESM output. These are synthetic
+reachability measurements, not application savings or a correctness proof.
+
+The optimization was not retained because broader execution tests exposed
+observable timing changes:
+
+- A getter-based one-export projection adds a promise reaction before the
+  bootstrap reads the live binding; the esbuild control can select a later
+  value.
+- An immediate `.then(module => ({ Page: module.Page }))` projection allows
+  tree-shaking, but Vite can place that selection inside its preload helper.
+  When the route is already statically imported, it can select an earlier
+  value than ordinary namespace loading.
+- An async loader with a namespace local, or a separate promise local, avoids
+  that particular early read. The tested Vite output retained the unused
+  payload, however, and the additional continuation can still delay rendering.
+- A real re-export facade preserves live bindings, but can introduce a new
+  asynchronous chunk when the original module is already eager. The native
+  eager/mutable-export matrix changed the selected value in 9 of 16 Vite/Rspack
+  comparisons. It is not a universal timing fix.
+
+Proving that an export is a local immutable `const`, or a function declaration
+with no writes, is insufficient: an unchanged function can read mutable module
+or store state when it finally runs. The contract must preserve the original
+bootstrap continuation, including selection, pre-hydrate work, rendering, and
+error timing. Current integration metadata describes output shape and export
+usage, not this stronger property. Transitive re-exports, CommonJS, unknown
+transforms, cycles, and HMR also need explicit handling.
+
+Keep whole-namespace loading until a separate change can prove both native
+tree-shaking and equivalent observable continuation behavior. Prefer a design
+that communicates exact export reachability to the bundler without adding a
+new promise or module-evaluation boundary. Its regression matrix must include
+eager, already-loaded, and genuinely lazy modules; mutable exports; immutable
+functions reading mutable state; missing/string-named exports; module effects;
+and errors. Do not substitute a narrow immutable-binding check for that proof.
+
+## Eligibility: prove the shell, stop at live frontiers
+
+The neutral compiler should return versioned summaries for component exports:
+render/call dependencies, Hydrate frontier sites, required client capabilities,
+input dependencies, module effects, and source-located reasons a proof failed.
+Resolve imported components and helpers through the real bundler graph. Compute
+a conservative fixed point across dependency cycles. Unknown means `full`.
+
+| Area                            | First-version rule                                                                                                                                                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| State and lifecycle             | No own or transitive stateful/custom hooks, effects, layout/insertion effects, imperative handles, refs, or client cleanup outside an island.                                                                                               |
+| Host behavior                   | No event handlers, spread-hidden handlers/refs, behavior attachment, portals, function form actions, controlled `value`/`checked`, or unknown host spreads. Native links and ordinary server forms can remain native.                       |
+| Context and subscriptions       | No live provider, context read, external-store subscription, router, shared store, or `use()` obligation crossing the frontier without an explicit bridge.                                                                                  |
+| Inputs and updates              | Request-specific values may be immutable snapshots. Changing root props, SPA navigation, browser-only reads, mutable globals, getters, unknown calls, and external mutations require an ordinary client path.                               |
+| Children and component identity | Dynamic tags, component-as-prop, render props, unknown renderables, escaped descriptors, mutable component properties/defaults, and unknown wrappers deopt. Proven inert slots may later use opaque server-owned HTML.                      |
+| Module behavior                 | Preserve live exports, bare imports, registrations, singleton identity, cycles, initializer order/errors, and stylesheet reachability. Direct eval and runtime TypeScript forms require a sound reference analysis or a conservative deopt. |
+| Boundaries and errors           | Suspense, ErrorBoundary, Activity, ViewTransition, head/resource ownership, custom renderers, and possible client error/retry behavior require a dedicated proof. Do not erase the only recovery owner.                                     |
+| IDs and data seeds              | Skipped shell IDs and each island's `useId()`/`use()` scope must be reconstructible exactly. Otherwise retain full hydration.                                                                                                               |
+
+Client behavior inside a frontier is allowed: that island still runs normally.
+For the first implementation, a nested Hydrate owned by a live outer island
+continues through today's parent-first runtime path. Do not give two roots
+reconciliation ownership of the same descendants.
+
+## Proposed protocol
+
+### 1. Build-time plan
+
+Produce one canonical, versioned manifest containing route/export identity,
+proof result and reasons, stable island entry/export references, and their
+concrete JavaScript/CSS assets. Separate component-invocation effects from
+module-evaluation effects. Keep the compiler's parsed-AST/copy-on-write/one-print
+architecture; do not discover safety by rewriting emitted JavaScript.
+
+Preserve actual module identity when partitioning declarations. A later shared
+support query may hold a dependency SCC used only by multiple islands. Start
+with simpler proven cases, such as immutable primitive constants; do not copy a
+stateful singleton into several chunks.
+
+### 2. Per-response SSR records
+
+The server renders the original component tree. It records the **instances
+actually rendered**, not merely lexical sites: branches, loops, keys, nesting,
+and streaming change which instances exist. Each record needs:
+
+- A manifest/build version, stable entry reference, and unique DOM/adoption ID.
+- The parent/owner relationship and activation strategy.
+- Only the required serializable props/captures, plus any explicitly supported
+  module-reference or context bridge.
+- The matching ID scope/count, `use()` seeds, and stream-readiness/ownership
+  token.
+- A defined error, cancellation, and disposal owner.
+
+Do not serialize the existing capture array blindly. It can contain callbacks,
+refs, promises, stores, DOM nodes, class instances, or a complete props object
+with server-only fields. Begin with a small allowlisted data codec, narrow
+captures to used values where safe, and reject accessors, unsupported identity,
+and non-serializable closures. Any future callable-reference format must name
+trusted build-manifest exports, not arbitrary import URLs. Escape inline data
+correctly and preserve CSP/nonce handling.
+
+Use the existing [Hydrate metadata and stream protocol](../packages/octane/src/constants.ts)
+where its meaning matches. New independent scopes must agree with SSR IDs and
+seeds regardless of activation order. Streaming records become activatable only
+after their validated, renderer-owned DOM range is ready. Abort/rejection must
+retain a valid server fallback or enter an explicitly available recovery path.
+
+Suspended retries need precise seed ownership as well. A runtime-only
+supersession prototype replayed an already-adopted ancestor to bypass an obsolete
+pending child; the ancestor then consumed a later child's remaining server seed
+as its own value. That prototype was discarded. Neither reopening an activation
+gate nor replaying the omitted shell is a safe resume protocol. Prove how each
+owner resumes its `use()` positions before permitting changed inputs, and test
+seeds on both sides of an externally owned suspension, cancellation, and
+out-of-order island activation.
+
+### 3. Client bootstrap and ownership
+
+Install the lightweight early event-capture entry before waiting for route or
+island code. A coordinator reads the trusted manifest/response records, starts
+strategies and permitted prefetch work, then imports the runtime and island
+entry when needed. Activation adopts existing DOM and commits refs/effects and
+replayed events through the ordinary runtime.
+
+Reuse the existing Hydrate scheduler, event replay, ID/seed handling, and error
+channels where possible. The coordinator owns registration and cancellation;
+the activated island owns its reconciled range and lifecycle. Removing a route
+or aborting its owner cancels pending activation and disposes live roots once.
+The immutable shell remains server-owned. A future live-context bridge or SPA
+promotion mechanism needs its own design and tests; it is not implied by this
+entry mode.
+
+## Vite, Rspack, and app integration
+
+Keep proof rules, reference IDs, manifest validation/versioning, and diagnostics
+in the bundler-neutral compiler/app-core layer. Native bundlers remain
+authoritative for resolution, package conditions, side effects, export liveness,
+shared chunks, and final asset URLs.
+
+- **Vite:** carry summaries in transform metadata; use `resolve`, `load`, and
+  `getModuleInfo` in a cycle-safe analysis before generating the selected client
+  entries. The existing cross-module void-component proof is precedent for
+  fingerprinting and fail-closed invalidation. `generateBundle` maps surviving
+  entries to assets; it is too late by itself to justify removing a graph root.
+- **Rspack:** transport serializable summaries through `module.buildInfo.octane`
+  and the parallel-loader/finalizer path. Analyze `moduleGraph` at
+  `finishModules`; use optimized used-export information to verify the plan.
+  Generate entries before optimization. At `processAssets`, map references via
+  `chunkGraph`, including concatenated/shared modules, to the same manifest ABI.
+- **App core:** keep route identity as module plus selected export, preserve
+  existing module-path asset lookups for ordinary routes, and choose the
+  bootstrap from the route plan. Plan server-graph analysis before client-root
+  pruning, then build client entries/assets and render the server against that
+  manifest. Do not infer SSR-only stylesheet reachability from an already-pruned
+  client graph.
+- **CSS:** include styles for the page, layout, configured pending/catch
+  boundaries, and rendered deferred descendants. Preserve scoped-style hashes,
+  cascade order, deduplication, and CSS imported only by a removed server shell.
+  No deferred island JavaScript should become module-preloaded merely to obtain
+  its stylesheet.
+
+Development/HMR must invalidate proofs when source, resolved exports, or graph
+ownership changes. A full reload is acceptable for the first specialized mode;
+silently retaining an old eligibility decision is not.
+
+## Delivery phases
+
+1. **Establish evidence and harden existing splitting.** Add representative
+   eager/split/shared/permanent-static fixtures, a split-retention report, and
+   regressions for unsafe lexical/declaration movement. Land composed-route CSS
+   fixes independently. Planned export-aware loading remains unshipped until
+   its continuation and reachability tests pass on both native bundlers. Record
+   matched Vite/Rspack baselines before claiming application savings.
+2. **Proof-only compiler and graph pass.** Emit capability/dependency summaries
+   and explain every `full` decision. Add negative controls for each rule above.
+   No runtime behavior changes in this phase.
+3. **Opt-in document prototype.** Support buffered/prerendered immutable
+   documents, known strategies, serializable inputs, and independent top-level
+   island frontiers. Add the versioned SSR records and bootstrap. Keep existing
+   full hydration as the default; prove that the shell need not execute.
+4. **Client-graph removal.** Connect proven entries to both native bundlers,
+   retain required exports/effects/CSS, and measure initial and total bytes.
+   Add shared/recursive declaration slicing only when measured benefit justifies
+   its identity and initialization complexity.
+5. **Expand deliberately.** Streaming, opaque slots, context bridges, nested
+   independent owners, richer serialization, and SPA promotion each require
+   separate acceptance tests and an explicit update/recovery contract.
+
+## Acceptance tests
+
+| Area                       | Required evidence                                                                                                                                                                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Compiler proof             | Public compiler tests in TSRX and TSX, dev and production, client and server. Each unsafe construct has a negative control that retains full hydration; diagnostics identify the authored reason. Shared exports and direct-eval/runtime-TS references remain usable.                   |
+| SSR and adoption           | Compare normal and specialized visible HTML. Activate islands in different orders; original nodes, user-entered values, focus, and caret survive. Repeated/keyed/nested instances receive correct props and unique IDs without mismatches.                                              |
+| Interactions and lifecycle | Withhold real production chunks in Chromium. Early native clicks/keyboard activation replay exactly once; later interactions remain live. Effects/refs run at the documented commit point. Cancellation, removal, import failure, retry, and cleanup do not leak or double-commit.      |
+| Updates and fallback       | Ineligible state/context/store/router/controlled-input fixtures retain normal behavior. Client-only mounts, `root.render(newProps)`, and navigation either use a supported ordinary path or are rejected before choosing immutable mode. No partial independent-root/full-root overlap. |
+| Graph and styles           | Real Vite and Rspack builds select the correct export when two routes share a module. Required module effects run in the same order/identity. Page/layout/root-boundary and deferred CSS is styled before activation, while withheld island JS is neither fetched nor preloaded early.  |
+| Errors, streams, security  | Catch ownership, unhandled errors, mismatch reporting, stream abort/rejection, and stale build manifests have defined outcomes. Payloads containing script delimiters cannot inject executable markup; CSP and manifest import restrictions hold.                                       |
+| Removed work               | In an eligible fixture with no recovery entry or other client references, the shell graph is absent from the emitted client manifest. An otherwise identical fixture with an effect, shared export, or mutable input retains it.                                                        |
+
+Extend the existing [hydration interactivity](../benchmarks/hydration-interactivity/README.md),
+[hydration stress](../benchmarks/hydration-stress/README.md), bundle-size,
+codegen-size, and [compiler-throughput](../benchmarks/compiler-throughput/README.md)
+harnesses. Report eager JS, deferred JS, total raw/gzip/Brotli bytes, CSS and
+payload bytes, chunk requests, parse/evaluation and activation latency, SSR
+throughput, compile time, and retained memory separately. Use matched
+baseline/candidate runs, warmup and repeated samples, with DOM/interaction
+semantic controls. Set deterministic ratio budgets from those measurements;
+do not turn generated helper names or marker counts into correctness tests.
+
+## Provenance
+
+- [x] An agent drafted this design from the repository's compiler, runtime,
+      bundler, and integration sources. Static-shell APIs and benefits remain
+      unimplemented and unmeasured; isolated export-retention measurements are
+      identified separately above.

--- a/packages/app-core/src/server/production.js
+++ b/packages/app-core/src/server/production.js
@@ -296,20 +296,35 @@ export function createHandler(manifest, deps) {
 		});
 		const dataScript = `<script id="__octane_data" type="application/json"${nonceAttribute(nonce)}>${escapeScript(routeData)}</script>`;
 
-		// Per-route asset hints from the client manifest: stylesheet links so
-		// page CSS applies before hydration, modulepreload so the page chunk
-		// downloads in parallel with the hydrate entry (which the template's own
-		// script tag already references).
+		// The page, layout, and configured root fallbacks can all contribute
+		// server HTML before hydration. Their asset records also include CSS for
+		// deferred Hydrate descendants, whose JavaScript must remain lazy. Keep
+		// page CSS first, preserve each record's order, and link shared files once.
 		/** @type {string[]} */
 		const preloadTags = [];
-		const entryAssets = entryPath ? manifest.clientAssets?.[entryPath] : undefined;
-		if (entryAssets) {
-			for (const cssFile of entryAssets.css) {
-				preloadTags.push(`<link rel="stylesheet" href="/${cssFile}">`);
+		const clientAssets = manifest.clientAssets;
+		const entryAssets = entryPath ? clientAssets?.[entryPath] : undefined;
+		if (clientAssets) {
+			/** @type {Set<string>} */
+			const stylesheets = new Set();
+			for (const modulePath of [
+				entryPath,
+				route.layout,
+				manifest.rootBoundary?.pending ? manifest.rootBoundaryEntries?.pending?.path : undefined,
+				manifest.rootBoundary?.catch ? manifest.rootBoundaryEntries?.catch?.path : undefined,
+			]) {
+				if (!modulePath) continue;
+				for (const cssFile of clientAssets[modulePath]?.css ?? []) {
+					if (stylesheets.has(cssFile)) continue;
+					stylesheets.add(cssFile);
+					preloadTags.push(`<link rel="stylesheet" href="/${cssFile}">`);
+				}
 			}
-			if (entryAssets.js) {
-				preloadTags.push(`<link rel="modulepreload" href="/${entryAssets.js}">`);
-			}
+		}
+		// Only the page chunk was already eager; do not promote layout, fallback,
+		// or island JavaScript while making their server-rendered CSS available.
+		if (entryAssets?.js) {
+			preloadTags.push(`<link rel="modulepreload" href="/${entryAssets.js}">`);
 		}
 
 		const headContent = [...preloadTags, dataScript].join('\n');

--- a/packages/app-core/tests/production-assets.test.ts
+++ b/packages/app-core/tests/production-assets.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { OCTANE_NONCE_STATE_KEY } from '../src/constants.js';
+import { RenderRoute } from '../src/routes.js';
+import { createHandler } from '../src/server/production.js';
+
+type ServerManifest = Parameters<typeof createHandler>[0];
+type HandlerOptions = Parameters<typeof createHandler>[1];
+type RenderMode = NonNullable<ServerManifest['render']>;
+type Body = (props: Record<string, any>, scope?: unknown) => string;
+
+const PENDING = Symbol('pending render');
+const TEMPLATE = `<!doctype html>
+<html><head><base href="/docs/"><!--ssr-head--></head><body><div id="root"><!--ssr-body--></div>
+<script type="module" data-octane-hydrate src="/assets/hydrate.js"></script></body></html>`;
+
+function streamOf(text: string): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(text));
+			controller.close();
+		},
+	});
+}
+
+function Page(props: { params: Record<string, string> }) {
+	if (props.params.phase === 'pending') throw PENDING;
+	if (props.params.phase === 'error') throw new Error('route failed');
+	return '<main class="page">page</main>';
+}
+
+function Layout(props: { children: Body }, scope?: unknown) {
+	return (
+		'<section class="layout"><button class="layout-island">island</button>' +
+		props.children({}, scope) +
+		'</section>'
+	);
+}
+
+const Pending = () => '<p class="pending">pending</p>';
+const Catch = () => '<p class="catch">caught</p>';
+const Other = () => '<main class="other">other</main>';
+
+// These renderer stubs exercise app-core's real route/boundary composition and
+// HTML assembly. Compiler-generated Hydrate assets are covered by the bundler
+// integration tests; their already-resolved CSS belongs in the same asset map.
+const renderOptions: HandlerOptions = {
+	htmlTemplate: TEMPLATE,
+	prerender: async (component) => ({ html: component({}, undefined), css: '' }),
+	renderToReadableStream: async (component) => streamOf(component({}, undefined)),
+	executeServerFunction: async () => '',
+	createElement:
+		(component: Body, props: Record<string, any>) => (_props: unknown, scope?: unknown) =>
+			component(props, scope),
+	Suspense(props, scope) {
+		try {
+			return props.children({}, scope);
+		} catch (error) {
+			if (error !== PENDING) throw error;
+			return props.fallback({}, scope);
+		}
+	},
+	ErrorBoundary(props, scope) {
+		try {
+			return props.children({}, scope);
+		} catch (error) {
+			if (error === PENDING) throw error;
+			return props.fallback(error, () => {})({}, scope);
+		}
+	},
+};
+
+function makeManifest(render: RenderMode): ServerManifest {
+	return {
+		routes: [
+			new RenderRoute({
+				path: '/selected/:phase',
+				entry: ['Page', '/src/Page.tsrx'],
+				layout: '/src/Layout.tsrx',
+			}),
+			new RenderRoute({ path: '/other', entry: ['Other', '/src/Other.tsrx'] }),
+		],
+		components: {
+			'/src/Page.tsrx': { Page },
+			'/src/Other.tsrx': { Other },
+		},
+		layouts: { '/src/Layout.tsrx': { Layout } },
+		middlewares: [
+			(context, next) => {
+				context.state.set(OCTANE_NONCE_STATE_KEY, 'asset-nonce');
+				return next();
+			},
+		],
+		render,
+		rootBoundary: { pending: Pending, catch: Catch },
+		rootBoundaryEntries: {
+			pending: { path: '/src/Pending.tsrx', exportName: null },
+			catch: { path: '/src/Catch.tsrx', exportName: null },
+		},
+		clientAssets: {
+			'/src/Page.tsrx': {
+				js: 'assets/page.js',
+				css: ['assets/shared.css', 'assets/page.css', 'assets/page-island.css'],
+			},
+			'/src/Layout.tsrx': {
+				js: 'assets/layout.js',
+				css: ['assets/shared.css', 'assets/layout.css', 'assets/layout-island.css'],
+			},
+			'/src/Pending.tsrx': {
+				js: 'assets/pending.js',
+				css: ['assets/shared.css', 'assets/pending.css'],
+			},
+			'/src/Catch.tsrx': {
+				js: 'assets/catch.js',
+				css: ['assets/shared.css', 'assets/catch.css'],
+			},
+			'/src/Other.tsrx': { js: 'assets/other.js', css: ['assets/other.css'] },
+		},
+	};
+}
+
+function assetHrefs(html: string, rel: 'stylesheet' | 'modulepreload') {
+	const head = html.slice(0, html.indexOf('</head>'));
+	return [...head.matchAll(/<link\b[^>]*>/g)]
+		.filter(([tag]) => tag.match(/\brel="([^"]*)"/)?.[1] === rel)
+		.map(([tag]) => tag.match(/\bhref="([^"]*)"/)?.[1]);
+}
+
+describe.each(['buffered', 'streaming'] as const)('%s production route assets', (render) => {
+	it.each([
+		['ready', 'class="layout-island"'],
+		['pending', 'class="pending"'],
+		['error', 'class="catch"'],
+	])('styles the %s response before client hydration', async (phase, content) => {
+		const handler = createHandler(makeManifest(render), renderOptions);
+		const response = await handler(new Request(`https://octane.test/selected/${phase}`));
+		const html = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(html).toContain(content);
+		expect(assetHrefs(html, 'stylesheet')).toEqual([
+			'/assets/shared.css',
+			'/assets/page.css',
+			'/assets/page-island.css',
+			'/assets/layout.css',
+			'/assets/layout-island.css',
+			'/assets/pending.css',
+			'/assets/catch.css',
+		]);
+		// CSS is needed by inert server HTML; only the already-eager page JS gets
+		// a preload. Neither layout/boundary nor deferred island JS is promoted.
+		expect(assetHrefs(html, 'modulepreload')).toEqual(['/assets/page.js']);
+		expect(html).toContain('<base href="/docs/">');
+		expect(html).toContain(
+			'<script id="__octane_data" type="application/json" nonce="asset-nonce">',
+		);
+		expect(html).toMatch(/<script(?=[^>]*data-octane-hydrate)(?=[^>]*nonce="asset-nonce")[^>]*>/);
+	});
+
+	it('only includes the matched page and its configured boundaries', async () => {
+		const handler = createHandler(makeManifest(render), renderOptions);
+		const response = await handler(new Request('https://octane.test/other'));
+		const html = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(html).toContain('class="other"');
+		expect(assetHrefs(html, 'stylesheet')).toEqual([
+			'/assets/other.css',
+			'/assets/shared.css',
+			'/assets/pending.css',
+			'/assets/catch.css',
+		]);
+		expect(assetHrefs(html, 'modulepreload')).toEqual(['/assets/other.js']);
+	});
+
+	it('keeps layout and boundary CSS when the page has no asset record', async () => {
+		const manifest = makeManifest(render);
+		delete manifest.clientAssets!['/src/Page.tsrx'];
+		const handler = createHandler(manifest, renderOptions);
+		const response = await handler(new Request('https://octane.test/selected/ready'));
+		const html = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(assetHrefs(html, 'stylesheet')).toEqual([
+			'/assets/shared.css',
+			'/assets/layout.css',
+			'/assets/layout-island.css',
+			'/assets/pending.css',
+			'/assets/catch.css',
+		]);
+		expect(assetHrefs(html, 'modulepreload')).toEqual([]);
+	});
+
+	it('ignores missing asset maps and boundaries that do not wrap the route', async () => {
+		const manifest = makeManifest(render);
+		manifest.rootBoundary = {};
+		const handler = createHandler(manifest, renderOptions);
+		const html = await (await handler(new Request('https://octane.test/other'))).text();
+		expect(assetHrefs(html, 'stylesheet')).toEqual(['/assets/other.css']);
+
+		delete manifest.clientAssets;
+		const withoutAssets = createHandler(manifest, renderOptions);
+		const unstyled = await (await withoutAssets(new Request('https://octane.test/other'))).text();
+		expect(assetHrefs(unstyled, 'stylesheet')).toEqual([]);
+		expect(assetHrefs(unstyled, 'modulepreload')).toEqual([]);
+	});
+});

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8219,6 +8219,15 @@ function activateHydrateBoundary(state: HydrateSlot): void {
 			}
 		}
 		renderBlock(block);
+		// The internal try slot owns the complete adopted child range. A
+		// descriptor-only child need not clone a compiled root template, and a
+		// suspended resume can leave the cursor inside that range. Claim its
+		// remainder before cleanup so live server content is not swept as stale.
+		// An earlier template-owned claim remains authoritative.
+		const adoptedSlot = block.slots[0] as TrySlot | undefined;
+		if (adoptedSlot?.__kind === 'trySlotSlot') {
+			hydration.claimRootRemainder(adoptedSlot.end.nextSibling);
+		}
 		drainHydrationRenderPhaseUpdates(block);
 		// Suspended initial adoption intentionally leaves its real server arm and
 		// cursor untouched. Sweep only after that same arm eventually commits.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8219,19 +8219,19 @@ function activateHydrateBoundary(state: HydrateSlot): void {
 			}
 		}
 		renderBlock(block);
-		// The internal try slot owns the complete adopted child range. A
-		// descriptor-only child need not clone a compiled root template, and a
-		// suspended resume can leave the cursor inside that range. Claim its
-		// remainder before cleanup so live server content is not swept as stale.
-		// An earlier template-owned claim remains authoritative.
-		const adoptedSlot = block.slots[0] as TrySlot | undefined;
-		if (adoptedSlot?.__kind === 'trySlotSlot') {
-			hydration.claimRootRemainder(adoptedSlot.end.nextSibling);
-		}
 		drainHydrationRenderPhaseUpdates(block);
 		// Suspended initial adoption intentionally leaves its real server arm and
 		// cursor untouched. Sweep only after that same arm eventually commits.
 		if (state.hydrated) {
+			// A descriptor-only child need not clone a compiled root template, and a
+			// resumed cursor can still be inside the internal try slot's owned range.
+			// Wait until adoption completes before claiming that range's remainder:
+			// a later template clone must get the first claim, and DOM added while
+			// suspended must not be skipped by an earlier fallback snapshot.
+			const adoptedSlot = block.slots[0] as TrySlot | undefined;
+			if (adoptedSlot?.__kind === 'trySlotSlot') {
+				hydration.claimRootRemainder(adoptedSlot.end.nextSibling);
+			}
 			hydration.flushClassWrites();
 			hydration.flushTextWarnings();
 			hydration.finishRoot();

--- a/packages/octane/tests/hydration/deferred-hydration-descriptor.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-descriptor.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as Client from 'octane';
+import { load, never, type HydrateProps, type HydrateWhen } from 'octane/hydration';
+import * as Server from 'octane/server';
+import { flushEffects } from '../_helpers.js';
+
+type EditorProps = {
+	pending?: Promise<void>;
+	onInput?: (value: string) => void;
+	onRef?: (element: HTMLInputElement | null) => void;
+};
+
+type AppProps = EditorProps & {
+	when: HydrateWhen;
+	onHydrated?: () => void;
+};
+
+type DescriptorRuntime = Pick<typeof Client, 'createElement' | 'Hydrate' | 'use'>;
+type Ownership = 'component-owned' | 'directly rooted';
+
+// Public createElement components exercise descriptor adoption without needing
+// a compiled template. use() has no compiler-assigned hook slot.
+function createDescriptorFixture(runtime: DescriptorRuntime) {
+	function Editor(props: EditorProps) {
+		if (props.pending) runtime.use(props.pending);
+		return runtime.createElement('input', {
+			id: 'descriptor-editor',
+			defaultValue: 'Server draft',
+			ref: props.onRef,
+			onInput: (event: Event) => props.onInput?.((event.target as HTMLInputElement).value),
+		});
+	}
+
+	function boundaryProps(props: AppProps): HydrateProps {
+		return {
+			when: props.when,
+			split: false,
+			onHydrated: props.onHydrated,
+			children: runtime.createElement(Editor, {
+				pending: props.pending,
+				onInput: props.onInput,
+				onRef: props.onRef,
+			}),
+		};
+	}
+
+	function App(props: AppProps) {
+		return runtime.createElement(runtime.Hydrate, boundaryProps(props));
+	}
+
+	return { App, boundaryProps };
+}
+
+const client = createDescriptorFixture(Client);
+const server = createDescriptorFixture(Server as unknown as DescriptorRuntime);
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((complete, fail) => {
+		resolve = complete;
+		reject = fail;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('deferred hydration of descriptor components', () => {
+	let container: HTMLElement;
+	let root: Client.Root | undefined;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(() => {
+		root?.unmount();
+		root = undefined;
+		container.remove();
+		flushEffects();
+	});
+
+	function renderServer(ownership: Ownership, props: AppProps): void {
+		container.innerHTML =
+			ownership === 'component-owned'
+				? Server.renderToString(server.App, props).html
+				: Server.renderToString(Server.Hydrate, server.boundaryProps(props)).html;
+	}
+
+	function hydrate(ownership: Ownership, props: AppProps, options?: Client.RootOptions): void {
+		root =
+			ownership === 'component-owned'
+				? Client.hydrateRoot(container, client.App, props, options)
+				: Client.hydrateRoot(container, Client.Hydrate, client.boundaryProps(props), options);
+	}
+
+	function update(ownership: Ownership, props: AppProps): void {
+		if (ownership === 'component-owned') root!.render(client.App, props);
+		else root!.render(Client.Hydrate, client.boundaryProps(props));
+	}
+
+	for (const ownership of ['component-owned', 'directly rooted'] as const) {
+		it(`${ownership}: immediately adopts the server input`, async () => {
+			const when = load();
+			const onInput = vi.fn();
+			const onRef = vi.fn();
+			const onHydrated = vi.fn();
+			const onRecoverableError = vi.fn();
+			renderServer(ownership, { when });
+			const input = container.querySelector('#descriptor-editor') as HTMLInputElement;
+			expect(input).not.toBeNull();
+
+			hydrate(ownership, { when, onInput, onRef, onHydrated }, { onRecoverableError });
+			await Client.act(() => {});
+
+			expect(container.querySelector('#descriptor-editor')).toBe(input);
+			expect(onHydrated).toHaveBeenCalledOnce();
+			expect(onRef).toHaveBeenCalledExactlyOnceWith(input);
+			input.value = 'Live draft';
+			await Client.act(() => input.dispatchEvent(new Event('input', { bubbles: true })));
+			expect(onInput).toHaveBeenCalledExactlyOnceWith('Live draft');
+			expect(onRecoverableError).not.toHaveBeenCalled();
+		});
+
+		it(`${ownership}: preserves the server input when suspended activation completes`, async () => {
+			const pending = deferred<void>();
+			const when = load();
+			const onInput = vi.fn();
+			const onRef = vi.fn();
+			const onHydrated = vi.fn();
+			const onRecoverableError = vi.fn();
+			renderServer(ownership, { when });
+			const input = container.querySelector('#descriptor-editor') as HTMLInputElement;
+			input.value = 'Typed before hydration';
+			input.focus();
+			input.setSelectionRange(3, 8);
+
+			hydrate(
+				ownership,
+				{ when, pending: pending.promise, onInput, onRef, onHydrated },
+				{ onRecoverableError },
+			);
+			await Client.act(() => {});
+			expect(container.querySelector('#descriptor-editor')).toBe(input);
+			expect(onRef).not.toHaveBeenCalled();
+			expect(onHydrated).not.toHaveBeenCalled();
+
+			await Client.act(() => pending.resolve());
+
+			expect(container.querySelector('#descriptor-editor')).toBe(input);
+			expect(input.value).toBe('Typed before hydration');
+			expect(document.activeElement).toBe(input);
+			expect([input.selectionStart, input.selectionEnd]).toEqual([3, 8]);
+			expect(onHydrated).toHaveBeenCalledOnce();
+			expect(onRef).toHaveBeenCalledExactlyOnceWith(input);
+			input.value = 'Live draft';
+			await Client.act(() => input.dispatchEvent(new Event('input', { bubbles: true })));
+			expect(onInput).toHaveBeenCalledExactlyOnceWith('Live draft');
+			expect(onRecoverableError).not.toHaveBeenCalled();
+
+			root!.unmount();
+			root = undefined;
+			expect(onRef.mock.calls).toEqual([[input], [null]]);
+			expect(container.textContent).toBe('');
+		});
+
+		it(`${ownership}: keeps canceled activation inert after its promise settles`, async () => {
+			const pending = deferred<void>();
+			const when = load();
+			const onInput = vi.fn();
+			const onRef = vi.fn();
+			const onHydrated = vi.fn();
+			renderServer(ownership, { when });
+			const input = container.querySelector('#descriptor-editor') as HTMLInputElement;
+			const props = { when, pending: pending.promise, onInput, onRef, onHydrated };
+			hydrate(ownership, props);
+			await Client.act(() => {});
+
+			await Client.act(() => update(ownership, { ...props, when: never() }));
+			await Client.act(() => pending.resolve());
+			await Client.act(() => input.dispatchEvent(new Event('input', { bubbles: true })));
+
+			expect(container.querySelector('#descriptor-editor')).toBe(input);
+			expect(onRef).not.toHaveBeenCalled();
+			expect(onHydrated).not.toHaveBeenCalled();
+			expect(onInput).not.toHaveBeenCalled();
+		});
+
+		it(`${ownership}: removes unmatched server content without discarding the resumed input`, async () => {
+			const pending = deferred<void>();
+			const when = load();
+			const onHydrated = vi.fn();
+			const onRecoverableError = vi.fn();
+			renderServer(ownership, { when });
+			const input = container.querySelector('#descriptor-editor') as HTMLInputElement;
+			const stale = document.createElement('p');
+			stale.textContent = 'Unmatched server content';
+			input.parentElement!.append(stale);
+			hydrate(ownership, { when, pending: pending.promise, onHydrated }, { onRecoverableError });
+			await Client.act(() => {});
+			expect(stale.isConnected).toBe(true);
+
+			await Client.act(() => pending.resolve());
+
+			expect(container.querySelector('#descriptor-editor')).toBe(input);
+			expect(stale.isConnected).toBe(false);
+			expect(onHydrated).toHaveBeenCalledOnce();
+			expect(onRecoverableError).toHaveBeenCalledOnce();
+		});
+
+		it(`${ownership}: does not revive an unmounted pending activation`, async () => {
+			const pending = deferred<void>();
+			const when = load();
+			const onRef = vi.fn();
+			const onHydrated = vi.fn();
+			renderServer(ownership, { when });
+			hydrate(ownership, { when, pending: pending.promise, onRef, onHydrated });
+			await Client.act(() => {});
+
+			root!.unmount();
+			root = undefined;
+			await Client.act(() => pending.resolve());
+
+			expect(container.childNodes).toHaveLength(0);
+			expect(onRef).not.toHaveBeenCalled();
+			expect(onHydrated).not.toHaveBeenCalled();
+		});
+
+		it(`${ownership}: reports a rejected activation without committing its input`, async () => {
+			const pending = deferred<void>();
+			const when = load();
+			const error = new Error('Descriptor data failed');
+			const onRef = vi.fn();
+			const onHydrated = vi.fn();
+			const onUncaughtError = vi.fn();
+			renderServer(ownership, { when });
+			hydrate(
+				ownership,
+				{ when, pending: pending.promise, onRef, onHydrated },
+				{ onUncaughtError },
+			);
+			await Client.act(() => {});
+
+			await Client.act(() => pending.reject(error));
+
+			expect(onUncaughtError).toHaveBeenCalledExactlyOnceWith(error);
+			expect(container.querySelector('#descriptor-editor')).toBeNull();
+			expect(onRef).not.toHaveBeenCalled();
+			expect(onHydrated).not.toHaveBeenCalled();
+		});
+	}
+});

--- a/packages/octane/tests/hydration/deferred-hydration-descriptor.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-descriptor.test.ts
@@ -208,6 +208,48 @@ describe('deferred hydration of descriptor components', () => {
 			expect(onRecoverableError).toHaveBeenCalledOnce();
 		});
 
+		for (const suspended of [false, true]) {
+			it(`${ownership}: cleans up the current server-range tail on ${suspended ? 'resumed' : 'immediate'} adoption`, async () => {
+				const pending = deferred<void>();
+				const when = load();
+				const onInput = vi.fn();
+				const onHydrated = vi.fn();
+				const onRecoverableError = vi.fn();
+				const onUncaughtError = vi.fn();
+				renderServer(ownership, { when });
+				const input = container.querySelector('#descriptor-editor') as HTMLInputElement;
+				input.value = 'Draft before activation';
+				const wrapper = input.parentElement!;
+				const stale = document.createElement('p');
+				stale.textContent = 'Added before activation completed';
+				// Another DOM integration can insert content at the boundary's tail
+				// while Octane has left its server HTML visible but inactive.
+				if (!suspended) wrapper.insertBefore(stale, wrapper.lastChild);
+				hydrate(
+					ownership,
+					{ when, pending: suspended ? pending.promise : undefined, onInput, onHydrated },
+					{ onRecoverableError, onUncaughtError },
+				);
+				await Client.act(() => {});
+				if (suspended) {
+					wrapper.insertBefore(stale, wrapper.lastChild);
+					expect(stale.isConnected).toBe(true);
+					expect(onHydrated).not.toHaveBeenCalled();
+					await Client.act(() => pending.resolve());
+				}
+
+				expect(container.querySelector('#descriptor-editor')).toBe(input);
+				expect(input.value).toBe('Draft before activation');
+				expect(stale.isConnected).toBe(false);
+				expect(onRecoverableError).toHaveBeenCalledOnce();
+				expect(onUncaughtError).not.toHaveBeenCalled();
+				expect(onHydrated).toHaveBeenCalledOnce();
+				input.value = 'Live draft after cleanup';
+				await Client.act(() => input.dispatchEvent(new Event('input', { bubbles: true })));
+				expect(onInput).toHaveBeenCalledExactlyOnceWith('Live draft after cleanup');
+			});
+		}
+
 		it(`${ownership}: does not revive an unmounted pending activation`, async () => {
 			const pending = deferred<void>();
 			const when = load();

--- a/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
@@ -113,6 +113,42 @@ export function Page() @{
 	write(root, 'src/page.css', '.route { color: rebeccapurple; }\n');
 	write(
 		root,
+		'src/Layout.tsrx',
+		`import { Hydrate, type OctaneNode } from 'octane';
+import { interaction } from 'octane/hydration';
+import { LayoutDeferredHydrationProof } from './layout-deferred-hydration.tsrx';
+
+export default function Layout(props: { children: OctaneNode }) @{
+	<section class="layout">
+		<Hydrate when={interaction()}>
+			<LayoutDeferredHydrationProof />
+		</Hydrate>
+		{props.children}
+	</section>
+}
+`,
+	);
+	write(
+		root,
+		'src/layout-deferred-hydration.tsrx',
+		`import { useState } from 'octane';
+import './layout-deferred-hydration.css';
+
+export function LayoutDeferredHydrationProof() @{
+	const [clicks, setClicks] = useState(0);
+	<button class="rsbuild-layout-deferred-hydration-proof" onClick={() => setClicks((count) => count + 1)}>
+		{'rsbuild-layout-deferred-hydration-chunk-proof: ' + clicks}
+	</button>
+}
+`,
+	);
+	write(
+		root,
+		'src/layout-deferred-hydration.css',
+		'.rsbuild-layout-deferred-hydration-proof { color: teal; }\n',
+	);
+	write(
+		root,
 		'src/deferred-hydration.js',
 		`import './deferred-hydration.css';
 
@@ -154,7 +190,7 @@ export default defineConfig({
 	],
 	router: {
 		routes: [
-			new RenderRoute({ path: '/', entry: '/src/Page.tsrx' }),
+			new RenderRoute({ path: '/', entry: '/src/Page.tsrx', layout: '/src/Layout.tsrx' }),
 			new ServerRoute({
 				path: '/api/health',
 				handler: (context) => compose([])(context, () => Response.json({
@@ -579,6 +615,24 @@ document.querySelector('#root')!.textContent = typeof Counter;
 		expect(deferredJavaScript).toBeTruthy();
 		expect(assetMap['/src/Page.tsrx'].css).toContain(deferredCss);
 		expect(assetMap['/src/Page.tsrx'].js).not.toBe(deferredJavaScript);
+		const layoutDeferredCss = listFiles(clientRoot).find(
+			(file) =>
+				file.endsWith('.css') &&
+				readFileSync(join(clientRoot, file), 'utf8').includes(
+					'.rsbuild-layout-deferred-hydration-proof',
+				),
+		);
+		const layoutDeferredJavaScript = listFiles(clientRoot).find(
+			(file) =>
+				file.endsWith('.js') &&
+				readFileSync(join(clientRoot, file), 'utf8').includes(
+					'rsbuild-layout-deferred-hydration-chunk-proof',
+				),
+		);
+		expect(layoutDeferredCss).toBeTruthy();
+		expect(layoutDeferredJavaScript).toBeTruthy();
+		expect(assetMap['/src/Layout.tsrx'].css).toContain(layoutDeferredCss);
+		expect(assetMap['/src/Layout.tsrx'].js).not.toBe(layoutDeferredJavaScript);
 
 		const entry = pathToFileURL(join(serverRoot, 'entry.js'));
 		entry.searchParams.set('test', String(Date.now()));
@@ -592,9 +646,12 @@ document.querySelector('#root')!.textContent = typeof Counter;
 		expect(response.status).toBe(200);
 		expect(body).toContain('data-rsbuild-ssr="ready"');
 		expect(body).toContain('Rsbuild route');
+		expect(body).toContain('rsbuild-layout-deferred-hydration-chunk-proof: 0');
 		for (const cssFile of assetMap['/src/Page.tsrx'].css) expect(body).toContain(cssFile);
+		expect(body).toContain(`<link rel="stylesheet" href="/${layoutDeferredCss}">`);
 		expect(body).toContain(`<link rel="modulepreload" href="/${assetMap['/src/Page.tsrx'].js}">`);
 		expect(body).not.toContain(`<link rel="modulepreload" href="/${deferredJavaScript}">`);
+		expect(body).not.toContain(`<link rel="modulepreload" href="/${layoutDeferredJavaScript}">`);
 		expect(body).toContain('id="__octane_data"');
 		expect(body).not.toContain('<!--ssr-body-->');
 

--- a/packages/vite-plugin-octane/tests/_fixtures/app/octane.config.ts
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/octane.config.ts
@@ -65,6 +65,11 @@ export default defineConfig({
 				entry: ['Page', '/src/Page.tsrx'],
 				layout: '/src/Layout.tsrx',
 			}),
+			new RenderRoute({
+				path: '/layout-assets',
+				entry: ['Page', '/src/Page.tsrx'],
+				layout: '/src/LayoutAssets.tsrx',
+			}),
 		],
 	},
 });

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/LayoutAssets.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/LayoutAssets.tsrx
@@ -1,0 +1,12 @@
+import { Hydrate, type OctaneNode } from 'octane';
+import { interaction } from 'octane/hydration';
+import { LayoutDeferredHydrationProof } from './layout-deferred-hydration.tsrx';
+
+export default function LayoutAssets(props: { children: OctaneNode }) @{
+	<section class="layout-assets">
+		<Hydrate when={interaction()}>
+			<LayoutDeferredHydrationProof />
+		</Hydrate>
+		{props.children}
+	</section>
+}

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/RootCatch.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/RootCatch.tsrx
@@ -1,3 +1,5 @@
+import './root-boundaries.css';
+
 export function RootCatch(props: { error: unknown; reset: () => void }) @{
 	<button class="root-catch" onClick={props.reset}>
 		{'Fixture failed: ' + String(props.error)}

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/RootPending.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/RootPending.tsrx
@@ -1,3 +1,5 @@
+import './root-boundaries.css';
+
 export default function RootPending() @{
 	<p class="root-pending">Loading fixture…</p>
 }

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/layout-deferred-hydration.css
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/layout-deferred-hydration.css
@@ -1,0 +1,3 @@
+.vite-layout-deferred-hydration-proof {
+	color: teal;
+}

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/layout-deferred-hydration.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/layout-deferred-hydration.tsrx
@@ -1,0 +1,12 @@
+import { useState } from 'octane';
+import './layout-deferred-hydration.css';
+
+export function LayoutDeferredHydrationProof() @{
+	const [clicks, setClicks] = useState(0);
+	<button
+		class="vite-layout-deferred-hydration-proof"
+		onClick={() => setClicks((count) => count + 1)}
+	>
+		{'vite-layout-deferred-hydration-chunk-proof: ' + clicks}
+	</button>
+}

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/root-boundaries.css
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/root-boundaries.css
@@ -1,0 +1,4 @@
+.root-pending,
+.root-catch {
+	color: rebeccapurple;
+}

--- a/packages/vite-plugin-octane/tests/production.test.ts
+++ b/packages/vite-plugin-octane/tests/production.test.ts
@@ -65,6 +65,13 @@ function listFiles(root: string, current = root): string[] {
 	});
 }
 
+function findBuiltAsset(root: string, extension: '.css' | '.js', contents: string) {
+	return listFiles(root).find(
+		(file) =>
+			file.endsWith(extension) && fs.readFileSync(path.join(root, file), 'utf8').includes(contents),
+	);
+}
+
 async function startBrowserProbeOrigin(): Promise<{ server: Server; origin: string }> {
 	const server = createHttpServer((_request, response) => {
 		response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -289,6 +296,46 @@ describe('production SSR build', { timeout: 30_000 }, () => {
 				expect(bodyRegionOf(html)).not.toContain('<title>');
 				expect(bodyRegionOf(html)).not.toContain('fixture page description');
 			}
+		}
+	});
+
+	it('styles layout-owned deferred content before its JavaScript loads', async () => {
+		const { handler } = await import(pathToFileURL(path.join(distDir, 'server/entry.js')).href);
+		const clientRoot = path.join(distDir, 'client');
+		const stylesheet = findBuiltAsset(clientRoot, '.css', '.vite-layout-deferred-hydration-proof');
+		const javascript = findBuiltAsset(
+			clientRoot,
+			'.js',
+			'vite-layout-deferred-hydration-chunk-proof',
+		);
+		expect(stylesheet).toBeTruthy();
+		expect(javascript).toBeTruthy();
+
+		const response = await handler(new Request('http://localhost/layout-assets'));
+		const html = await response.text();
+		expect(response.status).toBe(200);
+		expect(html).toContain('vite-layout-deferred-hydration-chunk-proof: 0');
+		expect(html).toContain(`<link rel="stylesheet" href="/${stylesheet}">`);
+		expect(html).not.toContain(`src="/${javascript}"`);
+		expect(html).not.toContain(`<link rel="modulepreload" href="/${javascript}">`);
+
+		const { chromium } = await import('playwright');
+		const browser = await chromium.launch({ headless: true });
+		try {
+			const context = await browser.newContext({ javaScriptEnabled: false });
+			const page = await context.newPage();
+			const requests: string[] = [];
+			page.on('request', (request) => requests.push(new URL(request.url()).pathname));
+			await page.goto(productionOrigin + '/layout-assets', { waitUntil: 'load' });
+			expect(
+				await page
+					.locator('.vite-layout-deferred-hydration-proof')
+					.evaluate((element) => getComputedStyle(element).color),
+			).toBe('rgb(0, 128, 128)');
+			expect(requests).not.toContain('/' + javascript);
+			await context.close();
+		} finally {
+			await browser.close();
 		}
 	});
 
@@ -573,6 +620,9 @@ describe('production SSR build', { timeout: 30_000 }, () => {
 		expect(response.status).toBe(200);
 		const prodHtml = await response.text();
 		expect(prodHtml).toContain('Fixture failed: Error: fixture root boundary');
+		const stylesheet = findBuiltAsset(path.join(distDir, 'client'), '.css', '.root-catch');
+		expect(stylesheet).toBeTruthy();
+		expect(prodHtml).toContain(`<link rel="stylesheet" href="/${stylesheet}">`);
 
 		const devResponse = await fetch(devOrigin + '/pages/error');
 		expect(devResponse.status).toBe(200);
@@ -633,6 +683,9 @@ describe('production SSR build', { timeout: 30_000 }, () => {
 		const html = await response.text();
 		expect(html).toContain('Loading fixture…');
 		expect(html).toContain('Fixture page pending');
+		const stylesheet = findBuiltAsset(path.join(distDir, 'client'), '.css', '.root-pending');
+		expect(stylesheet).toBeTruthy();
+		expect(html).toContain(`<link rel="stylesheet" href="/${stylesheet}">`);
 	});
 
 	it('bundles module-server exports and executes them through production RPC', async () => {


### PR DESCRIPTION
## Summary

- Preserve server-rendered descriptor components when a deferred `Hydrate` activation suspends and resumes.
- Include stylesheets from the matched page, layout, and configured root fallbacks before hydration, without preloading their deferred JavaScript.
- Record a staged design for immutable static shells and independently hydrated islands.

## Why

Hydrate's internal try range already owns the adopted server DOM, but descriptor-only children could leave the root cleanup cursor inside that range. Finishing activation then removed a live input or reported a false hydration mismatch. Separately, production asset hints read only the page's asset record, so layout-owned islands and root fallbacks could render without their CSS.

## Changes

- Claim the existing Hydrate-owned range remainder only after activation completes and render-phase updates drain. The first template-owned claim remains authoritative; no new persistent state or steady-render path is added.
- Merge and deduplicate CSS from at most four composed-route asset records, preserving page-first order and the existing page-only JavaScript preload.
- Add public descriptor lifecycle regressions, buffered/streaming handler coverage, Vite/Rsbuild integration fixtures, and patch changesets for `octane` and `@octanejs/app-core`.
- Update deferred-hydration documentation and describe the compiler, SSR manifest, ownership, serialization, and bundler work needed for static-shell elimination.

## Validation

- [x] Runtime regressions: the original baseline had 6 failures / 6 passes. The review regression fails exactly 2 suspended-tail cases on the previous PR head; the final candidate passes all 16 tests in each of development and production. Tests use the actual client/server runtime and an isolated Vitest config, without a substitute compiler.
- [x] Asset regression: baseline 10 failures / 2 passes; candidate 12 new tests plus 16 existing handler tests pass.
- [x] Parser-free production bundle comparison against the previous PR head: five capture/mount/update/hydrate-root entries are byte-identical; the Hydrate-enabled entry changes by +2 raw / +1 gzip / +28 Brotli bytes. All six paired semantic controls pass; this is a size/scope check, not a throughput claim.
- [x] Focused `runtime.ts` dependency-graph typecheck with the installed TypeScript native preview.
- [x] Scoped formatting with installed Prettier 3.9.6 / TSRX Prettier plugin 0.3.118, `node scripts/check-changesets.js`, and `git diff --check`.
- [x] `pnpm sync` completed offline with automatic dependency installation disabled and already-installed tooling; no generated diff.
- [ ] Repository-wide `pnpm format:check`, `pnpm typecheck`, and `pnpm test`.
- [ ] Native compiler-dependent Vite/Rsbuild/Chromium integration tests. The configured registry does not provide the required `@tsrx/core@0.1.58` and `oxc-tsrx@0.5.0`; no registry override or substitute-parser result is being used as evidence.

## Risk / follow-ups

The runtime change is confined to initial adoption of preserved Hydrate DOM. Review also reproduced a pre-existing compiled-fragment mismatch-recovery bug on the base commit: abandoning a framed fragment can remove an insertion anchor and throw `NotFoundError`. That separate range/seed-ownership repair is recorded in `docs/hydration-islands-plan.md`; this PR does not claim to fix it. CSS merging adds bounded per-request manifest work; no throughput improvement is claimed. Full compiler-mode and browser integration still need to run before readiness.

The selected-route-export optimization is deliberately **not** included. Its synthetic Vite/Rspack builds removed a large unused export graph, but adversarial tests exposed changed live-binding selection and bootstrap ordering. A broader stale-activation retry was also discarded after it consumed another component's SSR `use()` seed. The design document records both constraints and the next proof/acceptance steps. Static-shell elimination remains proposed, not shipped.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789823263&installation_model_id=432790&pr_number=805&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F805&signature=50d1d488dbde2ae61630eb3a270b1d7ec3a439c04e5f89a30f2043dc891740ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7f319fada9f171bde928d6ba7c9d708350a9094a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->