### PR TITLE
fix: keep generic boolean children empty on update

### DIFF
--- a/.changeset/generic-child-boolean-updates.md
+++ b/.changeset/generic-child-boolean-updates.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Keep boolean renderable children empty when updated from text, and correctly
+reapply anchored child text after a held transition resumes. Explicit string
+conversion and typed text bindings retain their existing coercion semantics.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -21646,6 +21646,11 @@ function planJsx(
 		// component calls; only the emitted runtime call differs.
 		if (cc.isChild) {
 			const V = () => b.id('_v');
+			// setText follows explicit text-binding coercion, which renders `true`.
+			// Renderable children suppress it. Normalize that one differing value
+			// while keeping the journaled text setter and its allocation-free path.
+			const childTextValue = () =>
+				b.conditional(b.binary('===', V(), b.literal(true)), b.literal(''), V());
 			// MARKERLESS only-child renderable: append a primitive as a single Text
 			// node (no `<!>`, no slot state), `setText` it inline on update — exactly
 			// like a `.tsrx` only-child text binding — and fall back to `childTextHole`
@@ -21695,7 +21700,7 @@ function planJsx(
 									b.unary('!', b.id('_o')),
 									b.binary('!==', V(), b.literal(null)),
 								]),
-								b.stmt(b.call('_$setText', b.id('_t'), V())),
+								b.stmt(b.call('_$setText', b.id('_t'), childTextValue())),
 								b.stmt(
 									b.assignment(
 										'=',
@@ -21811,13 +21816,15 @@ function planJsx(
 					org,
 					b.block([
 						b.const('_v', cc.valueExpr),
-						b.stmt(b.assignment('=', chp(), V())),
 						b.stmt(b.assignment('=', chv(), textHoleCall(V()))),
+						b.stmt(b.assignment('=', chp(), V())),
 					]),
 				);
 				continue;
 			}
 			ctx.runtimeNeeded.add('setText');
+			// Publish the raw value after the helper: setText must journal the old
+			// binding bag before a held transition can roll the DOM write back.
 			pushAfterStmt(
 				cc.id,
 				org,
@@ -21838,7 +21845,6 @@ function planJsx(
 					b.if(
 						b.logical('||', b.id('_o'), b.binary('!==', chp(), V())),
 						b.block([
-							b.stmt(b.assignment('=', chp(), V())),
 							b.const('_t', chv()),
 							b.if(
 								andChain([
@@ -21846,9 +21852,10 @@ function planJsx(
 									b.unary('!', b.id('_o')),
 									b.binary('!==', V(), b.literal(null)),
 								]),
-								b.stmt(b.call('_$setText', b.id('_t'), V())),
+								b.stmt(b.call('_$setText', b.id('_t'), childTextValue())),
 								b.stmt(b.assignment('=', chv(), textHoleCall(V()))),
 							),
+							b.stmt(b.assignment('=', chp(), V())),
 						]),
 						null,
 					),

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -20662,8 +20662,8 @@ export function textSlot(
 
 // Slow path for the compiler's INLINE text-hole codegen. The compiled `.tsx`
 // `{expr}` value hole caches its text node on the binding bag and, on update,
-// does `setText(node, _v)` directly when `_v` is a primitive and a node already
-// exists — matching the `.tsrx` `{… as string}` text-binding hot path exactly.
+// calls `setText` directly when the value is a primitive and a node already
+// exists, normalizing `true` to empty to preserve renderable-child semantics.
 // It only calls here when that inline fast path doesn't apply: `_v` is an
 // object/function (component / element / array), or there's no cached node yet
 // (first render, hydration, or a prior non-text render). We hand off to the full

--- a/packages/octane/tests/_fixtures/generic-child-transitions.tsrx
+++ b/packages/octane/tests/_fixtures/generic-child-transitions.tsrx
@@ -1,0 +1,56 @@
+import { use, useSyncExternalStore, useTransition, type OctaneNode } from 'octane';
+
+export interface GenericChildSnapshot {
+	value: OctaneNode;
+	request: Promise<string>;
+}
+
+export interface GenericChildStore {
+	get: () => GenericChildSnapshot;
+	subscribe: (listener: () => void) => () => void;
+}
+
+function PendingProbe() @{
+	const [pending] = useTransition();
+	<output id="pending">
+		{pending ? 'pending' : 'idle'}
+	</output>
+}
+
+function OnlyChild(props: { value: OctaneNode }) @{
+	<main id="only-child">{props.value}</main>
+}
+
+function AnchoredChild(props: { value: OctaneNode }) @{
+	<section id="anchored-child">
+		<span>{'before:'}</span>
+		{props.value}
+		<input id="retained-input" defaultValue="initial" />
+		<span>{':after'}</span>
+	</section>
+}
+
+function ReadyValue(props: { request: Promise<string> }) @{
+	const value = use(props.request);
+	<output id="ready">{value as string}</output>
+}
+
+function Contents(props: { snapshot: GenericChildSnapshot }) @{
+	<div>
+		<OnlyChild value={props.snapshot.value} />
+		<AnchoredChild value={props.snapshot.value} />
+		<ReadyValue request={props.snapshot.request} />
+	</div>
+}
+
+export function GenericChildTransition(props: { store: GenericChildStore }) @{
+	const snapshot = useSyncExternalStore(props.store.subscribe, props.store.get);
+	<div>
+		<PendingProbe />
+		@try {
+			<Contents snapshot={snapshot} />
+		} @pending {
+			<output id="fallback">{'loading'}</output>
+		}
+	</div>
+}

--- a/packages/octane/tests/_fixtures/hole-kind-flip.tsrx
+++ b/packages/octane/tests/_fixtures/hole-kind-flip.tsrx
@@ -1,11 +1,11 @@
-// Sole-child value holes whose kind flips into and out of the keyed-array
-// regime (array <-> text / null / component / pure host). Round-tripping back
-// to an array must remount items cleanly every cycle.
+// Value holes that switch between primitives, empty values, components, hosts,
+// and keyed arrays. Round-tripping back to an array must remount items cleanly
+// every cycle.
 //
 // Where a flip target is JSX, it is assigned in setup: a statically JSX-armed
 // ternary lowers to an @if-style block instead of the value hole under test.
 
-import { useState } from 'octane';
+import { useLayoutEffect, useState, type OctaneNode } from 'octane';
 
 function Chip() @{
 	<b>{'chip'}</b>
@@ -61,4 +61,51 @@ export function ArrayHostRoundTrip() @{
 		<button id="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
 		<div id="host">{content}</div>
 	</div>
+}
+
+export function OnlyValue(props: { value: OctaneNode }) @{
+	<main id="value-host">{props.value}</main>
+}
+
+export function SiblingValue(props: { value: OctaneNode }) @{
+	<main id="value-host">
+		<span data-static="before">before|</span>
+		{props.value}
+		<span data-static="after">|after</span>
+	</main>
+}
+
+export function OnlyStringValue(props: { value: unknown }) @{
+	<main id="value-host">{String(props.value)}</main>
+}
+
+export function SiblingStringValue(props: { value: unknown }) @{
+	<main id="value-host">
+		<span data-static="before">before|</span>
+		{String(props.value)}
+		<span data-static="after">|after</span>
+	</main>
+}
+
+export function OnlyTypedValue(props: { value: unknown }) @{
+	<main id="value-host">{props.value as string}</main>
+}
+
+export function SiblingTypedValue(props: { value: unknown }) @{
+	<main id="value-host">
+		<span data-static="before">before|</span>
+		{props.value as string}
+		<span data-static="after">|after</span>
+	</main>
+}
+
+export function StatefulValue(props: { id: string; log: (entry: string) => void }) @{
+	const [count, setCount] = useState(0);
+	useLayoutEffect(() => {
+		props.log('mount ' + props.id);
+		return () => props.log('unmount ' + props.id);
+	}, []);
+	<button data-child={props.id} onClick={() => setCount(count + 1)}>
+		{props.id + ':' + count}
+	</button>
 }

--- a/packages/octane/tests/generic-child-transitions.test.ts
+++ b/packages/octane/tests/generic-child-transitions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { startTransition } from '../src/index.js';
+import { act, mount } from './_helpers.js';
+import {
+	GenericChildTransition,
+	type GenericChildSnapshot,
+	type GenericChildStore,
+} from './_fixtures/generic-child-transitions.tsrx';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function makeStore(initial: GenericChildSnapshot): GenericChildStore & {
+	set: (snapshot: GenericChildSnapshot) => void;
+} {
+	let snapshot = initial;
+	const listeners = new Set<() => void>();
+	return {
+		get: () => snapshot,
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		set(next) {
+			snapshot = next;
+			for (const listener of listeners) listener();
+		},
+	};
+}
+
+describe('renderable children in a held transition', () => {
+	it.each([
+		{ kind: 'string', value: 'next', expected: 'next' },
+		{ kind: 'number', value: 0, expected: '0' },
+		{ kind: 'boolean', value: true, expected: '' },
+	])('reveals the latest $kind child after a suspended attempt', async ({ value, expected }) => {
+		const first = deferred<string>();
+		const second = deferred<string>();
+		first.resolve('ready:first');
+		const store = makeStore({ value: 'first', request: first.promise });
+		const root = mount(GenericChildTransition, { store });
+		try {
+			await act(() => {});
+			const onlyChild = root.find('#only-child');
+			const anchoredChild = root.find('#anchored-child');
+			const input = root.find('#retained-input') as HTMLInputElement;
+			input.value = 'typed by the user';
+			expect(onlyChild.textContent).toBe('first');
+			expect(anchoredChild.textContent).toBe('before:first:after');
+
+			// The store keeps its new snapshot while the later sibling suspends.
+			// Revealing must therefore reapply each child, not mistake its aborted
+			// update for content that already reached the screen.
+			await act(() => startTransition(() => store.set({ value, request: second.promise })));
+			expect(onlyChild.textContent).toBe('first');
+			expect(anchoredChild.textContent).toBe('before:first:after');
+			expect(root.find('#ready').textContent).toBe('ready:first');
+			expect(root.find('#pending').textContent).toBe('pending');
+			expect(root.findAll('#fallback')).toEqual([]);
+
+			await act(() => second.resolve('ready:second'));
+			expect(root.find('#only-child')).toBe(onlyChild);
+			expect(root.find('#anchored-child')).toBe(anchoredChild);
+			expect(onlyChild.textContent).toBe(expected);
+			expect(anchoredChild.textContent).toBe(`before:${expected}:after`);
+			expect(root.find('#ready').textContent).toBe('ready:second');
+			expect(root.find('#pending').textContent).toBe('idle');
+			expect(root.find('#retained-input')).toBe(input);
+			expect(input.value).toBe('typed by the user');
+			expect(root.findAll('#fallback')).toEqual([]);
+		} finally {
+			root.unmount();
+		}
+	});
+});

--- a/packages/octane/tests/hole-kind-roundtrip.test.ts
+++ b/packages/octane/tests/hole-kind-roundtrip.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect } from 'vitest';
-import { mount } from './_helpers';
+import { describe, it, expect, vi } from 'vitest';
+import { createElement, flushSync, hydrateRoot, type OctaneNode, type Root } from '../src/index.js';
+import * as ServerRuntime from 'octane/server';
+import { mount } from './_helpers.js';
+import { loadServerFixture } from './_server-fixture.js';
 import {
 	HoleKindRoundTrip,
 	ArrayNullRoundTrip,
 	ArrayComponentRoundTrip,
 	ArrayHostRoundTrip,
+	OnlyValue,
+	SiblingValue,
+	OnlyStringValue,
+	SiblingStringValue,
+	OnlyTypedValue,
+	SiblingTypedValue,
+	StatefulValue,
 } from './_fixtures/hole-kind-flip.tsrx';
 
 // A sole-child value hole may change kind on any render. Leaving the keyed
@@ -68,5 +78,225 @@ describe('value hole kind round-trip', () => {
 		r.click('#next');
 		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
 		r.unmount();
+	});
+});
+
+const primitiveValues: { value: OctaneNode; text: string }[] = [
+	{ value: true, text: '' },
+	{ value: 'x', text: 'x' },
+	{ value: true, text: '' },
+	{ value: 'y', text: 'y' },
+	{ value: false, text: '' },
+	{ value: 0, text: '0' },
+	{ value: true, text: '' },
+	{ value: 7, text: '7' },
+	{ value: null, text: '' },
+	{ value: 'z', text: 'z' },
+	{ value: undefined, text: '' },
+	{ value: '', text: '' },
+	{ value: false, text: '' },
+	{ value: 'last', text: 'last' },
+];
+
+const server = loadServerFixture('packages/octane/tests/_fixtures/hole-kind-flip.tsrx', {
+	compileOptions: {
+		hmr: false,
+		dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod',
+	},
+});
+
+const layouts = [
+	{
+		name: 'only child',
+		Body: OnlyValue,
+		StringBody: OnlyStringValue,
+		TypedBody: OnlyTypedValue,
+		ServerBody: server.OnlyValue,
+		ServerStringBody: server.OnlyStringValue,
+		ServerTypedBody: server.OnlyTypedValue,
+		prefix: '',
+		suffix: '',
+	},
+	{
+		name: 'between siblings',
+		Body: SiblingValue,
+		StringBody: SiblingStringValue,
+		TypedBody: SiblingTypedValue,
+		ServerBody: server.SiblingValue,
+		ServerStringBody: server.SiblingStringValue,
+		ServerTypedBody: server.SiblingTypedValue,
+		prefix: 'before|',
+		suffix: '|after',
+	},
+];
+
+function serverHostText(html: string): string | null {
+	const container = document.createElement('div');
+	container.innerHTML = html;
+	return container.querySelector('#value-host')!.textContent;
+}
+
+describe.each(layouts)('renderable values as $name', (layout) => {
+	const {
+		Body,
+		StringBody,
+		TypedBody,
+		ServerBody,
+		ServerStringBody,
+		ServerTypedBody,
+		prefix,
+		suffix,
+	} = layout;
+	const text = (value: string) => prefix + value + suffix;
+
+	it('keeps booleans and nullish values empty after string and number updates', () => {
+		const r = mount(Body, { value: primitiveValues[0].value });
+		const host = r.find('#value-host');
+		const siblings = [...host.children];
+		const observations = [host.textContent];
+		try {
+			for (const { value } of primitiveValues.slice(1)) {
+				r.update(Body, { value });
+				expect(r.find('#value-host')).toBe(host);
+				for (const sibling of siblings) expect(sibling.parentNode).toBe(host);
+				observations.push(host.textContent);
+			}
+			expect(observations).toEqual(primitiveValues.map((sample) => text(sample.text)));
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it.each([
+		{
+			name: 'explicit String conversion',
+			Client: StringBody,
+			Server: ServerStringBody,
+			convert: (value: OctaneNode) => String(value),
+		},
+		{
+			name: 'an explicit string assertion',
+			Client: TypedBody,
+			Server: ServerTypedBody,
+			convert: (value: OctaneNode) => (value == null || value === false ? '' : String(value)),
+		},
+	])('preserves $name on the client and server', async ({ Client, Server, convert }) => {
+		const r = mount(Client, { value: primitiveValues[0].value });
+		const clientText: (string | null)[] = [];
+		const serverText: (string | null)[] = [];
+		try {
+			for (const { value } of primitiveValues) {
+				r.update(Client, { value });
+				clientText.push(r.find('#value-host').textContent);
+				const { html } = await ServerRuntime.renderToString(Server, { value });
+				serverText.push(serverHostText(html));
+			}
+			const expected = primitiveValues.map(({ value }) => text(convert(value)));
+			expect(clientText).toEqual(expected);
+			expect(serverText).toEqual(expected);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('uses the same primitive-child semantics when server-rendering', async () => {
+		const observations: (string | null)[] = [];
+		for (const { value } of primitiveValues) {
+			const { html } = await ServerRuntime.renderToString(ServerBody, { value });
+			observations.push(serverHostText(html));
+		}
+		expect(observations).toEqual(primitiveValues.map((sample) => text(sample.text)));
+	});
+
+	it.each([
+		{ value: true, initialText: '' },
+		{ value: 'server', initialText: 'server' },
+		{ value: 0, initialText: '0' },
+		{ value: null, initialText: '' },
+	])('adopts server value $value and stays consistent through updates', async (initial) => {
+		const { html } = await ServerRuntime.renderToString(ServerBody, { value: initial.value });
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const host = container.querySelector('#value-host')!;
+		const siblings = [...host.children];
+		const serverText = initial.initialText
+			? [...host.childNodes].find(
+					(node) => node.nodeType === Node.TEXT_NODE && node.nodeValue === initial.initialText,
+				)
+			: undefined;
+		expect(host.textContent).toBe(text(initial.initialText));
+		if (initial.initialText) expect(serverText).toBeDefined();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		let root: Root | undefined;
+		try {
+			root = hydrateRoot(container, Body, { value: initial.value });
+			flushSync(() => {});
+			expect(container.querySelector('#value-host')).toBe(host);
+			for (const sibling of siblings) expect(sibling.parentNode).toBe(host);
+			if (serverText) expect(serverText.parentNode).toBe(host);
+			const observations: (string | null)[] = [];
+			for (const { value } of primitiveValues) {
+				flushSync(() => root!.render(Body, { value }));
+				expect(container.querySelector('#value-host')).toBe(host);
+				for (const sibling of siblings) expect(sibling.parentNode).toBe(host);
+				observations.push(host.textContent);
+			}
+			expect(observations).toEqual(primitiveValues.map((sample) => text(sample.text)));
+			expect(error.mock.calls.flat().map(String).join('\n')).not.toMatch(/hydration.*mismatch/i);
+		} finally {
+			root?.unmount();
+			error.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('preserves keyed child state and cleans up children when their value becomes empty', () => {
+		const events: string[] = [];
+		const log = (entry: string) => events.push(entry);
+		const child = (id: string) => createElement(StatefulValue, { key: id, id, log });
+		const r = mount(Body, { value: [child('a'), child('b')] });
+		const host = r.find('#value-host');
+		const siblings = [...host.querySelectorAll('[data-static]')];
+		const a = r.find('[data-child="a"]');
+		const b = r.find('[data-child="b"]');
+		try {
+			expect(events).toEqual(['mount a', 'mount b']);
+			r.click('[data-child="a"]');
+			r.update(Body, { value: [child('b'), child('a')] });
+			expect(r.findAll('[data-child]')).toEqual([b, a]);
+			expect(r.find('[data-child="a"]')).toBe(a);
+			expect(r.find('[data-child="b"]')).toBe(b);
+			expect(a.textContent).toBe('a:1');
+			expect(events).toEqual(['mount a', 'mount b']);
+
+			r.update(Body, { value: true });
+			expect(host.textContent).toBe(text(''));
+			expect(a.isConnected).toBe(false);
+			expect(b.isConnected).toBe(false);
+			expect(events.slice(2).sort()).toEqual(['unmount a', 'unmount b']);
+
+			r.update(Body, { value: child('c') });
+			const c = r.find('[data-child="c"]');
+			expect(c.textContent).toBe('c:0');
+			r.update(Body, { value: 'again' });
+			expect(c.isConnected).toBe(false);
+			expect(events.slice(4)).toEqual(['mount c', 'unmount c']);
+			r.update(Body, { value: false });
+			expect(host.textContent).toBe(text(''));
+			r.update(Body, { value: 0 });
+			expect(host.textContent).toBe(text('0'));
+			r.update(Body, { value: null });
+			expect(host.textContent).toBe(text(''));
+			expect(r.find('#value-host')).toBe(host);
+			for (const sibling of siblings) expect(sibling.parentNode).toBe(host);
+		} finally {
+			r.unmount();
+		}
+		expect(events.filter((event) => event.startsWith('unmount ')).sort()).toEqual([
+			'unmount a',
+			'unmount b',
+			'unmount c',
+		]);
 	});
 });


### PR DESCRIPTION
## Summary

Keep generic boolean children empty when updated from text, matching initial rendering and SSR.

## Why

A generic `<main>{props.value}</main>` correctly renders an initial `true` as empty, but updating from `"x"` to `true` reached the typed-text setter and rendered `"true"`. The anchored fast path also published its value cache before the journaled DOM write, which could leave stale text after a held transition resumed.

## Changes

- Normalize raw `true` only at the two generic-child text fast paths.
- Keep explicit `String(...)`, typed-text coercion, and runtime APIs unchanged.
- Publish anchored value caches after the runtime helper so rollback captures the previous value.
- Add only-child and anchored regressions for primitive transitions, SSR/hydration, keyed state and cleanup, retained DOM identity, and held-transition replay.
- Add an `octane` patch changeset.

## Validation

- [ ] `pnpm format:check` — full repository check not run.
- [ ] `pnpm typecheck` — full repository check not run.
- [ ] `pnpm test` — full repository check not run.
- [x] New regressions were run before the fix: 26 expected failures across development and production; 24 neighboring controls passed.
- [x] Targeted tests: `hole-kind-roundtrip.test.ts` and `generic-child-transitions.test.ts` — 50/50 passed.
- [x] Nearby child, compiler, hydration, and transition suites — 344/344 passed across 41 development/production file runs.
- [x] `pnpm typecheck:files` for the six changed source/test/fixture files.
- [x] `tsgo --noEmit -p packages/octane/tsconfig.json`.
- [x] Locked Prettier `--check` for all seven changed files and `git diff --check`.
- [x] `pnpm sync` — no additional generated changes.

Tests used the supported JavaScript parser with locked dependencies because the native parser package could not be downloaded locally.

## Performance / risk

Compared with base `87882aa503da9b3e6671e0f4a588b03706910a3d` using Node 26.4.0, the JavaScript parser, `@tsrx/core` 0.1.58, and esbuild 0.28.1:

- Each affected generic-hole fixture grows by 10 minified bytes; explicit `String(...)` output is byte-identical.
- The fixed `benchmarks/codegen-size` corpus grows from 75,450 to 75,530 minified bytes and from 26,798 to 26,848 gzip bytes (+0.187%).
- Equal-work string/number/null controls preserve visible output, DOM mutations, node identity, and cleanup.
- Six codegen parity guards pass unchanged. The aggregate gzip guard already exceeds its 1.06× ceiling on the base: 1.06337× → 1.06535×. No guard was changed.

The existing journaled setter and empty-text representation remain in use. No new runtime state or API is introduced. Native-parser execution, the full monorepo checks, and browser latency/paint performance remain unverified; no speedup is claimed.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 70c610dc27999881eac0a791c833a08322efb8cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789855392&installation_model_id=432790&pr_number=812&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F812&signature=a2d3117128449a688645e6773d53e6360fb3fe63d0a36525988ec44d2f4baa38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->