### PR TITLE
fix(rspack): resolve Octane runtimes with ESM conditions

### DIFF
--- a/.changeset/rspack-esm-runtime-resolution.md
+++ b/.changeset/rspack-esm-runtime-resolution.md
@@ -1,0 +1,8 @@
+---
+'@octanejs/rspack-plugin': patch
+---
+
+Resolve Octane runtime aliases with Rspack's ESM conditions and keep compiler
+helpers, server rendering, and profiling on the application's selected Octane
+package. This fixes callback-ref and linked-package context regressions and
+prevents the CommonJS runtime graph from being retained in browser bundles.

--- a/packages/rspack-plugin-octane/src/plugin.js
+++ b/packages/rspack-plugin-octane/src/plugin.js
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
-import { realpathSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
 	CLIENT_REFERENCE_MANIFEST_FILENAME,
@@ -23,6 +23,12 @@ const parallelLoaderPath = fileURLToPath(new URL('./parallel-loader.js', import.
 const DEFAULT_MAX_WORKERS = 4;
 const OCTANE_RULE = /\.(?:tsrx|tsx|ts|js)$/i;
 const TYPESCRIPT_RULE = /\.(?:tsrx|tsx|ts)$/i;
+const RUNTIME_SUBPATHS = [
+	'octane/server',
+	'octane/internal/client',
+	'octane/internal/server',
+	'octane/profiling',
+];
 
 function realRoot(path) {
 	try {
@@ -40,10 +46,10 @@ function addUniqueExtensions(resolveOptions) {
 	];
 }
 
-function resolveRuntimeModule(request, root) {
+function resolveRuntimeModule(resolver, request, root) {
 	if (isAbsolute(request)) return request;
 	try {
-		return createRequire(join(root, 'package.json')).resolve(request);
+		return resolver.resolveSync({}, root, request);
 	} catch {
 		// Let Rspack produce its normal resolution diagnostic. This fallback also
 		// keeps config inspection usable before peer dependencies are installed.
@@ -51,16 +57,80 @@ function resolveRuntimeModule(request, root) {
 	}
 }
 
-function addRuntimeAlias(resolveOptions, request, root) {
-	const aliases = resolveOptions.alias === false ? {} : (resolveOptions.alias ?? {});
-	resolveOptions.alias = {
-		...aliases,
-		octane$: resolveRuntimeModule(request, root),
-		// Compiler-emitted metadata imports this public subpath directly. Pin it
-		// alongside the runtime entry so raw/linked packages with their own nested
-		// Octane copy cannot split metadata registration from runtime recording.
-		'octane/profiling$': resolveRuntimeModule('octane/profiling', root),
+function octanePackageRoot(entry) {
+	if (typeof entry !== 'string' || !isAbsolute(entry)) return undefined;
+	let directory = dirname(entry);
+	while (true) {
+		try {
+			const { name } = JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'));
+			if (name === 'octane') return directory;
+			if (name !== undefined) return undefined;
+		} catch {
+			// Entry files may be several directories below their package manifest.
+		}
+		const parent = dirname(directory);
+		if (parent === directory) return undefined;
+		directory = parent;
+	}
+}
+
+function mergeRuntimeAliases(aliases, additions) {
+	return {
+		...additions,
+		...(aliases === false ? {} : aliases),
+		octane$: additions.octane$,
 	};
+}
+
+function addRuntimeAliases(compiler, request, root, explicitRuntime) {
+	const resolveOptions = compiler.options.resolve;
+	// The factory is created before Rspack applies mode/target defaults. Merge
+	// the finalized ESM options (including `...`) before resolving; require
+	// conditions would select Octane's separate, non-tree-shakeable CJS graph.
+	const { byDependency, ...base } = resolveOptions;
+	const esm = compiler.webpack.util.cleverMerge(base, byDependency?.esm ?? {});
+	const resolver = compiler.resolverFactory.get('normal', { ...esm, dependencyType: 'esm' });
+	const packageResolver = compiler.resolverFactory.get('normal', {
+		...esm,
+		alias: false,
+		dependencyType: 'esm',
+	});
+	const selected = resolveRuntimeModule(resolver, 'octane', root);
+	const override = explicitRuntime ? resolveRuntimeModule(resolver, request, root) : undefined;
+	const packageRoot = octanePackageRoot(override) ?? octanePackageRoot(selected) ?? root;
+	const aliases = esm.alias === false ? {} : (esm.alias ?? {});
+	const additions = {};
+	for (const subpath of RUNTIME_SUBPATHS) {
+		// Resolve package self-references without a broad `octane` alias. Linked
+		// packages must share the selected runtime's refs, context, and profiler.
+		// A consumer's explicit subpath override remains authoritative.
+		additions[`${subpath}$`] =
+			aliases[`${subpath}$`] ??
+			aliases[subpath] ??
+			resolveRuntimeModule(packageResolver, subpath, packageRoot);
+	}
+	const runtime = explicitRuntime
+		? override
+		: request === 'octane' || selected === false
+			? selected
+			: (additions[`${request}$`] ?? resolveRuntimeModule(resolver, request, root));
+	additions.octane$ = runtime;
+	// Exact entries precede any existing prefix alias; unrelated Octane subpaths
+	// (including universal renderer entries) keep their normal resolution.
+	resolveOptions.alias = mergeRuntimeAliases(resolveOptions.alias, additions);
+	if (byDependency?.esm?.alias !== undefined && byDependency.esm.alias !== false) {
+		// Rspack applies this map again during module resolution. A package
+		// selection here must not restore its client entry in a server graph.
+		// Preserve `false`: it explicitly disables all aliases for ESM requests.
+		resolveOptions.byDependency = {
+			...byDependency,
+			esm: {
+				...byDependency.esm,
+				alias: mergeRuntimeAliases(byDependency.esm.alias, additions),
+			},
+		};
+	}
+	return resolver;
 }
 
 function projectRendererModule(request, root) {
@@ -309,7 +379,6 @@ export class OctaneRspackPlugin {
 
 		compiler.options.resolve ??= {};
 		addUniqueExtensions(compiler.options.resolve);
-		addRuntimeAlias(compiler.options.resolve, runtimeRequest, root);
 		addProjectRendererAliases(compiler.options.resolve, this.options.renderers, root);
 		for (const specialization of Object.values(this.options.layerSpecializations ?? {})) {
 			addProjectRendererAliases(compiler.options.resolve, specialization.renderers, root);
@@ -364,17 +433,27 @@ export class OctaneRspackPlugin {
 				use: [{ loader: 'builtin:swc-loader', options: { detectSyntax: 'auto' } }],
 			});
 		}
+		const layerRuntimeAliases = [];
 		for (const [layer, specialization] of Object.entries(this.options.layerSpecializations ?? {})) {
 			if (specialization.runtime === undefined) continue;
+			const alias = { octane$: specialization.runtime };
+			layerRuntimeAliases.push([alias, specialization.runtime]);
 			compiler.options.module.rules.push({
 				issuerLayer: layer,
-				resolve: {
-					alias: {
-						octane$: resolveRuntimeModule(specialization.runtime, root),
-					},
-				},
+				resolve: { alias },
 			});
 		}
+		compiler.hooks.afterResolvers.tap(PLUGIN_NAME, () => {
+			const resolver = addRuntimeAliases(
+				compiler,
+				runtimeRequest,
+				root,
+				this.options.runtime !== undefined,
+			);
+			for (const [alias, request] of layerRuntimeAliases) {
+				alias.octane$ = resolveRuntimeModule(resolver, request, root);
+			}
+		});
 
 		let discovery;
 		const discover = () => {

--- a/packages/rspack-plugin-octane/tests/_fixtures/published-refs.tsrx
+++ b/packages/rspack-plugin-octane/tests/_fixtures/published-refs.tsrx
@@ -1,0 +1,25 @@
+import { createRoot } from 'octane';
+
+export function RefComponent(props: { callback: (node: HTMLDivElement | null) => void }) @{
+	<div ref={props.callback}>ready</div>
+}
+
+export async function run(container: HTMLElement, Component = RefComponent) {
+	const calls: string[] = [];
+	const first = (node: HTMLDivElement | null) => {
+		calls.push(node === null ? 'first:detach' : 'first:attach');
+	};
+	const second = (node: HTMLDivElement | null) => {
+		calls.push(node === null ? 'second:detach' : 'second:attach');
+	};
+	const root = createRoot(container);
+	root.render(Component, { callback: first });
+	await Promise.resolve();
+	const element = container.firstElementChild;
+	root.render(Component, { callback: second });
+	await Promise.resolve();
+	const sameElement = container.firstElementChild === element;
+	const text = container.textContent;
+	root.unmount();
+	return { calls, sameElement, text, cleaned: container.childNodes.length === 0 };
+}

--- a/packages/rspack-plugin-octane/tests/_fixtures/published-server.tsrx
+++ b/packages/rspack-plugin-octane/tests/_fixtures/published-server.tsrx
@@ -1,0 +1,20 @@
+import { createContext, useContext, type Context } from 'octane';
+import { renderToStaticMarkup } from 'octane/server';
+
+const MessageContext = createContext('unprovided');
+
+export function ServerMessage(props: { context: Context<string> }) @{
+	const message = useContext(props.context);
+	<span>{message as string}</span>
+}
+
+function ServerApp(props: { component: typeof ServerMessage }) @{
+	const Message = props.component;
+	<MessageContext.Provider value="provided">
+		<Message context={MessageContext} />
+	</MessageContext.Provider>
+}
+
+export function run(component = ServerMessage) {
+	return renderToStaticMarkup(ServerApp, { component });
+}

--- a/packages/rspack-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspack-plugin-octane/tests/plugin.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolve } from 'node:path';
+import { util } from '@rspack/core';
 
 const mocks = vi.hoisted(() => ({
 	createOctaneCompiler: vi.fn(),
@@ -37,12 +38,23 @@ function createCompiler(target: unknown = 'node') {
 			module: { rules: [] as any[] },
 		},
 		hooks: {
+			afterResolvers: hook(),
 			invalid: hook(),
 			watchRun: hook(),
 			thisCompilation: hook(),
 		},
-		webpack: { DefinePlugin },
+		resolverFactory: {
+			get: vi.fn(() => ({
+				resolveSync: (_context: object, _root: string, request: string) => request,
+			})),
+		},
+		webpack: { DefinePlugin, util },
 	};
+}
+
+function applyPlugin(plugin: OctaneRspackPlugin, compiler: ReturnType<typeof createCompiler>) {
+	plugin.apply(compiler as any);
+	compiler.hooks.afterResolvers.call(compiler);
 }
 
 describe('OctaneRspackPlugin', () => {
@@ -68,7 +80,7 @@ describe('OctaneRspackPlugin', () => {
 	it('configures server compilation, runtime resolution, rules, and discovery watching', () => {
 		const compiler = createCompiler();
 		const plugin = new OctaneRspackPlugin();
-		plugin.apply(compiler as any);
+		applyPlugin(plugin, compiler);
 
 		expect(mocks.createOctaneCompiler).toHaveBeenCalledWith(
 			expect.objectContaining({ root: '/project' }),
@@ -124,7 +136,7 @@ describe('OctaneRspackPlugin', () => {
 		['a custom worker limit', { maxWorkers: 2 }, 2],
 	] as const)('compiles modules in parallel with %s', (_label, parallel, maxWorkers) => {
 		const compiler = createCompiler('web');
-		new OctaneRspackPlugin(parallel === undefined ? {} : { parallel }).apply(compiler as any);
+		applyPlugin(new OctaneRspackPlugin(parallel === undefined ? {} : { parallel }), compiler);
 
 		const use = compiler.options.module.rules[0].use;
 		expect(use).toHaveLength(2);
@@ -140,7 +152,7 @@ describe('OctaneRspackPlugin', () => {
 
 	it('retains the standalone loader pipeline when parallel compilation is disabled', () => {
 		const compiler = createCompiler('web');
-		new OctaneRspackPlugin({ parallel: false }).apply(compiler as any);
+		applyPlugin(new OctaneRspackPlugin({ parallel: false }), compiler);
 
 		expect(compiler.options.module.rules[0].use).toEqual([
 			{
@@ -178,7 +190,7 @@ describe('OctaneRspackPlugin', () => {
 			},
 			transpile: false,
 		});
-		plugin.apply(compiler as any);
+		applyPlugin(plugin, compiler);
 
 		expect(mocks.resolveRuntimeRequest).not.toHaveBeenCalled();
 		const aliases = compiler.options.resolve.alias as Record<string, string>;
@@ -229,7 +241,7 @@ describe('OctaneRspackPlugin', () => {
 
 	it.each([true, false])('forwards strong: %s to discovery and module compilation', (strong) => {
 		const compiler = createCompiler('web');
-		new OctaneRspackPlugin({ strong }).apply(compiler as any);
+		applyPlugin(new OctaneRspackPlugin({ strong }), compiler);
 
 		expect(mocks.createOctaneCompiler).toHaveBeenCalledWith(
 			expect.objectContaining({ root: '/project', strong }),
@@ -258,7 +270,7 @@ describe('OctaneRspackPlugin', () => {
 			},
 			transpile: false,
 		});
-		plugin.apply(compiler as any);
+		applyPlugin(plugin, compiler);
 
 		expect(mocks.createOctaneCompiler).toHaveBeenCalledTimes(2);
 		expect(mocks.createOctaneCompiler).toHaveBeenNthCalledWith(
@@ -331,7 +343,7 @@ describe('OctaneRspackPlugin', () => {
 				},
 			},
 		});
-		plugin.apply(compiler as any);
+		applyPlugin(plugin, compiler);
 
 		const compilation = { fileDependencies: new Set(), missingDependencies: new Set() };
 		compiler.hooks.thisCompilation.call(compilation);
@@ -366,46 +378,64 @@ describe('OctaneRspackPlugin', () => {
 		const layeredBackground = createCachedCompiler();
 		const layeredMain = createCachedCompiler();
 
-		new OctaneRspackPlugin().apply(dom as any);
-		new OctaneRspackPlugin({
-			renderers: {
-				registry: { object: '/src/object-renderer.js' },
-				default: 'object',
-			},
-		}).apply(object as any);
-		new OctaneRspackPlugin({
-			renderers: {
-				registry: { object: '/src/object-renderer.js' },
-				default: 'object',
-				boundaries: {
-					'/src/object-boundaries.js': {
-						Canvas: {
-							ownerRenderer: 'dom',
-							childRenderer: 'object',
-							prop: 'children',
+		applyPlugin(new OctaneRspackPlugin(), dom);
+		applyPlugin(
+			new OctaneRspackPlugin({
+				renderers: {
+					registry: { object: '/src/object-renderer.js' },
+					default: 'object',
+				},
+			}),
+			object,
+		);
+		applyPlugin(
+			new OctaneRspackPlugin({
+				renderers: {
+					registry: { object: '/src/object-renderer.js' },
+					default: 'object',
+					boundaries: {
+						'/src/object-boundaries.js': {
+							Canvas: {
+								ownerRenderer: 'dom',
+								childRenderer: 'object',
+								prop: 'children',
+							},
 						},
 					},
 				},
-			},
-		}).apply(boundedObject as any);
-		new OctaneRspackPlugin({
-			runtime: '@octanejs/lynx/renderer',
-			universalRuntime: { runtime: 'lynx', thread: 'background' },
-		}).apply(nativeBackground as any);
-		new OctaneRspackPlugin({
-			runtime: '@octanejs/lynx/renderer',
-			universalRuntime: { runtime: 'lynx', thread: 'main-thread' },
-		}).apply(nativeMain as any);
-		new OctaneRspackPlugin({
-			layerSpecializations: {
-				main: { universalRuntime: { runtime: 'lynx', thread: 'background' } },
-			},
-		}).apply(layeredBackground as any);
-		new OctaneRspackPlugin({
-			layerSpecializations: {
-				main: { universalRuntime: { runtime: 'lynx', thread: 'main-thread' } },
-			},
-		}).apply(layeredMain as any);
+			}),
+			boundedObject,
+		);
+		applyPlugin(
+			new OctaneRspackPlugin({
+				runtime: '@octanejs/lynx/renderer',
+				universalRuntime: { runtime: 'lynx', thread: 'background' },
+			}),
+			nativeBackground,
+		);
+		applyPlugin(
+			new OctaneRspackPlugin({
+				runtime: '@octanejs/lynx/renderer',
+				universalRuntime: { runtime: 'lynx', thread: 'main-thread' },
+			}),
+			nativeMain,
+		);
+		applyPlugin(
+			new OctaneRspackPlugin({
+				layerSpecializations: {
+					main: { universalRuntime: { runtime: 'lynx', thread: 'background' } },
+				},
+			}),
+			layeredBackground,
+		);
+		applyPlugin(
+			new OctaneRspackPlugin({
+				layerSpecializations: {
+					main: { universalRuntime: { runtime: 'lynx', thread: 'main-thread' } },
+				},
+			}),
+			layeredMain,
+		);
 
 		expect((dom.options as any).cache.version).toMatch(/^user-cache\|octane-rspack@/);
 		expect((object.options as any).cache.version).toMatch(/^user-cache\|octane-rspack@/);
@@ -424,14 +454,14 @@ describe('OctaneRspackPlugin', () => {
 		// requireDirective flips which modules compile vs pass through, so a
 		// toggle must never reuse cached transform results.
 		const directive = createCachedCompiler();
-		new OctaneRspackPlugin({ requireDirective: true }).apply(directive as any);
+		applyPlugin(new OctaneRspackPlugin({ requireDirective: true }), directive);
 		expect((directive.options as any).cache.version).toMatch(/^user-cache\|octane-rspack@/);
 		expect((directive.options as any).cache.version).not.toBe((dom.options as any).cache.version);
 
 		const strong = createCachedCompiler();
 		const explicitCompatibility = createCachedCompiler();
-		new OctaneRspackPlugin({ strong: true }).apply(strong as any);
-		new OctaneRspackPlugin({ strong: false }).apply(explicitCompatibility as any);
+		applyPlugin(new OctaneRspackPlugin({ strong: true }), strong);
+		applyPlugin(new OctaneRspackPlugin({ strong: false }), explicitCompatibility);
 		expect((strong.options as any).cache.version).not.toBe((dom.options as any).cache.version);
 		expect((explicitCompatibility.options as any).cache.version).toBe(
 			(dom.options as any).cache.version,
@@ -440,7 +470,7 @@ describe('OctaneRspackPlugin', () => {
 
 	it('resolves a relative root from the Rspack context', () => {
 		const compiler = createCompiler('web');
-		new OctaneRspackPlugin({ root: 'apps/site' }).apply(compiler as any);
+		applyPlugin(new OctaneRspackPlugin({ root: 'apps/site' }), compiler);
 		expect(mocks.createOctaneCompiler).toHaveBeenCalledWith(
 			expect.objectContaining({ root: '/project/apps/site' }),
 		);

--- a/packages/rspack-plugin-octane/tests/published-package.test.ts
+++ b/packages/rspack-plugin-octane/tests/published-package.test.ts
@@ -1,0 +1,378 @@
+import {
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { constants as zlib, gzipSync } from 'node:zlib';
+import rspack from '@rspack/core';
+import { build } from 'esbuild';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { verifyScenario } from '../../../benchmarks/bundle-size/verify-reachability.mjs';
+import { buildPackageCommonjs } from '../../../scripts/build-package-commonjs.mjs';
+import { OctaneRspackPlugin } from '../src/index.js';
+
+const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+const octaneSourcePackage = join(repositoryRoot, 'packages/octane');
+const fixtures = fileURLToPath(new URL('./_fixtures/', import.meta.url));
+const packageRequire = createRequire(import.meta.url);
+const { JSDOM } = packageRequire('jsdom') as {
+	JSDOM: new (
+		markup: string,
+		options: { runScripts: 'outside-only'; pretendToBeVisual: boolean },
+	) => {
+		window: Window & {
+			eval(source: string): unknown;
+			close(): void;
+			__OCTANE_REACHABILITY__?: { run(container: HTMLElement): Promise<unknown> };
+		};
+	};
+};
+
+function write(root: string, relativePath: string, content: string) {
+	const file = join(root, relativePath);
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, content);
+	return file;
+}
+
+/** Build the real per-module runtime with the package's actual published exports. */
+async function installPublishedOctane(packageDirectory: string) {
+	const manifest = JSON.parse(readFileSync(join(octaneSourcePackage, 'package.json'), 'utf8'));
+	const sourceDirectory = join(packageDirectory, 'src');
+	const distDirectory = join(packageDirectory, 'dist');
+	cpSync(join(octaneSourcePackage, 'src'), sourceDirectory, { recursive: true });
+	write(
+		packageDirectory,
+		'package.json',
+		JSON.stringify({ ...manifest, ...manifest.publishConfig, publishConfig: undefined }) + '\n',
+	);
+	// Runtime dependencies remain real workspace-installed packages; the Octane
+	// package itself has no source entry or ambient workspace alias to fall back to.
+	symlinkSync(
+		join(octaneSourcePackage, 'node_modules'),
+		join(packageDirectory, 'node_modules'),
+		'dir',
+	);
+	const entryPoints = readdirSync(sourceDirectory, { recursive: true, encoding: 'utf8' })
+		.filter(
+			(file) =>
+				(file.endsWith('.ts') || file.endsWith('.js')) &&
+				!file.endsWith('.d.ts') &&
+				!file.startsWith(`compiler${sep}`),
+		)
+		.map((file) => join(sourceDirectory, file));
+	await build({
+		entryPoints,
+		outdir: distDirectory,
+		outbase: sourceDirectory,
+		format: 'esm',
+		platform: 'neutral',
+		target: 'esnext',
+		bundle: false,
+		logLevel: 'silent',
+	});
+	await buildPackageCommonjs({
+		packageDir: packageDirectory,
+		entries: ['src/index.ts', 'src/server/index.ts'],
+		outdir: 'dist/cjs',
+		sourceRoot: 'src',
+	});
+	cpSync(join(sourceDirectory, 'compiler'), join(distDirectory, 'compiler'), { recursive: true });
+	rmSync(sourceDirectory, { recursive: true, force: true });
+}
+
+function copyPublishedOctane(source: string, destination: string) {
+	cpSync(join(source, 'dist'), join(destination, 'dist'), { recursive: true });
+	cpSync(join(source, 'package.json'), join(destination, 'package.json'));
+	symlinkSync(join(octaneSourcePackage, 'node_modules'), join(destination, 'node_modules'), 'dir');
+}
+
+async function compile(config: Record<string, unknown>) {
+	const compiler = rspack(config as any) as any;
+	return new Promise<any>((resolve, reject) => {
+		compiler.run((error: Error | null, stats: any) => {
+			compiler.close((closeError: Error | null) => {
+				if (error || closeError) {
+					reject(error ?? closeError);
+					return;
+				}
+				if (!stats || stats.hasErrors()) {
+					const errors = stats?.toJson({ all: false, errors: true }).errors ?? [];
+					reject(
+						new Error(
+							errors.map((entry: any) => entry.message ?? String(entry)).join('\n') ||
+								'Rspack completed without stats.',
+						),
+					);
+					return;
+				}
+				resolve(stats);
+			});
+		});
+	});
+}
+
+interface ChunkModule {
+	nameForCondition?: string;
+	modules?: ChunkModule[];
+	children?: ChunkModule[];
+}
+
+/** Inspect emitted chunks, not modules that Rspack merely parsed and discarded. */
+function retainedModules(stats: any): string[] {
+	const retained = new Set<string>();
+	const visit = (modules: ChunkModule[]) => {
+		for (const module of modules) {
+			if (module.nameForCondition) retained.add(module.nameForCondition.split(sep).join('/'));
+			visit(module.modules ?? []);
+			visit(module.children ?? []);
+		}
+	};
+	const output = stats.toJson({
+		all: false,
+		chunks: true,
+		chunkModules: true,
+		dependentModules: true,
+		nestedModules: true,
+		orphanModules: true,
+		cachedModules: true,
+		chunkModulesSpace: 10_000,
+		nestedModulesSpace: 10_000,
+		groupModulesByAttributes: false,
+		groupModulesByCacheStatus: false,
+		groupModulesByExtension: false,
+		groupModulesByLayer: false,
+		groupModulesByPath: false,
+		groupModulesByType: false,
+	});
+	for (const chunk of output.chunks ?? []) visit(chunk.modules ?? []);
+	return [...retained].sort();
+}
+
+async function runRefs(code: string) {
+	const browser = new JSDOM('<!doctype html><div id="root"></div>', {
+		runScripts: 'outside-only',
+		pretendToBeVisual: true,
+	});
+	try {
+		browser.window.eval(code);
+		const scenario = browser.window.__OCTANE_REACHABILITY__;
+		expect(scenario?.run).toBeTypeOf('function');
+		const container = browser.window.document.getElementById('root')!;
+		const result = await scenario!.run(container);
+		// The bundle executes in a fresh browser realm; compare public JSON values.
+		return JSON.parse(JSON.stringify(result));
+	} finally {
+		browser.window.close();
+	}
+}
+
+const expectedRefs = {
+	calls: ['first:attach', 'first:detach', 'second:attach', 'second:detach'],
+	sameElement: true,
+	text: 'ready',
+	cleaned: true,
+};
+
+describe('published Octane package in Rspack', () => {
+	let scratch: string;
+	let root: string;
+	let installedOctane: string;
+	let nestedOctane: string;
+
+	beforeAll(async () => {
+		scratch = realpathSync(mkdtempSync(join(tmpdir(), 'octane-rspack-published-')));
+		root = join(scratch, 'app');
+		installedOctane = join(root, 'node_modules/octane');
+		await installPublishedOctane(installedOctane);
+		write(
+			root,
+			'package.json',
+			JSON.stringify({
+				name: 'published-rspack-consumer',
+				private: true,
+				type: 'module',
+				dependencies: { octane: '*', '@fixture/linked-refs': '*' },
+			}) + '\n',
+		);
+		const refSource = readFileSync(join(fixtures, 'published-refs.tsrx'), 'utf8');
+		const serverSource = readFileSync(join(fixtures, 'published-server.tsrx'), 'utf8');
+		write(root, 'src/Refs.tsrx', refSource);
+		write(root, 'src/Server.tsrx', serverSource);
+		write(root, 'src/refs.js', "export { run } from './Refs.tsrx';\n");
+		write(
+			root,
+			'src/static.tsrx',
+			readFileSync(
+				join(repositoryRoot, 'benchmarks/bundle-size/fixtures/minimal/root-static.tsrx'),
+				'utf8',
+			),
+		);
+		const linkedRoot = join(scratch, 'linked-refs');
+		write(
+			linkedRoot,
+			'package.json',
+			JSON.stringify({
+				name: '@fixture/linked-refs',
+				type: 'module',
+				exports: { '.': './Refs.tsrx', './server': './Server.tsrx' },
+				dependencies: { octane: '*' },
+			}) + '\n',
+		);
+		write(linkedRoot, 'Refs.tsrx', refSource);
+		write(linkedRoot, 'Server.tsrx', serverSource);
+		nestedOctane = join(linkedRoot, 'node_modules/octane');
+		copyPublishedOctane(installedOctane, nestedOctane);
+		mkdirSync(join(root, 'node_modules/@fixture'), { recursive: true });
+		symlinkSync(linkedRoot, join(root, 'node_modules/@fixture/linked-refs'), 'dir');
+		write(
+			root,
+			'src/linked.js',
+			`import { RefComponent } from '@fixture/linked-refs';
+import { run as runWithComponent } from './Refs.tsrx';
+export const run = (container) => runWithComponent(container, RefComponent);
+`,
+		);
+		write(
+			root,
+			'src/server.js',
+			`import { ServerMessage } from '@fixture/linked-refs/server';
+import { run as renderWithComponent } from './Server.tsrx';
+export const run = () => renderWithComponent(ServerMessage);
+`,
+		);
+		write(
+			root,
+			'src/profiled.js',
+			`import { profiler } from 'octane/profiling';
+import { run as runLinked } from './linked.js';
+export async function run(container) {
+	profiler.start();
+	try {
+		const result = await runLinked(container);
+		return { ...result, profiled: profiler.getEvents().some((event) => event.component === 'RefComponent') };
+	} finally {
+		profiler.stop();
+	}
+}
+`,
+		);
+	}, 60_000);
+
+	afterAll(async () => {
+		if (scratch)
+			await rm(scratch, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+	});
+
+	async function buildProduction(
+		entry: string,
+		name: string,
+		options: { runtime?: string; profile?: boolean } = {},
+		target: 'web' | 'node' = 'web',
+	) {
+		const outputPath = join(root, `dist-${name}`);
+		const filename = target === 'node' ? 'bundle.cjs' : 'bundle.js';
+		const stats = await compile({
+			context: root,
+			mode: 'production',
+			target,
+			entry: `./src/${entry}`,
+			devtool: false,
+			optimization: { minimize: true, splitChunks: false, runtimeChunk: false },
+			output: {
+				path: outputPath,
+				filename,
+				library:
+					target === 'node'
+						? { type: 'commonjs2' }
+						: { name: '__OCTANE_REACHABILITY__', type: 'var' },
+			},
+			plugins: [new OctaneRspackPlugin({ parallel: false, ...options })],
+		});
+		const file = join(outputPath, filename);
+		const code = readFileSync(file, 'utf8');
+		return {
+			code,
+			file,
+			modules: retainedModules(stats),
+			sizes: {
+				raw: Buffer.byteLength(code),
+				gzip: gzipSync(code, { level: zlib.Z_BEST_COMPRESSION }).length,
+			},
+		};
+	}
+
+	it('preserves changing callback refs through ordinary public imports', async () => {
+		const explicit = await buildProduction('refs.js', 'refs-explicit', {
+			runtime: join(installedOctane, 'dist/index.js'),
+		});
+		expect(await runRefs(explicit.code)).toEqual(expectedRefs);
+
+		const automatic = await buildProduction('refs.js', 'refs-automatic');
+		expect(await runRefs(automatic.code)).toEqual(expectedRefs);
+	}, 60_000);
+
+	it('keeps the CommonJS distribution out of an ESM production application', async () => {
+		// The package really has distinct conditional exports; source-only workspace
+		// packages resolve the same file for import and require and miss this case.
+		const requireEntry = createRequire(join(root, 'package.json')).resolve('octane');
+		expect(requireEntry).toBe(join(installedOctane, 'dist/cjs/index.cjs'));
+		const explicit = await buildProduction('static.tsrx', 'static-explicit', {
+			runtime: join(installedOctane, 'dist/index.js'),
+		});
+		const commonjs = await buildProduction('static.tsrx', 'static-commonjs', {
+			runtime: requireEntry,
+		});
+		const automatic = await buildProduction('static.tsrx', 'static-automatic');
+		await verifyScenario('root-static', explicit.code);
+		await verifyScenario('root-static', commonjs.code);
+		await verifyScenario('root-static', automatic.code);
+
+		const commonjsDirectory = `${installedOctane.split(sep).join('/')}/dist/cjs/`;
+		// A forced CommonJS build is a semantic negative control for the reachability
+		// observation, and verifies that an explicit absolute runtime remains respected.
+		expect(commonjs.modules.some((module) => module.startsWith(commonjsDirectory))).toBe(true);
+		expect(explicit.modules.filter((module) => module.startsWith(commonjsDirectory))).toEqual([]);
+		expect(
+			automatic.modules.filter((module) => module.startsWith(commonjsDirectory)),
+			`default ${JSON.stringify(automatic.sizes)}; explicit ESM ${JSON.stringify(explicit.sizes)}`,
+		).toEqual([]);
+	}, 60_000);
+
+	it('renders linked source components within the application server context', async () => {
+		const result = await buildProduction('server.js', 'server', { profile: true }, 'node');
+		const scenario = packageRequire(result.file) as { run(): { html: string; css: string } };
+		expect(scenario.run()).toEqual({ html: '<span>provided</span>', css: '' });
+		const nestedDirectory = `${nestedOctane.split(sep).join('/')}/`;
+		expect(result.modules.filter((module) => module.startsWith(nestedDirectory))).toEqual([]);
+	}, 60_000);
+
+	it.each([false, true])(
+		'shares the application runtime with linked source packages (profile=%s)',
+		async (profile) => {
+			const result = await buildProduction(
+				profile ? 'profiled.js' : 'linked.js',
+				`linked-${profile}`,
+				{ profile },
+			);
+			expect(await runRefs(result.code)).toEqual({
+				...expectedRefs,
+				...(profile ? { profiled: true } : {}),
+			});
+			const nestedDirectory = `${nestedOctane.split(sep).join('/')}/`;
+			expect(result.modules.filter((module) => module.startsWith(nestedDirectory))).toEqual([]);
+		},
+		60_000,
+	);
+});

--- a/packages/rspack-plugin-octane/tests/runtime-resolution.test.ts
+++ b/packages/rspack-plugin-octane/tests/runtime-resolution.test.ts
@@ -1,0 +1,497 @@
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import rspack, { type Compiler, type Configuration } from '@rspack/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { OctaneRspackPlugin } from '../src/index.js';
+import type { OctaneRspackPluginOptions } from '../types/index.js';
+
+const requireFixture = createRequire(import.meta.url);
+
+interface Identity {
+	origin: string;
+}
+
+interface RuntimeObservation {
+	runtime: Identity;
+	client: Identity;
+	server: Identity;
+	internalServer: Identity;
+	profiling: Identity;
+}
+
+interface ConditionalRuntime {
+	identity: Identity;
+	condition: string;
+}
+
+const observeRuntime = `
+import { identity as runtime } from 'octane';
+import { identity as client } from 'octane/internal/client';
+import { identity as server } from 'octane/server';
+import { identity as internalServer } from 'octane/internal/server';
+import { identity as profiling } from 'octane/profiling';
+export const observed = { runtime, client, server, internalServer, profiling };
+`;
+
+function write(root: string, relativePath: string, content: string) {
+	const filename = join(root, relativePath);
+	mkdirSync(dirname(filename), { recursive: true });
+	writeFileSync(filename, content);
+	return filename;
+}
+
+function writePackage(root: string, manifest: Record<string, unknown>) {
+	write(root, 'package.json', JSON.stringify(manifest) + '\n');
+}
+
+function installRuntime(
+	directory: string,
+	origin: string,
+	{ name = 'octane', conditional = false } = {},
+) {
+	const entry = (environment: 'client' | 'server') => ({
+		...(conditional
+			? {
+					'fixture-runtime': `./esm/${environment}-custom.mjs`,
+					browser: `./esm/${environment}-browser.mjs`,
+				}
+			: {}),
+		import: `./esm/${environment}.mjs`,
+		require: `./cjs/${environment}.cjs`,
+	});
+	writePackage(directory, {
+		name,
+		type: 'module',
+		main: './esm/client.mjs',
+		module: './esm/client.mjs',
+		exports: {
+			'.': entry('client'),
+			'./server': entry('server'),
+			'./internal/client': './esm/internal-client.mjs',
+			'./internal/server': './esm/internal-server.mjs',
+			'./profiling': './esm/profiling.mjs',
+			'./universal': './esm/universal.mjs',
+			'./compiler': './esm/compiler.mjs',
+		},
+	});
+	for (const environment of ['client', 'server'] as const) {
+		write(
+			directory,
+			`esm/${environment}.mjs`,
+			`export const identity = { origin: ${JSON.stringify(`${origin}:${environment}:import`)} };\nexport const condition = 'import';\n`,
+		);
+		write(
+			directory,
+			`cjs/${environment}.cjs`,
+			`exports.identity = { origin: ${JSON.stringify(`${origin}:${environment}:require`)} };\nexports.condition = 'require';\n`,
+		);
+		write(
+			directory,
+			`esm/internal-${environment}.mjs`,
+			`export { identity } from './${environment}.mjs';\n`,
+		);
+		if (conditional) {
+			for (const condition of ['browser', 'custom']) {
+				write(
+					directory,
+					`esm/${environment}-${condition}.mjs`,
+					`export { identity } from './${environment}.mjs';\nexport const condition = ${JSON.stringify(condition)};\n`,
+				);
+			}
+		}
+	}
+	write(directory, 'esm/profiling.mjs', "export { identity } from './client.mjs';\n");
+	for (const subpath of ['universal', 'compiler']) {
+		write(
+			directory,
+			`esm/${subpath}.mjs`,
+			`export const marker = ${JSON.stringify(`${origin}:${subpath}`)};\n`,
+		);
+	}
+	return directory;
+}
+
+async function compile(config: Configuration) {
+	const compiler = rspack(config);
+	await new Promise<void>((resolve, reject) => {
+		compiler.run((error, stats) => {
+			compiler.close((closeError) => {
+				if (error || closeError) {
+					reject(error ?? closeError);
+					return;
+				}
+				if (!stats) {
+					reject(new Error('Rspack completed without stats.'));
+					return;
+				}
+				if (stats.hasErrors()) {
+					const errors = stats.toJson({ all: false, errors: true }).errors ?? [];
+					reject(new Error(errors.map((entry) => entry.message ?? String(entry)).join('\n')));
+					return;
+				}
+				resolve();
+			});
+		});
+	});
+}
+
+function load<T>(directory: string, entry = 'main'): T {
+	return requireFixture(join(directory, `${entry}.cjs`)) as T;
+}
+
+function expectRuntime(
+	observed: RuntimeObservation,
+	origin: string,
+	environment: 'client' | 'server',
+) {
+	expect(observed.client.origin).toBe(`${origin}:client:import`);
+	expect(observed.server.origin).toBe(`${origin}:server:import`);
+	expect(observed.internalServer).toBe(observed.server);
+	expect(observed.profiling).toBe(observed.client);
+	expect(observed.runtime).toBe(observed[environment]);
+}
+
+function expectSharedRuntime(
+	observed: RuntimeObservation,
+	application: RuntimeObservation,
+	origin: string,
+	environment: 'client' | 'server',
+) {
+	expectRuntime(observed, origin, environment);
+	expect(observed.client).toBe(application.client);
+	expect(observed.server).toBe(application.server);
+}
+
+describe('Rspack runtime package resolution', () => {
+	let sandbox: string;
+	let root: string;
+	let buildNumber: number;
+
+	beforeEach(() => {
+		sandbox = mkdtempSync(join(tmpdir(), 'octane-rspack-resolution-'));
+		root = join(sandbox, 'application');
+		buildNumber = 0;
+		writePackage(root, {
+			name: 'runtime-resolution-fixture',
+			private: true,
+			type: 'module',
+			dependencies: { octane: '*' },
+		});
+	});
+
+	afterEach(async () => {
+		await rm(sandbox, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+	});
+
+	async function build(
+		options: OctaneRspackPluginOptions | false = {},
+		config: Configuration = {},
+	) {
+		const directory = join(root, `dist-${++buildNumber}`);
+		const { output, plugins = [], ...rest } = config;
+		await compile({
+			context: root,
+			mode: 'production',
+			target: 'web',
+			entry: './entry.mjs',
+			devtool: false,
+			optimization: { minimize: false, splitChunks: false, runtimeChunk: false },
+			...rest,
+			output: {
+				path: directory,
+				filename: '[name].cjs',
+				library: { type: 'commonjs2' },
+				...output,
+			},
+			plugins: [
+				...(options === false ? [] : [new OctaneRspackPlugin({ parallel: false, ...options })]),
+				...plugins,
+			],
+		});
+		return directory;
+	}
+
+	function installLinkedRuntimeObserver() {
+		const linked = join(sandbox, 'linked-package');
+		writePackage(root, {
+			name: 'runtime-resolution-fixture',
+			private: true,
+			type: 'module',
+			dependencies: { octane: '*', '@fixture/linked': '*' },
+		});
+		writePackage(linked, {
+			name: '@fixture/linked',
+			type: 'module',
+			exports: './index.mjs',
+			dependencies: { octane: '*' },
+		});
+		write(linked, 'index.mjs', observeRuntime);
+		installRuntime(join(linked, 'node_modules/octane'), 'nested');
+		mkdirSync(join(root, 'node_modules/@fixture'), { recursive: true });
+		symlinkSync(linked, join(root, 'node_modules/@fixture/linked'), 'dir');
+		write(root, 'observe.mjs', observeRuntime);
+		write(
+			root,
+			'entry.mjs',
+			"export { observed as application } from './observe.mjs';\nexport { observed as linked } from '@fixture/linked';\n",
+		);
+	}
+
+	it.each([
+		['browser defaults', {}, 'browser'],
+		['custom conditions', { conditionNames: ['fixture-runtime', '...'] }, 'custom'],
+		[
+			'ESM-specific conditions',
+			{ byDependency: { esm: { conditionNames: ['fixture-runtime', '...'] } } },
+			'custom',
+		],
+	] satisfies Array<[string, NonNullable<Configuration['resolve']>, string]>)(
+		'uses finalized %s for a conditional runtime',
+		async (_label, resolve, expected) => {
+			installRuntime(join(root, 'node_modules/octane'), 'application', { conditional: true });
+			write(root, 'entry.mjs', "export { identity, condition } from 'octane';\n");
+			const output = load<ConditionalRuntime>(await build({}, { resolve }));
+			expect(output.identity.origin).toBe('application:client:import');
+			expect(output.condition).toBe(expected);
+		},
+	);
+
+	it('uses configured application module roots for the shared runtime', async () => {
+		installRuntime(join(root, 'node_modules/octane'), 'ordinary');
+		const selectedModules = join(sandbox, 'selected-modules');
+		installRuntime(join(selectedModules, 'octane'), 'selected');
+		write(root, 'entry.mjs', observeRuntime);
+		const { observed } = load<{ observed: RuntimeObservation }>(
+			await build({}, { resolve: { modules: [selectedModules, 'node_modules'] } }),
+		);
+		expectRuntime(observed, 'selected', 'client');
+	});
+
+	it.each([
+		['web', 'client'],
+		['node', 'server'],
+	] as const)(
+		'shares the selected runtime across linked packages for %s',
+		async (target, environment) => {
+			installRuntime(join(root, 'node_modules/octane'), 'application');
+			installLinkedRuntimeObserver();
+			const output = load<{ application: RuntimeObservation; linked: RuntimeObservation }>(
+				await build({}, { target }),
+			);
+			expectRuntime(output.application, 'application', environment);
+			expectSharedRuntime(output.linked, output.application, 'application', environment);
+		},
+	);
+
+	it.each([
+		{ target: 'web', environment: 'client', scope: 'top-level' },
+		{ target: 'node', environment: 'server', scope: 'top-level' },
+		{ target: 'web', environment: 'client', scope: 'ESM-specific' },
+		{ target: 'node', environment: 'server', scope: 'ESM-specific' },
+	] as const)(
+		'anchors the $target graph to an application-selected $scope package alias',
+		async ({ target, environment, scope }) => {
+			installRuntime(join(root, 'node_modules/octane'), 'ordinary');
+			const selected = installRuntime(join(sandbox, 'selected-octane'), 'selected');
+			installLinkedRuntimeObserver();
+			const alias = { octane$: join(selected, 'esm/client.mjs') };
+			const resolve = scope === 'top-level' ? { alias } : { byDependency: { esm: { alias } } };
+			const output = load<{ application: RuntimeObservation; linked: RuntimeObservation }>(
+				await build({}, { target, resolve }),
+			);
+			expectRuntime(output.application, 'selected', environment);
+			expectSharedRuntime(output.linked, output.application, 'selected', environment);
+		},
+	);
+
+	it('preserves exact helper overrides and unrelated subpaths beside a broad package alias', async () => {
+		installRuntime(join(root, 'node_modules/octane'), 'ordinary');
+		const selected = installRuntime(join(sandbox, 'selected-octane'), 'selected');
+		const client = write(
+			sandbox,
+			'overrides/client.mjs',
+			"export const identity = { origin: 'explicit-client' };\n",
+		);
+		const profiling = write(
+			sandbox,
+			'overrides/profiling.mjs',
+			"export const identity = { origin: 'explicit-profiling' };\n",
+		);
+		for (const subpath of ['universal', 'compiler']) {
+			write(
+				selected,
+				`${subpath}.js`,
+				`export const marker = ${JSON.stringify(`broad-alias:${subpath}`)};\n`,
+			);
+		}
+		write(
+			root,
+			'entry.mjs',
+			observeRuntime +
+				"export { marker as universal } from 'octane/universal';\nexport { marker as compiler } from 'octane/compiler';\n",
+		);
+		const output = load<{
+			observed: RuntimeObservation;
+			universal: string;
+			compiler: string;
+		}>(
+			await build(
+				{},
+				{
+					resolve: {
+						alias: {
+							octane: selected,
+							'octane/internal/client$': client,
+							'octane/profiling$': profiling,
+						},
+					},
+				},
+			),
+		);
+		expect(output.observed.runtime.origin).toBe('selected:client:import');
+		expect(output.observed.client.origin).toBe('explicit-client');
+		expect(output.observed.profiling.origin).toBe('explicit-profiling');
+		expect(output.observed.server.origin).toBe('selected:server:import');
+		expect(output.observed.internalServer).toBe(output.observed.server);
+		expect(output.universal).toBe('broad-alias:universal');
+		expect(output.compiler).toBe('broad-alias:compiler');
+	});
+
+	it('preserves absolute and conditional-package runtime overrides', async () => {
+		installRuntime(join(root, 'node_modules/octane'), 'application');
+		installRuntime(join(root, 'node_modules/@fixture/runtime'), 'override', {
+			name: '@fixture/runtime',
+			conditional: true,
+		});
+		const absolute = write(
+			sandbox,
+			'absolute-runtime.mjs',
+			"export const identity = { origin: 'absolute-runtime' };\nexport const condition = 'absolute';\n",
+		);
+		write(root, 'entry.mjs', observeRuntime + "export { condition } from 'octane';\n");
+		for (const [runtime, origin, condition] of [
+			[absolute, 'absolute-runtime', 'absolute'],
+			['@fixture/runtime', 'override:client:import', 'browser'],
+		]) {
+			const output = load<{ observed: RuntimeObservation; condition: string }>(
+				await build({ runtime }),
+			);
+			expect(output.observed.runtime.origin).toBe(origin);
+			expect(output.condition).toBe(condition);
+			expect(output.observed.client.origin).toBe('application:client:import');
+			expect(output.observed.profiling).toBe(output.observed.client);
+			expect(output.observed.server.origin).toBe('application:server:import');
+			expect(output.observed.internalServer).toBe(output.observed.server);
+		}
+	});
+
+	it.each(['top-level', 'ESM-specific'] as const)(
+		'preserves an ignored %s runtime alias',
+		async (scope) => {
+			installRuntime(join(root, 'node_modules/octane'), 'application');
+			write(
+				root,
+				'entry.mjs',
+				"import * as runtime from 'octane';\nexport const ignored = !('identity' in runtime);\nexport { identity as client } from 'octane/internal/client';\n",
+			);
+			const alias = { octane$: false as const };
+			const resolve = scope === 'top-level' ? { alias } : { byDependency: { esm: { alias } } };
+			const output = load<{ ignored: boolean; client: Identity }>(await build({}, { resolve }));
+			expect(output.ignored).toBe(true);
+			expect(output.client.origin).toBe('application:client:import');
+		},
+	);
+
+	it('preserves ESM-wide alias opt-outs and native resolution behavior', async () => {
+		installRuntime(join(root, 'node_modules/octane'), 'application');
+		const dependency = join(root, 'node_modules/unrelated-alias');
+		writePackage(dependency, {
+			name: 'unrelated-alias',
+			type: 'module',
+			exports: './index.mjs',
+		});
+		write(dependency, 'index.mjs', "export const marker = 'package';\n");
+		const replacement = write(root, 'replacement.mjs', "export const marker = 'alias';\n");
+		write(root, 'entry.mjs', "export { marker } from 'unrelated-alias';\n");
+		const resolveOptions = (): NonNullable<Configuration['resolve']> => ({
+			alias: { 'unrelated-alias': replacement },
+			byDependency: { esm: { alias: false } },
+		});
+		const reference = load<{ marker: string }>(await build(false, { resolve: resolveOptions() }));
+		let configuredAlias: unknown;
+		const output = load<{ marker: string }>(
+			await build(
+				{},
+				{
+					resolve: resolveOptions(),
+					plugins: [
+						{
+							apply(compiler: Compiler) {
+								compiler.hooks.initialize.tap('InspectAliasOptOut', () => {
+									configuredAlias = compiler.options.resolve.byDependency?.esm?.alias;
+								});
+							},
+						},
+					],
+				},
+			),
+		);
+		expect(configuredAlias).toBe(false);
+		expect(output.marker).toBe(reference.marker);
+	});
+
+	it.each(['ordinary', 'ESM-selected'] as const)(
+		'retains layer-specific universal runtime overrides with an %s application runtime',
+		async (selection) => {
+			const application = installRuntime(join(root, 'node_modules/octane'), 'application');
+			for (const name of ['background', 'main']) {
+				installRuntime(join(root, `node_modules/@fixture/${name}-runtime`), name, {
+					name: `@fixture/${name}-runtime`,
+					conditional: true,
+				});
+				write(root, `${name}.mjs`, "export * from './layered.mjs';\n");
+			}
+			write(
+				root,
+				'layered.mjs',
+				"export { identity, condition } from 'octane';\nexport { marker as universal } from 'octane/universal';\n",
+			);
+			const output = await build(
+				{
+					runtime: '@fixture/background-runtime',
+					universalRuntime: { runtime: 'object', thread: 'background' },
+					layerSpecializations: {
+						'octane:main-thread': {
+							runtime: '@fixture/main-runtime',
+							universalRuntime: { runtime: 'object', thread: 'main-thread' },
+						},
+					},
+				},
+				{
+					...(selection === 'ESM-selected'
+						? {
+								resolve: {
+									byDependency: {
+										esm: { alias: { octane$: join(application, 'esm/client.mjs') } },
+									},
+								},
+							}
+						: {}),
+					entry: {
+						background: { import: './background.mjs', layer: 'octane:background' },
+						main: { import: './main.mjs', layer: 'octane:main-thread' },
+					},
+				},
+			);
+			for (const name of ['background', 'main']) {
+				const result = load<ConditionalRuntime & { universal: string }>(output, name);
+				expect(result.identity.origin).toBe(`${name}:client:import`);
+				expect(result.condition).toBe('browser');
+				expect(result.universal).toBe('application:universal');
+			}
+		},
+	);
+});


### PR DESCRIPTION
## Summary

Fix the published-package CommonJS/ESM regression in `@octanejs/rspack-plugin`.

## Why

The plugin resolved Octane through `createRequire().resolve()`, selecting the published CommonJS entry even for browser imports. Compiler-generated imports could still select ESM, retaining the CommonJS graph and splitting refs, context, and profiling across runtime instances.

## Changes

- Resolve runtime aliases with Rspack's finalized ESM conditions and anchor runtime/helper subpaths to the application's selected Octane package.
- Preserve custom conditions, explicit overrides, server and universal targets, layer-specific runtimes, linked packages, and alias opt-outs.
- Add source-built published-package regressions for callback-ref lifecycle, linked SSR context, profiling, and production bundle reachability, plus a patch changeset.

## Validation

- [ ] `pnpm format:check` — repository-wide check not run.
- [ ] `pnpm typecheck` — repository-wide check not run.
- [ ] `pnpm test` — full repository suite not run.
- [x] `pnpm format:files:check` — seven changed files.
- [x] `pnpm typecheck:files` — six changed source, test, and fixture files using `tsrx-tsc`.
- [x] `pnpm changeset:check`.
- [x] `pnpm sync` — no generated changes.
- [x] targeted tests: Rspack 2.1.4 suite — 114 passed.
- [x] targeted tests: Rspack 2.1.3 compatibility — 22 passed.
- [x] targeted tests: Rsbuild integration — 43 passed.
- [x] Published-package production controls verify rendered output, unmount cleanup, and exclusion of the CommonJS distribution from the default ESM bundle.

Source-built static-root production comparison (Node 22.22.3, Rspack 2.1.4, esbuild 0.28.1):

| Runtime selection | Raw bytes | Gzip bytes | Emitted CommonJS modules |
| --- | ---: | ---: | ---: |
| Automatic | 107,228 | 34,189 | 0 |
| Explicit ESM control | 107,228 | 34,189 | 0 |
| Forced CommonJS control | 325,746 | 96,969 | 27 |

All three pass the same DOM/unmount verifier. The automatic and explicit ESM bundles are byte-identical.

Targeted compiler tests used Octane's supported JavaScript parser adapter. The native-parser lane was not run.

## Risk / follow-ups

Run the full repository and native-parser lanes in CI. Explicit runtime overrides and ESM-wide alias opt-outs remain authoritative.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789855176&installation_model_id=432790&pr_number=811&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F811&signature=c0c7bdd52b24d5f9d3060d71b644f8e9069b14d87987456828d13e229c6aa8d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Rspack plugin aliases Octane’s runtime graph, which can affect bundle contents and identity of refs/context. Behavior is covered by new resolution and published-package tests, but wrong aliases would still break production apps.
> 
> **Overview**
> Stops `@octanejs/rspack-plugin` from resolving Octane via `createRequire()`, which picked the published CommonJS entry and split refs, context, and profiling across duplicate runtimes.
> 
> Runtime aliases now wait for `afterResolvers` and use Rspack’s finalized ESM conditions. Server, internal, and profiling subpaths pin to the application’s selected Octane package so linked copies share one graph. Explicit runtime/subpath aliases, ESM alias opt-outs, and layer-specific runtimes stay authoritative.
> 
> Adds published-package and resolution tests covering callback-ref lifecycle, linked SSR context, profiling, and exclusion of the CJS graph from ESM browser bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3600b577f7f01764533bf634a0e3c3801a830d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->