### PR TITLE
perf: fold proven CSS-module constants

### DIFF
--- a/.changeset/proven-css-module-constants.md
+++ b/.changeset/proven-css-module-constants.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/vite-plugin': patch
+---
+
+Fold provider-proven immutable CSS-module class strings before template planning. Production Vite builds retain a live class reference in each static subtree so unused and lazy component styles keep their existing delivery boundaries. Mutable default maps remain dynamic unless their CSS provider supplies an explicit immutable-export contract.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -868,6 +868,70 @@
     "note": "Inferred string children must not exceed the gzipped output of the equivalent explicit-string sentinel."
   },
   {
+    "suite": "codegen-size",
+    "op": "raw",
+    "target": "css-modules-client-proven",
+    "reference": "css-modules-client-control",
+    "maxRatio": 0.75,
+    "note": "Proven immutable CSS strings retain an original stylesheet read while removing repeated client class bindings. Both variants use identical source/provider bytes and verify equal CSS and SSR output."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "minified",
+    "target": "css-modules-client-proven",
+    "reference": "css-modules-client-control",
+    "maxRatio": 0.84,
+    "note": "The production CSS-module client sentinel must retain a material minified-code reduction with stylesheet ownership preserved."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "gzip",
+    "target": "css-modules-client-proven",
+    "reference": "css-modules-client-control",
+    "maxRatio": 0.86,
+    "note": "Same-run compressed client bytes guard the CSS proof optimization without depending on a particular Node/zlib version."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "brotli",
+    "target": "css-modules-client-proven",
+    "reference": "css-modules-client-control",
+    "maxRatio": 0.86,
+    "note": "Same-run Brotli client bytes guard the CSS proof optimization while the stylesheet and public SSR semantics remain equal."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "raw",
+    "target": "css-modules-server-proven",
+    "reference": "css-modules-server-control",
+    "maxRatio": 0.75,
+    "note": "Proven immutable CSS strings remove repeated server class serialization without dropping the stylesheet dependency."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "minified",
+    "target": "css-modules-server-proven",
+    "reference": "css-modules-server-control",
+    "maxRatio": 0.84,
+    "note": "The paired production CSS-module server sentinel must retain a material minified-code reduction."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "gzip",
+    "target": "css-modules-server-proven",
+    "reference": "css-modules-server-control",
+    "maxRatio": 0.96,
+    "note": "Same-run compressed server bytes guard the CSS proof optimization; source, stylesheet, and SSR HTML are identical in the control."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "brotli",
+    "target": "css-modules-server-proven",
+    "reference": "css-modules-server-control",
+    "maxRatio": 0.96,
+    "note": "Same-run Brotli server bytes retain the CSS proof saving without pinning compressor-specific absolute bytes."
+  },
+  {
     "suite": "bundle-size",
     "op": "app_gzip",
     "target": "octane-tsrx",

--- a/benchmarks/codegen-size/css-modules.mjs
+++ b/benchmarks/codegen-size/css-modules.mjs
@@ -1,0 +1,284 @@
+// Fixed, public CSS-module codegen sentinel. Both variants compile the same
+// component and immutable provider; only the host's class-string proof changes.
+// The measured JS contains the component and provider, not the framework. A
+// real stylesheet is emitted in both variants and checked separately, while a
+// full server bundle supplies the semantic control.
+import { compile } from 'octane/compiler';
+import { build, version as esbuildVersion } from 'esbuild';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { brotliCompressSync, constants as zc, gzipSync } from 'node:zlib';
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const COMPONENT = './css-modules.tsrx';
+const FILENAME = path.join(DIR, 'css-modules.tsrx');
+const MODULE = './css-modules.module.css';
+const STYLESHEET = './css-modules.styles.css';
+const CLASSES = Object.freeze({
+	root: '_css_root_a1b2',
+	header: '_css_header_b2c3',
+	mark: '_css_mark_c3d4',
+	icon: '_css_icon_d4e5',
+	heading: '_css_heading_e5f6',
+	caption: '_css_caption_f6a7',
+	content: '_css_content_a7b8',
+	nav: '_css_nav_b8c9',
+	link: '_css_link_c9d0',
+	list: '_css_list_d0e1',
+	row: '_css_row_e1f2',
+	label: '_css_label_f2a3',
+	meta: '_css_meta_a3b4',
+	empty: '_css_empty_b4c5',
+	footer: '_css_footer_c5d6',
+	action: '_css_action_d6e7',
+	note: '_css_note_e7f8',
+});
+
+const SOURCE = `import styles, { label } from './css-modules.module.css';
+import * as classes from './css-modules.module.css';
+
+interface Props {
+	title: string;
+	detail: string;
+	active: boolean;
+	rows: { id: string; label: string; detail: string }[];
+}
+
+export function CssModules(props: Props) @{
+	<section class={styles.root} data-active={props.active ? 'yes' : 'no'}>
+		<header class={styles.header}>
+			<div className={styles.mark}><span class={classes.icon}>*</span></div>
+			<h1 class={styles.heading}>{props.title as string}</h1>
+			<p class={styles.caption + ' muted'}>{props.detail as string}</p>
+		</header>
+		<div class={styles.content}>
+			<nav class={styles.nav}>
+				<a class={styles.link + ' active'} href="#overview">Overview</a>
+				<a class={styles.link} href="#details">Details</a>
+			</nav>
+			<ul class={styles.list}>
+				@for (const row of props.rows; key row.id) {
+					<li class={styles.row} data-id={row.id}>
+						<span class={label}>{row.label as string}</span>
+						<small class={styles.meta}>{row.detail as string}</small>
+					</li>
+				} @empty {
+					<li class={styles.empty}>No items</li>
+				}
+			</ul>
+		</div>
+		<footer class={styles.footer}>
+			<button class={styles.action} type="button">Continue</button>
+			<p class={styles.note}>Changes are saved.</p>
+		</footer>
+	</section>
+}`;
+
+// Object.freeze supplies the default-map immutability contract. The pure
+// annotation permits the unused allocation to disappear but does not erase its
+// independent stylesheet import. Named exports are initialized const strings.
+const PROVIDER = [
+	`import ${JSON.stringify(STYLESHEET)};`,
+	...Object.entries(CLASSES).map(
+		([name, value]) => `export const ${name}=${JSON.stringify(value)};`,
+	),
+	`export default /* @__PURE__ */ Object.freeze(${JSON.stringify(CLASSES)});`,
+].join('\n');
+const CSS = Object.values(CLASSES)
+	.map((value, index) => `.${value}{--css-module-sentinel:${index}}`)
+	.join('\n');
+
+const proof = (request, imported, property) => {
+	if (request !== MODULE) return undefined;
+	const name =
+		imported === 'default' || imported === '*' ? property : property === null ? imported : null;
+	return name !== null && Object.hasOwn(CLASSES, name) ? CLASSES[name] : undefined;
+};
+const hash = (value) => createHash('sha256').update(value).digest('hex');
+const val = (bytes) => ({ median: bytes, min: bytes, samples: 1 });
+const bytes = (value) => Buffer.byteLength(value);
+const compileFixture = (mode, resolveCssModuleConstant, preserveReferences = false) =>
+	compile(SOURCE, FILENAME, {
+		mode,
+		hmr: false,
+		dev: false,
+		profile: false,
+		...(resolveCssModuleConstant ? { resolveCssModuleConstant } : {}),
+		...(preserveReferences ? { preserveCssModuleReferences: [MODULE] } : {}),
+	}).code;
+
+async function bundleFixture(mode, code, minify, withRuntime = false) {
+	const entry = withRuntime
+		? `import { renderToString } from 'octane/server';
+import { CssModules } from ${JSON.stringify(COMPONENT)};
+export async function render(props) { return (await renderToString(CssModules, props)).html; }`
+		: `export { CssModules } from ${JSON.stringify(COMPONENT)};`;
+	const result = await build({
+		stdin: { contents: entry, loader: 'js', resolveDir: DIR, sourcefile: 'css-modules-entry.js' },
+		outdir: path.join(DIR, '.css-modules-output'),
+		bundle: true,
+		write: false,
+		format: 'esm',
+		platform: mode === 'server' ? 'node' : 'browser',
+		target: 'es2022',
+		minify,
+		legalComments: 'none',
+		logLevel: 'silent',
+		external: withRuntime ? [] : ['octane', 'octane/*'],
+		define: {
+			'process.env.NODE_ENV': '"production"',
+			__OCTANE_PROFILE_ENABLED__: 'false',
+		},
+		plugins: [
+			{
+				name: 'css-modules-codegen-sentinel',
+				setup(bundler) {
+					bundler.onResolve({ filter: /^\.\/css-modules\.tsrx$/ }, () => ({
+						path: FILENAME,
+						namespace: 'css-component',
+					}));
+					bundler.onResolve({ filter: /^\.\/css-modules\.module\.css$/ }, () => ({
+						path: MODULE,
+						namespace: 'css-provider',
+					}));
+					bundler.onResolve({ filter: /^\.\/css-modules\.styles\.css$/ }, () => ({
+						path: STYLESHEET,
+						namespace: 'css-stylesheet',
+					}));
+					bundler.onLoad({ filter: /.*/, namespace: 'css-component' }, () => ({
+						contents: code,
+						loader: 'js',
+						resolveDir: DIR,
+					}));
+					bundler.onLoad({ filter: /.*/, namespace: 'css-provider' }, () => ({
+						contents: PROVIDER,
+						loader: 'js',
+						resolveDir: DIR,
+					}));
+					bundler.onLoad({ filter: /.*/, namespace: 'css-stylesheet' }, () => ({
+						contents: CSS,
+						loader: 'css',
+					}));
+				},
+			},
+		],
+	});
+	const javascript = result.outputFiles.filter((file) => file.path.endsWith('.js'));
+	const stylesheets = result.outputFiles.filter((file) => file.path.endsWith('.css'));
+	assert.equal(javascript.length, 1, 'the sentinel must emit one JavaScript bundle');
+	assert.equal(stylesheets.length, 1, 'constant classes must retain their stylesheet');
+	const stylesheet = stylesheets[0].text;
+	for (const className of Object.values(CLASSES)) {
+		assert.ok(stylesheet.includes(`.${className}`), `missing stylesheet rule ${className}`);
+	}
+	return { code: javascript[0].text, stylesheet };
+}
+
+const SEMANTIC_INPUTS = [
+	{
+		props: {
+			title: 'First & <title>',
+			detail: 'Details & more',
+			active: true,
+			rows: [
+				{ id: 'a', label: 'Row <A>', detail: 'One & two' },
+				{ id: 'b', label: 'Row B', detail: 'Three' },
+			],
+		},
+		contains: ['First &amp; &lt;title&gt;', 'Row &lt;A&gt;', 'One &amp; two', 'data-active="yes"'],
+	},
+	{
+		props: { title: 'Empty', detail: '', active: false, rows: [] },
+		contains: ['No items', 'data-active="no"'],
+	},
+];
+
+export async function measureCssModules() {
+	const targets = [];
+	const measured = {};
+	let stylesheet;
+	const serverCode = {};
+	for (const mode of ['client', 'server']) {
+		const control = compileFixture(mode);
+		assert.equal(
+			compileFixture(mode, () => undefined),
+			control,
+			'an absent CSS proof must leave production code unchanged',
+		);
+		for (const [variant, code] of [
+			['control', control],
+			['proven', compileFixture(mode, proof, true)],
+			['ceiling', compileFixture(mode, proof)],
+		]) {
+			const raw = await bundleFixture(mode, code, false);
+			const minified = await bundleFixture(mode, code, true);
+			stylesheet ??= minified.stylesheet;
+			assert.equal(minified.stylesheet, stylesheet, 'CSS bytes must be equal in every variant');
+			const sizes = {
+				raw: bytes(raw.code),
+				minified: bytes(minified.code),
+				gzip: gzipSync(minified.code, { level: zc.Z_BEST_COMPRESSION }).length,
+				brotli: brotliCompressSync(minified.code, {
+					params: { [zc.BROTLI_PARAM_QUALITY]: zc.BROTLI_MAX_QUALITY },
+				}).length,
+			};
+			measured[`${mode}-${variant}`] = sizes;
+			if (variant !== 'ceiling') {
+				targets.push({
+					name: `css-modules-${mode}-${variant}`,
+					ops: Object.fromEntries(Object.entries(sizes).map(([name, value]) => [name, val(value)])),
+				});
+			}
+			if (mode === 'server') serverCode[variant] = code;
+		}
+	}
+
+	const html = {};
+	for (const variant of ['control', 'proven', 'ceiling']) {
+		const bundle = await bundleFixture('server', serverCode[variant], true, true);
+		assert.equal(bundle.stylesheet, stylesheet, 'SSR must retain the same stylesheet');
+		const module = await import(
+			`data:text/javascript;base64,${Buffer.from(bundle.code).toString('base64')}`
+		);
+		html[variant] = [];
+		for (const { props, contains } of SEMANTIC_INPUTS) {
+			const rendered = await module.render(props);
+			for (const expected of contains) assert.ok(rendered.includes(expected), expected);
+			assert.ok(rendered.includes(`class="${CLASSES.root}"`));
+			assert.ok(rendered.includes(`class="${CLASSES.caption} muted"`));
+			html[variant].push(rendered);
+		}
+	}
+	assert.deepEqual(html.proven, html.control, 'proven CSS strings must render identically');
+	assert.deepEqual(html.ceiling, html.control, 'fully owned CSS strings must render identically');
+	const summary = {
+		toolchain: {
+			nodeExecutable: process.execPath,
+			node: process.version,
+			zlib: process.versions.zlib,
+			brotli: process.versions.brotli,
+			esbuild: esbuildVersion,
+			gzipLevel: zc.Z_BEST_COMPRESSION,
+			brotliQuality: zc.BROTLI_MAX_QUALITY,
+		},
+		fixtureChecksum: hash(SOURCE),
+		providerChecksum: hash(PROVIDER),
+		semanticChecksum: hash(JSON.stringify(html.control)),
+		stylesheetChecksum: hash(stylesheet),
+		stylesheetBytes: bytes(stylesheet),
+		modes: measured,
+	};
+	for (const target of targets) {
+		target.meta = {
+			toolchain: summary.toolchain,
+			fixtureChecksum: summary.fixtureChecksum,
+			providerChecksum: summary.providerChecksum,
+			semanticChecksum: summary.semanticChecksum,
+			stylesheetChecksum: summary.stylesheetChecksum,
+			stylesheetBytes: summary.stylesheetBytes,
+		};
+	}
+	return { targets, summary };
+}

--- a/benchmarks/codegen-size/run.mjs
+++ b/benchmarks/codegen-size/run.mjs
@@ -22,6 +22,7 @@ import { gzipSync, constants as zc } from 'node:zlib';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { measureCssModules } from './css-modules.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.resolve(__dirname, '../..');
@@ -217,6 +218,11 @@ try {
 	textTypeProject.dispose();
 }
 
+// Paired sentinels keep new optimization claims out of the fixed corpus. The
+// CSS control and candidate use identical source/provider bytes and verify both
+// the emitted stylesheet and public SSR output before reporting their sizes.
+const cssModules = await measureCssModules();
+
 const payload = {
 	suite: 'codegen-size',
 	iterations: 1,
@@ -232,6 +238,7 @@ const payload = {
 		{ name: 'text-types-syntax', ops: textTypes.syntax },
 		{ name: 'text-types-explicit', ops: textTypes.explicit, meta: textTypes.meta },
 		{ name: 'text-types-inferred', ops: textTypes.inferred, meta: textTypes.meta },
+		...cssModules.targets,
 	],
 };
 
@@ -246,6 +253,13 @@ console.log(
 console.log(
 	`TypeScript text sentinel  inferred ${textTypes.inferred.raw.median}/${textTypes.inferred.minified.median}/${textTypes.inferred.gzip.median}  explicit ${textTypes.explicit.raw.median}/${textTypes.explicit.minified.median}/${textTypes.explicit.gzip.median}  syntax ${textTypes.syntax.raw.median}/${textTypes.syntax.minified.median}/${textTypes.syntax.gzip.median}`,
 );
+for (const mode of ['client', 'server']) {
+	const control = cssModules.summary.modes[`${mode}-control`];
+	const proven = cssModules.summary.modes[`${mode}-proven`];
+	console.log(
+		`CSS-module ${mode} sentinel  min ${control.minified} -> ${proven.minified}  gz ${control.gzip} -> ${proven.gzip}  br ${control.brotli} -> ${proven.brotli}`,
+	);
+}
 
 if (process.env.BENCH_JSON) {
 	fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/docs/compiler-css-module-constants.md
+++ b/docs/compiler-css-module-constants.md
@@ -1,0 +1,115 @@
+# CSS-module constants
+
+The Vite compiler can bake proven CSS-module strings into static `class` and
+`className` attributes. This removes repeated class-binding code without changing
+class composition, attribute escaping, spread ordering, or hydration behavior.
+The optimization runs only in a one-shot build, not in the dev server or watch
+mode.
+
+Vite's ordinary CSS-module output contains immutable named string exports. Those
+can be used automatically:
+
+```tsx
+import { panel, label } from './panel.module.css';
+
+export function Panel() @{
+  <section class={panel}>
+    <span class={label}>Ready</span>
+  </section>
+}
+```
+
+The ordinary **default export is a mutable object**. A different importer can
+change `styles.panel`, so importing `styles` and reading it locally is not enough
+to prove that property constant. Octane does not infer immutability from a CSS
+filename, TypeScript `readonly`, a literal object initializer, or conventional
+CSS-module usage.
+
+## Immutable CSS providers
+
+A CSS provider that guarantees immutable exports can opt in through the Vite
+plugin's experimental `cssModuleConstants` option:
+
+```ts
+import { octane, type OctaneCssModuleConstants } from 'octane/compiler/vite';
+
+const immutableCssMetadata = 'my-css-provider:immutable-constants';
+
+export default {
+  plugins: [
+    myImmutableCssProvider(),
+    octane({
+      cssModuleConstants({ meta }) {
+        // This metadata must come from a provider that owns the actual module.
+        // The provider has already made its runtime export immutable.
+        return meta[immutableCssMetadata] as OctaneCssModuleConstants | undefined;
+      },
+    }),
+  ],
+};
+```
+
+The returned value is `null`/`undefined`, or an object with either or both of:
+
+- `named`: a record of exported names and their string values.
+- `default`: a record of own, immutable string properties on the default export.
+
+Returning `null` or `undefined` adds no provider facts. Built-in immutable named
+exports can still be recognized.
+
+For example, a provider may expose a final module equivalent to:
+
+```js
+export const panel = '_panel_abc';
+export const label = '_label_abc';
+export default Object.freeze({ panel, label });
+```
+
+Its metadata can contain
+`{ named: { panel: '_panel_abc', label: '_label_abc' }, default: { panel: '_panel_abc', label: '_label_abc' } }`.
+This permits the existing `import styles from './panel.module.css'` authoring
+shape without asserting that arbitrary imported objects are immutable.
+
+The callback is a correctness contract: every reported value must already be
+initialized whenever the component can read it and must remain the same string
+for the module's lifetime. The callback receives the exact resolved ID, final
+transformed JavaScript, module metadata, and client/server target. Octane reads
+the final ESM without evaluating it and checks the reported strings against its
+literal exports. Malformed or stale assertions fail the build. Getters, spreads,
+mutable bindings, unknown re-exports, and unrecognized computed values are not
+accepted as literal-export evidence.
+
+Keep the provider's client and server class-name configuration consistent. Facts
+are collected separately for each build environment; Octane does not reuse a
+client's class map for the server or vice versa.
+
+## Stylesheet reachability
+
+Folding the last live CSS import can cause a bundler to omit the stylesheet.
+Marking every imported CSS module as side-effectful is not a substitute: that
+can make an unused component's stylesheet load eagerly.
+
+The Vite integration instead preserves an original class read in each
+independently retained static host subtree and folds the remaining eligible
+reads. Unused component exports can still be removed, and lazy components keep
+their existing CSS-loading boundary. The integration does not change the CSS
+provider's side-effect flags or execute a provider's application module.
+
+Custom compiler hosts can supply
+`resolveCssModuleConstant(request, imported, property)` directly. A named string
+uses `property: null`; a namespace read uses `imported: '*'`; a default-map read
+uses `imported: 'default'`. Hosts that rely on ordinary CSS import reachability
+must also supply `preserveCssModuleReferences` with the affected authored module
+requests. Omitting that option permits complete folding and is appropriate only
+when the host independently owns stylesheet delivery and initialization.
+
+Only direct authored `.module.css` requests (and the corresponding supported CSS
+preprocessor extensions) participate in this initial integration. Extensionless
+aliases, imports with attributes/assertions, and re-export barrels are left
+alone. CSS facts also stay disabled when renderer boundaries are configured:
+the initial stylesheet-preservation proof only covers DOM-owned host trees.
+An in-flight provider load is conservatively skipped to avoid cycles, so a
+concurrent first importer may retain its ordinary class bindings. Only complete,
+proven class strings are folded. Dynamic property names, arbitrary function calls, and mixed
+runtime expressions keep their normal behavior. Authored imports and source
+origins are preserved.

--- a/packages/octane/README.md
+++ b/packages/octane/README.md
@@ -21,6 +21,10 @@ Custom Node build pipelines can opt into project-aware string-child inference
 through `octane/compiler/typescript`. See the
 [type-aware text compilation guide](https://github.com/octanejs/octane/blob/main/docs/compiler-text-inference.md).
 
+Vite builds can fold proven immutable CSS-module class strings into templates.
+See the [CSS-module constants guide](https://github.com/octanejs/octane/blob/main/docs/compiler-css-module-constants.md)
+for the provider contract and stylesheet-loading guarantees.
+
 Direct Node or Bun server scripts can preload `octane/compiler/register` to
 compile imported Octane components without going through Vite. See the
 [SSR guide](https://github.com/octanejs/octane/blob/main/docs/ssr.md#run-an-ssg-script-directly).

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -34,6 +34,7 @@ import { formatCompileDiagnostic } from './native-change-diagnostics.js';
 import { findVoidComponentImports, findVoidRootImports, slotHooks } from './slot-hooks.js';
 import { rewriteServerRuntimeRequests } from './runtime-requests.js';
 import { assertStrongMode } from './strong-mode.js';
+import { findCssModuleImportRequests } from './css-module-imports.js';
 import {
 	assertNoLiveClientOnlyImports,
 	createClientOnlyServerStub,
@@ -915,6 +916,32 @@ class OctaneBundlerCompiler {
 		return findStaticRuntimeImportRequests(code, this._canonicalModuleId(id));
 	}
 
+	/** CSS proof discovery uses the same ownership gate as the eventual compile. */
+	findCssModuleImportRequests(code, id, environment = 'client') {
+		if (typeof code !== 'string' || !code.includes('.module.')) return [];
+		// The live-read witness currently follows DOM host ownership only. Even
+		// a DOM-owned module can delegate a JSX-valued prop to another renderer.
+		if (Object.keys(this.renderers.boundaries).length > 0) return [];
+		const file = cleanModuleId(id);
+		const collected = { dependencies: new Set(), missingDependencies: new Set() };
+		if (!this._isFullCompileSource(file, collected)) return [];
+		const filename = this._canonicalModuleId(file);
+		const pragmaOwned =
+			this.requireDirective &&
+			file.endsWith('.tsx') &&
+			this._isProjectOwnedSource(file) &&
+			this._pragmaClaimsOwnership(code);
+		if (!this._passesOwnershipGate(file, filename, pragmaOwned)) return [];
+		const renderer = resolveRendererForFile(this.renderers, filename);
+		if (
+			renderer.target !== 'dom' ||
+			(environment === 'server' && renderer.server === 'client-only')
+		) {
+			return [];
+		}
+		return findCssModuleImportRequests(code, filename);
+	}
+
 	/**
 	 * requireDirective ownership for code-less classification: a project
 	 * `.tsrx` is Octane's by extension; any other project module needs its
@@ -1079,6 +1106,10 @@ class OctaneBundlerCompiler {
 				};
 			}
 			const hasRendererBoundaries = Object.keys(this.renderers.boundaries).length > 0;
+			const collectCssModuleConstants =
+				renderer.target === 'dom' &&
+				!hasRendererBoundaries &&
+				typeof options.resolveCssModuleConstant === 'function';
 			const compileFilename =
 				hydrateBoundaryPath === null
 					? filename
@@ -1109,15 +1140,27 @@ class OctaneBundlerCompiler {
 				...(typeof options.isDescriptorChildrenImport === 'function'
 					? { isDescriptorChildrenImport: options.isDescriptorChildrenImport }
 					: null),
+				...(collectCssModuleConstants
+					? {
+							resolveCssModuleConstant: options.resolveCssModuleConstant,
+							...(options.preserveCssModuleReferences === undefined
+								? null
+								: { preserveCssModuleReferences: options.preserveCssModuleReferences }),
+						}
+					: null),
 			};
 			const collectVoidComponentExports =
 				environment === 'client' && options.collectVoidComponentExports === true;
 			let out;
 			let voidComponentAst = null;
-			if (collectVoidComponentExports) {
+			let cssModuleConstantImports;
+			if (collectVoidComponentExports || collectCssModuleConstants) {
 				const compilation = compileForBundler(code, compileFilename, compileOptions);
 				out = compilation.result;
-				voidComponentAst = compilation.hydrateAst;
+				if (collectVoidComponentExports) voidComponentAst = compilation.hydrateAst;
+				if (collectCssModuleConstants) {
+					cssModuleConstantImports = compilation.cssModuleConstantImports;
+				}
 			} else {
 				out = compile(code, compileFilename, compileOptions);
 			}
@@ -1135,6 +1178,7 @@ class OctaneBundlerCompiler {
 					: {
 							voidComponentExports: findVoidComponentExports(voidComponentAst, filename),
 						}),
+				...(cssModuleConstantImports === undefined ? null : { cssModuleConstantImports }),
 				descriptorChildrenExports: findDescriptorChildrenExports(code, filename),
 				...finishMetadata(collected),
 			};

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -77,6 +77,7 @@ import { nsForChildren, nsForSelf } from './jsx-namespace.js';
 import { analyzeNativeChangeDiagnostics } from './native-change-diagnostics.js';
 import { assertStrongMode } from './strong-mode.js';
 import { createTextTypeFactsLookup } from './text-type-facts.js';
+import { applyCssModuleConstants } from './css-module-constants.js';
 import { assertUniversalRuntimeTarget, normalizeUniversalRuntime } from './universal-runtime.js';
 
 // DOM truth tables shared with the client/server runtimes (via constants.ts) —
@@ -7833,9 +7834,9 @@ export function compile(source, filename, options) {
 // always validates authored source and only exposes the hydrate slice that the
 // same compilation already prepared for production void-export classification.
 export function compileForBundler(source, filename, options) {
-	const metadata = { hydrateAst: null };
+	const metadata = { hydrateAst: null, cssModuleConstantImports: [] };
 	const result = compileAuthored(source, filename, options, metadata);
-	return { result, hydrateAst: metadata.hydrateAst };
+	return { result, ...metadata };
 }
 
 function compileAuthored(source, filename, options, bundlerMetadata) {
@@ -7855,11 +7856,23 @@ function compileAuthored(source, filename, options, bundlerMetadata) {
 		cleanFilename,
 		options?.textTypeFacts,
 	);
+	let constantAst = textTypedAst;
+	if (typeof options?.resolveCssModuleConstant === 'function') {
+		const constants = applyCssModuleConstants(
+			textTypedAst,
+			options.resolveCssModuleConstant,
+			options.preserveCssModuleReferences,
+		);
+		constantAst = constants.ast;
+		if (bundlerMetadata !== null) {
+			bundlerMetadata.cssModuleConstantImports = constants.imports;
+		}
+	}
 	return compileInternal(
 		source,
 		filename,
 		options,
-		textTypedAst,
+		constantAst,
 		mode,
 		bundlerMetadata,
 		textTypedAst !== analyzedAst,

--- a/packages/octane/src/compiler/css-module-constants.js
+++ b/packages/octane/src/compiler/css-module-constants.js
@@ -1,0 +1,324 @@
+import { builders as b } from '@tsrx/core';
+import { createLexicalAnalysis } from './compile-universal.js';
+
+const SKIP_KEYS = new Set(['type', 'loc', 'start', 'end', 'range', 'metadata', 'parent', 'css']);
+
+function unwrapExpression(node) {
+	while (
+		node?.type === 'TSAsExpression' ||
+		node?.type === 'TSTypeAssertion' ||
+		node?.type === 'TSNonNullExpression' ||
+		node?.type === 'TSSatisfiesExpression' ||
+		node?.type === 'ParenthesizedExpression'
+	) {
+		node = node.expression;
+	}
+	return node;
+}
+
+function memberName(node) {
+	if (node?.type !== 'MemberExpression' || node.optional) return undefined;
+	if (!node.computed && node.property?.type === 'Identifier') return node.property.name;
+	if (
+		node.computed &&
+		(node.property?.type === 'Literal' || node.property?.type === 'StringLiteral') &&
+		typeof node.property.value === 'string'
+	) {
+		return node.property.value;
+	}
+	return undefined;
+}
+
+function isClassAttribute(node) {
+	return (
+		node?.type === 'JSXAttribute' &&
+		node.name?.type === 'JSXIdentifier' &&
+		(node.name.name === 'class' || node.name.name === 'className') &&
+		node.value?.type === 'JSXExpressionContainer'
+	);
+}
+
+// These nodes have separate ownership, namespace, raw-text, or parser-repair
+// behavior. Do not borrow a stylesheet witness across one of those boundaries.
+const SEPARATE_HOSTS = new Set([
+	'head',
+	'html',
+	'body',
+	'script',
+	'style',
+	'textarea',
+	'title',
+	'meta',
+	'link',
+	'option',
+	'select',
+	'pre',
+	'listing',
+	'noscript',
+	'template',
+	'svg',
+	'math',
+	'foreignObject',
+	'annotation-xml',
+]);
+const OPAQUE_CONTENT_HOSTS = new Set([
+	'script',
+	'style',
+	'textarea',
+	'title',
+	'option',
+	'noscript',
+	'template',
+	'svg',
+	'math',
+]);
+
+/**
+ * Bake only complete, side-effect-free class strings whose imported values the
+ * host has proved initialized and immutable. A CSS filename or a read-only use
+ * in this module is not that proof: ordinary CSS-module default maps are mutable
+ * and may be changed by another importer. The resolver owns that module-graph
+ * contract, including stylesheet side effects; this pass retains every import.
+ *
+ * Run before template planning so the existing client/SSR static-attribute
+ * writers still own escaping, class composition, spreads, and hydration. No
+ * generated JavaScript is reparsed or changed after printing.
+ */
+export function applyCssModuleConstants(ast, resolveConstant, preserveReferences) {
+	if (typeof resolveConstant !== 'function') return { ast, imports: [] };
+	if (
+		preserveReferences !== undefined &&
+		(!Array.isArray(preserveReferences) ||
+			preserveReferences.some((request) => typeof request !== 'string'))
+	) {
+		throw new TypeError('preserveCssModuleReferences must be an array of module requests.');
+	}
+	const preserve = new Set(preserveReferences);
+	const imports = new Map();
+	for (const statement of ast.body ?? []) {
+		if (
+			statement.type !== 'ImportDeclaration' ||
+			statement.importKind === 'type' ||
+			statement.attributes?.length > 0 ||
+			statement.assertions?.length > 0
+		) {
+			continue;
+		}
+		const request = statement.source?.value;
+		if (typeof request !== 'string') continue;
+		for (const specifier of statement.specifiers ?? []) {
+			if (specifier.importKind === 'type' || specifier.local?.type !== 'Identifier') continue;
+			const imported =
+				specifier.type === 'ImportDefaultSpecifier'
+					? 'default'
+					: specifier.type === 'ImportNamespaceSpecifier'
+						? '*'
+						: (specifier.imported?.name ?? specifier.imported?.value);
+			if (typeof imported === 'string') {
+				imports.set(specifier.local.name, { request, imported, source: statement.source });
+			}
+		}
+	}
+	if (imports.size === 0) return { ast, imports: [] };
+
+	const lexical = createLexicalAnalysis(ast);
+	const values = new Map();
+	const usedImports = new Set();
+	const importValue = (node, property) => {
+		if (node?.type !== 'Identifier') return undefined;
+		const imported = imports.get(node.name);
+		if (imported === undefined) return undefined;
+		const binding = lexical.resolveBinding(
+			lexical.nodeScopes.get(node) ?? lexical.rootScope,
+			node.name,
+		);
+		if (binding?.importSource !== imported.source) return undefined;
+		const key = JSON.stringify([imported.request, imported.imported, property]);
+		if (!values.has(key)) {
+			const value = resolveConstant(imported.request, imported.imported, property);
+			if (value !== undefined && typeof value !== 'string') {
+				throw new Error(
+					`Invalid CSS-module constant for ${JSON.stringify(imported.request)}: expected a string or undefined.`,
+				);
+			}
+			values.set(key, value);
+		}
+		const value = values.get(key);
+		return value === undefined ? undefined : { value, imports: [imported.request] };
+	};
+
+	const stringValue = (expression) => {
+		const node = unwrapExpression(expression);
+		if (
+			(node?.type === 'Literal' || node?.type === 'StringLiteral') &&
+			typeof node.value === 'string'
+		) {
+			return { value: node.value, imports: [] };
+		}
+		if (node?.type === 'Identifier') return importValue(node, null);
+		const property = memberName(node);
+		if (property !== undefined) return importValue(unwrapExpression(node.object), property);
+		if (node?.type === 'BinaryExpression' && node.operator === '+') {
+			const left = stringValue(node.left);
+			if (left === undefined) return undefined;
+			const right = stringValue(node.right);
+			if (right === undefined) return undefined;
+			return { value: left.value + right.value, imports: [...left.imports, ...right.imports] };
+		}
+		if (node?.type === 'TemplateLiteral') {
+			let value = node.quasis[0]?.value?.cooked;
+			if (typeof value !== 'string') return undefined;
+			const imports = [];
+			for (let i = 0; i < node.expressions.length; i++) {
+				const part = stringValue(node.expressions[i]);
+				const tail = node.quasis[i + 1]?.value?.cooked;
+				if (part === undefined || typeof tail !== 'string') return undefined;
+				value += part.value + tail;
+				imports.push(...part.imports);
+			}
+			return { value, imports };
+		}
+		return undefined;
+	};
+
+	// Vite emits a CSS module's stylesheet only while one of its exports is
+	// retained. A global side-effect override would make styles belonging to a
+	// dropped component eager. Instead retain one ORIGINAL class read for each
+	// stylesheet in each contiguous static host tree. Components, directives,
+	// expression branches, and separate roots cannot borrow each other's witness.
+	// The witness has one class prop and no spread, so source-order/duplicate-prop
+	// lowering cannot discard it. Callers that own CSS emission independently can
+	// omit this option and bake every proven string.
+	const groups = [];
+	const newGroup = () => {
+		const group = { candidates: [], witnessed: new Set(), retained: new Set() };
+		groups.push(group);
+		return group;
+	};
+	const seen = new WeakSet();
+	const collect = (node, inheritedGroup = null) => {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (Array.isArray(node)) {
+			for (const child of node) collect(child);
+			return;
+		}
+		if (node.type === 'JSXElement' || node.type === 'Element') {
+			const tag = node.openingElement?.name ?? node.id ?? node.name;
+			const name = tag?.type === 'JSXIdentifier' || tag?.type === 'Identifier' ? tag.name : null;
+			const attributes = node.openingElement?.attributes ?? node.attributes ?? [];
+			const ordinary = typeof name === 'string' && /^[a-z][A-Za-z0-9]*$/.test(name);
+			const separate = SEPARATE_HOSTS.has(name);
+			const customized =
+				(typeof name === 'string' && name.includes('-')) ||
+				attributes.some((attribute) => attribute.name?.name === 'is');
+			const hasSpread = attributes.some((attribute) => attribute.type === 'JSXSpreadAttribute');
+			const ownsContent = attributes.some((attribute) =>
+				['dangerouslySetInnerHTML', 'innerHTML', 'textContent'].includes(attribute.name?.name),
+			);
+			const group =
+				ordinary && !separate && !customized ? (inheritedGroup ?? newGroup()) : newGroup();
+			const classAttributes = attributes.filter(
+				(attribute) =>
+					attribute.type === 'JSXAttribute' &&
+					(attribute.name?.name === 'class' || attribute.name?.name === 'className'),
+			);
+			const canWitness =
+				ordinary && !separate && !customized && !hasSpread && classAttributes.length === 1;
+			for (const attribute of attributes) {
+				if (!customized && !separate && isClassAttribute(attribute)) {
+					const constant = stringValue(attribute.value.expression);
+					if (constant !== undefined && constant.imports.length > 0) {
+						group.candidates.push({ attribute, constant, canWitness });
+					}
+				}
+				// A JSX-valued prop/render function owns a separate template.
+				collect(attribute.value?.expression ?? attribute.argument);
+			}
+			if (!ownsContent && !OPAQUE_CONTENT_HOSTS.has(name)) {
+				const childGroup = ordinary && !separate && !customized && !hasSpread ? group : null;
+				for (const child of node.children ?? []) collect(child, childGroup);
+			}
+			return;
+		}
+		if (node.type === 'JSXFragment' || node.type === 'Fragment') {
+			for (const child of node.children ?? []) collect(child, inheritedGroup);
+			return;
+		}
+		for (const key of Object.keys(node)) {
+			if (!SKIP_KEYS.has(key)) collect(node[key]);
+		}
+	};
+	collect(ast);
+	const replacements = new WeakMap();
+	for (const group of groups) {
+		for (const { attribute, constant, canWitness } of group.candidates) {
+			if (
+				canWitness &&
+				constant.imports.some((request) => preserve.has(request) && !group.witnessed.has(request))
+			) {
+				group.retained.add(attribute);
+				for (const request of constant.imports) group.witnessed.add(request);
+			}
+		}
+		for (const { attribute, constant } of group.candidates) {
+			if (
+				group.retained.has(attribute) ||
+				constant.imports.some((request) => preserve.has(request) && !group.witnessed.has(request))
+			) {
+				continue;
+			}
+			for (const request of constant.imports) usedImports.add(request);
+			replacements.set(attribute, {
+				...attribute,
+				value: {
+					...attribute.value,
+					expression: b.literal(
+						constant.value,
+						JSON.stringify(constant.value),
+						attribute.value.expression,
+					),
+				},
+			});
+		}
+	}
+	if (usedImports.size === 0) return { ast, imports: [] };
+
+	const rewritten = new WeakMap();
+	const visit = (node) => {
+		if (node === null || typeof node !== 'object') return node;
+		if (rewritten.has(node)) return rewritten.get(node);
+		rewritten.set(node, node);
+		if (Array.isArray(node)) {
+			let next = null;
+			for (let i = 0; i < node.length; i++) {
+				const child = visit(node[i]);
+				if (next === null && child !== node[i]) next = node.slice(0, i);
+				if (next !== null) next.push(child);
+			}
+			const result = next ?? node;
+			rewritten.set(node, result);
+			return result;
+		}
+		if (typeof node.type !== 'string') return node;
+		const replacement = replacements.get(node);
+		if (replacement !== undefined) {
+			rewritten.set(node, replacement);
+			return replacement;
+		}
+		let next = null;
+		for (const key of Object.keys(node)) {
+			if (SKIP_KEYS.has(key)) continue;
+			const child = visit(node[key]);
+			if (child !== node[key]) {
+				next ??= { ...node };
+				next[key] = child;
+			}
+		}
+		const result = next ?? node;
+		rewritten.set(node, result);
+		return result;
+	};
+	const result = visit(ast);
+	return { ast: result, imports: [...usedImports] };
+}

--- a/packages/octane/src/compiler/css-module-imports.js
+++ b/packages/octane/src/compiler/css-module-imports.js
@@ -1,0 +1,238 @@
+import { parseModule } from '@tsrx/core';
+import { createLexicalAnalysis } from './compile-universal.js';
+
+const CSS_MODULE_REQUEST = /\.module\.(?:css|less|sass|scss|styl|stylus|pcss|postcss)(?:$|[?#])/;
+const PLAIN_CSS_MODULE_ID = /\.module\.(?:css|less|sass|scss|styl|stylus|pcss|postcss)$/;
+
+export function isPlainCssModuleId(id) {
+	return typeof id === 'string' && !id.startsWith('\0') && PLAIN_CSS_MODULE_ID.test(id);
+}
+
+/** Only authored CSS-module imports can ask the host for this narrow proof. */
+export function findCssModuleImportRequests(source, id) {
+	if (typeof source !== 'string' || !source.includes('.module.')) return [];
+	let ast;
+	try {
+		ast = parseModule(source, id);
+	} catch {
+		return [];
+	}
+	const requests = new Set();
+	for (const statement of ast.body ?? []) {
+		if (
+			statement.type !== 'ImportDeclaration' ||
+			statement.importKind === 'type' ||
+			statement.attributes?.length > 0 ||
+			statement.assertions?.length > 0 ||
+			typeof statement.source?.value !== 'string' ||
+			!CSS_MODULE_REQUEST.test(statement.source.value)
+		) {
+			continue;
+		}
+		if (statement.specifiers?.some((specifier) => specifier.importKind !== 'type')) {
+			requests.add(statement.source.value);
+		}
+	}
+	return [...requests];
+}
+
+function stringValue(node, strings) {
+	if (
+		(node?.type === 'Literal' || node?.type === 'StringLiteral') &&
+		typeof node.value === 'string'
+	) {
+		return node.value;
+	}
+	if (node?.type === 'Identifier') return strings.get(node.name);
+	return undefined;
+}
+
+function exportedName(node) {
+	if (node?.type === 'Identifier') return node.name;
+	return typeof node?.value === 'string' ? node.value : undefined;
+}
+
+function frozenRecordArgument(node) {
+	if (
+		node?.type !== 'CallExpression' ||
+		node.optional === true ||
+		node.arguments?.length !== 1 ||
+		node.callee?.type !== 'MemberExpression' ||
+		node.callee.computed === true ||
+		node.callee.optional === true ||
+		node.callee.object?.type !== 'Identifier' ||
+		node.callee.object.name !== 'Object' ||
+		node.callee.property?.type !== 'Identifier' ||
+		node.callee.property.name !== 'freeze'
+	) {
+		return null;
+	}
+	return node.arguments[0];
+}
+
+function recordValue(node, strings) {
+	if (node?.type !== 'ObjectExpression') return null;
+	const record = new Map();
+	for (const property of node.properties ?? []) {
+		if (
+			property.type !== 'Property' ||
+			property.kind !== 'init' ||
+			property.computed === true ||
+			property.method === true
+		) {
+			return null;
+		}
+		const key = exportedName(property.key);
+		const value = stringValue(property.value, strings);
+		// In an object literal this spelling sets the prototype instead of
+		// defining an own property. Never manufacture a class that is absent.
+		if (key === undefined || key === '__proto__' || value === undefined || record.has(key)) {
+			return null;
+		}
+		record.set(key, value);
+	}
+	return record;
+}
+
+/**
+ * Read an external CSS provider's final ESM source without running it. This
+ * never receives an Octane-printed Program. The automatic proof accepts
+ * only a pure sequence of initialized const strings and literal export maps.
+ * A default map is deliberately data, not proof of immutability. A provider
+ * must separately guarantee its lifetime and initialization before it can be
+ * used. Calls, re-exports, getters, spreads, and mutable bindings never become
+ * automatic facts.
+ */
+export function readCssModuleExports(source) {
+	let ast;
+	try {
+		ast = parseModule(source, 'css-module.js');
+	} catch {
+		return null;
+	}
+	const strings = new Map();
+	const frozenRecords = new Map();
+	const named = new Map();
+	let defaultRecord = null;
+	let pure = true;
+	let lexical = null;
+	const freezeArgument = (node) => {
+		const argument = frozenRecordArgument(node);
+		if (argument === null) return null;
+		lexical ??= createLexicalAnalysis(ast);
+		const object = node.callee.object;
+		return lexical.resolveBinding(lexical.nodeScopes.get(object) ?? lexical.rootScope, 'Object') ==
+			null
+			? argument
+			: null;
+	};
+	const publish = (name, value) => {
+		if (name === undefined || value === undefined || named.has(name)) return false;
+		named.set(name, value);
+		return true;
+	};
+	const readDefault = (node) => {
+		const value = stringValue(node, strings);
+		if (value !== undefined) return publish('default', value);
+		if (node?.type === 'Identifier' && frozenRecords.has(node.name)) {
+			defaultRecord = frozenRecords.get(node.name);
+			return true;
+		}
+		const frozen = freezeArgument(node);
+		if (frozen !== null) pure = false;
+		const record = recordValue(frozen ?? node, strings);
+		if (record === null || defaultRecord !== null) return false;
+		defaultRecord = record;
+		return true;
+	};
+	for (const statement of ast.body ?? []) {
+		const exported = statement.type === 'ExportNamedDeclaration';
+		const declaration = exported ? statement.declaration : statement;
+		if (declaration?.type === 'VariableDeclaration' && declaration.kind === 'const') {
+			for (const item of declaration.declarations ?? []) {
+				if (item.id?.type !== 'Identifier') {
+					pure = false;
+					continue;
+				}
+				const value = stringValue(item.init, strings);
+				if (value !== undefined) {
+					strings.set(item.id.name, value);
+					if (exported && !publish(item.id.name, value)) pure = false;
+					continue;
+				}
+				const frozen = freezeArgument(item.init);
+				const record = frozen === null ? null : recordValue(frozen, strings);
+				if (record !== null) frozenRecords.set(item.id.name, record);
+				pure = false;
+			}
+			continue;
+		}
+		if (statement.type === 'ExportDefaultDeclaration') {
+			if (!readDefault(statement.declaration)) pure = false;
+			continue;
+		}
+		if (exported && statement.declaration == null && statement.source == null) {
+			for (const specifier of statement.specifiers ?? []) {
+				const local = exportedName(specifier.local);
+				const name = exportedName(specifier.exported);
+				if (name === 'default' && frozenRecords.has(local)) {
+					if (defaultRecord !== null) pure = false;
+					else defaultRecord = frozenRecords.get(local);
+				} else if (!publish(name, strings.get(local))) {
+					pure = false;
+				}
+			}
+			continue;
+		}
+		if (statement.type !== 'EmptyStatement') pure = false;
+	}
+	return { named, default: defaultRecord, pure };
+}
+
+function ownDataProperties(value, invalid, label) {
+	if (
+		value === null ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		(Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)
+	) {
+		invalid(`${label} must be a plain record`);
+	}
+	const descriptors = Object.getOwnPropertyDescriptors(value);
+	const properties = new Map();
+	for (const key of Reflect.ownKeys(descriptors)) {
+		const descriptor = descriptors[key];
+		if (typeof key !== 'string' || !Object.hasOwn(descriptor, 'value')) {
+			invalid(`${label} must contain only own data properties`);
+		}
+		properties.set(key, descriptor.value);
+	}
+	return properties;
+}
+
+/** Validate an explicit host assertion against the exact module it describes. */
+export function validateCssModuleConstants(provided, exports, id) {
+	if (provided == null) return null;
+	const invalid = (reason) => {
+		throw new TypeError(
+			`octane/compiler/vite: invalid cssModuleConstants for ${JSON.stringify(id)}: ${reason}.`,
+		);
+	};
+	const fields = ownDataProperties(provided, invalid, 'the provider result');
+	for (const field of fields.keys()) {
+		if (field !== 'named' && field !== 'default') invalid(`unknown field ${JSON.stringify(field)}`);
+	}
+	const result = { named: new Map(), default: new Map() };
+	for (const field of ['named', 'default']) {
+		if (!fields.has(field)) continue;
+		const values = ownDataProperties(fields.get(field), invalid, field);
+		for (const [name, value] of values) {
+			if (typeof value !== 'string') invalid(`${field}.${name} is not a string`);
+			if (exports?.[field]?.get(name) !== value) {
+				invalid(`${field}.${name} does not match an initialized string in the final module`);
+			}
+			result[field].set(name, value);
+		}
+	}
+	return result;
+}

--- a/packages/octane/src/compiler/index.d.ts
+++ b/packages/octane/src/compiler/index.d.ts
@@ -34,6 +34,23 @@ export interface CompileOptions {
 	dataCallbackHooks?: readonly string[];
 	/** Exact authored-source facts from octane/compiler/typescript. */
 	textTypeFacts?: TextTypeFacts;
+	/**
+	 * Trusted bundler/provider proof of an already initialized, immutable CSS
+	 * class string. `property` is null for a named string import, or the static
+	 * member name for a default/namespace import. Returning undefined leaves the
+	 * expression dynamic. The host must preserve the stylesheet's side effects.
+	 */
+	resolveCssModuleConstant?: (
+		request: string,
+		imported: string,
+		property: string | null,
+	) => string | undefined;
+	/**
+	 * CSS modules whose extraction depends on retaining a live export. Keep one
+	 * original class read in each static host subtree that uses such a module;
+	 * unused/lazy component styles then retain their normal bundler ownership.
+	 */
+	preserveCssModuleReferences?: readonly string[];
 	renderer?: CompileRenderer;
 	rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, CompileRendererBoundary>>>>;
 	rendererRegistry?: Readonly<

--- a/packages/octane/src/compiler/vite.d.ts
+++ b/packages/octane/src/compiler/vite.d.ts
@@ -56,6 +56,27 @@ export interface OctaneRendererConfigOptions {
 	rules?: readonly OctaneRendererRuleOptions[];
 }
 
+/** The fully transformed module in one Vite build environment. */
+export interface OctaneCssModuleConstantModule {
+	/** Exact bundler-resolved identity, including virtual prefixes and queries. */
+	id: string;
+	/** Final JavaScript; no application module is evaluated to obtain it. */
+	code: string;
+	meta: Readonly<Record<string, unknown>>;
+	environment: 'client' | 'server';
+}
+
+/**
+ * An explicit provider guarantee, checked against the final module's literal
+ * exports. Each supplied value must already be initialized and remain the same
+ * string for every read. `default` requires own immutable data properties; an
+ * ordinary mutable CSS-module default object does not satisfy that contract.
+ */
+export interface OctaneCssModuleConstants {
+	named?: Readonly<Record<string, string>>;
+	default?: Readonly<Record<string, string>>;
+}
+
 export interface OctaneVitePluginOptions {
 	/** Override HMR code generation. It defaults to on while Vite is serving. */
 	hmr?: boolean;
@@ -91,6 +112,17 @@ export interface OctaneVitePluginOptions {
 	requireDirective?: boolean;
 	/** @experimental Declarative renderer selection for this compiler instance. */
 	renderers?: OctaneRendererConfigOptions;
+	/**
+	 * @experimental Authenticate immutable CSS-module exports supplied by a
+	 * trusted CSS provider. Used only in one-shot production builds, never serve
+	 * or watch. Values are checked against the exact final ESM; malformed or stale
+	 * assertions fail the build. Returning null/undefined supplies no additional
+	 * facts; built-in named-string proofs may still apply. This must not be used
+	 * to declare mutable default maps constant.
+	 */
+	cssModuleConstants?: (
+		module: OctaneCssModuleConstantModule,
+	) => OctaneCssModuleConstants | null | undefined;
 }
 
 /** The direct Octane compiler integration for Vite. */

--- a/packages/octane/src/compiler/vite.js
+++ b/packages/octane/src/compiler/vite.js
@@ -26,6 +26,11 @@ import {
 	findDescriptorChildrenImports,
 	findVoidComponentImports,
 } from './bundler.js';
+import {
+	isPlainCssModuleId,
+	readCssModuleExports,
+	validateCssModuleConstants,
+} from './css-module-imports.js';
 
 export { discoverOctaneSourceDependencies };
 
@@ -66,6 +71,130 @@ function voidImportKey(request, imported) {
 
 function compiledCodeFingerprint(code) {
 	return nodeCrypto.createHash('sha256').update(code).digest('base64url');
+}
+
+function createCssModuleProofState() {
+	return { modules: new Map(), inFlight: new Set(), consumed: new Map() };
+}
+
+async function loadCssModuleProof(context, id, environment, provider, state) {
+	// A virtual CSS provider may itself pass through Octane and import its
+	// caller. Never await the same proof promise through that in-flight graph.
+	// A concurrent first importer can conservatively miss this optimization;
+	// completed module proofs remain reusable for the rest of the build.
+	if (state.inFlight.has(id)) return null;
+	let proof = state.modules.get(id);
+	if (proof === undefined) {
+		state.inFlight.add(id);
+		proof = (async () => {
+			let loaded;
+			try {
+				// Only the module itself is needed. Walking its imports here would
+				// make a CSS provider's virtual graph capable of deadlocking an
+				// importer that is still in its pre-transform hook.
+				loaded = await context.load({ id, resolveDependencies: false });
+			} catch {
+				return null;
+			}
+			const moduleInfo = context.getModuleInfo(id) ?? loaded;
+			if (moduleInfo?.id !== id || typeof moduleInfo.code !== 'string') return null;
+			const code = moduleInfo.code;
+			const exports = readCssModuleExports(code);
+			const supplied =
+				provider === undefined
+					? null
+					: validateCssModuleConstants(
+							provider(Object.freeze({ id, code, meta: moduleInfo.meta ?? {}, environment })),
+							exports,
+							id,
+						);
+			// Vite's normal CSS-module output has immutable named const strings,
+			// but its default object is mutable. Only the explicit host contract
+			// can make a default-map member a constant.
+			const named = isPlainCssModuleId(id) && exports?.pure ? new Map(exports.named) : new Map();
+			for (const [name, value] of supplied?.named ?? []) named.set(name, value);
+			const defaultMap = supplied?.default ?? new Map();
+			if (named.size === 0 && defaultMap.size === 0) return null;
+			return { id, fingerprint: compiledCodeFingerprint(code), named, default: defaultMap };
+		})().finally(() => state.inFlight.delete(id));
+		state.modules.set(id, proof);
+	}
+	return proof;
+}
+
+async function loadCssModuleImports(context, requests, importer, environment, provider, state) {
+	if (
+		requests.length === 0 ||
+		typeof context.resolve !== 'function' ||
+		typeof context.load !== 'function' ||
+		typeof context.getModuleInfo !== 'function'
+	) {
+		return null;
+	}
+	const imports = new Map();
+	const resolvedImports = await Promise.all(
+		requests.map(async (request) => {
+			let resolved;
+			try {
+				resolved = await context.resolve(request, importer, { skipSelf: true });
+			} catch {
+				return;
+			}
+			if (
+				resolved == null ||
+				resolved.external ||
+				typeof resolved.id !== 'string' ||
+				cleanModuleId(resolved.id) === cleanModuleId(importer)
+			) {
+				return;
+			}
+			const proof = await loadCssModuleProof(context, resolved.id, environment, provider, state);
+			return proof === null ? undefined : [request, proof];
+		}),
+	);
+	for (const entry of resolvedImports) {
+		if (entry !== undefined) imports.set(entry[0], entry[1]);
+	}
+	if (imports.size === 0) return null;
+	return {
+		requests: [...imports.keys()],
+		resolve(request, imported, property) {
+			const proof = imports.get(request);
+			if (proof === undefined) return undefined;
+			if (property === null) return proof.named.get(imported);
+			if (imported === '*') return proof.named.get(property);
+			if (imported === 'default') return proof.default.get(property);
+			return undefined;
+		},
+		consume(requests) {
+			for (const request of requests ?? []) {
+				const proof = imports.get(request);
+				if (proof === undefined || state.consumed.has(proof.id)) continue;
+				const moduleInfo = context.getModuleInfo(proof.id);
+				if (
+					moduleInfo == null ||
+					typeof moduleInfo.code !== 'string' ||
+					compiledCodeFingerprint(moduleInfo.code) !== proof.fingerprint
+				) {
+					throw new Error(`CSS-module constant proof changed for ${JSON.stringify(proof.id)}.`);
+				}
+				state.consumed.set(proof.id, proof.fingerprint);
+			}
+		},
+	};
+}
+
+function verifyCssModuleProofs(context, state) {
+	for (const [id, fingerprint] of state.consumed) {
+		const moduleInfo = context.getModuleInfo?.(id);
+		if (
+			moduleInfo == null ||
+			typeof moduleInfo.code !== 'string' ||
+			compiledCodeFingerprint(moduleInfo.code) !== fingerprint
+		) {
+			throw new Error(`CSS-module constant proof changed for ${JSON.stringify(id)}.`);
+		}
+	}
 }
 
 async function loadImportMetadata(
@@ -406,6 +535,14 @@ export function octane(options = {}) {
 	if (options.strong !== undefined && typeof options.strong !== 'boolean') {
 		throw new TypeError('octane/compiler/vite: `strong` must be a boolean when provided.');
 	}
+	if (
+		options.cssModuleConstants !== undefined &&
+		typeof options.cssModuleConstants !== 'function'
+	) {
+		throw new TypeError(
+			'octane/compiler/vite: `cssModuleConstants` must be a function when provided.',
+		);
+	}
 	if (options.parallelUse !== undefined) {
 		// Removed 2026-07-16: the parallel-use() pipeline is unconditional compiled
 		// semantics (docs/suspense-parallel-use-plan.md). Warn instead of throwing
@@ -416,6 +553,7 @@ export function octane(options = {}) {
 	}
 	let hmrEnabled = options.hmr;
 	let specializeProductionRoots = false;
+	let specializeCssModuleConstants = false;
 	let emitClientReferenceManifest = options.ssr !== true;
 	// Profiling is intentionally independent of serve/HMR. `ssr: true` is the
 	// adapter's explicit server-only override, where client profiling must stay off.
@@ -449,6 +587,19 @@ export function octane(options = {}) {
 	const descriptorSourceCache = new Map();
 	const descriptorExportCache = new Map();
 	const descriptorGraphCache = new Map();
+	// Vite can share a plugin instance between client and server environments.
+	// CSS naming/virtual providers can differ between them, so never key a proof
+	// merely by its path or share a previous build's final-module snapshot.
+	const cssModuleProofStates = new Map();
+	const cssModuleProofState = (context, environment) => {
+		const key = context.environment ?? environment;
+		let state = cssModuleProofStates.get(key);
+		if (state === undefined) {
+			state = createCssModuleProofState();
+			cssModuleProofStates.set(key, state);
+		}
+		return state;
+	};
 	// Rollup's one-shot build graph can safely load an unresolved virtual module
 	// to collect its transform metadata. Vite's dev plugin container cannot: a
 	// transform awaiting `this.load()` for a virtual dependency can wait on the
@@ -472,6 +623,7 @@ export function octane(options = {}) {
 		descriptorSourceCache.clear();
 		descriptorExportCache.clear();
 		descriptorGraphCache.clear();
+		cssModuleProofStates.clear();
 		projectRoot = nodePath.resolve(root);
 		compiler = createOctaneCompiler({
 			root: projectRoot,
@@ -545,6 +697,23 @@ export function octane(options = {}) {
 			// reruns when only an imported module's output contract changes. Keep the
 			// proof to one-shot production builds where the graph is compiled together.
 			specializeProductionRoots = config.command === 'build' && config.build?.watch == null;
+			specializeCssModuleConstants = specializeProductionRoots && !hmrEnabled;
+		},
+		buildStart() {
+			if (this.environment === undefined) cssModuleProofStates.clear();
+			else cssModuleProofStates.delete(this.environment);
+		},
+		buildEnd(error) {
+			const keys = this.environment === undefined ? ['client', 'server'] : [this.environment];
+			for (const key of keys) {
+				const state = cssModuleProofStates.get(key);
+				if (state === undefined) continue;
+				try {
+					if (!error) verifyCssModuleProofs(this, state);
+				} finally {
+					cssModuleProofStates.delete(key);
+				}
+			}
 		},
 		watchChange(id) {
 			compiler.invalidate(id);
@@ -553,6 +722,7 @@ export function octane(options = {}) {
 			descriptorSourceCache.clear();
 			descriptorExportCache.clear();
 			descriptorGraphCache.clear();
+			cssModuleProofStates.clear();
 		},
 		generateBundle(_outputOptions, bundle) {
 			if (!emitClientReferenceManifest) return;
@@ -576,12 +746,30 @@ export function octane(options = {}) {
 				forceSsr !== undefined
 					? forceSsr
 					: transformOptions?.ssr === true || this.environment?.config?.consumer === 'server';
-			const transformWithProof = (proven, descriptorProven = new Set(), clientOnlyImports = []) => {
+			const environment = server ? 'server' : 'client';
+			const cssRequests = specializeCssModuleConstants
+				? compiler.findCssModuleImportRequests(code, id, environment)
+				: [];
+			const loadCssImports = () =>
+				loadCssModuleImports(
+					this,
+					cssRequests,
+					id,
+					environment,
+					options.cssModuleConstants,
+					cssModuleProofState(this, environment),
+				);
+			const transformWithProof = (
+				proven,
+				descriptorProven = new Set(),
+				clientOnlyImports = [],
+				cssImports = null,
+			) => {
 				const propagatedExports = [...descriptorProven]
 					.filter((key) => key.startsWith('export\0'))
 					.map((key) => key.slice('export\0'.length));
 				const result = compiler.transform(code, id, {
-					environment: server ? 'server' : 'client',
+					environment,
 					hmr: !server && hmrEnabled ? 'vite' : false,
 					// DEV server transforms also carry SSR-only diagnostics. HMR itself
 					// remains client-only; an explicit `hmr: false` keeps both transforms
@@ -603,6 +791,15 @@ export function octane(options = {}) {
 									descriptorProven.has(voidImportKey(request, imported)),
 							}
 						: {}),
+					...(cssImports === null
+						? null
+						: {
+								resolveCssModuleConstant: cssImports.resolve,
+								// A real class read must survive in each independently retained
+								// template. A global side-effect override would make styles from
+								// an unused exported component newly eager.
+								preserveCssModuleReferences: cssImports.requests,
+							}),
 				});
 				if (result === null) {
 					if (propagatedExports.length === 0) return null;
@@ -616,6 +813,7 @@ export function octane(options = {}) {
 						},
 					};
 				}
+				cssImports?.consume(result.cssModuleConstantImports);
 				for (const dependency of result.dependencies) this.addWatchFile?.(dependency);
 				const meta = {};
 				if (result.clientReference !== undefined) {
@@ -660,8 +858,9 @@ export function octane(options = {}) {
 						descriptorGraphCache,
 						allowDescriptorGraphLoad,
 					),
-				]).then(([imports, descriptorProven]) =>
-					transformWithProof(null, descriptorProven, imports),
+					loadCssImports(),
+				]).then(([imports, descriptorProven, cssImports]) =>
+					transformWithProof(null, descriptorProven, imports, cssImports),
 				);
 			}
 
@@ -672,7 +871,7 @@ export function octane(options = {}) {
 			const descriptorImports = findDescriptorChildrenImports(code, id).filter(
 				(candidate) => candidate.local !== undefined || !nodeFs.existsSync(cleanModuleId(id)),
 			);
-			if (voidImports.length === 0 && descriptorImports.length === 0) {
+			if (voidImports.length === 0 && descriptorImports.length === 0 && cssRequests.length === 0) {
 				return transformWithProof(null);
 			}
 			return Promise.all([
@@ -686,7 +885,10 @@ export function octane(options = {}) {
 					descriptorGraphCache,
 					allowDescriptorGraphLoad,
 				),
-			]).then(([proven, descriptorProven]) => transformWithProof(proven, descriptorProven));
+				loadCssImports(),
+			]).then(([proven, descriptorProven, cssImports]) =>
+				transformWithProof(proven, descriptorProven, [], cssImports),
+			);
 		},
 	};
 }

--- a/packages/octane/tests/_fixtures/css-module-constants.styles.ts
+++ b/packages/octane/tests/_fixtures/css-module-constants.styles.ts
@@ -1,0 +1,20 @@
+// A small generated-CSS-provider stand-in. Real Vite CSS emission is covered by
+// the production adapter tests; these exports make the compiler proof's value
+// and immutability contract executable in both runtimes.
+export const badge = '_sheet_badge';
+export const tail = '_sheet_tail';
+
+const styles = Object.freeze({
+	root: '_sheet_root composed',
+	escaped: '_sheet_&"<',
+	empty: '',
+	tail,
+});
+
+export const mutableStyles = { current: '_mutable_first' };
+
+export function setMutableClass(value: string) {
+	mutableStyles.current = value;
+}
+
+export default styles;

--- a/packages/octane/tests/_fixtures/css-module-constants.tsrx
+++ b/packages/octane/tests/_fixtures/css-module-constants.tsrx
@@ -1,0 +1,35 @@
+import styles, { badge, mutableStyles } from './css-module-constants.styles.js';
+import * as classes from './css-module-constants.styles.js';
+
+interface Props {
+	label: string;
+	selected: 'root' | 'tail';
+	attrs: { class?: string; className?: string };
+	shadow: string;
+	rows: { id: string; root: string }[];
+	onClick: () => void;
+	ref: { current: HTMLElement | null };
+}
+
+function Shadow(styles: { root: string }) @{
+	<aside data-case="shadow" class={styles.root} />
+}
+
+export function CssConstants(props: Props) @{
+	<main class={styles.root} ref={props.ref}>
+		<h1 className={`${badge} ${classes.tail}`}>{props.label as string}</h1>
+		<p data-case="escaped" class={styles['escaped']} />
+		<p data-case="empty" class={styles.empty} />
+		<p data-case="computed" class={styles[props.selected]} />
+		<p data-case="mutable" class={mutableStyles.current} />
+		<div data-case="before-spread" class={styles.root} {...props.attrs} />
+		<div data-case="after-spread" {...props.attrs} className={styles.root} />
+		<Shadow root={props.shadow} />
+		<ul>
+			@for (const styles of props.rows; key styles.id) {
+				<li class={styles.root}>{styles.id as string}</li>
+			}
+		</ul>
+		<button class={badge + ' action'} onClick={props.onClick}>Go</button>
+	</main>
+}

--- a/packages/octane/tests/compiler/css-module-vite.test.ts
+++ b/packages/octane/tests/compiler/css-module-vite.test.ts
@@ -1,0 +1,506 @@
+// @vitest-environment node
+
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { build, type Plugin, type Rolldown } from 'vite';
+import { createOctaneCompiler } from '../../src/compiler/bundler.js';
+import {
+	octane,
+	type OctaneCssModuleConstants,
+	type OctaneVitePluginOptions,
+} from '../../src/compiler/vite.js';
+
+const PACKAGE_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const IMMUTABLE_META = 'fixture:immutable-css-constants';
+const MOCK_ROOT = '/project';
+const roots: string[] = [];
+type Output = Rolldown.OutputChunk | Rolldown.OutputAsset;
+
+function fixture(files: Record<string, string>) {
+	const root = realpathSync(mkdtempSync(join(tmpdir(), 'octane-css-module-vite-')));
+	roots.push(root);
+	mkdirSync(join(root, 'node_modules'));
+	symlinkSync(PACKAGE_ROOT, join(root, 'node_modules/octane'), 'dir');
+	writeFileSync(
+		join(root, 'package.json'),
+		JSON.stringify({ type: 'module', dependencies: { octane: '0.0.0' } }),
+	);
+	for (const [file, source] of Object.entries(files)) {
+		const filename = join(root, file);
+		mkdirSync(dirname(filename), { recursive: true });
+		writeFileSync(filename, source);
+	}
+	return root;
+}
+
+async function buildFixture(
+	root: string,
+	entry: string,
+	options: {
+		server?: boolean;
+		plugins?: Plugin[];
+		compiler?: OctaneVitePluginOptions;
+	} = {},
+): Promise<Output[]> {
+	const result = await build({
+		root,
+		configFile: false,
+		logLevel: 'silent',
+		css: { modules: { generateScopedName: 'mapped_[local]' } },
+		...(options.server ? { ssr: { noExternal: true } } : {}),
+		plugins: [...(options.plugins ?? []), octane({ hmr: false, ...options.compiler })],
+		build: {
+			write: false,
+			minify: true,
+			cssMinify: false,
+			manifest: true,
+			...(options.server ? { ssr: join(root, entry) } : {}),
+			rolldownOptions: {
+				input: join(root, entry),
+				...(options.server
+					? {}
+					: { external: (id: string) => id === 'octane' || id.startsWith('octane/') }),
+			},
+		},
+	});
+	const outputs = Array.isArray(result) ? result : [result];
+	return outputs.flatMap((output) => {
+		if (!('output' in output)) throw new Error('Expected a one-shot Vite build.');
+		return output.output;
+	});
+}
+
+function cssSource(output: Output[]) {
+	return output
+		.filter(
+			(item): item is Rolldown.OutputAsset =>
+				item.type === 'asset' && item.fileName.endsWith('.css'),
+		)
+		.map((item) => String(item.source))
+		.join('\n');
+}
+
+function initialCss(output: Output[]) {
+	const chunks = new Map(
+		output
+			.filter((item): item is Rolldown.OutputChunk => item.type === 'chunk')
+			.map((chunk) => [chunk.fileName, chunk]),
+	);
+	const visited = new Set<string>();
+	const css = new Set<string>();
+	const visit = (filename: string) => {
+		if (visited.has(filename)) return;
+		visited.add(filename);
+		const chunk = chunks.get(filename);
+		if (chunk === undefined) return;
+		for (const stylesheet of chunk.viteMetadata?.importedCss ?? []) css.add(stylesheet);
+		for (const dependency of chunk.imports) visit(dependency);
+	};
+	for (const chunk of chunks.values()) if (chunk.isEntry) visit(chunk.fileName);
+	return [...css];
+}
+
+let evaluatedModule = 0;
+async function serverModule(output: Output[]): Promise<Record<string, any>> {
+	const entry = output.find(
+		(item): item is Rolldown.OutputChunk => item.type === 'chunk' && item.isEntry,
+	);
+	if (entry === undefined) throw new Error('Missing server entry.');
+	return import(
+		`data:text/javascript;base64,${Buffer.from(entry.code).toString('base64')}#css-vite-${evaluatedModule++}`
+	);
+}
+
+function immutableProvider(root: string, finalLabel = 'provided_label'): Plugin {
+	const id = '\0fixture:styles.module.css.js?immutable=1';
+	const constants: OctaneCssModuleConstants = {
+		named: { root: 'provided_root', label: 'provided_label', tail: 'provided_tail' },
+		default: { root: 'provided_root', label: 'provided_label', tail: 'provided_tail' },
+	};
+	return {
+		name: 'fixture-immutable-css-provider',
+		enforce: 'pre',
+		resolveId(request) {
+			return request === './virtual.module.css' ? id : null;
+		},
+		load(request) {
+			if (request !== id) return null;
+			return {
+				code: `import ${JSON.stringify(join(root, 'provider.css'))};
+export const root = 'provided_root';
+export const label = ${JSON.stringify(finalLabel)};
+export const tail = 'provided_tail';
+export default Object.freeze({ root, label, tail });`,
+				meta: { [IMMUTABLE_META]: constants },
+				// This provider deliberately lets a dead exported value take its
+				// stylesheet with it. Octane must preserve that ownership policy.
+				moduleSideEffects: false,
+			};
+		},
+	};
+}
+
+const provideImmutableConstants: NonNullable<OctaneVitePluginOptions['cssModuleConstants']> = ({
+	meta,
+}) => meta[IMMUTABLE_META] as OctaneCssModuleConstants | undefined;
+
+function configuredPlugin(
+	options: OctaneVitePluginOptions = {},
+	command: 'serve' | 'build' = 'build',
+	buildOptions: { watch?: object } = {},
+) {
+	const plugin = octane({ hmr: false, ...options });
+	(plugin.config as any)({ root: MOCK_ROOT }, { command, mode: 'production' });
+	(plugin.configResolved as any)({
+		root: MOCK_ROOT,
+		command,
+		build: buildOptions,
+		define: {},
+	});
+	return plugin;
+}
+
+function moduleContext(source: string, id = `${MOCK_ROOT}/styles.module.css`) {
+	const module = { id, code: source, meta: {}, moduleSideEffects: false };
+	return {
+		module,
+		context: {
+			resolve: vi.fn(async () => ({ id })),
+			load: vi.fn(async () => module),
+			getModuleInfo: vi.fn((request: string) => (request === id ? module : null)),
+		},
+	};
+}
+
+const NAMED_SOURCE = `import { root, label } from './styles.module.css';
+export function App() @{ <main class={root}><span class={label}>ready</span></main> }`;
+const NAMED_EXPORTS = `export const root = 'mapped_root';
+export const label = 'mapped_label';
+export default { root, label };`;
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('CSS-module constants in Vite builds', () => {
+	it('keeps used CSS, drops unused component CSS, and leaves lazy CSS deferred', async () => {
+		const root = fixture({
+			'used.module.css': '.root { color: red } .label { color: blue } .tail { color: green }',
+			'unused.module.css': '.unusedRoot { color: purple } .unusedLabel { color: orange }',
+			'Components.tsrx': `
+import { root, label, tail } from './used.module.css';
+import * as classes from './used.module.css';
+import { unusedRoot, unusedLabel } from './unused.module.css';
+export function Used() @{
+  <main class={root}><span class={label}>live</span><i class={classes.tail} /></main>
+}
+export function Unused() @{
+  <aside class={unusedRoot}><b class={unusedLabel}>unused</b></aside>
+}
+export function Plain() @{ <p>plain</p> }
+`,
+			'used.js': `import { Used } from './Components.tsrx'; globalThis.cssComponent = Used;`,
+			'unused.js': `import { Plain } from './Components.tsrx'; globalThis.cssComponent = Plain;`,
+			'lazy.js': `export { Used } from './Components.tsrx';`,
+			'entry.js': `globalThis.loadCssComponent = () => import('./lazy.js');`,
+		});
+		const used = await buildFixture(root, 'used.js');
+		expect(cssSource(used)).toContain('.mapped_root');
+		expect(cssSource(used)).toContain('.mapped_label');
+		expect(cssSource(used)).not.toContain('.mapped_unusedRoot');
+		expect(initialCss(used).length).toBeGreaterThan(0);
+
+		const unused = await buildFixture(root, 'unused.js');
+		expect(cssSource(unused)).toBe('');
+		expect(initialCss(unused)).toEqual([]);
+
+		const lazy = await buildFixture(root, 'entry.js');
+		expect(cssSource(lazy)).toContain('.mapped_root');
+		expect(cssSource(lazy)).not.toContain('.mapped_unusedRoot');
+		expect(initialCss(lazy)).toEqual([]);
+		expect(
+			lazy.some(
+				(item) =>
+					item.type === 'chunk' &&
+					item.isDynamicEntry &&
+					(item.viteMetadata?.importedCss.size ?? 0) > 0,
+			),
+		).toBe(true);
+	});
+
+	it('does not treat the ordinary mutable default map as immutable', async () => {
+		const root = fixture({
+			'styles.module.css': '.root { color: red } .label { color: blue }',
+			'App.tsrx': `import styles from './styles.module.css';
+export function App() @{ <main class={styles.root}><span class={styles.label}>live</span></main> }`,
+			'mutator.js': `import styles from './styles.module.css';
+export function mutate() { styles.root = 'changed_root'; styles.label = 'changed_label'; }`,
+			'entry.js': `import { App } from './App.tsrx';
+import { renderToStaticMarkup } from 'octane/server';
+export { mutate } from './mutator.js';
+export function render() { return renderToStaticMarkup(App).html; }`,
+		});
+		const api = await serverModule(await buildFixture(root, 'entry.js', { server: true }));
+		expect(api.render()).toBe(
+			'<main class="mapped_root"><span class="mapped_label">live</span></main>',
+		);
+		api.mutate();
+		expect(api.render()).toBe(
+			'<main class="changed_root"><span class="changed_label">live</span></main>',
+		);
+	});
+
+	it.each([
+		['metadata', '<meta class={root} name="fixture" content="value" />'],
+		['preload links', '<link class={root} rel="preload" as="image" href="/fixture.png" />'],
+	])('keeps CSS used beside hoisted %s', async (_name, resource) => {
+		const root = fixture({
+			'styles.module.css': '.root { color: red } .label { color: blue }',
+			'App.tsrx': `import { root, label } from './styles.module.css';
+export function App() @{ <main>${resource}<span class={label}>live</span></main> }`,
+			'entry.js': `import { App } from './App.tsrx'; globalThis.cssComponent = App;`,
+		});
+		const output = await buildFixture(root, 'entry.js');
+		expect(cssSource(output)).toContain('.mapped_label');
+		expect(initialCss(output).length).toBeGreaterThan(0);
+	});
+
+	it('authenticates virtual immutable maps without changing their stylesheet ownership', async () => {
+		const root = fixture({
+			'provider.css': '.provided_root { color: red } .provided_label { color: blue }',
+			'App.tsrx': `import styles from './virtual.module.css';
+export function App() @{
+  <main class={styles.root}><span class={styles.label}>provided</span><i class={styles.tail} /></main>
+}
+export function Plain() @{ <p>plain</p> }`,
+			'used.js': `import { App } from './App.tsrx'; globalThis.cssComponent = App;`,
+			'unused.js': `import { Plain } from './App.tsrx'; globalThis.cssComponent = Plain;`,
+			'entry.js': `import { App } from './App.tsrx';
+import { renderToStaticMarkup } from 'octane/server';
+export function render() { return renderToStaticMarkup(App).html; }`,
+		});
+		const provider = vi.fn(provideImmutableConstants);
+		const options = {
+			plugins: [immutableProvider(root)],
+			compiler: { cssModuleConstants: provider },
+		};
+		expect(cssSource(await buildFixture(root, 'used.js', options))).toContain('.provided_label');
+		expect(cssSource(await buildFixture(root, 'unused.js', options))).toBe('');
+		const api = await serverModule(
+			await buildFixture(root, 'entry.js', { ...options, server: true }),
+		);
+		expect(api.render()).toBe(
+			'<main class="provided_root"><span class="provided_label">provided</span><i class="provided_tail"></i></main>',
+		);
+		expect(provider.mock.calls.some(([module]) => module.environment === 'client')).toBe(true);
+		expect(provider.mock.calls.some(([module]) => module.environment === 'server')).toBe(true);
+		for (const [module] of provider.mock.calls) {
+			expect(module.id).toBe('\0fixture:styles.module.css.js?immutable=1');
+			expect(module.code).toContain('Object.freeze');
+		}
+	});
+
+	it('rejects provider values that disagree with the final transformed module', async () => {
+		const root = fixture({
+			'provider.css': '.provided_root { color: red }',
+			'App.tsrx': `import styles from './virtual.module.css';
+export function App() @{ <main class={styles.root}><span class={styles.label} /></main> }`,
+			'entry.js': `import { App } from './App.tsrx'; globalThis.cssComponent = App;`,
+		});
+		await expect(
+			buildFixture(root, 'entry.js', {
+				plugins: [immutableProvider(root, 'changed_by_later_transform')],
+				compiler: { cssModuleConstants: provideImmutableConstants },
+			}),
+		).rejects.toThrow(/invalid cssModuleConstants.*label.*final module/);
+	});
+
+	it('declines an in-flight CSS proof in a circular virtual provider graph', async () => {
+		const root = fixture({
+			'provider.css': '.provided_root { color: red } .provided_label { color: blue }',
+			'App.tsrx': `import styles from './virtual.module.css';
+export function App() @{ <main class={styles.root}><span class={styles.label}>cycle</span></main> }`,
+			'entry.js': `import { App } from './App.tsrx'; globalThis.cssComponent = App;`,
+		});
+		const firstId = '\0fixture:cyclic-first.tsrx';
+		const secondId = '\0fixture:cyclic-second.tsrx';
+		const provider: Plugin = {
+			name: 'fixture-cyclic-css-provider',
+			enforce: 'pre',
+			resolveId(request) {
+				if (request === './virtual.module.css') return firstId;
+				if (request === './other.module.css') return secondId;
+				return null;
+			},
+			load(id) {
+				if (id === firstId) {
+					return {
+						code: `import other from './other.module.css';
+import ${JSON.stringify(join(root, 'provider.css'))};
+export { App } from ${JSON.stringify(join(root, 'App.tsrx'))};
+export const root = 'provided_root';
+export const label = 'provided_label';
+export default Object.freeze({ root, label });`,
+						meta: {
+							[IMMUTABLE_META]: { default: { root: 'provided_root', label: 'provided_label' } },
+						},
+						moduleSideEffects: false,
+					};
+				}
+				if (id === secondId) {
+					return {
+						code: `import first from './virtual.module.css';
+export const other = 'provided_other';
+export default Object.freeze({ other });`,
+						meta: { [IMMUTABLE_META]: { default: { other: 'provided_other' } } },
+						moduleSideEffects: false,
+					};
+				}
+				return null;
+			},
+		};
+		const output = await buildFixture(root, 'entry.js', {
+			plugins: [provider],
+			compiler: { cssModuleConstants: provideImmutableConstants },
+		});
+		expect(cssSource(output)).toContain('.provided_label');
+	}, 10_000);
+
+	it('keeps one-shot proofs out of serve, watch, and host-owned TSX transforms', async () => {
+		for (const [command, buildOptions] of [
+			['serve', {}],
+			['build', { watch: {} }],
+		] as const) {
+			const provider = vi.fn(provideImmutableConstants);
+			const plugin = configuredPlugin({ cssModuleConstants: provider }, command, buildOptions);
+			const { context } = moduleContext(NAMED_EXPORTS);
+			await (plugin.transform as any).call(context, NAMED_SOURCE, `${MOCK_ROOT}/App.tsrx`);
+			expect(context.resolve).not.toHaveBeenCalled();
+			expect(context.load).not.toHaveBeenCalled();
+			expect(provider).not.toHaveBeenCalled();
+		}
+
+		const provider = vi.fn(provideImmutableConstants);
+		const plugin = configuredPlugin({ requireDirective: true, cssModuleConstants: provider });
+		const { context } = moduleContext(NAMED_EXPORTS);
+		await (plugin.transform as any).call(
+			context,
+			`import { root } from './styles.module.css'; export const App = () => <main className={root} />;`,
+			`${MOCK_ROOT}/App.tsx`,
+		);
+		expect(context.resolve).not.toHaveBeenCalled();
+		expect(provider).not.toHaveBeenCalled();
+	});
+
+	it.each(['with', 'assert'])('declines CSS imports carrying %s attributes', async (keyword) => {
+		const provider = vi.fn(provideImmutableConstants);
+		const plugin = configuredPlugin({ cssModuleConstants: provider });
+		const { context } = moduleContext(NAMED_EXPORTS);
+		const source = NAMED_SOURCE.replace(
+			"'./styles.module.css';",
+			`'./styles.module.css' ${keyword} { type: 'css' };`,
+		);
+		const result = await (plugin.transform as any).call(context, source, `${MOCK_ROOT}/App.tsrx`);
+		expect(result.code).toContain('styles.module.css');
+		expect(result.code).not.toContain('mapped_label');
+		expect(context.resolve).not.toHaveBeenCalled();
+		expect(provider).not.toHaveBeenCalled();
+	});
+
+	it('declines stylesheet proofs outside an exclusively DOM-owned renderer configuration', async () => {
+		const source = NAMED_SOURCE.replace('>ready<', '><');
+		const registry = { object: '@fixture/object-renderer' };
+		const configurations: NonNullable<OctaneVitePluginOptions['renderers']>[] = [
+			{ registry, default: 'object' },
+			{
+				registry,
+				boundaries: {
+					'@fixture/bridge': {
+						Canvas: { ownerRenderer: 'dom', childRenderer: 'object', prop: 'children' },
+					},
+				},
+			},
+		];
+		for (const renderers of configurations) {
+			const provider = vi.fn(provideImmutableConstants);
+			const plugin = configuredPlugin({ renderers, cssModuleConstants: provider });
+			const { context } = moduleContext(NAMED_EXPORTS);
+			await (plugin.transform as any).call(context, source, `${MOCK_ROOT}/App.tsrx`);
+			expect(context.resolve).not.toHaveBeenCalled();
+			expect(provider).not.toHaveBeenCalled();
+
+			const resolveCssModuleConstant = vi.fn(() => 'unproven_class');
+			const compiler = createOctaneCompiler({ root: MOCK_ROOT, hmr: false, renderers });
+			const result = compiler.transform(source, `${MOCK_ROOT}/App.tsrx`, {
+				resolveCssModuleConstant,
+				preserveCssModuleReferences: ['./styles.module.css'],
+			});
+			expect(result?.code).not.toContain('unproven_class');
+			expect(resolveCssModuleConstant).not.toHaveBeenCalled();
+		}
+	});
+
+	it('validates the exact consumed module again before completing a build', async () => {
+		const plugin = configuredPlugin();
+		const { context, module } = moduleContext(NAMED_EXPORTS);
+		const result = await (plugin.transform as any).call(
+			context,
+			NAMED_SOURCE,
+			`${MOCK_ROOT}/App.tsrx`,
+		);
+		expect(result.map.sourcesContent).toContain(NAMED_SOURCE);
+		expect(module.moduleSideEffects).toBe(false);
+		module.code = NAMED_EXPORTS.replace('mapped_label', 'changed_label');
+		expect(() => (plugin.buildEnd as any).call(context)).toThrow(
+			/CSS-module constant proof changed/,
+		);
+	});
+
+	it('keeps final-module facts separate between client and server environments', async () => {
+		const provider = vi.fn(provideImmutableConstants);
+		const plugin = configuredPlugin({ cssModuleConstants: provider });
+		const client = moduleContext(NAMED_EXPORTS);
+		const server = moduleContext(NAMED_EXPORTS.replaceAll('mapped_', 'server_'));
+		const clientContext = { ...client.context, environment: { config: { consumer: 'client' } } };
+		const serverContext = { ...server.context, environment: { config: { consumer: 'server' } } };
+		const clientResult = await (plugin.transform as any).call(
+			clientContext,
+			NAMED_SOURCE,
+			`${MOCK_ROOT}/App.tsrx`,
+		);
+		const serverResult = await (plugin.transform as any).call(
+			serverContext,
+			NAMED_SOURCE,
+			`${MOCK_ROOT}/App.tsrx`,
+		);
+		expect(clientResult.code).toContain('mapped_label');
+		expect(serverResult.code).toContain('server_label');
+		expect(provider.mock.calls.map(([module]) => module.environment)).toEqual(['client', 'server']);
+	});
+
+	it('rejects getters, mutable bindings, spreads, and shadowed freeze helpers as export evidence', async () => {
+		const source = `import styles from './styles.module.css';
+export function App() @{ <main class={styles.root}><span class={styles.label} /></main> }`;
+		const invalidModules = [
+			`export default { get root() { return 'mapped_root' }, label: 'mapped_label' };`,
+			`export let label = 'mapped_label'; export default { root: 'mapped_root', label };`,
+			`const values = { root: 'mapped_root', label: 'mapped_label' }; export default { ...values };`,
+			`const Object = { freeze: value => value }; export default Object.freeze({ root: 'mapped_root', label: 'mapped_label' });`,
+			`export { default } from './other.js';`,
+		];
+		for (const module of invalidModules) {
+			const plugin = configuredPlugin({
+				cssModuleConstants: () => ({
+					default: { root: 'mapped_root', label: 'mapped_label' },
+				}),
+			});
+			const { context } = moduleContext(module);
+			await expect(
+				(plugin.transform as any).call(context, source, `${MOCK_ROOT}/App.tsrx`),
+			).rejects.toThrow(/invalid cssModuleConstants.*final module/);
+		}
+	});
+});

--- a/packages/octane/tests/css-module-constants.test.ts
+++ b/packages/octane/tests/css-module-constants.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { build } from 'esbuild';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+import { compile, type CompileOptions } from 'octane/compiler';
+import styles, { badge, tail } from './_fixtures/css-module-constants.styles.js';
+import { decodeMappings } from './_source-map.js';
+
+const packageRoot = resolve(import.meta.dirname, '..');
+const fixture = resolve(import.meta.dirname, '_fixtures/css-module-constants.tsrx');
+const stylesheet = resolve(import.meta.dirname, '_fixtures/css-module-constants.styles.ts');
+const source = readFileSync(fixture, 'utf8');
+const request = './css-module-constants.styles.js';
+const named: Readonly<Record<string, string>> = { badge, tail };
+
+const proof: NonNullable<CompileOptions['resolveCssModuleConstant']> = (
+	module,
+	imported,
+	property,
+) => {
+	if (module !== request) return undefined;
+	if (imported === 'default' && property !== null && Object.hasOwn(styles, property)) {
+		return styles[property as keyof typeof styles];
+	}
+	const name = imported === '*' ? property : property === null ? imported : null;
+	return name !== null && Object.hasOwn(named, name) ? named[name] : undefined;
+};
+
+type FixtureModule = Record<string, any>;
+type ProofMode = 'none' | 'full' | 'preserve';
+
+async function bundleFixture(mode: 'client' | 'server', proofMode: ProofMode, dev: boolean) {
+	const runtime = mode === 'client' ? 'octane' : 'octane/server';
+	const exports = mode === 'client' ? 'createRoot, hydrateRoot, flushSync' : 'renderToString';
+	const result = await build({
+		stdin: {
+			contents: `export * from ${JSON.stringify(fixture)};
+export { ${exports} } from ${JSON.stringify(runtime)};
+export { setMutableClass } from ${JSON.stringify(stylesheet)};`,
+			loader: 'js',
+			resolveDir: packageRoot,
+			sourcefile: 'css-constants-entry.js',
+		},
+		bundle: true,
+		write: false,
+		format: mode === 'client' ? 'iife' : 'esm',
+		...(mode === 'client' ? { globalName: 'cssFixture' } : {}),
+		platform: mode === 'client' ? 'browser' : 'node',
+		target: 'esnext',
+		minify: !dev,
+		logLevel: 'silent',
+		define: {
+			'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production'),
+			__OCTANE_PROFILE_ENABLED__: 'false',
+		},
+		plugins: [
+			{
+				name: 'compile-css-constant-fixture',
+				setup(bundler) {
+					bundler.onLoad({ filter: /\.tsrx$/ }, ({ path }) => {
+						if (path !== fixture) return undefined;
+						return {
+							contents: compile(source, fixture, {
+								mode,
+								hmr: false,
+								dev,
+								...(proofMode === 'none' ? {} : { resolveCssModuleConstant: proof }),
+								...(proofMode === 'preserve' ? { preserveCssModuleReferences: [request] } : {}),
+							}).code,
+							loader: 'js',
+							resolveDir: resolve(fixture, '..'),
+						};
+					});
+				},
+			},
+		],
+	});
+	return result.outputFiles[0].text;
+}
+
+function clientModule(code: string) {
+	const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+		runScripts: 'outside-only',
+		url: 'https://example.test/',
+	});
+	dom.window.eval(code);
+	return {
+		dom,
+		api: (dom.window as unknown as { cssFixture: FixtureModule }).cssFixture,
+		container: dom.window.document.getElementById('root')!,
+	};
+}
+
+let serverModuleId = 0;
+async function serverModule(code: string): Promise<FixtureModule> {
+	return import(
+		`data:text/javascript;base64,${Buffer.from(code).toString('base64')}#css-${serverModuleId++}`
+	);
+}
+
+function props(label = 'First') {
+	return {
+		label,
+		selected: 'root',
+		attrs: { class: 'from-spread' },
+		shadow: 'shadow-first',
+		rows: [
+			{ id: 'a', root: 'row-a' },
+			{ id: 'b', root: 'row-b' },
+		],
+		onClick: vi.fn(),
+		ref: { current: null as HTMLElement | null },
+	};
+}
+
+function observed(container: Element) {
+	return Array.from(
+		container.querySelectorAll('main, h1, p, div[data-case], aside, li, button'),
+	).map((element) => [element.tagName, element.getAttribute('class'), element.textContent]);
+}
+
+describe('proven CSS-module class strings', () => {
+	for (const dev of [false, true]) {
+		it(`preserves classes, spread ordering, events, and keyed updates (${dev ? 'dev' : 'prod'})`, async () => {
+			const bundles = await Promise.all([
+				bundleFixture('client', 'none', dev),
+				bundleFixture('client', 'full', dev),
+				bundleFixture('client', 'preserve', dev),
+			]);
+			const results = [];
+			for (const code of bundles) {
+				const { dom, api, container } = clientModule(code);
+				const initial = props();
+				const root = api.createRoot(container);
+				try {
+					root.render(api.CssConstants, initial);
+					api.flushSync(() => {});
+					const main = container.querySelector('main');
+					const rowA = container.querySelector('li');
+					expect(main?.className).toBe(styles.root);
+					expect(container.querySelector('h1')?.className).toBe(`${badge} ${tail}`);
+					expect(container.querySelector('[data-case="escaped"]')?.getAttribute('class')).toBe(
+						styles.escaped,
+					);
+					expect(container.querySelector('[data-case="empty"]')?.getAttribute('class')).toBe('');
+					expect(initial.ref.current).toBe(main);
+					(container.querySelector('button') as HTMLButtonElement).click();
+					expect(initial.onClick).toHaveBeenCalledOnce();
+					const first = observed(container);
+					api.setMutableClass('_mutable_second');
+					api.flushSync(() =>
+						root.render(api.CssConstants, {
+							...initial,
+							label: 'Second',
+							selected: 'tail',
+							attrs: { className: 'next-spread' },
+							shadow: 'shadow-second',
+							rows: [initial.rows[1], initial.rows[0]],
+						}),
+					);
+					expect(container.querySelector('main')).toBe(main);
+					expect(container.querySelectorAll('li')[1]).toBe(rowA);
+					expect(container.querySelector('[data-case="mutable"]')?.className).toBe(
+						'_mutable_second',
+					);
+					expect(container.querySelector('[data-case="computed"]')?.className).toBe(tail);
+					expect(container.querySelector('[data-case="shadow"]')?.className).toBe('shadow-second');
+					results.push([first, observed(container)]);
+				} finally {
+					root.unmount();
+					expect(initial.ref.current).toBeNull();
+					expect(container.textContent).toBe('');
+					dom.window.close();
+				}
+			}
+			expect(results[1]).toEqual(results[0]);
+			expect(results[2]).toEqual(results[0]);
+		});
+
+		it(`hydrates existing DOM and keeps later dynamic reads live (${dev ? 'dev' : 'prod'})`, async () => {
+			const [serverControl, serverCandidate, serverPreserved, ...clients] = await Promise.all([
+				bundleFixture('server', 'none', dev).then(serverModule),
+				bundleFixture('server', 'full', dev).then(serverModule),
+				bundleFixture('server', 'preserve', dev).then(serverModule),
+				bundleFixture('client', 'none', dev),
+				bundleFixture('client', 'full', dev),
+				bundleFixture('client', 'preserve', dev),
+			]);
+			const html = serverCandidate.renderToString(serverCandidate.CssConstants, props()).html;
+			expect(html).toBe(serverControl.renderToString(serverControl.CssConstants, props()).html);
+			expect(html).toBe(serverPreserved.renderToString(serverPreserved.CssConstants, props()).html);
+			for (const code of clients) {
+				const { dom, api, container } = clientModule(code);
+				container.innerHTML = html;
+				const initial = props();
+				const main = container.querySelector('main');
+				const button = container.querySelector('button');
+				const root = api.hydrateRoot(container, api.CssConstants, initial);
+				try {
+					api.flushSync(() => {});
+					expect(container.querySelector('main')).toBe(main);
+					expect(container.querySelector('button')).toBe(button);
+					expect(container.querySelector('[data-case="empty"]')?.getAttribute('class')).toBe('');
+					expect(initial.ref.current).toBe(main);
+					(button as HTMLButtonElement).click();
+					expect(initial.onClick).toHaveBeenCalledOnce();
+					api.setMutableClass('_after_hydration');
+					api.flushSync(() => root.render(api.CssConstants, { ...initial, label: 'Hydrated' }));
+					expect(container.querySelector('h1')?.textContent).toBe('Hydrated');
+					expect(container.querySelector('[data-case="mutable"]')?.className).toBe(
+						'_after_hydration',
+					);
+				} finally {
+					root.unmount();
+					expect(initial.ref.current).toBeNull();
+					dom.window.close();
+				}
+			}
+		});
+	}
+
+	it('retains original source locations and rejects non-string proof values', () => {
+		const result = compile(source, fixture, {
+			hmr: false,
+			resolveCssModuleConstant: proof,
+			inspect: true,
+		});
+		expect(result.map.sourcesContent).toContain(source);
+		const classOffset = source.indexOf('class={styles.root}') + 'class={'.length;
+		const classLine = source.slice(0, classOffset).split('\n').length - 1;
+		expect(
+			decodeMappings(result.map.mappings)
+				.flat()
+				.some((segment) => segment[2] === classLine),
+		).toBe(true);
+		expect(() =>
+			compile(source, fixture, {
+				resolveCssModuleConstant: (() => 123) as unknown as typeof proof,
+			}),
+		).toThrow('Invalid CSS-module constant');
+	});
+
+	it('does not borrow a proof across import attributes', () => {
+		const resolveCssModuleConstant = vi.fn(() => '_wrong_module');
+		compile(
+			'import styles from "./sheet.module.css" with { type: "css" }; ' +
+				'export function App() @{ <div class={styles.root}/> }',
+			'/ImportAttributes.tsrx',
+			{ hmr: false, resolveCssModuleConstant },
+		);
+		expect(resolveCssModuleConstant).not.toHaveBeenCalled();
+	});
+});

--- a/packages/vite-plugin-octane/src/index.js
+++ b/packages/vite-plugin-octane/src/index.js
@@ -221,7 +221,7 @@ function collect_hydrate_module_paths(config) {
  * it). An explicit `profile` (true or false) always takes precedence over
  * `devtools`.
  *
- * @param {{ hmr?: boolean, profile?: boolean, devtools?: boolean, strong?: boolean, exclude?: string[], requireDirective?: boolean, renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions }} [inlineOptions]
+ * @param {{ hmr?: boolean, profile?: boolean, devtools?: boolean, strong?: boolean, exclude?: string[], requireDirective?: boolean, renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions, cssModuleConstants?: import('octane/compiler/vite').OctaneVitePluginOptions['cssModuleConstants'] }} [inlineOptions]
  * @returns {Plugin[]}
  */
 export function octane(inlineOptions = {}) {
@@ -884,6 +884,7 @@ export function octane(inlineOptions = {}) {
 	 *   exclude?: string[],
 	 *   requireDirective?: boolean,
 	 *   renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions,
+	 *   cssModuleConstants?: import('octane/compiler/vite').OctaneVitePluginOptions['cssModuleConstants'],
 	 * }}
 	 */
 	const compilerOptions = {};
@@ -898,6 +899,9 @@ export function octane(inlineOptions = {}) {
 		compilerOptions.requireDirective = inlineOptions.requireDirective;
 	}
 	if (inlineOptions.renderers !== undefined) compilerOptions.renderers = inlineOptions.renderers;
+	if (inlineOptions.cssModuleConstants !== undefined) {
+		compilerOptions.cssModuleConstants = inlineOptions.cssModuleConstants;
+	}
 	const compilerPlugin = /** @type {Plugin} */ (octaneCompiler(compilerOptions));
 	const compilerConfigHook = compilerPlugin.config;
 	if (typeof compilerConfigHook === 'function') {

--- a/packages/vite-plugin-octane/tests/plugin.test.ts
+++ b/packages/vite-plugin-octane/tests/plugin.test.ts
@@ -207,6 +207,44 @@ describe('octane() plugin factory', () => {
 		}
 	});
 
+	it('forwards immutable CSS-provider facts to the bundled compiler', async () => {
+		const cssId = '/repo/src/panel.module.css';
+		const cssCode = 'export default Object.freeze({root:"_panel_root",label:"_panel_label"});';
+		const cssModule = { id: cssId, code: cssCode, meta: {}, moduleSideEffects: false };
+		const provider = vi.fn(() => ({
+			default: { root: '_panel_root', label: '_panel_label' },
+		}));
+		const [compiler] = octane({ hmr: false, cssModuleConstants: provider });
+		await (compiler.config as (config: { root: string }) => unknown)({ root: '/repo' });
+		(compiler.configResolved as (config: unknown) => void)({
+			root: '/repo',
+			command: 'build',
+			build: {},
+			define: {},
+		});
+		const source =
+			'import styles from "./panel.module.css"; ' +
+			'export function Panel() @{ <section class={styles.root}><span class={styles.label}>Ready</span></section> }';
+		const output = await (compiler.transform as any).call(
+			{
+				resolve: async (request: string) =>
+					request === './panel.module.css' ? { id: cssId } : null,
+				load: async () => cssModule,
+				getModuleInfo: (id: string) => (id === cssId ? cssModule : null),
+			},
+			source,
+			'/repo/src/Panel.tsrx',
+		);
+		expect(provider).toHaveBeenCalledWith({
+			id: cssId,
+			code: cssCode,
+			meta: {},
+			environment: 'client',
+		});
+		expect(output.code).toContain('_panel_label');
+		expect(cssModule.moduleSideEffects).toBe(false);
+	});
+
 	it.each([true, false])('forwards strong=%s to the bundled compiler', async (strong) => {
 		const [compiler] = octane({ hmr: false, strong });
 		await (compiler.config as (config: { root: string }) => unknown)({ root: '/repo' });

--- a/packages/vite-plugin-octane/types/index.d.ts
+++ b/packages/vite-plugin-octane/types/index.d.ts
@@ -1,4 +1,5 @@
 import type { Plugin, ViteDevServer } from 'vite';
+import type { OctaneVitePluginOptions } from 'octane/compiler/vite';
 import type {
 	ConfigModuleRunner,
 	ExperimentalRendererConfigOptions,
@@ -42,6 +43,8 @@ export interface OctanePluginOptions {
 	 * reads `compiler.renderers` from `octane.config.ts` before transforming modules.
 	 */
 	renderers?: ExperimentalRendererConfigOptions;
+	/** @experimental Authenticate immutable CSS-module exports in production builds. */
+	cssModuleConstants?: OctaneVitePluginOptions['cssModuleConstants'];
 }
 
 /** The Octane compiler plugin plus Vite app/metaframework integration. */


### PR DESCRIPTION
## Summary

- Fold proven immutable CSS-module strings into static `class`/`className` template attributes.
- Preserve stylesheet reachability for used, unused, and lazy components without changing the provider's global side-effect flags.
- Add an experimental immutable-provider contract to both Vite integrations, behavioral/build coverage, and paired codegen-size guards.

## Why

Class-dense components currently retain repeated class-binding and serialization code even when a CSS provider knows the final class strings. An ordinary CSS-module default object is mutable, so a filename or locally read-only use is not sufficient evidence to fold it. Dropping the last live CSS export can also drop its stylesheet.

## Changes

- Apply a copy-on-write authored-AST pass before template planning. Only complete, proven string expressions are folded; existing client/SSR writers still own escaping, composition, spreads, and hydration.
- Read the exact resolved provider's final ESM without executing it. Standard pure named-string exports are recognized automatically; default-map values require an explicit initialized-and-immutable provider guarantee. Validate supplied values and consumed source fingerprints.
- Retain an original class read per independently retained static host subtree. Decline unsupported ownership boundaries, mutable defaults, import attributes, serve/watch, and unresolved circular proofs.
- Cover public DOM updates, refs/events, keyed identity, SSR/hydration, source maps, mutable neighbors, stale providers, and actual Vite CSS assets. The head-hoisted `meta`/`link` stylesheet-loss regression was demonstrated failing with its guard removed and passing after restoration.
- Add patch changesets for `octane` and `@octanejs/vite-plugin`.

### Size evidence

The new public sentinel uses identical component/provider source, external framework imports, identical 703-byte CSS, and equal SSR output. Node 26.2.0, esbuild 0.28.1, gzip level 9, Brotli quality 11:

| Output | Minified | Gzip | Brotli |
| --- | ---: | ---: | ---: |
| Client control → proven | 3,042 → 2,370 | 1,454 → 1,118 (−23.1%) | 1,226 → 950 |
| Server control → proven | 2,514 → 1,922 | 957 → 870 (−9.1%) | 858 → 755 |

These are component-code measurements, not a claim about whole-application delivered bytes. The eight new same-run size guards pass. No runtime ABI or hot-path runtime code is added.

## Validation

- [ ] `pnpm format:check` — full-repository check not run.
- [ ] `pnpm typecheck` — full-monorepo check not run.
- [ ] `pnpm test` — full-monorepo/native-parser run not available locally.
- [x] `pnpm format:files:check` for the changed files/compiler directory.
- [x] `pnpm typecheck:files` for the changed compiler, fixture, test, and Vite-plugin files.
- [x] `pnpm sync`.
- [x] Targeted tests: 162 development/compiler tests, 111 production/SSR/hydration tests, and the Vite-wrapper forwarding test passed. The final empty-class render/hydration additions also passed in both runtime projects (12 tests).
- [x] `node benchmarks/codegen-size/run.mjs` — semantic/CSS controls and all eight new paired size guards pass.
- [ ] `node benchmarks/bench.mjs codegen-size --ratios` — 14 of 15 applicable guards pass. The pre-existing aggregate `compiled/source` gzip guard is 1.0653 against its 1.06 limit on Node 26.4.0. A clean `c0ff085c0` compiler and this branch emit byte-identical code for all 16 fixed-corpus files (both 26,847 gzip bytes); the unrelated threshold is unchanged.

Local compiler validation used the supported JavaScript parser with the exact lockfile-selected dependencies and repository patch. Native-parser-dependent nested Vite tests remain unverified.

## Risk / follow-ups

- `cssModuleConstants` is an experimental correctness contract, not permission to declare an ordinary mutable default map constant. Providers must keep client/server names consistent.
- An in-flight/circular provider load can conservatively miss folding. Compiler-throughput and full-application performance are not claimed here.
- Component-children representation changes are intentionally excluded: the descriptor experiment regressed update CPU, while the safe single-site static hoist had negligible compressed savings. Repeated-static-renderer interning needs a separate measured design.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789857526&installation_model_id=432790&pr_number=814&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F814&signature=70f412ae834ed0021cd2093ed6690d90e8d3691dce5cecdc392e1138e9543691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production compiler and Vite transform paths for class attributes and CSS reachability. Incorrect proofs could drop stylesheets or bake mutable class names, but folding is gated to one-shot builds with conservative validation.
> 
> **Overview**
> Folds proven immutable CSS-module class strings into static `class`/`className` attributes before template planning, shrinking repeated client/SSR class-binding code without changing composition, spreads, escaping, or hydration.
> 
> Named CSS-module string exports are recognized automatically in one-shot production Vite builds. Ordinary mutable default maps stay dynamic unless a provider opts in via experimental `cssModuleConstants`, which is checked against the final ESM (never evaluated). One original class read is kept per static host subtree so unused and lazy component styles keep their existing delivery boundaries.
> 
> Disabled in serve/watch, with import attributes, renderer boundaries, and in-flight circular provider graphs. Adds compiler/Vite tests, docs, and paired codegen-size sentinels that require equal CSS and SSR output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace262ddcbfd08129e2ee294577d258f52448d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->