### PR TITLE
fix(octane): improve Activity parity and batch hidden updates

### DIFF
--- a/.changeset/activity-parity-and-hidden-work.md
+++ b/.changeset/activity-parity-and-hidden-work.md
@@ -1,0 +1,21 @@
+---
+'octane': patch
+---
+
+Improve Activity parity across compiled JSX, element descriptors, server rendering,
+hydration, and universal renderers. Hidden boundaries now disconnect public refs,
+preserve the latest authored styles and text, hide logically owned portals, and
+contain suspended work without activating an enclosing visible fallback. Retained
+insertion effects replay safely after suspended hidden renders, including memoized
+children and nested boundaries.
+
+Support Activity aliases, namespaces, spreads, children props, and ordered keys
+without changing the direct mode-only compiler fast path. Integrate Activity
+visibility changes with ViewTransition enter/exit animations and expose native
+pseudo-element animations through the transition instance.
+
+Coalesce hidden descendant visibility scans once per render wave and keep optional
+Activity implementation and ref tracking off unrelated application paths. Add
+production browser benchmarks and deterministic work, ref, and bundle controls.
+Octane's synchronous hidden-work scheduling and existing structural-transaction
+limitations remain unchanged.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -212,6 +212,7 @@ internally, get their own baseline and guard namespace.
 | `application-composition` | application-composition | none (builds) | lifecycle resources, large forms, store fan-out, async recovery, form submission, and navigation teardown in one app |
 | `scaling-curves` | scaling-curves | none (builds) | independently correctness-gated controlled updates at 8, 32, 96, 256, and 512 components |
 | `effectful-list` | effectful-list | Octane + reference frameworks | effect/ref cleanup churn |
+| `activity` | activity | none (builds) | same-source Octane/React Activity lifecycle, hidden/nested work, retained state/effects/DOM, cold-vs-used ordinary-ref controls, and optional-runtime bundle reachability |
 | `list-clear` | list-clear | Octane-only | keyed-list bulk clear by parent shape — the only coverage of the shared-parent path |
 | `memo-wall` | memo-wall | Octane + reference frameworks | memo bail + context walk |
 | `portal-swarm` | portal-swarm | Octane + reference frameworks | portal render/dispatch |

--- a/benchmarks/activity/App.tsrx
+++ b/benchmarks/activity/App.tsrx
@@ -1,0 +1,57 @@
+import { Activity, useEffect, useLayoutEffect, useState } from 'octane';
+import { GROUPS, ROW_INDICES } from './contract.mjs';
+import type { AppProps, Model } from './model';
+
+type RowProps = { model: Model; index: number; generation: number };
+
+function Row(props: RowProps) @{
+	const [local, setLocal] = useState(0);
+	const model = props.model;
+	const index = props.index;
+	useLayoutEffect(() => model.connectLayout(index, setLocal), [model, index]);
+	useEffect(() => model.connectPassive(index), [model, index]);
+	<article
+		data-row={String(index)}
+		data-generation={String(props.generation)}
+		data-local={String(local)}
+		style={model.displayStyle}
+	>
+		<button
+			type="button"
+			onClick={() => setLocal((value) => value + 1)}
+		>{`${index}:${props.generation}:${local}` as string}</button>
+		<input aria-label={`Draft ${index}`} defaultValue={`row-${index}`} />
+	</article>
+}
+
+function Rows(props: { model: Model; indices: readonly number[]; generation: number }) @{
+	<>
+		@for (const index of props.indices; key index) {
+			<Row model={props.model} index={index} generation={props.generation} />
+		}
+	</>
+}
+
+// This exact authored source is compiled for both targets. The React build
+// resolves the public `octane` import above to React and uses @tsrx/react plus
+// the repository's production React Compiler preset.
+export function App(props: AppProps) @{
+	<section data-shell="activity">
+		<output data-tick="">{String(props.tick) as string}</output>
+		@if (props.shape === 'plain') {
+			<Rows model={props.model} indices={ROW_INDICES} generation={props.generation} />
+		} @else {
+			<Activity mode={props.mode}>
+				@if (props.shape === 'nested') {
+					@for (const group of GROUPS; key group.id) {
+						<Activity mode={props.innerMode}>
+							<Rows model={props.model} indices={group.indices} generation={props.generation} />
+						</Activity>
+					}
+				} @else {
+					<Rows model={props.model} indices={ROW_INDICES} generation={props.generation} />
+				}
+			</Activity>
+		}
+	</section>
+}

--- a/benchmarks/activity/README.md
+++ b/benchmarks/activity/README.md
@@ -1,0 +1,165 @@
+# Activity lifecycle and hidden work
+
+A production-browser comparison of Octane's `<Activity>` and React's public
+Activity API. Both targets compile the **same `App.tsrx` source**: Octane uses
+its production compiler; React resolves the public hook import to React and uses
+`@tsrx/react` followed by the repository's production React Compiler preset.
+There is no StrictMode or hand-written substitute for Activity.
+
+The fixture has 256 independently stateful rows, each with a layout effect, a
+passive effect, an uncontrolled input, and authored `display: inline-block`.
+The nested case divides those rows among 16 inner Activities, without inserting
+host wrappers that would hide the cost of overlapping host ownership.
+
+| Operation | Measured work |
+| --- | --- |
+| `mount_visible` | Mount all rows and connect their effects. |
+| `mount_hidden_commit`, `mount_hidden_ready` | Initial hidden commit, then actual completion of every hidden row. |
+| `hide_reveal` | Eight complete hide/reveal cycles, including effect disconnect/reconnect. |
+| `visible_updates` | Twelve distinct visible prop updates inside Activity. |
+| `hidden_burst_commit`, `hidden_burst_ready` | Twelve urgent shell commits while hidden content receives new props; then all hidden rows reach the final generation. React may coalesce its background work. |
+| `hidden_descendant_updates_commit`, `hidden_descendant_updates_ready` | One batch of 256 retained public state setters while their Activity is hidden; then every row reaches its new state. |
+| `nested_hide_reveal` | Eight cycles of outer hide → inner hide → outer reveal while inner remains hidden → inner reveal. |
+| `plain_updates` | The same twelve visible updates without any Activity boundary. |
+| `plain_descendant_updates` | The same 256 independent state setters without Activity; a control for the shared component scheduler. |
+
+## Semantic and measurement controls
+
+Every sample asserts **every** row's text, generation, local state, computed
+visibility, DOM identity, and uncontrolled input value. Effect setups and
+cleanups must match the operation exactly. Hidden samples then reveal outside
+the timer and must restore authored display, show the latest hidden state, and
+reconnect all effects once. A real button click must still update the preserved
+component. Unmount must empty the root and balance every effect lifetime.
+An additional untimed gate checks the intermediate nested visibility states.
+
+Root creation and sample preparation are outside the timer. The synchronous
+timer includes Octane's public `drainPassiveEffects()` after `flushSync`, matching
+the established effectful-list benchmark and React's sync-commit effect dispatch.
+It does not force React's offscreen scheduler to become synchronous. Separate
+`*_ready` measurements end only when the actual DOM and effect state are ready;
+they include scheduler delay and completion detection, not just framework CPU.
+The synchronous and completed-work numbers must not be substituted for one
+another. Three warmup samples precede the requested samples. Optional explicit
+Chromium GC runs before each sample, outside its timer.
+
+`work.mjs` uses a separate unminified production build and jitless Chromium
+precise-call coverage. It records Activity range visits, display enforcement,
+effect deactivation, and block renders without probes in component render
+bodies. A separate MutationObserver pass counts actual style/state writes and
+row insertion/removal. Both passes retain the semantic controls. The
+`activity-work-model` target provides row/update denominators and a one-flush
+denominator for hidden descendant range scans. These support reviewed ratio
+guards; no timing budget should be guessed before a representative paired run.
+
+## Ordinary-ref and optional-bundle controls
+
+The ref controls use a **separate entry and fresh browser realms**, so the cold
+lane has never rendered Activity. The after-Activity lane first mounts, hides,
+reveals, and unmounts a small Activity in another root. A third lane keeps a
+separate hidden Activity mounted throughout the measurement. All three perform the
+same ordinary, Activity-free workload: twelve replacements of 256 cleanup-bearing
+callback refs, the same replacements under sixteen additional component layers,
+and eight complete mount/unmount cycles. Every attachment/cleanup pair must be
+balanced; replacement preserves every host node and leaves each callback pointing
+at the current element. The deeper lane makes repeated ownership-ancestor walks
+visible. `refs-work.mjs` observes the same public work through production call
+coverage. These are matched ordinary-tree controls, not a comparison against the
+old runtime's incorrect Activity ref-disconnection behavior.
+
+`bundle.mjs` reuses the existing bundle-reachability suite's specialized root,
+reusable root, state-hook, and component-owned-effect fixtures and their exact
+executable jsdom oracles. It adds an ordinary `createElement` descriptor root
+using the reusable-root oracle. Each measured production IIFE must execute before
+raw/gzip/Brotli bytes are reported. An unminified diagnostic checks whether the
+optional Activity implementation was retained; generated source is saved under
+`dist/bundle-controls`. Direct production compiler-output sizes and hashes for
+the two browser fixtures are reported separately. These checks complement, and
+do not replace, the broader existing bundle-reachability byte budgets.
+
+## Regression guards
+
+The unified runner has 32 deterministic guards for this suite: coalesced linear
+hidden-descendant work, retained rows and bounded display writes, cold ref and
+insertion-recovery walks, cached ordinary-ref ownership, and optional Activity
+bundle reachability. They are checked only after the semantic gates pass.
+
+The initial audit deliberately adds **no wall-clock timing ceiling**. The hidden
+setter improvement is substantial, but repeated hide/reveal is slower and the
+plain-tree timing change is not attributed to a specific helper. Those costs are
+reported in the audit instead of setting a new permissive timing ceiling. Existing
+bundle byte budgets remain unchanged; their normal-toolchain validation is still
+required after the audit's parser dependency limitation is resolved.
+
+## Run
+
+```bash
+node benchmarks/bench.mjs --quick activity
+node benchmarks/bench.mjs --ratios activity
+node benchmarks/activity/run.mjs 8
+node benchmarks/activity/work.mjs
+node benchmarks/activity/refs.mjs 8
+node benchmarks/activity/refs-work.mjs
+node benchmarks/activity/bundle.mjs
+pnpm exec tsrx-tsc --noEmit -p benchmarks/activity/tsconfig.json
+```
+
+The browser scripts accept `--target=octane-tsrx` or `--target=react`, and `--no-build`
+reuses their existing matching production build. `BENCH_JSON` writes the shared
+result contract, including raw timing samples, semantic checksums, browser and
+tool versions, lockfile hash, and the exact Octane source hash.
+
+To compare a runtime change with a commit that predates this benchmark, pin the
+**entire Octane package and compiler**, while retaining the same fixture and
+installed dependencies. The examples use the public upstream baseline
+`2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192`. Its runtime/compiler, package manifest,
+and lockfile are byte-identical to the local merge commit used for the original
+audit measurements; only unrelated inherited tests and a changeset differ.
+
+```bash
+BENCH_JSON=benchmarks/activity/dist/baseline.json node benchmarks/activity/run.mjs 8 --octane-revision=2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192
+BENCH_JSON=benchmarks/activity/dist/baseline-work.json node benchmarks/activity/work.mjs --octane-revision=2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192
+BENCH_JSON=benchmarks/activity/dist/candidate.json node benchmarks/activity/run.mjs 8
+BENCH_JSON=benchmarks/activity/dist/candidate-work.json node benchmarks/activity/work.mjs
+BENCH_JSON=benchmarks/activity/dist/baseline-refs.json node benchmarks/activity/refs.mjs 8 --octane-revision=2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192
+BENCH_JSON=benchmarks/activity/dist/candidate-refs.json node benchmarks/activity/refs.mjs 8
+BENCH_JSON=benchmarks/activity/dist/baseline-bundle.json node benchmarks/activity/bundle.mjs --octane-revision=2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192
+BENCH_JSON=benchmarks/activity/dist/candidate-bundle.json node benchmarks/activity/bundle.mjs
+```
+
+The revision option extracts `git archive` into the ignored `dist/revisions`
+directory and resolves Octane's public exports and compiler from that snapshot.
+The normal run explicitly resolves those same exports from the current worktree,
+even when its dependency directories are linked from another checkout. Build
+and result paths for the snapshot and working tree are separate. Run baseline
+and candidate sequentially on the same machine with identical iterations and
+toolchain. Treat timing changes within observed variance as inconclusive.
+
+`OCTANE_ACTIVITY_REVISION=<commit>` supplies the same pin to all child scripts
+when using the unified runner; an explicit `--octane-revision` takes precedence.
+
+### Audit environment
+
+The [Activity parity audit](../../docs/activity-audit.md) records the findings
+and limits of the initial run. That worktree could not install the locked native
+`oxc-tsrx` parser because the registry returned HTTP 403. Its ignored
+`dist/use-js-parser.mjs` Node loader redirects `#octane/compiler-parser` to the
+selected compiler's supported sibling `parser.browser.js` and sets
+`OCTANE_ACTIVITY_PARSER` in the result metadata. Both the frozen revision and
+working-tree builds used that same parser policy and dependency installation:
+
+```bash
+BENCH_JSON=benchmarks/activity/dist/candidate.json node --import ./benchmarks/activity/dist/use-js-parser.mjs benchmarks/activity/run.mjs 8
+NODE_OPTIONS='--import=/absolute/path/to/octane/benchmarks/activity/dist/use-js-parser.mjs' node benchmarks/bench.mjs --quick --ratios activity
+```
+
+The frozen-baseline guard check used `OCTANE_ACTIVITY_REVISION=1ac62305379c6ee735580ce34886142dd806d29c`
+and `--results-dir=benchmarks/activity/dist/ratio-baseline`; it failed exactly the
+three quadratic-work guards. The matching working-tree check used
+`--results-dir=benchmarks/activity/dist/ratio-candidate` and passed all 32. Their
+merged raw result files are `dist/ratio-baseline/activity.json` and
+`dist/ratio-candidate/activity.json`.
+
+The loader is local audit plumbing, not a replacement for the normal compiler.
+Use the package-default commands above in a complete installation, and do not
+compare timing or byte results across different parser/toolchain configurations.

--- a/benchmarks/activity/RefControl.tsrx
+++ b/benchmarks/activity/RefControl.tsrx
@@ -1,0 +1,47 @@
+import { Activity } from 'octane';
+import { ROW_INDICES } from './contract.mjs';
+import type { Mode } from './model';
+import type { RefProps } from './ref-model';
+
+function RefLayer(props: RefProps) @{
+	<>
+		@if (props.depth > 0) {
+			<RefLayer
+				model={props.model}
+				present={props.present}
+				variant={props.variant}
+				depth={props.depth - 1}
+			/>
+		} @else {
+			@if (props.present) {
+				@for (const index of ROW_INDICES; key index) {
+					<button
+						type="button"
+						data-ref-row={String(index)}
+						data-variant={String(props.variant)}
+						ref={props.model.callbacks[props.variant][index]}
+					>{`${index}:${props.variant}` as string}</button>
+				}
+			}
+		}
+	</>
+}
+
+export function RefControl(props: RefProps) @{
+	<section data-ref-shell="">
+		<RefLayer
+			model={props.model}
+			present={props.present}
+			variant={props.variant}
+			depth={props.depth}
+		/>
+	</section>
+}
+
+// Rendered only by the primed lanes, in a separate root that is either unmounted
+// before measurement or deliberately kept hidden throughout the ordinary work.
+export function ActivityRefPrimer(props: { mode: Mode }) @{
+	<Activity mode={props.mode}>
+		<span>prime Activity</span>
+	</Activity>
+}

--- a/benchmarks/activity/browser.ts
+++ b/benchmarks/activity/browser.ts
@@ -1,0 +1,386 @@
+import {
+	ASYNC_OPERATIONS,
+	CYCLE_COUNT,
+	ROW_COUNT,
+	UPDATE_COUNT,
+	assertOperation,
+} from './contract.mjs';
+import { Model, ensure, type AppProps, type Counts, type Renderer } from './model';
+
+const increment = (value: number) => value + 1;
+const DRAFT = 'retained draft';
+const TIMEOUT_MS = 10_000;
+
+type Session = {
+	operation: string;
+	model: Model;
+	renderer: Renderer;
+	props: AppProps;
+	locals: number[];
+	nodes: HTMLElement[] | null;
+	draft: boolean;
+};
+
+type Timing = { commitMs: number; readyMs: number };
+
+function isVisible(session: Session) {
+	return (
+		session.props.shape === 'plain' ||
+		(session.props.mode === 'visible' &&
+			(session.props.shape !== 'nested' || session.props.innerMode === 'visible'))
+	);
+}
+
+function expectedCounts(operation: string): Counts {
+	const mounts = operation === 'mount_visible' ? ROW_COUNT : 0;
+	const cycles =
+		operation === 'hide_reveal' || operation === 'nested_hide_reveal' ? ROW_COUNT * CYCLE_COUNT : 0;
+	return {
+		layoutMounts: mounts + cycles,
+		layoutCleanups: cycles,
+		passiveMounts: mounts + cycles,
+		passiveCleanups: cycles,
+	};
+}
+
+export function installBenchmark(target: HTMLElement, createRenderer: () => Renderer) {
+	let current: Session | null = null;
+
+	function sessionFor(operation?: string): Session {
+		ensure(current !== null, 'Activity benchmark has not been prepared');
+		if (operation !== undefined) {
+			ensure(current.operation === operation, `Prepared ${current.operation}, not ${operation}`);
+		}
+		return current;
+	}
+
+	function rows() {
+		return Array.from(target.querySelectorAll<HTMLElement>('[data-row]'));
+	}
+
+	function ready(session: Session): boolean {
+		const visible = isVisible(session);
+		const expectedActive = visible ? ROW_COUNT : 0;
+		if (
+			session.model.layoutActive.size !== expectedActive ||
+			session.model.passiveActive.size !== expectedActive ||
+			target.querySelector('[data-tick]')?.textContent !== String(session.props.tick)
+		) {
+			return false;
+		}
+		const elements = rows();
+		if (elements.length !== ROW_COUNT) return false;
+		for (let index = 0; index < elements.length; index++) {
+			const element = elements[index];
+			if (
+				element.dataset.row !== String(index) ||
+				element.dataset.generation !== String(session.props.generation) ||
+				element.dataset.local !== String(session.locals[index]) ||
+				element.style.display !== (visible ? 'inline-block' : 'none')
+			) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	function waitUntilReady(session: Session): Promise<void> {
+		if (ready(session)) return Promise.resolve();
+		return new Promise((resolve, reject) => {
+			let finished = false;
+			let timeout: ReturnType<typeof setTimeout>;
+			const observer = new MutationObserver(check);
+			const unsubscribe = session.model.onChange(check);
+			function dispose() {
+				observer.disconnect();
+				unsubscribe();
+				clearTimeout(timeout);
+			}
+			function check() {
+				if (finished || !ready(session)) return;
+				finished = true;
+				dispose();
+				resolve();
+			}
+			observer.observe(target, {
+				attributes: true,
+				attributeFilter: ['data-generation', 'data-local', 'style'],
+				childList: true,
+				characterData: true,
+				subtree: true,
+			});
+			timeout = setTimeout(() => {
+				if (finished) return;
+				finished = true;
+				dispose();
+				reject(
+					new Error(
+						`Timed out in ${session.operation}: rows=${rows().length}, ` +
+							`layout=${session.model.layoutActive.size}, passive=${session.model.passiveActive.size}, ` +
+							`generation=${session.props.generation}, visible=${isVisible(session)}`,
+					),
+				);
+			}, TIMEOUT_MS);
+			check();
+		});
+	}
+
+	function render(session: Session, next: Partial<AppProps>) {
+		session.props = { ...session.props, ...next };
+		session.renderer.render(session.props);
+	}
+
+	function captureIdentity(session: Session) {
+		if (session.nodes !== null) return;
+		session.nodes = rows();
+		ensure(session.nodes.length === ROW_COUNT, 'Cannot capture an incomplete Activity tree');
+		const input = session.nodes[0].querySelector('input');
+		ensure(input !== null, 'Missing uncontrolled input');
+		input.value = DRAFT;
+		session.draft = true;
+	}
+
+	function assertState(session: Session) {
+		ensure(ready(session), `Incomplete ${session.operation} state`);
+		const elements = rows();
+		const visible = isVisible(session);
+		for (let index = 0; index < elements.length; index++) {
+			const element = elements[index];
+			if (session.nodes !== null) {
+				ensure(element === session.nodes[index], `Row ${index} lost its DOM identity`);
+			}
+			ensure(
+				element.querySelector('button')?.textContent?.trim() ===
+					`${index}:${session.props.generation}:${session.locals[index]}`,
+				`Row ${index} has stale visible text`,
+			);
+			const input = element.querySelector('input');
+			ensure(
+				input?.value === (index === 0 && session.draft ? DRAFT : `row-${index}`),
+				`Row ${index} lost its uncontrolled input value`,
+			);
+			ensure(
+				getComputedStyle(element).display === (visible ? 'inline-block' : 'none'),
+				`Row ${index} has incorrect computed visibility`,
+			);
+		}
+	}
+
+	async function cleanup() {
+		if (current === null) return;
+		const session = current;
+		session.renderer.unmount();
+		ensure(target.childNodes.length === 0, 'Activity root retained DOM after unmount');
+		session.model.assertReleased();
+		current = null;
+	}
+
+	async function prepare(operation: string) {
+		assertOperation(operation);
+		await cleanup();
+		const model = new Model();
+		const session: Session = {
+			operation,
+			model,
+			renderer: createRenderer(),
+			props: {
+				model,
+				shape:
+					operation === 'plain_updates' || operation === 'plain_descendant_updates'
+						? 'plain'
+						: operation === 'nested_hide_reveal'
+							? 'nested'
+							: 'flat',
+				mode: operation === 'mount_hidden' ? 'hidden' : 'visible',
+				innerMode: 'visible',
+				generation: 0,
+				tick: 0,
+			},
+			locals: Array.from({ length: ROW_COUNT }, () => 0),
+			nodes: null,
+			draft: false,
+		};
+		current = session;
+		if (operation === 'mount_visible' || operation === 'mount_hidden') return;
+
+		session.renderer.render(session.props);
+		await waitUntilReady(session);
+		captureIdentity(session);
+		// Seed real component state through its public native click handler. The
+		// retained setter used by the hidden-descendant lane was obtained from a
+		// real, connected layout effect, not from a render-body instrumentation hook.
+		const button = session.nodes![0].querySelector('button');
+		ensure(button !== null, 'Missing stateful button');
+		session.locals[0]++;
+		session.renderer.flush(() => button.click());
+		await waitUntilReady(session);
+		assertState(session);
+		if (operation === 'hidden_burst' || operation === 'hidden_descendant_updates') {
+			render(session, { mode: 'hidden' });
+			await waitUntilReady(session);
+			assertState(session);
+		}
+		model.resetSample();
+	}
+
+	async function run(operation: string, checkpoints = false): Promise<Timing> {
+		const session = sessionFor(operation);
+		if (operation === 'hidden_descendant_updates' || operation === 'plain_descendant_updates') {
+			for (let index = 0; index < ROW_COUNT; index++) session.locals[index]++;
+		}
+		const started = performance.now();
+		switch (operation) {
+			case 'mount_visible':
+			case 'mount_hidden':
+				session.renderer.render(session.props);
+				break;
+			case 'hide_reveal':
+				for (let cycle = 0; cycle < CYCLE_COUNT; cycle++) {
+					render(session, { mode: 'hidden' });
+					if (checkpoints) assertState(session);
+					render(session, { mode: 'visible' });
+					if (checkpoints) assertState(session);
+				}
+				break;
+			case 'nested_hide_reveal':
+				for (let cycle = 0; cycle < CYCLE_COUNT; cycle++) {
+					render(session, { mode: 'hidden' });
+					if (checkpoints) assertState(session);
+					render(session, { innerMode: 'hidden' });
+					if (checkpoints) assertState(session);
+					render(session, { mode: 'visible' });
+					if (checkpoints) assertState(session);
+					render(session, { innerMode: 'visible' });
+					if (checkpoints) assertState(session);
+				}
+				break;
+			case 'visible_updates':
+			case 'hidden_burst':
+			case 'plain_updates':
+				for (let generation = 1; generation <= UPDATE_COUNT; generation++) {
+					render(session, { generation, tick: generation });
+				}
+				break;
+			case 'hidden_descendant_updates':
+			case 'plain_descendant_updates':
+				session.renderer.flush(() => {
+					for (const setter of session.model.setters) {
+						ensure(setter !== null, 'A visible row did not publish its state setter');
+						setter(increment);
+					}
+				});
+				break;
+			default:
+				throw new Error(`Unknown operation: ${operation}`);
+		}
+		const commitMs = performance.now() - started;
+		let readyMs = commitMs;
+		if (!ready(session)) {
+			await waitUntilReady(session);
+			readyMs = performance.now() - started;
+		}
+		if (!ASYNC_OPERATIONS.has(operation)) {
+			ensure(readyMs === commitMs, `${operation} did not complete in its sync commit`);
+		}
+		return { commitMs, readyMs };
+	}
+
+	function verify(operation: string) {
+		const session = sessionFor(operation);
+		captureIdentity(session);
+		assertState(session);
+		const expected = expectedCounts(operation);
+		const actual = session.model.sample();
+		for (const key of Object.keys(expected) as Array<keyof Counts>) {
+			ensure(
+				actual[key] === expected[key],
+				`${operation}: ${key} ${actual[key]} != ${expected[key]}`,
+			);
+		}
+		return {
+			rows: ROW_COUNT,
+			generation: session.props.generation,
+			localChecksum: session.locals.reduce((sum, value, index) => sum + (index + 1) * value, 0),
+			visible: isVisible(session),
+			shellTick: session.props.tick,
+			effects: actual,
+			identitiesPreserved: true,
+			draftRetained: true,
+		};
+	}
+
+	async function confirm() {
+		const session = sessionFor();
+		if (!isVisible(session)) {
+			const before = { ...session.model.total };
+			render(session, { mode: 'visible', innerMode: 'visible' });
+			await waitUntilReady(session);
+			assertState(session);
+			ensure(
+				session.model.total.layoutMounts - before.layoutMounts === ROW_COUNT &&
+					session.model.total.passiveMounts - before.passiveMounts === ROW_COUNT,
+				'Revealing hidden work did not reconnect every effect exactly once',
+			);
+		}
+		const button = session.nodes![0].querySelector('button');
+		ensure(button !== null, 'Missing stateful button after reveal');
+		session.locals[0]++;
+		session.renderer.flush(() => button.click());
+		await waitUntilReady(session);
+		assertState(session);
+	}
+
+	async function gate(operation: string) {
+		await prepare(operation);
+		await run(operation, true);
+		const snapshot = verify(operation);
+		await confirm();
+		await cleanup();
+		return snapshot;
+	}
+
+	async function observeWork(operation: string) {
+		const counts = { styleWrites: 0, stateAttributeWrites: 0, addedRows: 0, removedRows: 0 };
+		const countRows = (node: Node) =>
+			node instanceof Element
+				? Number(node.matches('[data-row]')) + node.querySelectorAll('[data-row]').length
+				: 0;
+		function collect(records: MutationRecord[]) {
+			for (const record of records) {
+				if (record.type === 'attributes' && (record.target as Element).matches('[data-row]')) {
+					if (record.attributeName === 'style') counts.styleWrites++;
+					else counts.stateAttributeWrites++;
+				} else if (record.type === 'childList') {
+					for (const node of record.addedNodes) counts.addedRows += countRows(node);
+					for (const node of record.removedNodes) counts.removedRows += countRows(node);
+				}
+			}
+		}
+		const observer = new MutationObserver(collect);
+		observer.observe(target, {
+			attributes: true,
+			attributeFilter: ['style', 'data-generation', 'data-local'],
+			childList: true,
+			subtree: true,
+		});
+		try {
+			await run(operation);
+			collect(observer.takeRecords());
+		} finally {
+			observer.disconnect();
+		}
+		const snapshot = verify(operation);
+		return { counts, snapshot };
+	}
+
+	const api = { prepare, run, verify, confirm, cleanup, gate, observeWork };
+	Object.assign(window, {
+		__activityBench: api,
+		__activityPrepare: prepare,
+		__activityRun: run,
+		__activityVerify: verify,
+		__activityConfirm: confirm,
+		__activityCleanup: cleanup,
+		__ready: true,
+	});
+}

--- a/benchmarks/activity/bundle.mjs
+++ b/benchmarks/activity/bundle.mjs
@@ -1,0 +1,197 @@
+// Reuse the established minimal-import fixtures and executable oracles. This
+// focused audit adds source-revision pinning and an ordinary descriptor control.
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { brotliCompressSync, constants as zlib, gzipSync } from 'node:zlib';
+import { verifyScenario } from '../bundle-size/verify-reachability.mjs';
+import {
+	countStat,
+	hashOctaneSources,
+	octanePackageAt,
+	packageVersion,
+	parseOptions,
+	writePayload,
+} from './harness.mjs';
+
+const options = parseOptions(process.argv.slice(2));
+if (!options.targets.includes('octane-tsrx') || options.noBuild) {
+	throw new Error('Activity bundle controls require an Octane build');
+}
+process.env.NODE_ENV = 'production';
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const requireFromNews = createRequire(new URL('../news/package.json', import.meta.url));
+const source = octanePackageAt(options.revision);
+const requireFromOctane = createRequire(path.join(source.packageRoot, 'package.json'));
+const sourceHash = hashOctaneSources(source.packageRoot);
+const { build } = await import(pathToFileURL(requireFromNews.resolve('vite')).href);
+const { octane } = await import(
+	pathToFileURL(requireFromOctane.resolve('octane/compiler/vite')).href
+);
+const { compile } = await import(pathToFileURL(requireFromOctane.resolve('octane/compiler')).href);
+const { transformSync } = requireFromOctane('esbuild');
+const toolchain = {
+	node: process.version,
+	vite: requireFromNews('vite/package.json').version,
+	esbuild: requireFromOctane('esbuild').version,
+	tsrxCore: packageVersion(requireFromOctane, '@tsrx/core'),
+	parser: process.env.OCTANE_ACTIVITY_PARSER ?? 'package-default',
+};
+const outputRoot = path.join(
+	HERE,
+	'dist/bundle-controls',
+	options.revision ? source.revision : 'working',
+);
+const scenarios = [
+	['root-static-specialized', '../bundle-size/fixtures/minimal/root-static-specialized.ts'],
+	['root-static', '../bundle-size/fixtures/minimal/root-static.tsrx'],
+	['hooks-state', '../bundle-size/fixtures/minimal/hooks-state.tsrx'],
+	['component-owned-effects', '../bundle-size/fixtures/minimal/component-owned-effects.ts'],
+	['root-descriptor', './root-descriptor.ts', 'root-static'],
+];
+const targets = [];
+let failure;
+
+async function buildEntry(entry, minify) {
+	const result = await build({
+		configFile: false,
+		root: HERE,
+		mode: 'production',
+		logLevel: 'error',
+		plugins: [
+			{
+				name: 'activity-bundle-public-imports',
+				enforce: 'pre',
+				resolveId(request) {
+					if (request === 'octane' || request.startsWith('octane/')) {
+						return requireFromOctane.resolve(request);
+					}
+					return null;
+				},
+			},
+			octane({ hmr: false, profile: false }),
+		],
+		define: {
+			__OCTANE_PROFILE_ENABLED__: 'false',
+			'process.env.NODE_ENV': JSON.stringify('production'),
+		},
+		build: {
+			write: false,
+			minify,
+			target: 'esnext',
+			lib: { entry, formats: ['iife'], name: '__OCTANE_REACHABILITY__' },
+		},
+	});
+	const built = Array.isArray(result) ? result : [result];
+	assert.equal(built.length, 1, 'Expected one production build');
+	const chunks = built[0].output.filter((file) => file.type === 'chunk');
+	assert.equal(chunks.length, 1, 'Expected one executable bundle');
+	assert.deepEqual(chunks[0].imports, [], 'Unexpected external dependency');
+	assert.deepEqual(chunks[0].dynamicImports, [], 'Deferred bytes escaped the measured bundle');
+	return chunks[0];
+}
+
+try {
+	for (const [name, relative, oracle = name] of scenarios) {
+		const entry = path.resolve(HERE, relative);
+		const chunk = await buildEntry(entry, 'esbuild');
+		const snapshot = await verifyScenario(oracle, chunk.code);
+		const diagnostic = await buildEntry(entry, false);
+		// This is an optimization diagnostic, not a correctness assertion about
+		// private runtime names. Renaming/replacing a feature requires reviewing
+		// this reachability probe alongside the authoritative byte totals.
+		const activityReachable = /\bfunction (?:activityBlock|hideActivityRange)\s*\(/.test(
+			diagnostic.code,
+		);
+		const bytes = Buffer.from(chunk.code);
+		const measured = {
+			raw: bytes.length,
+			gzip: gzipSync(bytes, { level: zlib.Z_BEST_COMPRESSION }).length,
+			brotli: brotliCompressSync(bytes, {
+				params: { [zlib.BROTLI_PARAM_QUALITY]: zlib.BROTLI_MAX_QUALITY },
+			}).length,
+			activity_reachable: Number(activityReachable),
+		};
+		fs.mkdirSync(outputRoot, { recursive: true });
+		fs.writeFileSync(path.join(outputRoot, `${name}.js`), chunk.code);
+		fs.writeFileSync(path.join(outputRoot, `${name}.diagnostic.js`), diagnostic.code);
+		targets.push({
+			name: `activity-bundle-${name}`,
+			ops: Object.fromEntries(
+				Object.entries(measured).map(([metric, value]) => [metric, countStat(value)]),
+			),
+			meta: {
+				octaneRevision: source.revision,
+				octaneSource: source.packageRoot,
+				octaneSourceSha256: sourceHash,
+				parser: process.env.OCTANE_ACTIVITY_PARSER ?? 'package-default',
+				toolchain,
+				bundleSha256: createHash('sha256').update(chunk.code).digest('hex'),
+				entry,
+				oracle,
+				snapshot,
+				activityReachable,
+				build: outputRoot,
+			},
+		});
+		console.log(`PASS activity/bundle/${name}: ${JSON.stringify(measured)}`);
+	}
+	for (const name of ['App', 'RefControl']) {
+		const entry = path.join(HERE, `${name}.tsrx`);
+		const { code } = compile(fs.readFileSync(entry, 'utf8'), entry, {
+			mode: 'client',
+			hmr: false,
+			dev: false,
+			profile: false,
+		});
+		const minified = transformSync(code, { loader: 'js', minify: true }).code;
+		const measured = {
+			raw: Buffer.byteLength(code),
+			minified: Buffer.byteLength(minified),
+			gzip: gzipSync(Buffer.from(minified), { level: zlib.Z_BEST_COMPRESSION }).length,
+		};
+		fs.writeFileSync(path.join(outputRoot, `${name}.compiled.js`), code);
+		targets.push({
+			name: `activity-codegen-${name}`,
+			ops: Object.fromEntries(
+				Object.entries(measured).map(([metric, value]) => [metric, countStat(value)]),
+			),
+			meta: {
+				octaneRevision: source.revision,
+				octaneSourceSha256: sourceHash,
+				parser: process.env.OCTANE_ACTIVITY_PARSER ?? 'package-default',
+				toolchain,
+				entry,
+				codeSha256: createHash('sha256').update(code).digest('hex'),
+				semanticControl:
+					'the same authored fixture is executed by activity/run.mjs or activity/refs.mjs',
+			},
+		});
+		console.log(`PASS activity/codegen/${name}: ${JSON.stringify(measured)}`);
+	}
+	targets.push({
+		name: 'activity-bundle-model',
+		ops: { activity_reachable: countStat(1) },
+		meta: { note: 'A unit denominator for optional Activity implementation reachability.' },
+	});
+	assert.equal(
+		hashOctaneSources(source.packageRoot),
+		sourceHash,
+		'Octane source changed during bundle controls',
+	);
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+}
+
+writePayload({
+	suite: 'activity-bundle',
+	targets,
+	...(failure ? { failed: failure } : {}),
+});
+if (failure) {
+	console.error(`FAIL Activity bundle controls: ${failure}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/activity/contract.mjs
+++ b/benchmarks/activity/contract.mjs
@@ -1,0 +1,46 @@
+export const ROW_COUNT = 256;
+export const GROUP_SIZE = 16;
+export const UPDATE_COUNT = 12;
+export const CYCLE_COUNT = 8;
+export const ROW_INDICES = Object.freeze(Array.from({ length: ROW_COUNT }, (_, index) => index));
+export const GROUPS = Object.freeze(
+	Array.from({ length: ROW_COUNT / GROUP_SIZE }, (_, id) =>
+		Object.freeze({
+			id,
+			indices: Object.freeze(ROW_INDICES.slice(id * GROUP_SIZE, (id + 1) * GROUP_SIZE)),
+		}),
+	),
+);
+
+export const TARGETS = ['octane-tsrx', 'react'];
+export const OPERATIONS = [
+	'mount_visible',
+	'mount_hidden',
+	'hide_reveal',
+	'visible_updates',
+	'hidden_burst',
+	'hidden_descendant_updates',
+	'nested_hide_reveal',
+	'plain_updates',
+	'plain_descendant_updates',
+];
+
+export const ASYNC_OPERATIONS = new Set([
+	'mount_hidden',
+	'hidden_burst',
+	'hidden_descendant_updates',
+]);
+
+export const WORK_OPERATIONS = [
+	'hide_reveal',
+	'hidden_burst',
+	'hidden_descendant_updates',
+	'nested_hide_reveal',
+	'plain_updates',
+	'plain_descendant_updates',
+];
+
+export function assertOperation(operation) {
+	if (!OPERATIONS.includes(operation)) throw new Error(`Unknown Activity operation: ${operation}`);
+	return operation;
+}

--- a/benchmarks/activity/harness.mjs
+++ b/benchmarks/activity/harness.mjs
@@ -1,0 +1,353 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { TARGETS } from './contract.mjs';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const REPO = path.resolve(HERE, '../..');
+const requireFromNews = createRequire(new URL('../news/package.json', import.meta.url));
+const requireFromReact = createRequire(new URL('../news/react/package.json', import.meta.url));
+const requireFromRepo = createRequire(new URL('../../package.json', import.meta.url));
+const workingPackage = path.join(REPO, 'packages/octane');
+
+function git(args) {
+	return execFileSync('git', args, { cwd: REPO, encoding: 'utf8' }).trim();
+}
+
+function hashFile(file) {
+	return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+export function packageVersion(resolver, name) {
+	let directory = path.dirname(resolver.resolve(name));
+	while (directory !== path.dirname(directory)) {
+		const file = path.join(directory, 'package.json');
+		if (fs.existsSync(file)) {
+			const metadata = JSON.parse(fs.readFileSync(file, 'utf8'));
+			if (metadata.name === name) return metadata.version;
+		}
+		directory = path.dirname(directory);
+	}
+	throw new Error(`Cannot find package metadata for ${name}`);
+}
+
+function hashFixture(scenario) {
+	const hash = createHash('sha256');
+	const files =
+		scenario === 'refs'
+			? [
+					'RefControl.tsrx',
+					'ref-browser.ts',
+					'ref-contract.mjs',
+					'ref-model.ts',
+					'contract.mjs',
+					'model.ts',
+					'octane-refs.ts',
+					'react-refs.ts',
+				]
+			: ['App.tsrx', 'browser.ts', 'contract.mjs', 'model.ts', 'octane.ts', 'react.ts'];
+	for (const file of files) {
+		hash
+			.update(file)
+			.update('\0')
+			.update(fs.readFileSync(path.join(HERE, file)))
+			.update('\0');
+	}
+	return hash.digest('hex');
+}
+
+function builtAssets(outDir) {
+	const hash = createHash('sha256');
+	let javascriptBytes = 0;
+	function visit(directory) {
+		for (const entry of fs
+			.readdirSync(directory, { withFileTypes: true })
+			.sort((a, b) => a.name.localeCompare(b.name))) {
+			const file = path.join(directory, entry.name);
+			if (entry.isDirectory()) visit(file);
+			else if (entry.isFile() && entry.name.endsWith('.js')) {
+				const contents = fs.readFileSync(file);
+				javascriptBytes += contents.byteLength;
+				hash.update(path.relative(outDir, file)).update('\0').update(contents).update('\0');
+			}
+		}
+	}
+	visit(outDir);
+	return { javascriptBytes, assetsSha256: hash.digest('hex') };
+}
+
+export function hashOctaneSources(packageRoot) {
+	const hash = createHash('sha256');
+	function visit(relative) {
+		const file = path.join(packageRoot, relative);
+		const stat = fs.statSync(file);
+		if (stat.isDirectory()) {
+			for (const entry of fs.readdirSync(file).sort()) visit(path.join(relative, entry));
+		} else if (stat.isFile()) {
+			hash.update(relative).update('\0').update(fs.readFileSync(file)).update('\0');
+		}
+	}
+	visit('package.json');
+	visit('src');
+	return hash.digest('hex');
+}
+
+export function octanePackageAt(revision) {
+	if (!revision) return { packageRoot: workingPackage, revision: git(['rev-parse', 'HEAD']) };
+	if (!/^[a-f\d]{7,40}$/i.test(revision)) {
+		throw new Error('--octane-revision must be a hexadecimal Git commit');
+	}
+	const commit = git(['rev-parse', '--verify', `${revision}^{commit}`]);
+	const snapshot = path.join(HERE, 'dist/revisions', commit);
+	const packageRoot = path.join(snapshot, 'packages/octane');
+	const complete = path.join(snapshot, '.complete');
+	if (!fs.existsSync(complete)) {
+		fs.mkdirSync(snapshot, { recursive: true });
+		const archive = execFileSync('git', ['archive', '--format=tar', commit, 'packages/octane'], {
+			cwd: REPO,
+			maxBuffer: 128 * 1024 * 1024,
+		});
+		execFileSync('tar', ['-x', '-C', snapshot], { input: archive });
+		fs.writeFileSync(complete, `${commit}\n`);
+	}
+	const dependencies = path.join(packageRoot, 'node_modules');
+	if (!fs.lstatSync(dependencies, { throwIfNoEntry: false })) {
+		fs.symlinkSync(path.join(workingPackage, 'node_modules'), dependencies, 'dir');
+	}
+	return { packageRoot, revision: commit };
+}
+
+export function parseOptions(argv, { iterations = false } = {}) {
+	const options = {
+		noBuild: false,
+		revision: process.env.OCTANE_ACTIVITY_REVISION || undefined,
+		targets: TARGETS,
+		iterations: 8,
+	};
+	let positional = false;
+	for (const arg of argv) {
+		if (arg === '--no-build') options.noBuild = true;
+		else if (arg.startsWith('--octane-revision=')) {
+			options.revision = arg.split('=')[1];
+			if (!options.revision) throw new Error('--octane-revision requires a Git commit');
+		} else if (arg.startsWith('--target=')) options.targets = [arg.split('=')[1]];
+		else if (iterations && !arg.startsWith('--') && !positional) {
+			options.iterations = Number(arg);
+			positional = true;
+		} else throw new Error(`Unknown Activity benchmark argument: ${arg}`);
+	}
+	if (!Number.isSafeInteger(options.iterations) || options.iterations < 1) {
+		throw new Error('Activity benchmark iterations must be a positive integer');
+	}
+	for (const target of options.targets) {
+		if (!TARGETS.includes(target)) throw new Error(`Unknown Activity target: ${target}`);
+	}
+	return options;
+}
+
+export function chromium() {
+	return requireFromNews('playwright').chromium;
+}
+
+export function environmentFor(browser, extra = {}) {
+	return {
+		node: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		osRelease: os.release(),
+		cpu: os.cpus()[0]?.model ?? 'unknown',
+		chromium: browser.version(),
+		...extra,
+	};
+}
+
+export async function startFixture({
+	target,
+	work = false,
+	noBuild = false,
+	revision,
+	scenario = 'activity',
+} = {}) {
+	if (!TARGETS.includes(target)) throw new Error(`Unknown Activity target: ${target}`);
+	if (scenario !== 'activity' && scenario !== 'refs') {
+		throw new Error(`Unknown Activity fixture scenario: ${scenario}`);
+	}
+	process.env.NODE_ENV = 'production';
+	const source = octanePackageAt(revision);
+	const requireFromOctane = createRequire(path.join(source.packageRoot, 'package.json'));
+	const { build, preview } = await import(pathToFileURL(requireFromNews.resolve('vite')).href);
+	const octaneEntry = requireFromOctane.resolve('octane');
+	if (octaneEntry !== path.join(source.packageRoot, 'src/index.ts')) {
+		throw new Error(`Octane source resolver escaped the selected package: ${octaneEntry}`);
+	}
+	const publicImports = {
+		name: 'activity-workspace-public-imports',
+		enforce: 'pre',
+		resolveId(request) {
+			if (target === 'react' && request === 'octane') return requireFromReact.resolve('react');
+			if (target === 'octane-tsrx' && (request === 'octane' || request.startsWith('octane/'))) {
+				return requireFromOctane.resolve(request);
+			}
+			if (
+				request === 'react' ||
+				request.startsWith('react/') ||
+				request === 'react-dom' ||
+				request.startsWith('react-dom/') ||
+				request === '@tsrx/react' ||
+				request.startsWith('@tsrx/react/')
+			) {
+				return requireFromReact.resolve(request);
+			}
+			return null;
+		},
+	};
+	let compilerPlugins;
+	if (target === 'octane-tsrx') {
+		const { octane } = await import(
+			pathToFileURL(requireFromOctane.resolve('octane/compiler/vite')).href
+		);
+		compilerPlugins = [octane({ hmr: false, profile: false })];
+	} else {
+		const { default: tsrxReact } = await import(
+			pathToFileURL(requireFromReact.resolve('@tsrx/vite-plugin-react')).href
+		);
+		const { reactCompiler } = await import('../react-compiler.mjs');
+		compilerPlugins = [tsrxReact(), reactCompiler()];
+	}
+	const entry = `${target === 'octane-tsrx' ? 'octane' : 'react'}${scenario === 'refs' ? '-refs' : ''}.html`;
+	const buildIdentity = revision ? source.revision : 'working';
+	const buildKind = `${work ? 'work' : 'timing'}${scenario === 'refs' ? '-refs' : ''}`;
+	const outDir = path.join(HERE, 'dist/builds', buildIdentity, target, buildKind);
+	const inputs = {
+		octaneRevision: source.revision,
+		octaneSource: source.packageRoot,
+		octaneSourceSha256: hashOctaneSources(source.packageRoot),
+		fixtureSourceSha256: hashFixture(scenario),
+		lockfileSha256: hashFile(path.join(REPO, 'pnpm-lock.yaml')),
+		parser: process.env.OCTANE_ACTIVITY_PARSER ?? 'package-default',
+		tsrxCore: packageVersion(requireFromOctane, '@tsrx/core'),
+		tsrxReact: packageVersion(requireFromReact, '@tsrx/react'),
+		react: requireFromReact('react/package.json').version,
+		reactCompilerVersion: packageVersion(requireFromRepo, 'babel-plugin-react-compiler'),
+		vite: requireFromNews('vite/package.json').version,
+		esbuild: packageVersion(createRequire(requireFromNews.resolve('vite')), 'esbuild'),
+		playwright: requireFromNews('playwright/package.json').version,
+		production: true,
+		reactCompiler: target === 'react',
+	};
+	const inputsFile = path.join(outDir, 'activity-build.json');
+	if (!noBuild) {
+		await build({
+			configFile: false,
+			root: HERE,
+			logLevel: 'warn',
+			plugins: [publicImports, ...compilerPlugins],
+			define: {
+				'process.env.NODE_ENV': JSON.stringify('production'),
+				__OCTANE_PROFILE_ENABLED__: 'false',
+			},
+			build: {
+				outDir,
+				emptyOutDir: true,
+				target: 'esnext',
+				minify: work ? false : 'esbuild',
+				rollupOptions: {
+					input: path.join(HERE, entry),
+					output: {
+						entryFileNames: 'assets/[name]-[hash].js',
+						chunkFileNames: 'assets/[name]-[hash].js',
+					},
+				},
+			},
+		});
+		if (inputs.octaneSourceSha256 !== hashOctaneSources(source.packageRoot)) {
+			throw new Error('Octane source changed during the Activity build; rerun after edits finish');
+		}
+		if (inputs.fixtureSourceSha256 !== hashFixture(scenario)) {
+			throw new Error('Activity fixture changed during its build; rerun after edits finish');
+		}
+		fs.writeFileSync(inputsFile, `${JSON.stringify(inputs, null, '\t')}\n`);
+	} else if (
+		!fs.existsSync(inputsFile) ||
+		JSON.stringify(JSON.parse(fs.readFileSync(inputsFile, 'utf8'))) !== JSON.stringify(inputs)
+	) {
+		throw new Error('Activity --no-build inputs are stale; rebuild the selected target');
+	}
+	if (!fs.existsSync(path.join(outDir, entry))) {
+		throw new Error(`Missing production Activity fixture: ${outDir}`);
+	}
+	const server = await preview({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		build: { outDir },
+		preview: { host: '127.0.0.1', port: 0, strictPort: true },
+	});
+	const address = server.httpServer.address();
+	if (address === null || typeof address === 'string') {
+		await server.close();
+		throw new Error('The Activity preview did not expose a TCP port');
+	}
+	return {
+		url: `http://127.0.0.1:${address.port}/${entry}`,
+		meta: {
+			...inputs,
+			...builtAssets(outDir),
+			build: outDir,
+		},
+		close: () => server.close(),
+	};
+}
+
+export async function openCase(browser, url) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const errors = [];
+	page.on('pageerror', (error) => errors.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'error') errors.push(message.text());
+	});
+	try {
+		await page.goto(url, { waitUntil: 'load' });
+		await page.waitForFunction(() => window.__ready === true, null, { timeout: 10_000 });
+		return { context, page, errors };
+	} catch (error) {
+		await context.close();
+		throw new Error(`Activity production fixture failed to start: ${errors.join('; ')}`, {
+			cause: error,
+		});
+	}
+}
+
+export function checkBrowserErrors(target, errors) {
+	if (errors.length !== 0) throw new Error(`${target}: browser errors: ${errors.join('; ')}`);
+}
+
+export async function closeResources(...resources) {
+	const errors = [];
+	for (const resource of resources) {
+		if (!resource) continue;
+		try {
+			await resource.close();
+		} catch (error) {
+			errors.push(error instanceof Error ? (error.stack ?? error.message) : String(error));
+		}
+	}
+	return errors;
+}
+
+export function writePayload(payload) {
+	if (process.env.BENCH_JSON) {
+		fs.mkdirSync(path.dirname(path.resolve(process.env.BENCH_JSON)), { recursive: true });
+		fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+	}
+}
+
+export function countStat(value) {
+	if (!Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid work count: ${value}`);
+	return { score: value, median: value, min: value, samples: 1 };
+}

--- a/benchmarks/activity/model.ts
+++ b/benchmarks/activity/model.ts
@@ -1,0 +1,108 @@
+import { ROW_COUNT } from './contract.mjs';
+
+export type StateSetter = (value: number | ((previous: number) => number)) => void;
+export type Mode = 'visible' | 'hidden';
+export type Shape = 'flat' | 'nested' | 'plain';
+export type Counts = {
+	layoutMounts: number;
+	layoutCleanups: number;
+	passiveMounts: number;
+	passiveCleanups: number;
+};
+
+const countKeys = ['layoutMounts', 'layoutCleanups', 'passiveMounts', 'passiveCleanups'] as const;
+
+const zeroCounts = (): Counts => ({
+	layoutMounts: 0,
+	layoutCleanups: 0,
+	passiveMounts: 0,
+	passiveCleanups: 0,
+});
+
+export function ensure(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
+export class Model {
+	readonly displayStyle = Object.freeze({ display: 'inline-block' });
+	readonly layoutActive = new Set<number>();
+	readonly passiveActive = new Set<number>();
+	readonly setters: Array<StateSetter | null> = Array.from({ length: ROW_COUNT }, () => null);
+	readonly total = zeroCounts();
+	private baseline = zeroCounts();
+	private readonly listeners = new Set<() => void>();
+
+	connectLayout(index: number, setState: StateSetter) {
+		ensure(!this.layoutActive.has(index), `Duplicate layout setup for row ${index}`);
+		this.layoutActive.add(index);
+		this.setters[index] = setState;
+		this.total.layoutMounts++;
+		this.notify();
+		return () => {
+			ensure(this.layoutActive.delete(index), `Duplicate layout cleanup for row ${index}`);
+			this.total.layoutCleanups++;
+			this.notify();
+		};
+	}
+
+	connectPassive(index: number) {
+		ensure(!this.passiveActive.has(index), `Duplicate passive setup for row ${index}`);
+		this.passiveActive.add(index);
+		this.total.passiveMounts++;
+		this.notify();
+		return () => {
+			ensure(this.passiveActive.delete(index), `Duplicate passive cleanup for row ${index}`);
+			this.total.passiveCleanups++;
+			this.notify();
+		};
+	}
+
+	onChange(listener: () => void) {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	private notify() {
+		for (const listener of this.listeners) listener();
+	}
+
+	resetSample() {
+		this.baseline = { ...this.total };
+	}
+
+	sample(): Counts {
+		return Object.fromEntries(
+			countKeys.map((key) => [key, this.total[key] - this.baseline[key]]),
+		) as Counts;
+	}
+
+	assertReleased() {
+		ensure(this.layoutActive.size === 0, 'Layout effects remain connected after unmount');
+		ensure(this.passiveActive.size === 0, 'Passive effects remain connected after unmount');
+		ensure(
+			this.total.layoutMounts === this.total.layoutCleanups,
+			`Unbalanced layout effects: ${JSON.stringify(this.total)}`,
+		);
+		ensure(
+			this.total.passiveMounts === this.total.passiveCleanups,
+			`Unbalanced passive effects: ${JSON.stringify(this.total)}`,
+		);
+		this.setters.fill(null);
+		this.listeners.clear();
+	}
+}
+
+export type AppProps = {
+	model: Model;
+	shape: Shape;
+	mode: Mode;
+	innerMode: Mode;
+	generation: number;
+	tick: number;
+};
+
+export type Renderer = {
+	render: (props: AppProps) => void;
+	flush: (callback: () => void) => void;
+	unmount: () => void;
+};

--- a/benchmarks/activity/octane-refs.html
+++ b/benchmarks/activity/octane-refs.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Octane ordinary refs benchmark</title>
+	</head>
+	<body>
+		<div id="main"></div>
+		<script type="module" src="./octane-refs.ts"></script>
+	</body>
+</html>

--- a/benchmarks/activity/octane-refs.ts
+++ b/benchmarks/activity/octane-refs.ts
@@ -1,0 +1,26 @@
+import { createRoot, drainPassiveEffects, flushSync } from 'octane';
+import { ActivityRefPrimer, RefControl } from './RefControl.tsrx';
+import { installRefBenchmark } from './ref-browser';
+
+const target = document.getElementById('main');
+if (target === null) throw new Error('Missing #main');
+const flush = (callback: () => void) => {
+	flushSync(callback);
+	drainPassiveEffects();
+};
+
+installRefBenchmark(
+	target,
+	() => {
+		const root = createRoot(target);
+		return {
+			render: (props) => flush(() => root.render(RefControl, props)),
+			unmount: () => flush(() => root.unmount()),
+		};
+	},
+	(container, modes) => {
+		const root = createRoot(container);
+		for (const mode of modes) flush(() => root.render(ActivityRefPrimer, { mode }));
+		return () => flush(() => root.unmount());
+	},
+);

--- a/benchmarks/activity/octane.html
+++ b/benchmarks/activity/octane.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Octane Activity benchmark</title>
+	</head>
+	<body>
+		<div id="main"></div>
+		<script type="module" src="./octane.ts"></script>
+	</body>
+</html>

--- a/benchmarks/activity/octane.ts
+++ b/benchmarks/activity/octane.ts
@@ -1,0 +1,21 @@
+import { createRoot, drainPassiveEffects, flushSync } from 'octane';
+import { App } from './App.tsrx';
+import { installBenchmark } from './browser';
+
+const target = document.getElementById('main');
+if (target === null) throw new Error('Missing #main');
+
+installBenchmark(target, () => {
+	const root = createRoot(target);
+	const flush = (callback: () => void) => {
+		flushSync(callback);
+		// Match React's sync-commit passive dispatch, as effectful-list does.
+		// Hidden background completion is still observed through the real DOM.
+		drainPassiveEffects();
+	};
+	return {
+		render: (props) => flush(() => root.render(App, props)),
+		flush,
+		unmount: () => flush(() => root.unmount()),
+	};
+});

--- a/benchmarks/activity/react-refs.html
+++ b/benchmarks/activity/react-refs.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>React ordinary refs benchmark</title>
+	</head>
+	<body>
+		<div id="main"></div>
+		<script type="module" src="./react-refs.ts"></script>
+	</body>
+</html>

--- a/benchmarks/activity/react-refs.ts
+++ b/benchmarks/activity/react-refs.ts
@@ -1,0 +1,26 @@
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
+import { ActivityRefPrimer, RefControl } from './RefControl.tsrx';
+import { installRefBenchmark } from './ref-browser';
+
+const target = document.getElementById('main');
+if (target === null) throw new Error('Missing #main');
+
+installRefBenchmark(
+	target,
+	() => {
+		const root = createRoot(target);
+		return {
+			render: (props) => flushSync(() => root.render(createElement(RefControl, props))),
+			unmount: () => flushSync(() => root.unmount()),
+		};
+	},
+	(container, modes) => {
+		const root = createRoot(container);
+		for (const mode of modes) {
+			flushSync(() => root.render(createElement(ActivityRefPrimer, { mode })));
+		}
+		return () => flushSync(() => root.unmount());
+	},
+);

--- a/benchmarks/activity/react.html
+++ b/benchmarks/activity/react.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>React Activity benchmark</title>
+	</head>
+	<body>
+		<div id="main"></div>
+		<script type="module" src="./react.ts"></script>
+	</body>
+</html>

--- a/benchmarks/activity/react.ts
+++ b/benchmarks/activity/react.ts
@@ -1,0 +1,17 @@
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
+import { App } from './App.tsrx';
+import { installBenchmark } from './browser';
+
+const target = document.getElementById('main');
+if (target === null) throw new Error('Missing #main');
+
+installBenchmark(target, () => {
+	const root = createRoot(target);
+	return {
+		render: (props) => flushSync(() => root.render(createElement(App, props))),
+		flush: (callback) => flushSync(callback),
+		unmount: () => flushSync(() => root.unmount()),
+	};
+});

--- a/benchmarks/activity/ref-browser.ts
+++ b/benchmarks/activity/ref-browser.ts
@@ -1,0 +1,209 @@
+import { CYCLE_COUNT, ROW_COUNT, UPDATE_COUNT } from './contract.mjs';
+import { REF_DEPTH, REF_OPERATIONS } from './ref-contract.mjs';
+import { ensure } from './model';
+import { RefModel, type RefPrimer, type RefProps, type RefRenderer } from './ref-model';
+
+type Operation = 'ref_replacements' | 'deep_ref_replacements' | 'ref_mount_unmount';
+type Session = {
+	operation: Operation;
+	model: RefModel;
+	renderer: RefRenderer;
+	props: RefProps;
+	nodes: HTMLButtonElement[] | null;
+};
+
+export function installRefBenchmark(
+	target: HTMLElement,
+	createRenderer: () => RefRenderer,
+	primeActivity: RefPrimer,
+) {
+	let current: Session | null = null;
+	let primed = false;
+	let primer: { container: HTMLElement; release: () => void } | null = null;
+
+	function sessionFor(operation?: Operation): Session {
+		ensure(current !== null, 'Ref control has not been prepared');
+		if (operation !== undefined) {
+			ensure(current.operation === operation, `Prepared ${current.operation}, not ${operation}`);
+		}
+		return current;
+	}
+
+	function rows() {
+		return Array.from(target.querySelectorAll<HTMLButtonElement>('[data-ref-row]'));
+	}
+
+	function assertPrimerHidden() {
+		if (primer === null) return;
+		const child = primer.container.querySelector('span');
+		ensure(
+			child !== null && child.isConnected && getComputedStyle(child).display === 'none',
+			'The unrelated Activity did not remain mounted and hidden',
+		);
+	}
+
+	function assertState(session: Session) {
+		assertPrimerHidden();
+		const elements = rows();
+		const count = session.props.present ? ROW_COUNT : 0;
+		ensure(elements.length === count, `Ref control row count ${elements.length} != ${count}`);
+		ensure(
+			session.model.active.size === count,
+			`Ref control retained ${session.model.active.size} refs`,
+		);
+		for (let index = 0; index < elements.length; index++) {
+			const element = elements[index];
+			const active = session.model.active.get(index);
+			ensure(element.dataset.refRow === String(index), `Ref row ${index} was reordered`);
+			ensure(
+				element.dataset.variant === String(session.props.variant),
+				`Ref row ${index} is stale`,
+			);
+			ensure(
+				element.textContent?.trim() === `${index}:${session.props.variant}`,
+				`Ref row ${index} has stale text`,
+			);
+			ensure(
+				active?.element === element && active.variant === session.props.variant,
+				`Ref ${index} does not point at its current live element`,
+			);
+			if (session.nodes !== null) {
+				ensure(element === session.nodes[index], `Ref replacement remounted row ${index}`);
+			}
+		}
+	}
+
+	function render(session: Session, next: Partial<RefProps>) {
+		session.props = { ...session.props, ...next };
+		session.renderer.render(session.props);
+	}
+
+	function cleanup() {
+		if (current === null) return;
+		current.renderer.unmount();
+		ensure(target.childNodes.length === 0, 'Ref control root retained DOM after unmount');
+		current.model.assertReleased();
+		current = null;
+		assertPrimerHidden();
+	}
+
+	function prime(lane: 'after-activity' | 'live-hidden-activity' = 'after-activity') {
+		ensure(current === null, 'Cannot prime Activity during a ref sample');
+		ensure(!primed, 'Activity was already primed in this page');
+		ensure(
+			lane === 'after-activity' || lane === 'live-hidden-activity',
+			`Unknown Activity primer lane: ${lane}`,
+		);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		try {
+			const release = primeActivity(
+				container,
+				lane === 'live-hidden-activity' ? ['visible', 'hidden'] : ['visible', 'hidden', 'visible'],
+			);
+			if (lane === 'live-hidden-activity') {
+				const child = container.querySelector('span');
+				ensure(
+					child !== null && getComputedStyle(child).display === 'none',
+					'Live Activity primer is not hidden',
+				);
+				primer = { container, release };
+			} else {
+				release();
+				ensure(container.childNodes.length === 0, 'Primer retained DOM after unmount');
+			}
+		} finally {
+			if (primer === null) container.remove();
+		}
+		primed = true;
+	}
+
+	function finish() {
+		ensure(current === null, 'Clean up the measured ref tree before its primer');
+		if (primer === null) return;
+		const { container, release } = primer;
+		primer = null;
+		try {
+			release();
+			ensure(container.childNodes.length === 0, 'Live primer retained DOM after unmount');
+		} finally {
+			container.remove();
+		}
+	}
+
+	function prepare(operation: Operation) {
+		ensure(REF_OPERATIONS.includes(operation), `Unknown ref operation: ${operation}`);
+		cleanup();
+		const model = new RefModel();
+		const session: Session = {
+			operation,
+			model,
+			renderer: createRenderer(),
+			props: {
+				model,
+				present: operation !== 'ref_mount_unmount',
+				variant: 0,
+				depth: operation === 'deep_ref_replacements' ? REF_DEPTH : 0,
+			},
+			nodes: null,
+		};
+		current = session;
+		session.renderer.render(session.props);
+		assertState(session);
+		if (session.props.present) session.nodes = rows();
+		model.resetSample();
+	}
+
+	function run(operation: Operation) {
+		const session = sessionFor(operation);
+		const started = performance.now();
+		if (operation !== 'ref_mount_unmount') {
+			for (let index = 1; index <= UPDATE_COUNT; index++) {
+				render(session, { variant: (index % 2) as 0 | 1 });
+			}
+		} else {
+			for (let index = 0; index < CYCLE_COUNT; index++) {
+				render(session, { present: true });
+				render(session, { present: false });
+			}
+		}
+		return performance.now() - started;
+	}
+
+	function verify(operation: Operation) {
+		const session = sessionFor(operation);
+		assertState(session);
+		const expected = ROW_COUNT * (operation === 'ref_mount_unmount' ? CYCLE_COUNT : UPDATE_COUNT);
+		const counts = session.model.sample();
+		ensure(
+			counts.attaches === expected && counts.cleanups === expected,
+			`${operation}: ref lifecycle ${JSON.stringify(counts)} != ${expected} pairs`,
+		);
+		return {
+			rows: session.props.present ? ROW_COUNT : 0,
+			variant: session.props.variant,
+			depth: session.props.depth,
+			counts,
+			identitiesPreserved: true,
+		};
+	}
+
+	function gate(operation: Operation) {
+		prepare(operation);
+		run(operation);
+		const snapshot = verify(operation);
+		cleanup();
+		return snapshot;
+	}
+
+	Object.assign(window, {
+		__activityRefBench: { prime, prepare, run, verify, cleanup, gate, finish },
+		__activityRefPrime: prime,
+		__activityRefPrepare: prepare,
+		__activityRefRun: run,
+		__activityRefVerify: verify,
+		__activityRefCleanup: cleanup,
+		__activityRefFinish: finish,
+		__ready: true,
+	});
+}

--- a/benchmarks/activity/ref-contract.mjs
+++ b/benchmarks/activity/ref-contract.mjs
@@ -1,0 +1,3 @@
+export const REF_DEPTH = 16;
+export const REF_OPERATIONS = ['ref_replacements', 'deep_ref_replacements', 'ref_mount_unmount'];
+export const REF_LANES = ['cold', 'after-activity', 'live-hidden-activity'];

--- a/benchmarks/activity/ref-model.ts
+++ b/benchmarks/activity/ref-model.ts
@@ -1,0 +1,55 @@
+import { ROW_COUNT } from './contract.mjs';
+import { ensure, type Mode } from './model';
+
+export type RefCounts = { attaches: number; cleanups: number };
+type RefCallback = (element: HTMLButtonElement | null) => () => void;
+
+export class RefModel {
+	readonly active = new Map<number, { element: HTMLButtonElement; variant: number }>();
+	readonly total: RefCounts = { attaches: 0, cleanups: 0 };
+	readonly callbacks: readonly (readonly RefCallback[])[];
+	private baseline: RefCounts = { attaches: 0, cleanups: 0 };
+
+	constructor() {
+		this.callbacks = [0, 1].map((variant) =>
+			Array.from({ length: ROW_COUNT }, (_, index) => (element: HTMLButtonElement | null) => {
+				ensure(element !== null, `Cleanup-bearing ref ${index} received a null attachment`);
+				ensure(!this.active.has(index), `Ref ${index} attached before its prior cleanup`);
+				this.active.set(index, { element, variant });
+				this.total.attaches++;
+				return () => {
+					const active = this.active.get(index);
+					ensure(
+						active?.element === element && active.variant === variant,
+						`Ref ${index} cleaned up the wrong attachment`,
+					);
+					this.active.delete(index);
+					this.total.cleanups++;
+				};
+			}),
+		);
+	}
+
+	resetSample() {
+		this.baseline = { ...this.total };
+	}
+
+	sample(): RefCounts {
+		return {
+			attaches: this.total.attaches - this.baseline.attaches,
+			cleanups: this.total.cleanups - this.baseline.cleanups,
+		};
+	}
+
+	assertReleased() {
+		ensure(this.active.size === 0, 'Ordinary tree retained refs after unmount');
+		ensure(
+			this.total.attaches === this.total.cleanups,
+			`Unbalanced ref lifetimes: ${JSON.stringify(this.total)}`,
+		);
+	}
+}
+
+export type RefProps = { model: RefModel; present: boolean; variant: 0 | 1; depth: number };
+export type RefRenderer = { render: (props: RefProps) => void; unmount: () => void };
+export type RefPrimer = (container: HTMLElement, modes: readonly Mode[]) => () => void;

--- a/benchmarks/activity/refs-work.mjs
+++ b/benchmarks/activity/refs-work.mjs
@@ -1,0 +1,105 @@
+import { CYCLE_COUNT, ROW_COUNT, UPDATE_COUNT } from './contract.mjs';
+import { REF_DEPTH, REF_LANES, REF_OPERATIONS } from './ref-contract.mjs';
+import { collectPreciseCalls } from '../lib/precise-work.mjs';
+import {
+	chromium,
+	closeResources,
+	countStat,
+	environmentFor,
+	parseOptions,
+	startFixture,
+	writePayload,
+} from './harness.mjs';
+
+const options = parseOptions(process.argv.slice(2));
+const METRICS = [
+	'queueRefAttach',
+	'queueRefDetach',
+	'attachRef',
+	'drainRefAttaches',
+	'drainRefDetaches',
+	'findHiddenActivity',
+	'findActivityRefOwners',
+	'registerActivityRef',
+	'hideActivityRefs',
+	'queueCurrentActivityRefs',
+];
+const targets = [];
+const failures = [];
+let browser;
+let fixture;
+
+try {
+	browser = await chromium().launch({
+		headless: true,
+		args: ['--no-sandbox', '--js-flags=--jitless'],
+	});
+	const environment = environmentFor(browser, { jitless: true });
+	if (options.targets.includes('octane-tsrx')) {
+		fixture = await startFixture({
+			...options,
+			target: 'octane-tsrx',
+			scenario: 'refs',
+			work: true,
+		});
+		for (const lane of REF_LANES) {
+			const ops = {};
+			const observations = {};
+			for (const operation of REF_OPERATIONS) {
+				const calls = await collectPreciseCalls(browser, {
+					url: fixture.url,
+					before: [
+						...(lane !== 'cold' ? [{ name: '__activityRefPrime', arg: lane }] : []),
+						{ name: '__activityRefPrepare', arg: operation },
+					],
+					operation: { name: '__activityRefRun', arg: operation },
+					after: [
+						{ name: '__activityRefVerify', arg: operation },
+						'__activityRefCleanup',
+						'__activityRefFinish',
+					],
+					metrics: METRICS,
+				});
+				for (const [metric, value] of Object.entries(calls)) {
+					ops[`${operation}_${metric}`] = countStat(value);
+				}
+				observations[operation] = calls;
+				console.log(`PASS activity/refs-${lane}-work/${operation}: ${JSON.stringify(calls)}`);
+			}
+			targets.push({
+				name: `octane-tsrx-refs-${lane}-work`,
+				ops,
+				meta: {
+					...fixture.meta,
+					environment,
+					rows: ROW_COUNT,
+					deepComponentLayers: REF_DEPTH,
+					activityPrimed: lane !== 'cold',
+					liveHiddenActivity: lane === 'live-hidden-activity',
+					correctness: 'pass',
+					observations,
+				},
+			});
+		}
+		const budget = {};
+		for (const operation of REF_OPERATIONS) {
+			const pairs = ROW_COUNT * (operation === 'ref_mount_unmount' ? CYCLE_COUNT : UPDATE_COUNT);
+			for (const metric of METRICS) budget[`${operation}_${metric}`] = countStat(pairs);
+		}
+		targets.push({ name: 'activity-ref-model', ops: budget, meta: { rows: ROW_COUNT } });
+	}
+} catch (error) {
+	failures.push(error instanceof Error ? (error.stack ?? error.message) : String(error));
+} finally {
+	failures.push(...(await closeResources(browser, fixture)));
+}
+
+writePayload({
+	suite: 'activity-refs-work',
+	targets,
+	...(failures.length ? { failed: failures.join('\n') } : {}),
+});
+if (failures.length) {
+	console.error(`FAIL activity refs work: ${failures.join('\n')}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/activity/refs.mjs
+++ b/benchmarks/activity/refs.mjs
@@ -1,0 +1,136 @@
+import { CYCLE_COUNT, ROW_COUNT, UPDATE_COUNT } from './contract.mjs';
+import { REF_DEPTH, REF_LANES, REF_OPERATIONS } from './ref-contract.mjs';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import {
+	checkBrowserErrors,
+	chromium,
+	closeResources,
+	environmentFor,
+	openCase,
+	parseOptions,
+	startFixture,
+	writePayload,
+} from './harness.mjs';
+
+const options = parseOptions(process.argv.slice(2), { iterations: true });
+const WARMUP = 3;
+const targets = [];
+const failures = [];
+let browser;
+
+try {
+	browser = await chromium().launch({
+		headless: true,
+		args: ['--no-sandbox', '--js-flags=--expose-gc'],
+	});
+	const environment = environmentFor(browser);
+	for (const target of options.targets) {
+		let fixture;
+		try {
+			fixture = await startFixture({ ...options, target, scenario: 'refs' });
+			for (const lane of REF_LANES) {
+				const sample = await openCase(browser, fixture.url);
+				try {
+					if (lane !== 'cold') {
+						await sample.page.evaluate((value) => window.__activityRefBench.prime(value), lane);
+					}
+					const gcBeforeSample = await sample.page.evaluate(
+						() => typeof globalThis.gc === 'function',
+					);
+					const ops = {};
+					const rawSamples = {};
+					const semanticChecksums = {};
+					for (const operation of REF_OPERATIONS) {
+						semanticChecksums[operation] = await sample.page.evaluate(
+							(op) => window.__activityRefBench.gate(op),
+							operation,
+						);
+						const durations = [];
+						for (let index = 0; index < WARMUP + options.iterations; index++) {
+							await sample.page.evaluate((op) => window.__activityRefBench.prepare(op), operation);
+							await sample.page.evaluate(() => globalThis.gc?.());
+							const result = await sample.page.evaluate((op) => {
+								const api = window.__activityRefBench;
+								const duration = api.run(op);
+								const snapshot = api.verify(op);
+								return { duration, snapshot };
+							}, operation);
+							await sample.page.evaluate(() => window.__activityRefBench.cleanup());
+							checkBrowserErrors(`${target}/${lane}`, sample.errors);
+							semanticChecksums[operation] = result.snapshot;
+							if (index >= WARMUP) durations.push(result.duration);
+						}
+						rawSamples[operation] = durations;
+						ops[operation] = timingStatForJson(summarizeSamples(durations), { p99: true });
+						console.log(`PASS activity/${target}-refs-${lane}/${operation}`);
+					}
+					targets.push({
+						name: `${target}-refs-${lane}`,
+						ops,
+						meta: {
+							...fixture.meta,
+							environment,
+							gcBeforeSample,
+							activityPrimed: lane !== 'cold',
+							liveHiddenActivity: lane === 'live-hidden-activity',
+							rows: ROW_COUNT,
+							deepComponentLayers: REF_DEPTH,
+							updatesPerSample: UPDATE_COUNT,
+							cyclesPerSample: CYCLE_COUNT,
+							warmup: WARMUP,
+							correctness: 'pass',
+							rawSamples,
+							semanticChecksums,
+						},
+					});
+					await sample.page.evaluate(() => window.__activityRefBench.finish());
+					checkBrowserErrors(`${target}/${lane}`, sample.errors);
+				} finally {
+					await sample.context.close();
+				}
+			}
+		} catch (error) {
+			failures.push(
+				`${target}: ${error instanceof Error ? (error.stack ?? error.message) : error}`,
+			);
+		} finally {
+			failures.push(...(await closeResources(fixture)));
+		}
+	}
+} catch (error) {
+	failures.push(error instanceof Error ? (error.stack ?? error.message) : String(error));
+} finally {
+	failures.push(...(await closeResources(browser)));
+}
+
+const expected = targets[0]?.meta.semanticChecksums;
+for (const target of targets) {
+	if (JSON.stringify(target.meta.semanticChecksums) !== JSON.stringify(expected)) {
+		failures.push(`${target.name}: ordinary-ref semantic controls differ`);
+	}
+}
+
+writePayload({
+	suite: 'activity-refs',
+	iterations: options.iterations,
+	targets,
+	...(failures.length ? { failed: failures.join('\n') } : {}),
+});
+if (targets.length) {
+	console.table(
+		targets.flatMap((target) =>
+			Object.entries(target.ops).map(([operation, stat]) => ({
+				target: target.name,
+				operation,
+				score_ms: Number(stat.score.toFixed(3)),
+				median_ms: Number(stat.median.toFixed(3)),
+				p95_ms: Number(stat.p95.toFixed(3)),
+				rme_pct: Number(stat.rme.toFixed(1)),
+			})),
+		),
+	);
+}
+if (failures.length) {
+	console.error(`FAIL activity refs: ${failures.join('\n')}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/activity/root-descriptor.ts
+++ b/benchmarks/activity/root-descriptor.ts
@@ -1,0 +1,11 @@
+import { createElement, createRoot } from 'octane';
+
+// The reusable descriptor API must not retain an unused Activity implementation.
+// Reuse bundle-reachability's root-static semantic oracle for these exact bytes.
+export function run(container: HTMLElement) {
+	const root = createRoot(container);
+	root.render(createElement('main', { id: 'minimal-root' }, 'Octane'));
+	const text = container.textContent;
+	root.unmount();
+	return { text, cleaned: container.childNodes.length === 0 };
+}

--- a/benchmarks/activity/run.mjs
+++ b/benchmarks/activity/run.mjs
@@ -1,0 +1,143 @@
+import {
+	ASYNC_OPERATIONS,
+	CYCLE_COUNT,
+	GROUP_SIZE,
+	OPERATIONS,
+	ROW_COUNT,
+	UPDATE_COUNT,
+} from './contract.mjs';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import {
+	checkBrowserErrors,
+	chromium,
+	closeResources,
+	environmentFor,
+	openCase,
+	parseOptions,
+	startFixture,
+	writePayload,
+} from './harness.mjs';
+
+const options = parseOptions(process.argv.slice(2), { iterations: true });
+const WARMUP = 3;
+const targets = [];
+const failures = [];
+let browser;
+
+try {
+	browser = await chromium().launch({
+		headless: true,
+		args: ['--no-sandbox', '--js-flags=--expose-gc'],
+	});
+	const environment = environmentFor(browser);
+	for (const target of options.targets) {
+		let fixture;
+		let sample;
+		try {
+			fixture = await startFixture({ ...options, target });
+			sample = await openCase(browser, fixture.url);
+			const gcBeforeSample = await sample.page.evaluate(() => typeof globalThis.gc === 'function');
+			const ops = {};
+			const rawSamples = {};
+			const semanticChecksums = {};
+			for (const operation of OPERATIONS) {
+				// Intermediate nested visibility is checked outside timing; every timed
+				// sample independently verifies all state, effects, identities and text.
+				semanticChecksums[operation] = await sample.page.evaluate(
+					(op) => window.__activityBench.gate(op),
+					operation,
+				);
+				const commits = [];
+				const completions = [];
+				for (let index = 0; index < WARMUP + options.iterations; index++) {
+					await sample.page.evaluate((op) => window.__activityBench.prepare(op), operation);
+					await sample.page.evaluate(() => globalThis.gc?.());
+					const result = await sample.page.evaluate(async (op) => {
+						const api = window.__activityBench;
+						const times = await api.run(op);
+						const snapshot = api.verify(op);
+						return { times, snapshot };
+					}, operation);
+					await sample.page.evaluate(() => window.__activityBench.confirm());
+					await sample.page.evaluate(() => window.__activityBench.cleanup());
+					checkBrowserErrors(target, sample.errors);
+					semanticChecksums[operation] = result.snapshot;
+					if (index >= WARMUP) {
+						commits.push(result.times.commitMs);
+						completions.push(result.times.readyMs);
+					}
+				}
+				if (ASYNC_OPERATIONS.has(operation)) {
+					rawSamples[`${operation}_commit`] = commits;
+					rawSamples[`${operation}_ready`] = completions;
+				} else rawSamples[operation] = commits;
+				console.log(`PASS activity/${target}/${operation}`);
+			}
+			for (const [operation, samples] of Object.entries(rawSamples)) {
+				ops[operation] = timingStatForJson(summarizeSamples(samples), { p99: true });
+			}
+			targets.push({
+				name: target,
+				ops,
+				meta: {
+					...fixture.meta,
+					environment,
+					gcBeforeSample,
+					rows: ROW_COUNT,
+					groupSize: GROUP_SIZE,
+					updatesPerSample: UPDATE_COUNT,
+					cyclesPerSample: CYCLE_COUNT,
+					warmup: WARMUP,
+					correctness: 'pass',
+					rawSamples,
+					semanticChecksums,
+				},
+			});
+		} catch (error) {
+			failures.push(
+				`${target}: ${error instanceof Error ? (error.stack ?? error.message) : error}`,
+			);
+		} finally {
+			failures.push(...(await closeResources(sample?.context, fixture)));
+		}
+	}
+} catch (error) {
+	failures.push(error instanceof Error ? (error.stack ?? error.message) : String(error));
+} finally {
+	failures.push(...(await closeResources(browser)));
+}
+
+const react = targets.find((target) => target.name === 'react');
+const octane = targets.find((target) => target.name === 'octane-tsrx');
+if (
+	react &&
+	octane &&
+	JSON.stringify(react.meta.semanticChecksums) !== JSON.stringify(octane.meta.semanticChecksums)
+) {
+	failures.push('Octane and React produced different Activity semantic checksums');
+}
+
+writePayload({
+	suite: 'activity',
+	iterations: options.iterations,
+	targets,
+	...(failures.length ? { failed: failures.join('\n') } : {}),
+});
+if (targets.length) {
+	console.table(
+		targets.flatMap((target) =>
+			Object.entries(target.ops).map(([operation, stat]) => ({
+				target: target.name,
+				operation,
+				score_ms: Number(stat.score.toFixed(3)),
+				median_ms: Number(stat.median.toFixed(3)),
+				p95_ms: Number(stat.p95.toFixed(3)),
+				rme_pct: Number(stat.rme.toFixed(1)),
+			})),
+		),
+	);
+}
+if (failures.length) {
+	console.error(`FAIL activity: ${failures.join('\n')}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/activity/tsconfig.json
+++ b/benchmarks/activity/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "include": ["*.ts", "*.tsrx"],
+  "exclude": ["react.ts", "react-refs.ts", "dist"],
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2024"],
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "target": "ES2024",
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "paths": {
+      "octane": ["../../packages/octane/src/index.ts"],
+      "octane/*": ["../../packages/octane/src/*"]
+    },
+    "plugins": [{ "name": "@tsrx/typescript-plugin" }]
+  }
+}

--- a/benchmarks/activity/work.mjs
+++ b/benchmarks/activity/work.mjs
@@ -1,0 +1,160 @@
+import { CYCLE_COUNT, ROW_COUNT, UPDATE_COUNT, WORK_OPERATIONS } from './contract.mjs';
+import { collectPreciseCalls } from '../lib/precise-work.mjs';
+import {
+	checkBrowserErrors,
+	chromium,
+	closeResources,
+	countStat,
+	environmentFor,
+	openCase,
+	parseOptions,
+	startFixture,
+	writePayload,
+} from './harness.mjs';
+
+const options = parseOptions(process.argv.slice(2));
+const METRICS = [
+	'activityBlock',
+	'hideActivityRange',
+	'rehideActivityAfterDescendantRender',
+	'enforceHiddenDisplay',
+	'retainHiddenDisplay',
+	'releaseHiddenDisplay',
+	'deactivateScope',
+	'forEachSubtreeChild',
+	'detachSubtreeRefs',
+	'collectVisibleSubtreeRefs',
+	'hideActivityRefs',
+	'queueCurrentActivityRefs',
+	'snapshotSubtreeEffectDeps',
+	'renderBlock',
+];
+const targets = [];
+const failures = [];
+let browser;
+
+try {
+	browser = await chromium().launch({
+		headless: true,
+		args: ['--no-sandbox', '--js-flags=--jitless'],
+	});
+	const environment = environmentFor(browser, { jitless: true });
+	for (const target of options.targets) {
+		let fixture;
+		let sample;
+		try {
+			fixture = await startFixture({ ...options, target, work: true });
+			const ops = {};
+			const observations = {};
+			for (const operation of WORK_OPERATIONS) {
+				let calls = {};
+				if (target === 'octane-tsrx') {
+					calls = await collectPreciseCalls(browser, {
+						url: fixture.url,
+						before: [{ name: '__activityPrepare', arg: operation }],
+						operation: { name: '__activityRun', arg: operation },
+						after: [
+							{ name: '__activityVerify', arg: operation },
+							'__activityConfirm',
+							'__activityCleanup',
+						],
+						metrics: METRICS,
+					});
+					for (const [metric, value] of Object.entries(calls)) {
+						ops[`${operation}_${metric}`] = countStat(value);
+					}
+				}
+				// MutationObserver sees real browser writes, including repeated writes
+				// of an unchanged style. It is enabled only in this untimed work pass.
+				sample = await openCase(browser, fixture.url);
+				await sample.page.evaluate((op) => window.__activityBench.prepare(op), operation);
+				const observed = await sample.page.evaluate(
+					(op) => window.__activityBench.observeWork(op),
+					operation,
+				);
+				await sample.page.evaluate(() => window.__activityBench.confirm());
+				await sample.page.evaluate(() => window.__activityBench.cleanup());
+				checkBrowserErrors(target, sample.errors);
+				await sample.context.close();
+				sample = undefined;
+				for (const [metric, value] of Object.entries(observed.counts)) {
+					ops[`${operation}_${metric}`] = countStat(value);
+				}
+				observations[operation] = {
+					calls,
+					dom: observed.counts,
+					semanticChecksum: observed.snapshot,
+				};
+				console.log(
+					`PASS activity/${target}-work/${operation}: ${JSON.stringify(observations[operation])}`,
+				);
+			}
+			targets.push({
+				name: `${target}-work`,
+				ops,
+				meta: { ...fixture.meta, environment, correctness: 'pass', observations },
+			});
+		} catch (error) {
+			failures.push(
+				`${target}: ${error instanceof Error ? (error.stack ?? error.message) : error}`,
+			);
+		} finally {
+			failures.push(...(await closeResources(sample?.context, fixture)));
+		}
+	}
+	// Meaningful public-work denominators, not a second implementation. This
+	// target lets reviewed deterministic ceilings survive machine-speed changes.
+	const budget = {};
+	for (const operation of WORK_OPERATIONS) {
+		const rowVisits =
+			operation === 'hide_reveal' || operation === 'nested_hide_reveal'
+				? ROW_COUNT * CYCLE_COUNT
+				: operation === 'hidden_burst' || operation === 'plain_updates'
+					? ROW_COUNT * UPDATE_COUNT
+					: ROW_COUNT;
+		for (const metric of [...METRICS, 'styleWrites', 'stateAttributeWrites']) {
+			budget[`${operation}_${metric}`] = countStat(rowVisits);
+		}
+		if (operation === 'hidden_descendant_updates') {
+			// All retained row setters belong to one boundary and one public flush.
+			// This denominator catches a range scan per row even if row count changes.
+			budget[`${operation}_hideActivityRange`] = countStat(1);
+			budget[`${operation}_rehideActivityAfterDescendantRender`] = countStat(1);
+		}
+		budget[`${operation}_addedRows`] = countStat(1);
+		budget[`${operation}_removedRows`] = countStat(1);
+	}
+	targets.push({
+		name: 'activity-work-model',
+		ops: budget,
+		meta: { rows: ROW_COUNT, updates: UPDATE_COUNT, cycles: CYCLE_COUNT },
+	});
+} catch (error) {
+	failures.push(error instanceof Error ? (error.stack ?? error.message) : String(error));
+} finally {
+	failures.push(...(await closeResources(browser)));
+}
+
+const react = targets.find((target) => target.name === 'react-work');
+const octane = targets.find((target) => target.name === 'octane-tsrx-work');
+if (react && octane) {
+	for (const operation of WORK_OPERATIONS) {
+		if (
+			JSON.stringify(react.meta.observations[operation].semanticChecksum) !==
+			JSON.stringify(octane.meta.observations[operation].semanticChecksum)
+		) {
+			failures.push(`Octane and React produced different ${operation} work controls`);
+		}
+	}
+}
+
+// Work observations must not overwrite the timing run's iteration count.
+writePayload({
+	suite: 'activity-work',
+	targets,
+	...(failures.length ? { failed: failures.join('\n') } : {}),
+});
+if (failures.length) {
+	console.error(`FAIL activity work: ${failures.join('\n')}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -2621,5 +2621,262 @@
     "reference": "runtime-form",
     "maxRatio": 1.02,
     "note": "Same-run clean tree-shaken application plus Octane runtime: closure-free lowering must stay within 2% gzip of the runtime-form control. No instrumentation contributes to these bytes."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_hideActivityRange",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 1,
+    "note": "One public flush updates 256 retained rows under one hidden Activity. The original runtime scanned its range 256 times; the semantically checked candidate scans once. Keep the boundary walk coalesced per drain."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_rehideActivityAfterDescendantRender",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 1,
+    "note": "The 256 hidden descendant setters share one re-hide pass, not one pass per rendered row. Measured 256 calls before and 1 after; every row's state, visibility, DOM identity and reveal result are verified."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_enforceHiddenDisplay",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 1,
+    "note": "Bounds hidden display enforcement to one visit per affected host: 65,536 calls before, 256 after for 256 rows. This is the deterministic linear-work guard, independent of browser timing."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_stateAttributeWrites",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 1,
+    "minRatio": 1,
+    "note": "All 256 distinct retained state updates must reach their public data-local attributes exactly once. The semantic gate separately checks every row's text/state and the latest reveal."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_styleWrites",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "An already-hidden descendant state batch must not rewrite unchanged display styles. Both Octane and React measured zero style mutations while updating every retained row."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_addedRows",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "Hidden descendant state updates preserve all accepted host rows; the MutationObserver must see no inserted rows. The semantic gate also compares every survivor identity."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_removedRows",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "Hidden descendant state updates must not remove retained host rows. This independent DOM observation prevents a fast remount from masquerading as retained hidden work."
+  },
+  {
+    "suite": "activity",
+    "op": "hide_reveal_styleWrites",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 2,
+    "note": "Eight complete visibility cycles over 256 rows measured 4,096 style writes in both revisions and React. Permit at most one hide and one reveal write per row/cycle, with intermediate visibility and final authored display verified."
+  },
+  {
+    "suite": "activity",
+    "op": "hide_reveal_detachSubtreeRefs",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "This effectful Activity fixture has no refs. The hasRefs gate must keep ref-detachment manifest traversal cold during visibility changes; callback-ref semantics are covered by separate conformance tests."
+  },
+  {
+    "suite": "activity",
+    "op": "hide_reveal_collectVisibleSubtreeRefs",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "A ref-free Activity reveal must not walk subtree ref manifests. The measured candidate performs zero such visits while reconnecting every required layout/passive effect."
+  },
+  {
+    "suite": "activity",
+    "op": "nested_hide_reveal_styleWrites",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 2,
+    "note": "Eight complete visibility cycles over 256 rows measured 4,096 style writes in both revisions and React. Permit at most one hide and one reveal write per row/cycle, with intermediate visibility and final authored display verified."
+  },
+  {
+    "suite": "activity",
+    "op": "nested_hide_reveal_detachSubtreeRefs",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "This effectful Activity fixture has no refs. The hasRefs gate must keep ref-detachment manifest traversal cold during visibility changes; callback-ref semantics are covered by separate conformance tests."
+  },
+  {
+    "suite": "activity",
+    "op": "nested_hide_reveal_collectVisibleSubtreeRefs",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "A ref-free Activity reveal must not walk subtree ref manifests. The measured candidate performs zero such visits while reconnecting every required layout/passive effect."
+  },
+  {
+    "suite": "activity",
+    "op": "hide_reveal_snapshotSubtreeEffectDeps",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The fixture has layout/passive effects but no insertion effects or speculative Suspense work. Insertion-abort recovery must not introduce subtree dependency snapshots on this ordinary path; measured zero."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_burst_snapshotSubtreeEffectDeps",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The fixture has layout/passive effects but no insertion effects or speculative Suspense work. Insertion-abort recovery must not introduce subtree dependency snapshots on this ordinary path; measured zero."
+  },
+  {
+    "suite": "activity",
+    "op": "hidden_descendant_updates_snapshotSubtreeEffectDeps",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The fixture has layout/passive effects but no insertion effects or speculative Suspense work. Insertion-abort recovery must not introduce subtree dependency snapshots on this ordinary path; measured zero."
+  },
+  {
+    "suite": "activity",
+    "op": "nested_hide_reveal_snapshotSubtreeEffectDeps",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The fixture has layout/passive effects but no insertion effects or speculative Suspense work. Insertion-abort recovery must not introduce subtree dependency snapshots on this ordinary path; measured zero."
+  },
+  {
+    "suite": "activity",
+    "op": "plain_updates_snapshotSubtreeEffectDeps",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The fixture has layout/passive effects but no insertion effects or speculative Suspense work. Insertion-abort recovery must not introduce subtree dependency snapshots on this ordinary path; measured zero."
+  },
+  {
+    "suite": "activity",
+    "op": "plain_descendant_updates_snapshotSubtreeEffectDeps",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The fixture has layout/passive effects but no insertion effects or speculative Suspense work. Insertion-abort recovery must not introduce subtree dependency snapshots on this ordinary path; measured zero."
+  },
+  {
+    "suite": "activity",
+    "op": "plain_updates_hideActivityRange",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The matched plain-tree control contains no Activity. Its public updates must not enter Activity range hiding; all row state, effects and DOM identities are still verified."
+  },
+  {
+    "suite": "activity",
+    "op": "plain_descendant_updates_hideActivityRange",
+    "target": "octane-tsrx-work",
+    "reference": "activity-work-model",
+    "maxRatio": 0,
+    "note": "The matched plain-tree control contains no Activity. Its public updates must not enter Activity range hiding; all row state, effects and DOM identities are still verified."
+  },
+  {
+    "suite": "activity",
+    "op": "deep_ref_replacements_registerActivityRef",
+    "target": "octane-tsrx-refs-cold-work",
+    "reference": "activity-ref-model",
+    "maxRatio": 0,
+    "note": "Before any Activity is rendered, 3,072 ordinary ref replacements through sixteen component layers must not register Activity ownership or scan ancestors. Exact callback attachments/cleanups and live target identities are verified."
+  },
+  {
+    "suite": "activity",
+    "op": "deep_ref_replacements_findActivityRefOwners",
+    "target": "octane-tsrx-refs-cold-work",
+    "reference": "activity-ref-model",
+    "maxRatio": 0,
+    "note": "Before any Activity is rendered, 3,072 ordinary ref replacements through sixteen component layers must not register Activity ownership or scan ancestors. Exact callback attachments/cleanups and live target identities are verified."
+  },
+  {
+    "suite": "activity",
+    "op": "deep_ref_replacements_registerActivityRef",
+    "target": "octane-tsrx-refs-after-activity-work",
+    "reference": "activity-ref-model",
+    "maxRatio": 0,
+    "note": "After the last Activity unmounts, the optional ref-ownership hook must be cold again. The deep ordinary-tree control measured zero Activity registration/owner searches across 3,072 correct ref replacements."
+  },
+  {
+    "suite": "activity",
+    "op": "deep_ref_replacements_findActivityRefOwners",
+    "target": "octane-tsrx-refs-after-activity-work",
+    "reference": "activity-ref-model",
+    "maxRatio": 0,
+    "note": "After the last Activity unmounts, the optional ref-ownership hook must be cold again. The deep ordinary-tree control measured zero Activity registration/owner searches across 3,072 correct ref replacements."
+  },
+  {
+    "suite": "activity",
+    "op": "deep_ref_replacements_findActivityRefOwners",
+    "target": "octane-tsrx-refs-live-hidden-activity-work",
+    "reference": "activity-ref-model",
+    "maxRatio": 0,
+    "note": "A separate hidden Activity remains mounted throughout 3,072 ordinary depth-16 ref replacements. Cached negative ownership must avoid repeated ancestor searches; the unrelated hidden root and all ref lifetimes are checked."
+  },
+  {
+    "suite": "activity",
+    "op": "ref_mount_unmount_findActivityRefOwners",
+    "target": "octane-tsrx-refs-live-hidden-activity-work",
+    "reference": "activity-ref-model",
+    "maxRatio": 1,
+    "note": "Fresh ordinary ref-bearing blocks may require one ownership lookup while another root has a live hidden Activity. Eight 256-row mount/unmount cycles measured 2,048 searches for 2,048 new blocks, with balanced ref lifetimes."
+  },
+  {
+    "suite": "activity",
+    "op": "activity_reachable",
+    "target": "activity-bundle-root-static-specialized",
+    "reference": "activity-bundle-model",
+    "maxRatio": 0,
+    "note": "The executed ordinary production bundle must tree-shake the optional Activity implementation. The shared reachability oracle verifies actual behavior before the diagnostic is accepted; existing bundle byte budgets are not loosened."
+  },
+  {
+    "suite": "activity",
+    "op": "activity_reachable",
+    "target": "activity-bundle-root-static",
+    "reference": "activity-bundle-model",
+    "maxRatio": 0,
+    "note": "The executed ordinary production bundle must tree-shake the optional Activity implementation. The shared reachability oracle verifies actual behavior before the diagnostic is accepted; existing bundle byte budgets are not loosened."
+  },
+  {
+    "suite": "activity",
+    "op": "activity_reachable",
+    "target": "activity-bundle-hooks-state",
+    "reference": "activity-bundle-model",
+    "maxRatio": 0,
+    "note": "The executed ordinary production bundle must tree-shake the optional Activity implementation. The shared reachability oracle verifies actual behavior before the diagnostic is accepted; existing bundle byte budgets are not loosened."
+  },
+  {
+    "suite": "activity",
+    "op": "activity_reachable",
+    "target": "activity-bundle-component-owned-effects",
+    "reference": "activity-bundle-model",
+    "maxRatio": 0,
+    "note": "The executed ordinary production bundle must tree-shake the optional Activity implementation. The shared reachability oracle verifies actual behavior before the diagnostic is accepted; existing bundle byte budgets are not loosened."
+  },
+  {
+    "suite": "activity",
+    "op": "activity_reachable",
+    "target": "activity-bundle-root-descriptor",
+    "reference": "activity-bundle-model",
+    "maxRatio": 0,
+    "note": "The executed ordinary production bundle must tree-shake the optional Activity implementation. The shared reachability oracle verifies actual behavior before the diagnostic is accepted; existing bundle byte budgets are not loosened."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -364,6 +364,21 @@ const SUITES = [
 		],
 	},
 	{
+		// Public Activity lifecycle and hidden descendant work. The paired fixture
+		// builds itself, and a separate production-work pass defends the range walk.
+		name: 'activity',
+		cwd: 'activity',
+		servers: [],
+		iter: { normal: 8, quick: 2 },
+		runs: [
+			{ script: 'run.mjs', args: (n) => [String(n)] },
+			{ label: 'work', script: 'work.mjs', args: () => [] },
+			{ label: 'refs', script: 'refs.mjs', args: (n) => [String(n)] },
+			{ label: 'refs-work', script: 'refs-work.mjs', args: () => [] },
+			{ label: 'bundle', script: 'bundle.mjs', args: () => [] },
+		],
+	},
+	{
 		name: 'effectful-list',
 		cwd: 'effectful-list',
 		servers: [

--- a/docs/activity-audit.md
+++ b/docs/activity-audit.md
@@ -1,0 +1,317 @@
+# Activity parity and performance audit
+
+Audit started on 2026-08-21 from Octane commit
+`1ac62305379c6ee735580ce34886142dd806d29c`, in an isolated worktree. That local
+merge commit has byte-identical runtime/compiler source, package manifest, and
+lockfile to the public upstream baseline
+`2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192`. PR preparation used the public baseline
+to exclude three unrelated inherited test/changeset files without changing the
+measured source. Benchmark reproduction commands use that public commit; raw
+audit results retain their original local-merge provenance.
+
+The React references are the repository's [pinned upstreams](../packages/octane/audit/react-upstreams.json):
+stable `v19.2.7` (`6117d7cca4906492c51fe6a03381e35adfd86e7d`) and canary
+`b740af2510de1e19fcb399abb862af26ff95ac80`. The current
+[React Activity reference](https://react.dev/reference/react/Activity) was also
+checked.
+
+This audit concerns the observable component contract: preserved state and host
+identity, visibility, refs, effects, suspension, authoring, and server output.
+It does not claim that Octane implements React's Fiber scheduler, every
+experimental Activity surface, or every upstream test. The repository's
+[differences contract](./differences-from-react.md) remains authoritative.
+
+## Verified contracts and regression coverage
+
+| Area | Behavior covered | Executable evidence |
+| --- | --- | --- |
+| Identity and effects | `visible` is the default. Hide/reveal preserves compatible DOM, component state, and uncontrolled input values. Layout/passive effects disconnect and reconnect; hiding alone does not disconnect insertion effects. An inner hidden Activity stays inactive when its outer Activity reveals. | [Activity lifecycle](../packages/octane/tests/activity.test.ts), [DOM conformance](../packages/octane/tests/conformance/activity-dom.test.ts) |
+| Public refs | Initially hidden host refs are not attached. Hiding disconnects object/callback refs, honoring callback cleanup; revealing attaches the latest ref. Replacing a ref while hidden does not publish it, and hidden unmount does not repeat cleanup. Fragment refs inside the boundary follow the same visibility lifetime. | [DOM conformance](../packages/octane/tests/conformance/activity-dom.test.ts), [Fragment visibility](../packages/octane/tests/conformance/fragment-refs-activity.test.ts), [Fragment descriptors](../packages/octane/tests/conformance/fragment-refs-descriptors.test.ts) |
+| Authored DOM values | Hidden roots remain hidden across descendant updates and Suspense resumes. Reveal restores the latest authored `display` and bare-text values, including removal of an authored display property. Overlapping Activity/Suspense owners cannot reveal one another's content. | [DOM conformance](../packages/octane/tests/conformance/activity-dom.test.ts), [Activity lifecycle](../packages/octane/tests/activity.test.ts) |
+| Portals | Logical Activity ownership reaches deeply nested portals, newly inserted portal children, nested Activities, and portaled Suspense content. Revealing one owner does not override another hidden owner. | [DOM conformance](../packages/octane/tests/conformance/activity-dom.test.ts); see the canary scope below |
+| Hidden suspension | Background suspension stays within the hidden Activity instead of replacing a visible sibling with an enclosing fallback. Resolved work remains hidden until reveal. A visible Activity still participates in normal Suspense handling. | [DOM conformance](../packages/octane/tests/conformance/activity-dom.test.ts), [universal Activity](../packages/octane/tests/universal-activity.test.ts) |
+| Insertion-effect retries | A hidden attempt that suspends does not publish its queued insertion effects. Successful retries preserve memo/cached-child effects, invalidate superseded or omitted hooks, retain repeated custom-hook enqueues, and transfer pending work to a nested Activity that suspends. This queue guarantee does not make eager structural deletion transactional; see the limit below. | [DOM conformance](../packages/octane/tests/conformance/activity-dom.test.ts), [custom-hook helper](../packages/octane/tests/conformance/_fixtures/activity-dom-insertion-helpers.ts) |
+| Public API and compiler | Direct, imported-alias, namespace, dynamic-tag, spread-configured, children-prop, returned-JSX, and `createElement(Activity, …)` forms resolve to the same boundary. Props retain source-order precedence, including explicit keys before or after spreads on runtime-selected tags; nested children override a children prop; changing the effective key resets state. Unrelated module, callback, and block-scoped bindings named `Activity` stay ordinary components. The client/server export types accept JSX without changing sentinel identity. | [Authoring matrix](../packages/octane/tests/activity-authoring.test.ts), [TSRX fixture](../packages/octane/tests/_fixtures/activity-authoring.tsrx), [returned JSX](../packages/octane/tests/_fixtures/activity-authoring-returned.tsx), [lexical shadows](../packages/octane/tests/_fixtures/activity-authoring-shadowed.tsx) |
+| SSR and hydration | Visible content renders normally. Hidden children are not evaluated or serialized; hydratable output retains an empty internal range, while static markup omits it. Both stream transports finish without executing hidden descriptor children. Hydration adopts visible server nodes and can populate an empty hidden range without consuming a neighboring server node. | [Authoring matrix](../packages/octane/tests/activity-authoring.test.ts), [Activity hydration](../packages/octane/tests/hydration/activity-hydrate.test.ts), [SSR contract](./ssr.md#how-it-works) |
+| Universal renderers | Capability-gated visibility preserves accepted hosts, state, resources, and insertion effects while disconnecting public refs, events, and layout/passive effects. Hidden suspension retains the accepted range and queued state; rejection reaches the enclosing catch boundary. Aborted preparation, rejected host work, recreated instances, and physical attachment notifications cannot expose an unaccepted or hidden ref. | [Universal Activity](../packages/octane/tests/universal-activity.test.ts), [retained Suspense](../packages/octane/tests/universal-retained-suspense.test.ts), [host attachments](../packages/octane/tests/universal-host-attachments.test.ts), [architecture](./universal-renderer-architecture.md#6-nested-owners-and-renderer-identity) |
+| ViewTransition | Transition-driven reveal/hide fires enter/exit in both nesting orders. Visible updates fire update; hidden-only updates do not activate an animation. Native Chromium tests observe fulfilled transition readiness, real new/old pseudo-element animations, and the same edited input through hide/reveal. | [Conformance](../packages/octane/tests/conformance/view-transition.test.ts), [native browser integration](../packages/octane/tests/browser/activity-view-transition/activity-view-transition.test.ts) |
+
+The lifecycle/ref reference is React's stable
+[Activity tests](https://github.com/facebook/react/blob/v19.2.7/packages/react-reconciler/src/__tests__/Activity-test.js)
+and [commit implementation](https://github.com/facebook/react/blob/v19.2.7/packages/react-reconciler/src/ReactFiberCommitWork.js).
+Hidden suspension is grounded in the stable
+[Activity/Suspense tests](https://github.com/facebook/react/blob/v19.2.7/packages/react-reconciler/src/__tests__/ActivitySuspense-test.js).
+The [pinned canary commit implementation](https://github.com/facebook/react/blob/b740af2510de1e19fcb399abb862af26ff95ac80/packages/react-reconciler/src/ReactFiberCommitWork.js)
+also disconnects and reconnects Fragment refs inside hidden Activity trees.
+
+### Stable versus canary portal scope
+
+The deeper portal expectations come from
+[ReactDOMActivity-test.js at the pinned canary](https://github.com/facebook/react/blob/b740af2510de1e19fcb399abb862af26ff95ac80/packages/react-dom/src/__tests__/ReactDOMActivity-test.js),
+including portals below host elements, insertion while hidden, nested hidden
+ownership, and a Suspense fallback inside a portal. A direct React 19.2.7 DOM
+probe left a deeply nested portaled host visible when its logical Activity hid.
+Stable React is therefore not the oracle for that particular group; the Octane
+tests deliberately target the later pinned behavior. This distinction must be
+preserved when updating React versions or adding differential tests.
+
+## Intentional differences and limits
+
+- **Hidden work is synchronous.** Octane renders hidden children in the same
+  pass. It has no React offscreen/idle lane, general time slicing, or equivalent
+  background-priority/coalescing guarantee. Compatible committed state and
+  visibility do not imply matching render counts or completion timing. See
+  [scheduling differences](./differences-from-react.md#scheduler-synchronous-two-priorities).
+- **Hydration is not selective hydration.** Matching visible HTML, hidden
+  server omission, full-root adoption, and streamed-boundary adoption are
+  supported contracts. Adding an always-visible Activity does not give Octane
+  React's independently prioritized hydration units or synthetic event replay.
+  React's partial-prerender/resume machinery is not part of this parity claim.
+  See [SSR and hydration differences](./differences-from-react.md#ssr-and-streaming).
+- **Other framework differences still apply.** Compiler-keyed hooks, inferred
+  dependencies, parallel `use()`, native events, synchronous initial mounting,
+  and the absence of classes, legacy roots, React Server Components, and
+  StrictMode double invocation are unchanged. Hidden Activity is a suspension
+  boundary, not an error boundary.
+- **General structural deletion is not an atomic hidden transaction.** The DOM
+  runtime still mutates same-identity trees eagerly. If a hidden render removes
+  an already-committed child and a later sibling suspends, that child's DOM,
+  state, and insertion cleanup can be destroyed before the Activity knows the
+  attempt is incomplete. React 19.2.7 retains the old child and defers cleanup
+  until successful completion; canceling the removal does not recreate it.
+  Discarding queued effects cannot undo a cleanup that has already executed.
+  This is part of the existing
+  [per-swap Suspense limitation](../packages/octane/audit/SUSPENSE_DIVERGENCE.md#4-per-swap-off-screen-rendering--cross-boundary-reveal-gap--closed),
+  not a closed parity gap. A general fix needs owner-state staging/rollback for
+  branch removal, descriptor-kind changes, component/key replacement, lists,
+  and portals. An `@if`-only delay or fresh-tree preflight would not preserve the
+  full state/identity contract. See the
+  [deferred-commit plan](./transition-deferred-commit-plan.md).
+
+The deletion counterexample is small: first commit `Before`, whose insertion
+effect logs mount/cleanup; then remove it while `Later` reads an unresolved
+promise. React's expected log is unchanged until that promise resolves. Restoring
+`showBefore` before resolution must cause neither cleanup nor remount.
+
+```tsx
+<Activity mode="hidden">
+  {showBefore ? <Before /> : null}
+  <Later promise={promise} />
+</Activity>
+```
+
+## Validation record
+
+The first new DOM conformance run used the unchanged Octane baseline and failed
+all 13 cases in both compiler modes: **26 intended semantic failures**. They
+exposed attached hidden refs, stale display/text restoration, visible portaled
+content, and an outer fallback activated by hidden suspension. The universal
+tests likewise failed before their owning runtime was corrected. A final frozen
+baseline recheck reproduced four state/rejection/renderer-region failures,
+including state owned directly by the Activity body.
+
+| Gate | Result |
+| --- | --- |
+| New DOM regressions against the original runtime | 26/26 failed for the intended contracts |
+| Final Activity DOM conformance, development + production | **64/64 passed**, including insertion-abort and nested retry cases |
+| Universal Activity and neighboring universal suites, development + production | **652/652 passed across 34 files** |
+| Native Chromium Activity/ViewTransition integration, development + production | **4/4 passed**; the same four cases failed before the visibility/animation-handle fixes |
+| Unified Activity benchmark regression guards | **32/32 passed** on the candidate; frozen baseline failed exactly the three quadratic range-work guards |
+| Final integrated Activity, compiler/authoring, SSR, hydration, Fragment, Suspense, conditional-hook, and ViewTransition run | **971/971 passed across 57 files** |
+| Broad core run and corrected environment cohorts | **13,639 passed assertions across 861 file executions** in the diagnostic aggregate; **6 environment-failed executions / 8 assertions remain**. This is not a single green full-suite invocation. |
+| Full workspace suite and normal native-parser configuration | **Not established by this audit run** |
+| Strict core typecheck | **Passed** using the unchanged core tsconfig with a paths overlay to real installed Volar declarations |
+| Scoped Activity typecheck | **Passed** with `tsrx-tsc` and real dependency declaration paths; the broader changed-file graph still reports pre-existing universal-object and ViewTransition fixture typing errors |
+
+The worktree could not install the locked native parser dependencies: the
+registry returned HTTP 403, including the approved retry. Existing installed
+dependencies were reused. The local validation config used the supported
+`parser.browser.js` adapter, the worktree's actual compiler/runtime sources, and
+the root configuration's renderer-boundary registrations. The recorded
+universal command was:
+
+```bash
+./node_modules/.bin/vitest run --config .test-scratch/activity-audit/vitest.config.mjs packages/octane/tests/universal-*.test.ts --reporter=dot --silent=passed-only
+```
+
+That config is an ignored, environment-specific workaround, not a replacement
+for the normal repository gates. A clean installation should repeat the
+focused files through the root Vitest configuration, then run the required
+typecheck and full-suite checks. File-level coverage here does not automatically
+close every entry in the [React conformance ledger](./react-parity-coverage.md).
+
+The initial broad invocation passed 13,260 assertions and failed 47 across 57
+file executions. Every failure was classified against the root configuration and
+frozen-source controls:
+
+| Cause | Failed file executions | Failed assertions | Follow-up |
+| --- | ---: | ---: | --- |
+| Missing differential React precompile | 40 | 0 | Correct root global setup; differential/profile rerun passed 43 files / 327 tests |
+| Profile-only fixtures run in ordinary projects | 6 | 34 | Run once in the root-equivalent profile project; included in the 327 above |
+| Missing native `oxc-tsrx` | 4 | 6 | Same failure with frozen and candidate compiler entry points; complete install still required |
+| Missing Volar runtime dependencies | 3 | 0 | Real preserved dependency packages plus the repository's checked-in parser patch; language cohort passed 4 files / 64 tests |
+| Unpatched parser / old esrap | 1 | 4 | Same four failures on frozen source; included in the repaired language cohort above |
+| Borrowed pnpm install lacks workspace-package layout | 2 | 2 | Real workspace links in ignored scratch make all three transform controls pass on both revisions; normal installed-layout tests still need a complete install |
+| Hydration timeout under the broad run | 1 | 1 | Both revisions passed in isolation; full file rerun passed 2 files / 42 tests |
+
+No candidate-only source regression was isolated in that review. The ignored
+`core-failure-classification.json` records the reports and exact aggregation;
+the aggregate replaces rerun files and counts the profile project only once.
+No fake package, ambient TSRX declaration, shared dependency modification, or
+manifest/lockfile change was used to obtain these results.
+
+## Performance measurement
+
+The new [Activity benchmark](../benchmarks/activity/README.md) compiles the same
+stateful fixture for production Octane and React. It measures visible/hidden
+mounts, hide/reveal, visible and hidden updates, descendant state updates, and
+nested visibility, with plain-tree controls. Every sample checks retained
+identity, state, uncontrolled input values, visibility, and balanced effect
+lifetimes before its timing is accepted.
+
+Synchronous `*_commit` and completed-work `*_ready` results are separate because
+React may defer or combine hidden work. The completed-work result includes
+scheduling and readiness detection; it is not just framework CPU time. A
+separate work-count pass measures runtime visits and actual DOM mutations.
+Baseline and candidate must use the same fixture, production settings,
+iteration count, browser, and dependency installation.
+
+The completed [universal external-store control](../benchmarks/universal-external-store/README.md)
+used two production `universal-native.ts` bundles differing only in
+`universal-core.ts`, in baseline/candidate/candidate/baseline order with seven
+samples per run (Node 26.4.0, macOS arm64, Apple M5 Max). All semantic gates
+passed. Stable and inline subscription lifetimes remained 128 acquisitions and
+128 releases; the changing-subscription control remained 37,248 of each; the
+state-replacement work counter remained 3. Timing variation did not establish a
+speedup or regression. The full native bundle changed from 165,508 to 166,264
+minified bytes and from 45,908 to 46,115 gzip bytes (**+207 gzip bytes**). This
+isolated control does not determine the final DOM bundle cost or Activity
+browser ratios.
+
+### Browser timings
+
+Final measurements used Node 26.4.0, Chromium 149.0.7827.55, macOS arm64 on an
+Apple M5 Max, React 19.2.7, Vite 8.1.5, esbuild 0.28.1, and the same supported
+JavaScript parser fallback for both Octane revisions. Baseline and candidate retained the identical fixture,
+installed dependencies, and production settings. The candidate source-content
+hash was `30e6d2632fe06a679441af4dd35e0db3f79603cbc381488f8c7f1a2d060ad4be`;
+this is a source hash, not a Git commit. The shared fixture hash was
+`4c3f5357…`.
+
+The first quiet paired run used eight measured samples per operation after three
+warmups. Values below are the benchmark library's steady-window **scores in
+milliseconds**, not full-sample means. React values are from the candidate's
+same-toolchain run.
+
+| Operation | Original Octane | Candidate Octane | React |
+| --- | ---: | ---: | ---: |
+| Visible mount | 1.12 | 0.98 | 1.54 |
+| Hidden mount — synchronous commit | 1.12 | 1.12 | 0.06 |
+| Hidden mount — completed work | 1.12 | 1.12 | 1.96 |
+| Eight hide/reveal cycles | 2.80 | 4.14 | 1.42 |
+| Twelve visible prop updates | 1.60 | 1.84 | 3.98 |
+| Hidden prop burst — synchronous commit | 1.80 | 2.14 | 0.06 |
+| Hidden prop burst — completed work | 1.80 | 2.14 | 0.80 |
+| 256 hidden descendant setters — synchronous commit | 8.58 | 0.30 | 0.08 |
+| 256 hidden descendant setters — completed work | 8.58 | 0.30 | 0.88 |
+| Eight nested hide/reveal cycles | 5.44 | 7.88 | 1.90 |
+| Twelve plain-tree prop updates | 1.62 | 1.76 | 3.94 |
+| 256 plain-tree descendant setters | 0.24 | 0.28 | 0.46 |
+
+A reverse-order Octane-only repeat used the same cached builds and 16 samples to
+check drift. The hidden-setter improvement persisted: **9.271 → 0.286 ms, about
+32× faster**. The repeat also confirmed costs that must not be hidden:
+
+| Repeat control | Original | Candidate | Change |
+| --- | ---: | ---: | ---: |
+| Eight hide/reveal cycles | 2.957 ms | 4.300 ms | +45% |
+| Eight nested hide/reveal cycles | 5.786 ms | 7.671 ms | +33% |
+| Twelve plain-tree prop updates | 1.729 ms | 1.943 ms | +12% |
+
+The repeated flat-toggle full-sample RME was 2.3% / 5.8% (baseline / candidate),
+and nested-toggle RME was 2.9% / 6.7%. Sub-millisecond samples have substantially
+larger relative error and timer quantization; raw samples, both RME measures,
+means, medians, and percentiles are retained. React also moved between paired
+runs, so small timing changes should not be given a causal explanation from
+these scores alone. In particular, the plain-tree timing increase did not come
+with additional named Activity helper calls or additional render/DOM work.
+
+### Deterministic work and ordinary-tree controls
+
+- **Hidden descendant batch:** `hideActivityRange` and descendant rehide calls
+  fell from **256 each to 1 each**. Display enforcement fell from **65,536 to
+  256**. All 256 component renders and state-attribute writes remain; style writes,
+  row insertion, and row removal remain zero. This removes quadratic range work
+  without skipping state updates.
+- **Hide/reveal:** flat and nested workloads still perform exactly 4,096 style
+  writes each, with no remounts. Component-render, effect-deactivation, and shared
+  subtree-visit counts are unchanged. Ref-free boundaries do zero ref-manifest
+  walks, and this no-insertion-effect fixture does zero speculative effect
+  snapshots. The added work is per-boundary suspension/ref gating and authored
+  display restoration/ownership bookkeeping, not extra DOM mutations.
+- **Plain trees:** the prop-update control still performs 6,168 block renders,
+  6,144 effect-hook calls, and 3,084 `setText` calls; the independent-setter control
+  performs 256 / 512 / 256 respectively. None of the newly added named Activity
+  helpers execute in either operation.
+- **Ordinary refs:** cold shallow/deep replacement and mount/unmount scores were
+  1.56 / 1.90 / 2.42 ms before and 1.56 / 1.86 / 2.38 ms after. Candidate
+  after-Activity scores were 1.52 / 1.88 / 2.40 ms; keeping an unrelated hidden
+  Activity live gave 1.58 / 1.88 / 2.54 ms. All semantic gates pass. Cold and
+  after-last-Activity operations do zero Activity ref registration/owner searches.
+  With an unrelated hidden Activity live, 3,072 shallow or deep ref replacements
+  cause zero owner-discovery misses; 2,048 newly mounted blocks cause exactly
+  2,048 misses. Negative ownership caching avoids repeated ancestor walks.
+
+The benchmark adds 32 narrow deterministic ceilings for linear hidden work, no
+extra DOM churn, cold ref/snapshot paths, and optional bundle reachability. The
+unified `--quick --ratios activity` run passes all 32 on the candidate; the frozen
+baseline fails exactly the three quadratic hide/re-hide/display-scan guards. It
+does **not** add a wall-clock ceiling that would enshrine the slower toggle path,
+nor loosen any existing absolute bundle-size budget.
+
+### Compiler output and bundle cost
+
+Direct mode-only Activity output is byte-identical to the frozen compiler:
+the shared App emits 5,980 client bytes and 4,547 server bytes; the ordinary ref
+fixture emits 4,080 client bytes. Simple, key-only, and spread-only generic
+component controls are also unchanged. A 30-sample alternating same-parser
+compiler probe measured a scoped client compilation cost of about 6%
+(3.717 → 3.940 ms; paired-ratio RME 3.52%) for the Activity fixture's
+binding-correctness analysis. Server and ordinary-component differences were
+within noise. This is not a native-parser throughput result.
+
+All five ordinary production bundle controls execute successfully and exclude
+the optional Activity implementation. Cold descriptor registration avoided the
+roughly 6 KB gzip retention found during the first implementation review. The
+remaining shared correctness machinery still has a measurable size cost:
+
+| Ordinary entry | Original gzip | Candidate gzip | Delta |
+| --- | ---: | ---: | ---: |
+| Specialized static root | 12,266 B | 12,577 B | +311 B |
+| Reusable static root | 36,475 B | 36,993 B | +518 B |
+| State-hook root | 37,620 B | 38,155 B | +535 B |
+| Component-owned effects | 36,868 B | 37,406 B | +538 B |
+| Plain element-descriptor root | 36,430 B | 36,933 B | +503 B |
+
+The Activity application's production JavaScript grew from 151,808 to 157,850
+bytes (+6,042 bytes) while adding the corrected contracts. The existing
+bundle-reachability budgets remain authoritative; their normal-toolchain gate
+still needs a complete installation. The borrowed fallback toolchain already
+differs from some committed absolute budgets at the frozen baseline, so this
+audit does not rewrite those budgets to fit its environment.
+
+### Reproduction and remaining optimization work
+
+Ignored local results are in `benchmarks/activity/dist/`: `baseline.json`,
+`candidate.json`, the `*-repeat.json` pair, the `*-refs.json` pair, and the
+`*-work.json`, `*-refs-work.json`, and `*-bundle.json` pairs. They include exact
+source/toolchain hashes and semantic checks. The [benchmark README](../benchmarks/activity/README.md#run)
+documents how to regenerate them from either revision.
+
+The audit establishes a large hidden-update improvement, not universal
+optimality. Visibility-only toggles still rerender and reconnect large retained
+subtrees, and the corrected visibility bookkeeping adds cost. These measured
+paths, shared bundle bytes, and the structural-transaction limitation above are
+explicit follow-up work. Any future bailout must preserve the latest hidden
+state, conditional hooks, current refs, insertion-effect retry ownership, and
+the native animation contract now covered by the tests.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -702,8 +702,11 @@ Other consequences:
   unchanged values (the concurrent-interleaving window it guards doesn't exist
   here).
 - A hidden `<Activity>` subtree renders synchronously in the same pass — there
-  is no offscreen/idle lane deprioritizing hidden work. Hide/reveal semantics
-  (state preserved, effects unmounted while hidden) match React.
+  is no offscreen/idle lane deprioritizing hidden work. Compatible state and DOM
+  are preserved; refs and layout/passive effects disconnect while hidden and
+  reconnect on reveal. Insertion effects stay connected. Hidden suspension is
+  contained by the Activity, but general structural-deletion atomicity still has
+  the per-swap limitation above. See the [Activity audit](./activity-audit.md).
 - `useId` generates `:<prefix>in-<n>:` identifiers (React 19.2 uses
   `_r_<n>_`). Both are opaque; only the format differs.
 - `version` reports Octane's own package version (`0.x`), not a React version —

--- a/docs/universal-renderer-architecture.md
+++ b/docs/universal-renderer-architecture.md
@@ -916,13 +916,18 @@ boundary.
 
 Visibility is inherited through owner records. Hidden Activity and retained
 Suspense hosts keep logical/public identity, resources, state, and insertion
-effects while layout/passive effects and event delivery disconnect. Activity
-keeps refs attached; retained Suspense cycles refs through null and reattaches
-the same public instance on reveal. A fallback is a coexisting visible owner,
-not a replacement for the hidden primary, and repeated pending renders cannot
-duplicate either range. Host visibility commands are capability-gated and
-transactional, so an aborted or rejected transition leaves the accepted tree
-unchanged.
+effects while public refs, layout/passive effects, and event delivery disconnect.
+Initially hidden hosts do not publish refs; reveal attaches the latest ref to
+the preserved public instance. A recycling driver's physical attachment
+notification cannot reconnect a logically hidden ref. Hidden Activity contains
+suspension and retains its accepted range without activating an outer fallback;
+ordinary errors still reach the enclosing error boundary. Retained Suspense's
+fallback is a coexisting visible owner, not a replacement for its hidden
+primary, and repeated pending renders cannot duplicate either range. Host
+visibility commands are capability-gated and transactional, so an aborted or
+rejected transition leaves the accepted tree unchanged. See the
+[Activity audit](./activity-audit.md) for the React reference and executable
+coverage.
 
 The universal runtime preserves Octane's compiler-assigned slot model,
 dependency inference, current-state getter, and parallel-`use()` behavior.
@@ -1149,8 +1154,8 @@ The object driver and executable fixtures demonstrate:
   template directive, Providers/consumers, early returns, errors, and retained
   suspension;
 - remove followed by resource destroy;
-- public callback/object ref attachment after commit and detachment on change
-  or teardown;
+- public callback/object ref attachment after commit, detachment on accepted
+  hide/change/teardown, and reconnection of the current ref on reveal;
 - insertion/layout/passive effect ordering around the batch;
 - prepared-token abort, render error, and suspension with no public mutation
   and exact staged-resource release;
@@ -1199,7 +1204,7 @@ declare, implement, or reject these independently.
 | Events | Driver classification lowers event props to listener-ID/priority commands; replacement, removal, teardown, owner-routed dispatch, and scoped multi-listener delivery are transactional. The local Three driver supplies the R3F-shaped ray/pointer surface. | A transported renderer must serialize native delivery/priority semantics. There is deliberately no synthetic event layer. |
 | Styles | No renderer-neutral style object or stylesheet lifecycle. | Add typed renderer extensions for material/style application and disposal; do not copy CSS rules into native renderers. |
 | Assets | No prepare-time asset allocation. | Add cancellable/resource-owned capabilities whose acquisition is staged or externally cached. |
-| Visibility / `Activity` | Core-owned Activity and retained Suspense issue capability-gated visibility commands, retain identity/resources/insertion effects, disconnect events and layout/passive effects, and apply their distinct ref contracts. Three maps that state onto `Object3D.visible`, and its client pending/error projection is implemented. | Cross-boundary DOM-owner Activity propagation remains separate from local Three visibility. |
+| Visibility / `Activity` | Core-owned Activity and retained Suspense issue capability-gated visibility commands, retain identity/resources/insertion effects, and disconnect public refs, events, and layout/passive effects. Hidden Activity contains suspension without replacing the visible shell; reveal reconnects the current refs. Three maps visibility onto `Object3D.visible`, and its client pending/error projection is implemented. | Cross-boundary DOM-owner Activity propagation remains separate from local Three visibility. |
 | Portal | `createPortal` creates a logical range whose hosts are placed under an opaque, root-scoped driver target handle. Registration, stable reuse, retarget, retained Suspense, abort, rejected preparation, removal, and teardown are transactional. Three Milestone 6 supplies borrowed `Object3D` targets, R3F-style state/event enclaves, nested context, shared frame/interaction state, and physical Three event bubbling. | Transported renderers must resolve serializable target tokens without sharing local objects; cross-renderer portals remain unsupported. |
 | Hydration / serialization | Client-only renderers preserve server exports, omit declared regions, and expose stable manifest identity for one client mount without serializing the host tree. | A live renderer serializer/adopter must define seed identity and mismatch behavior separately; absence remains valid. |
 | Layout measurement | Local public instances are available after commit. A transported adapter installs a cloned public/layout snapshot before acknowledgement; refs and layout effects run only after that acknowledgement. There is no neutral live measure call. | A native renderer may add an explicitly asynchronous measure capability; it must not imply synchronous access to a remote live object. |
@@ -1234,9 +1239,10 @@ The architecture is acceptable only while these invariants hold:
 9. The committed logical topology advances only with the accepted batch.
 10. Reordering a keyed range preserves compatible survivor host identity and
     produces the requested final order without physical comment markers.
-11. Public refs attach only after their instances exist, detach only after the
-    replacement/removal batch is accepted and before any replacement ref
-    attaches, and never observe an abandoned draft.
+11. Public refs attach only after their instances exist and are logically
+    visible, detach only after the hide/replacement/removal batch is accepted
+    and before any replacement ref attaches, and never observe an abandoned
+    draft. Physical reattachment does not override logical visibility.
 12. A mixed boundary reads context and routes render errors through its owning
     DOM scope; its host commit is gated by that scope's layout commit.
 13. Renderer events become visible only with their accepted host batch;
@@ -1280,7 +1286,7 @@ observation boundaries:
 | Mixed ownership | A DOM parent provides context to an object child; child render errors reach the DOM error owner; ref and effect ordering straddle the single object commit correctly; DOM unmount tears the external root down. |
 | Renderer regions | Imported aliases and stable module/export metadata lower `Canvas`-shaped DOM-to-universal children and explicit-target `DOMRegion` universal-to-DOM children through the same descriptor mechanism. |
 | Events | Registration, replacement, removal, scoped multi-listener dispatch, priority, teardown, and abandoned work are observable on the object driver's public surface. |
-| Retained ownership | Activity and Suspense prove host/state/resource identity, visibility, distinct ref semantics, insertion retention, layout/passive disconnection, event suppression, fallback coexistence, reveal/reject, and capability failure. |
+| Retained ownership | Activity and Suspense prove host/state/resource identity, visibility, ref disconnection/reconnection, insertion retention, layout/passive disconnection, event suppression, hidden-Activity suspension containment, fallback coexistence, reveal/reject, and capability failure. |
 | Client-only graph | Neutral, Vite, Rspack, and Rsbuild builds remove server imports/regions, preserve exports without authored execution, reject live use, and agree on client-reference/manifest identity; raw Rspack proves graph split and Vite/Rsbuild prove one client mount over an adopted DOM shell. |
 | Compiler facilities | Universal maps point to authored TSRX; HMR, profiling, and parallel-`use()` plans remain executable; Volar chooses file-local intrinsics without global merging; the DOM golden stays byte-identical. |
 | Capability gates | Text and Activity/visibility compile only under explicit policies. Portal descriptors materialize normally, renderer metadata may advertise them for tooling, and preparation requires an active driver target capability. Missing capabilities and every unsupported renderer concept fail clearly. |

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1471,13 +1471,16 @@ function lowerImportedErrorBoundaries(ast) {
 //     the component's boundary capability bit. componentSlot and ssrComponent
 //     read the same bit from the resolved component, so the two sides always
 //     agree without retaining the concrete builtins in the generic component
-//     path. Activity remains a compiler-lowered sentinel rather than a function.
+//     path. Generic Activity sites retain their symbol-aware boundary wrapper.
 // `bodyNodes` is the normalized, HeadHoist-filtered root list of a `@{ … }`
 // (JSXCodeBlock) body — callers gate on the body form.
 function inheritSoleCompRoot(bodyNodes, ctx) {
 	if (bodyNodes.length !== 1) return false;
 	const n = bodyNodes[0];
 	if (n.type !== 'Element' || !isComponentTag(n)) return false;
+	// Returned-JSX extraction can merge an authored key/spread config into one
+	// spread hole. Its descriptor still needs its own keyed reconciliation range.
+	if (n.openingElement?.metadata?.orderedComponentConfig === true) return false;
 	const id = n.openingElement?.name || n.id;
 	if (!id) return false;
 	if (
@@ -8304,6 +8307,7 @@ function compileInternal(
 		ctx.octaneImportLocals = imports.locals;
 		ctx.octaneImportNamespaces = imports.namespaces;
 		ctx.foreignImportLocals = imports.foreignLocals;
+		ctx.activityModuleAst = ast;
 	}
 	if (ctx.dev) {
 		for (const node of ast.body) {
@@ -9478,6 +9482,7 @@ function compileServer(
 		ctx.octaneImportLocals = imports.locals;
 		ctx.octaneImportNamespaces = imports.namespaces;
 		ctx.foreignImportLocals = imports.foreignLocals;
+		ctx.activityModuleAst = ast;
 	}
 	// M3 inherit-range exclusion set — must match the client compile's
 	// (see inheritSoleCompRoot; both modes read the same import declarations).
@@ -11432,7 +11437,11 @@ function ssrEmitComponent(node, ctx, name, inlinedSubs, parentNs, cssHash, compo
 	// this context flag. Only this component's immediate children sub inherits the
 	// returned-fragment mode; control-flow arm subs intentionally reset it.
 	const returnedFragmentTemplate = ctx._returnedFragmentTemplate === true;
-	const compExpr = tagExprNode(node);
+	const activityDescriptor = isActivityLongForm(node, ctx);
+	const descriptorConfig = activityDescriptor || hasKeyedSpreadConfig(node);
+	const compExpr = activityDescriptor
+		? inheritOriginLoc(b.id(requireRuntimeForContext(ctx, 'Activity')), node)
+		: tagExprNode(node);
 	const attrs = node.attributes || node.openingElement?.attributes || [];
 	const propNodes = [];
 	let keyExpr = null;
@@ -11444,7 +11453,7 @@ function ssrEmitComponent(node, ctx, name, inlinedSubs, parentNs, cssHash, compo
 		if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
 		const attrName = attr.name.name || attr.name;
 		const val = attr.value;
-		if (attrName === 'key') {
+		if (attrName === 'key' && !descriptorConfig) {
 			if (val != null) {
 				const inner = val.type === 'JSXExpressionContainer' ? val.expression : val;
 				keyExpr = tsrxExprNode(inner, ctx, name, inlinedSubs);
@@ -11503,7 +11512,7 @@ function ssrEmitComponent(node, ctx, name, inlinedSubs, parentNs, cssHash, compo
 		);
 	} else if (sourceChildren.length > 0) {
 		const children = rewriteOpaqueTitles(sourceChildren, ctx, 'opaque');
-		const opaqueChildren = !isActivityLongForm(node) && !isFragmentLongForm(node, ctx);
+		const opaqueChildren = !activityDescriptor && !isFragmentLongForm(node, ctx);
 		const descriptorChildren =
 			(tagBindingName(node) !== null &&
 				ctx.descriptorChildrenBindings?.has(tagBindingName(node))) ||
@@ -11573,6 +11582,26 @@ function ssrEmitComponent(node, ctx, name, inlinedSubs, parentNs, cssHash, compo
 				),
 			);
 		}
+	}
+	if (descriptorConfig) {
+		// The direct mode-only Activity was lowered to ActivityStatement. Richer
+		// Activity configs and generic explicit-key + spread sites keep one ordered
+		// element config, matching createElement without changing simple call sites.
+		ctx.runtimeNeeded.add('createElement');
+		ctx.runtimeNeeded.add('ssrChild');
+		const descriptor = ssrCall(
+			'createElement',
+			[compExpr, inheritOriginLoc(b.object(propNodes), node)],
+			node,
+		);
+		const child = ssrCall('ssrChild', [descriptor, b.id('__s')], node);
+		if (componentNs === null) return child;
+		ctx.runtimeNeeded.add('ssrInNamespace');
+		return ssrCall(
+			'ssrInNamespace',
+			[b.literal(componentNs, JSON.stringify(componentNs)), ssrThunk(child, node)],
+			node,
+		);
 	}
 	const explicitNamespace = componentNs !== null;
 	const helper = explicitNamespace ? 'ssrComponentNS' : 'ssrComponent';
@@ -16901,9 +16930,32 @@ function hasJsxSpreadAttribute(node) {
 	);
 }
 
-// Merge the complete Fragment config in authored order: object-spread getters,
-// explicit values, key expressions, and the final ref all evaluate exactly once.
-function fragmentSpreadRefExpression(node) {
+// An explicit key cannot be split from a spread config: whichever occurs last
+// wins, and all getters/expressions must run in source order. Extracted templates
+// retain the proof after the complete config becomes a single spread hole.
+function hasKeyedSpreadConfig(node) {
+	if (node.openingElement?.metadata?.orderedComponentConfig === true) return true;
+	const attributes = node.attributes || node.openingElement?.attributes || [];
+	if (attributes.length < 2) return false;
+	let key = false;
+	let spread = false;
+	for (const attribute of attributes) {
+		if (attribute.type === 'SpreadAttribute' || attribute.type === 'JSXSpreadAttribute') {
+			spread = true;
+		} else if (
+			(attribute.type === 'Attribute' || attribute.type === 'JSXAttribute') &&
+			jsxAttrRawName(attribute) === 'key'
+		) {
+			key = true;
+		}
+		if (key && spread) return true;
+	}
+	return false;
+}
+
+// Merge a complete JSX config in authored order. Boundary lowering must not
+// move spread getters after later explicit values or discard ignored props.
+function jsxAttributeConfigExpression(node) {
 	const properties = [];
 	for (const attr of node.attributes || node.openingElement?.attributes || []) {
 		if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') {
@@ -16936,7 +16988,12 @@ function fragmentSpreadRefExpression(node) {
 			),
 		);
 	}
-	return inheritOriginLoc(b.member(inheritOriginLoc(b.object(properties), node), 'ref'), node);
+	return inheritOriginLoc(b.object(properties), node);
+}
+
+// Fragment only consumes ref, but every authored config expression still runs.
+function fragmentSpreadRefExpression(node) {
+	return inheritOriginLoc(b.member(jsxAttributeConfigExpression(node), 'ref'), node);
 }
 
 // Activity is always compiler-owned template syntax. Long-form Fragment only
@@ -16944,7 +17001,7 @@ function fragmentSpreadRefExpression(node) {
 // descendant that itself needs normalization. An ordinary/no-ref/keyed Fragment
 // remains a runtime descriptor so its explicit reconciliation boundary survives.
 function isLongFormTemplateSentinel(node, parentNs = 'html', allowHeadHoists = true, ctx = null) {
-	if (isActivityLongForm(node)) return true;
+	if (isActivityLongForm(node, ctx)) return true;
 	if (!isFragmentLongForm(node, ctx)) return false;
 	if (hasJsxAttribute(node, 'ref') || hasJsxSpreadAttribute(node)) return true;
 	return (node.children || []).some((child) =>
@@ -17035,7 +17092,7 @@ function requiresTemplateNormalization(
 	const childAllowsHeadHoists =
 		allowHeadHoists &&
 		tag !== 'noscript' &&
-		(!isComponentTag(node) || isActivityLongForm(node) || isFragmentLongForm(node, ctx));
+		(!isComponentTag(node) || isActivityLongForm(node, ctx) || isFragmentLongForm(node, ctx));
 	return (node.children || []).some((child) =>
 		requiresTemplateNormalization(child, childNs, childAllowsHeadHoists, ctx),
 	);
@@ -17152,6 +17209,11 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 	const attrs = node.attributes || node.openingElement?.attributes || [];
 	const newAttrs = [];
 	const mergedFragmentSpread = isFragmentLongForm(node, ctx) && hasJsxSpreadAttribute(node);
+	const mergedKeyedSpreadConfig =
+		!mergedFragmentSpread && isComponentTag(node) && hasKeyedSpreadConfig(node);
+	const mergedComponentConfig =
+		mergedKeyedSpreadConfig ||
+		(isActivityLongForm(node, ctx) && !isDirectActivityLongForm(node, ctx));
 	if (mergedFragmentSpread) {
 		// Hoisting each spread operand separately delays its getters until the
 		// renderer runs, after later attributes and child holes already evaluated.
@@ -17173,7 +17235,21 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 					),
 		);
 	}
-	for (const attr of mergedFragmentSpread ? [] : attrs) {
+	if (mergedComponentConfig) {
+		// Keep the WHOLE config together at returned-JSX sites. Capturing spread
+		// operands individually would defer their getters until the hoisted
+		// renderer, after subsequent attributes and child expressions had run.
+		const expression = jsxAttributeConfigExpression(node);
+		const hn = `h${holeProps.length}`;
+		holeProps.push(objectProp(hn, rewriteJsxValues(expression, ctx)));
+		newAttrs.push(
+			inheritOriginLoc(
+				b.jsx_spread_attribute(memberProps(hn, expression)),
+				node.openingElement || node,
+			),
+		);
+	}
+	for (const attr of mergedFragmentSpread || mergedComponentConfig ? [] : attrs) {
 		if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') {
 			// `{...expr}` — the spread expression is a DYNAMIC input too. Thread it out
 			// as an `hN` hole (exactly like an attribute value) so any prop/local it
@@ -17589,6 +17665,12 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 	// The emission normalizes from `openingElement.attributes`, so update it too.
 	if (node.openingElement) {
 		out.openingElement = { ...node.openingElement, attributes: newAttrs };
+		if (mergedKeyedSpreadConfig) {
+			out.openingElement.metadata = {
+				...node.openingElement.metadata,
+				orderedComponentConfig: true,
+			};
+		}
 	}
 	return out;
 }
@@ -17619,7 +17701,7 @@ function extractFragmentRoot(node, ctx, holeProps, parentNs = 'html') {
 	if (
 		(node.type === 'Element' || node.type === 'JSXElement') &&
 		isComponentTag(node) &&
-		!isActivityLongForm(node) &&
+		!isActivityLongForm(node, ctx) &&
 		!isFragmentLongForm(node, ctx)
 	) {
 		return extractFragmentComponent(node, ctx, holeProps, parentNs);
@@ -18482,15 +18564,18 @@ function autoMemoReturnedProviderChild(node, nameNode, ctx) {
 // component Element node. Recurses into prop values so nested JSX values lower too.
 function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 	const nameNode = node.openingElement?.name || node.id;
-	const componentTag = isComponentTag(node);
+	const activity = isActivityLongForm(node, ctx);
+	const componentTag = activity || isComponentTag(node);
 	// Host (lowercase) tag → string literal (`'li'`) for the de-opt renderer;
 	// component (capitalized / member / dynamic) → the identifier/member ref.
-	const compNode = componentTag
-		? jsxNameToExpr(nameNode)
-		: inheritOriginLoc(
-				b.literal(nameNode.name != null ? nameNode.name : String(nameNode)),
-				nameNode,
-			);
+	const compNode = activity
+		? inheritOriginLoc(b.id(requireRuntimeForContext(ctx, 'Activity')), nameNode)
+		: componentTag
+			? jsxNameToExpr(nameNode)
+			: inheritOriginLoc(
+					b.literal(nameNode.name != null ? nameNode.name : String(nameNode)),
+					nameNode,
+				);
 	if (!componentTag) {
 		rejectVoidElementContent(compNode.value, node, ctx);
 		rejectDangerouslySetInnerHTMLChildren(compNode.value, node, ctx);
@@ -19220,7 +19305,7 @@ function rewriteOpaqueTitles(node, ctx, namespace = 'html') {
 	if (type === 'Element' || type === 'JSXElement') {
 		const tag = jsxTagName(node) || elementTagName(node);
 		const ordinaryComponent =
-			isComponentTag(node) && !isActivityLongForm(node) && !isFragmentLongForm(node, ctx);
+			isComponentTag(node) && !isActivityLongForm(node, ctx) && !isFragmentLongForm(node, ctx);
 		if (
 			!ordinaryComponent &&
 			tag === 'title' &&
@@ -19608,11 +19693,10 @@ function normalizeChildren(nodes, inSvg = false, ctx = null, inNoscript = false)
 				}
 				continue;
 			}
-			// `<Activity mode={…}>…</Activity>` (React 19). Matched by name BEFORE
-			// the generic Element branch (it would otherwise route through
-			// componentSlot). Lower to an ActivityStatement carrying the mode expr
-			// and the raw children (compiled into one body by makeActivityCall).
-			if (isActivityLongForm(n)) {
+			// The mode-only builtin keeps its direct boundary lowering. Richer
+			// configs retain the ordinary element descriptor path below, where keys,
+			// spreads, children props, and authored evaluation order are preserved.
+			if (isDirectActivityLongForm(n, ctx)) {
 				const modeAttr = (n.openingElement.attributes || []).find(
 					(a) =>
 						(a.type === 'Attribute' || a.type === 'JSXAttribute') &&
@@ -19670,6 +19754,9 @@ function normalizeChildren(nodes, inSvg = false, ctx = null, inNoscript = false)
 				selfClosing: n.openingElement.selfClosing,
 				loc: n.loc, // preserve element position for dev hydration LOC (component slots)
 			};
+			// `unstable_Activity` starts with a lowercase letter but is a component
+			// when it resolves to the builtin. Keep that fact on this rare node only.
+			if (isActivityLongForm(n, ctx)) element.activityDescriptor = true;
 			// Preserve @tsrx/core's raw-text script discriminator without changing
 			// the normalized object shape of every ordinary element.
 			if (elementTagName(element) === 'script' && typeof n.content === 'string') {
@@ -25179,14 +25266,77 @@ function makeActivityCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = n
 	};
 }
 
-/** Long-form `<Activity>` tag — matched by name, mirroring isFragmentLongForm. */
-function isActivityLongForm(node) {
+function isActivityName(value) {
+	return value === 'Activity' || value === 'unstable_Activity';
+}
+
+// The component-local set does not include a module callback's parameters or
+// names declared inside nested JavaScript blocks. Resolve those rare builtin
+// candidates against the authored AST's actual scopes. Only modules containing
+// an Activity candidate allocate this analysis; normalized tags retain their
+// original name node, and synthesized names use the conservative fallback.
+function activityReferenceBinding(name, node, ctx) {
+	if (!ctx?.activityModuleAst) return undefined;
+	const lexical = (ctx.activityLexical ??= createLexicalAnalysis(ctx.activityModuleAst));
+	const scope =
+		lexical.nodeScopes.get(name) ??
+		lexical.nodeScopes.get(node.openingElement) ??
+		lexical.nodeScopes.get(node);
+	return scope === undefined ? undefined : lexical.resolveBinding(scope, name.name);
+}
+
+/** Resolve builtin Activity tags without claiming foreign or shadowed names. */
+function isActivityLongForm(node, ctx = null) {
 	const name = node.openingElement?.name || node.id;
 	if (!name) return false;
-	if (name.type !== 'Identifier' && name.type !== 'JSXIdentifier') return false;
-	// `unstable_Activity` mirrors the unstable_ViewTransition alias so React
-	// experimental-channel ports compile unchanged.
-	return name.name === 'Activity' || name.name === 'unstable_Activity';
+	if (name.type === 'Identifier' || name.type === 'JSXIdentifier') {
+		const local = name.name;
+		if (ctx?.currentComponentLocals?.has(local)) return false;
+		const imported = ctx?.octaneImportLocals?.get(local);
+		if (imported !== undefined) {
+			if (!isActivityName(imported)) return false;
+			const binding = activityReferenceBinding(name, node, ctx);
+			return binding === undefined || binding?.importSource?.value === 'octane';
+		}
+		if (!isActivityName(local)) return false;
+		if (ctx?.foreignImportLocals?.has(local)) return false;
+		if (ctx?.componentInfo?.has(local)) return false;
+		const binding = activityReferenceBinding(name, node, ctx);
+		if (binding !== undefined) return binding === null;
+		// A synthesized conventional spelling has no original scope identity.
+		if (ctx?.activityModuleAst) {
+			ctx.activityModuleBindingNames ??= collectModuleLevelBindings(ctx.activityModuleAst.body);
+			if (ctx.activityModuleBindingNames.has(local)) return false;
+		}
+		return true;
+	}
+	if (name.type !== 'MemberExpression' && name.type !== 'JSXMemberExpression') return false;
+	const object = name.object;
+	const property = name.property;
+	if (
+		name.computed !== true &&
+		(object?.type === 'Identifier' || object?.type === 'JSXIdentifier') &&
+		(property?.type === 'Identifier' || property?.type === 'JSXIdentifier') &&
+		isActivityName(property.name) &&
+		ctx?.octaneImportNamespaces?.has(object.name) === true &&
+		!ctx.currentComponentLocals?.has(object.name)
+	) {
+		const binding = activityReferenceBinding(object, node, ctx);
+		return binding === undefined || binding?.importSource?.value === 'octane';
+	}
+	return false;
+}
+
+/** Only a mode-only config can skip ordinary JSX element/key semantics. */
+function isDirectActivityLongForm(node, ctx = null) {
+	if (!isActivityLongForm(node, ctx)) return false;
+	const attrs = node.attributes || node.openingElement?.attributes || [];
+	return (
+		attrs.length === 0 ||
+		(attrs.length === 1 &&
+			(attrs[0].type === 'Attribute' || attrs[0].type === 'JSXAttribute') &&
+			(attrs[0].name?.name || attrs[0].name) === 'mode')
+	);
 }
 
 // ===========================================================================
@@ -25223,6 +25373,7 @@ function isFragmentLongForm(node, ctx = null) {
 }
 
 function isComponentTag(node) {
+	if (node.activityDescriptor === true) return true;
 	const name = node.openingElement?.name || node.id;
 	if (!name) return false;
 	if (name.type === 'MemberExpression' || name.type === 'JSXMemberExpression') return true;
@@ -25472,9 +25623,13 @@ function makeCompCall(
 	const id = ctx.nextHelperId++;
 	const compName = tagBindingName(node);
 	const staticFragmentRenderer = node.openingElement?.metadata?.staticFragmentRenderer;
-	const compNode = staticFragmentRenderer
-		? inheritOriginLoc(b.id(staticFragmentRenderer.name), node.openingElement?.name || node.id)
-		: tagExprNode(node);
+	const activityDescriptor = isActivityLongForm(node, ctx);
+	const descriptorConfig = activityDescriptor || hasKeyedSpreadConfig(node);
+	const compNode = activityDescriptor
+		? inheritOriginLoc(b.id(requireRuntimeForContext(ctx, 'Activity')), node)
+		: staticFragmentRenderer
+			? inheritOriginLoc(b.id(staticFragmentRenderer.name), node.openingElement?.name || node.id)
+			: tagExprNode(node);
 	// `</Card>` emits nothing — lend it the opening name's generated ranges so a
 	// closing tag is reachable for components the way it is for host elements.
 	registerOriginAlias(ctx, node.closingElement?.name, node.id || node.openingElement?.name);
@@ -25488,11 +25643,9 @@ function makeCompCall(
 	let hasSpreadProp = false;
 	let hasChildrenProp = false;
 	const propDependencyNodes = [];
-	// `key={expr}` is consumed by the componentSlot runtime (drives key-driven
-	// remount on identity change), NOT passed as a prop — matches React, where
-	// `props.key` is undefined inside the component body. When `key` follows a
-	// spread, the spread cannot inject `key` either: we filter it out of the
-	// emitted propsExpr but keep its expression for the slot arg.
+	// Simple `key={expr}` sites pass the key separately to componentSlot. When
+	// explicit keys and spreads coexist, keep the complete config ordered and let
+	// createElement extract the effective key without passing it to the component.
 	let keyExpr = null;
 	for (const attr of attrs) {
 		if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') {
@@ -25503,7 +25656,7 @@ function makeCompCall(
 		if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
 		const attrName = attr.name.name || attr.name;
 		const val = attr.value;
-		if (attrName === 'key') {
+		if (attrName === 'key' && !descriptorConfig) {
 			// `<Foo key/>` (no value) is meaningless — skip silently.
 			if (val == null) continue;
 			const keyInner = val.type === 'JSXExpressionContainer' ? val.expression : val;
@@ -25558,7 +25711,7 @@ function makeCompCall(
 	} else if (sourceChildren.length > 0) {
 		const children = rewriteOpaqueTitles(sourceChildren, ctx, 'opaque');
 		const childrenParentNs =
-			!isActivityLongForm(node) && !isFragmentLongForm(node, ctx) ? 'opaque' : parentNs;
+			!activityDescriptor && !isFragmentLongForm(node, ctx) ? 'opaque' : parentNs;
 		if (compName !== null && ctx.descriptorChildrenBindings?.has(compName)) {
 			const kids = children
 				.map((child) => lowerInspectableJsxChild(child, ctx))
@@ -25610,6 +25763,17 @@ function makeCompCall(
 
 	// The props object as a node; the call-site emit embeds it directly.
 	const propsExpr = staticFragmentRenderer?.props ?? inheritOriginLoc(b.object(propNodes), node);
+	if (descriptorConfig) {
+		ctx.runtimeNeeded.add('createElement');
+		return {
+			id,
+			loc: devLoc(ctx, node),
+			origin: node,
+			isChild: true,
+			anchorlessAppendSafe: true,
+			valueExpr: inheritOriginLoc(b.call('_$createElement', compNode, propsExpr), node),
+		};
+	}
 
 	// Design (c) v0: decide whether the call site can use componentSlotLite
 	// (Scope-only, no Block / no Comment markers / no CompSlot wrapper).

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1606,9 +1606,9 @@ function serverDescNeedsBlocks(v: unknown): boolean {
 	if (!isElementDescriptor(v) && childrenIterator(v) !== null) return true;
 	const d = v as ElementDescriptor;
 	if (d.$$kind === ELEMENT_TAG) {
-		// A Fragment below a host descriptor is reconciled by childSlot's
-		// fragment-aware list path, including when all of its leaves are pure hosts.
-		if (d.type === Fragment) return true;
+		// Fragment and Activity descriptors own reconcilable boundaries even when
+		// all of their descendants are pure hosts/text.
+		if (d.type === Fragment || d.type === Activity) return true;
 		return typeof d.type === 'function' || serverDescNeedsBlocks(d.children);
 	}
 	return false;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -552,18 +552,23 @@ const PORTAL_TAG = Symbol.for('octane.portal');
 export const Fragment: unique symbol = Symbol.for('octane.Fragment');
 
 /**
- * React-19 `<Activity>` sentinel. Server-compiled template sites lower directly
- * to `ssrActivity`; this export keeps `import { Activity } from 'octane'`
- * resolvable after the server compiler retargets it to `octane/server`.
+ * React-19 `<Activity>` sentinel. Direct template sites lower to `ssrActivity`;
+ * generic component and descriptor sites dispatch by this same symbol identity.
+ * Its public type is component-shaped so aliases and JSX values type-check.
  */
-export const Activity: unique symbol = Symbol.for('octane.Activity');
+export const Activity = Symbol.for('octane.Activity') as unknown as (props: {
+	mode?: 'visible' | 'hidden';
+	children?: unknown;
+	name?: string;
+	key?: string | number | bigint | null | undefined;
+}) => unknown;
 
 interface ElementDescriptor {
 	$$kind: typeof ELEMENT_TAG;
 	// A server ComponentBody (component-value form, e.g. `{<Comp/>}`) OR a host tag
 	// string (`'li'`), produced when host JSX appears at a VALUE position (a
 	// `.map(...)` callback, a render-prop arrow body, an array literal).
-	type: ServerComponent | string | typeof Fragment;
+	type: ServerComponent | string | typeof Fragment | typeof Activity;
 	props: any;
 	// React-style `key`, lifted out of props (consulted by the client's de-opt list
 	// path on hydration; the server only renders it into markup).
@@ -654,7 +659,7 @@ export function createScopedValue(readElement: () => ElementDescriptor): Element
 
 /** Server twin of the compiler-only scope-preserving JSX descriptor factory. */
 export function createScopedElement(
-	type: ServerComponent | string | typeof Fragment,
+	type: ServerComponent | string | typeof Fragment | typeof Activity,
 	props: any,
 	readChildren: () => unknown,
 ): ElementDescriptor {
@@ -697,7 +702,7 @@ export function createScopedElement(
 // literal) to this call in BOTH modes, so the same lowered call resolves to the
 // client-or-server `createElement` per build, and `ssrChild` renders the result.
 export function createElement(
-	type: ServerComponent | string | typeof Fragment,
+	type: ServerComponent | string | typeof Fragment | typeof Activity,
 	props?: any,
 	...children: any[]
 ): ElementDescriptor {
@@ -1713,6 +1718,16 @@ export function ssrFragmentMarker(open: boolean, _ref?: unknown): string {
  */
 export function ssrActivity(mode: string, render: () => string): string {
 	return ssrBlock(mode === 'hidden' ? '' : render());
+}
+
+/** Cold twin of the client's generic Activity body and its ordinary child slot. */
+function renderActivityDescriptor(
+	props: { mode?: 'visible' | 'hidden'; children?: unknown },
+	scope: SSRScope,
+): string {
+	// Keep the accessor inside the visibility branch: scoped JSX children may
+	// start data work or throw, and hidden server Activities must evaluate neither.
+	return ssrActivity(props.mode ?? 'visible', () => ssrChild(props.children, scope));
 }
 
 /**
@@ -3489,12 +3504,21 @@ function renderComponentFramed(
  */
 export function ssrComponent(
 	parent: SSRScope,
-	comp: ServerComponent | string,
+	comp: ServerComponent | string | typeof Activity,
 	props: any,
 	inherit?: boolean,
 	key?: unknown,
 	identityScoped?: boolean,
 ): string {
+	// A runtime-resolved Activity is a symbol, not a callable component. Keep its
+	// original identity for async keys, then use the stable cold body below. A
+	// spread-only key has not been split into the compiler's explicit key argument.
+	// Unlike the client cold registration, SSR must also accept a public
+	// `octane` Activity descriptor when this server export was tree-shaken away.
+	// The shared Symbol.for identity keeps that mixed-entry path working; retaining
+	// this small string-rendering wrapper does not retain the client Activity engine.
+	const activity = comp === Activity;
+	if (activity && key === undefined) key = props?.key;
 	// Component recursion is one of SSR's hottest and deepest paths. Install the
 	// same async-identity membrane inline instead of recursing back through
 	// ssrComponent from two wrapper callbacks. Besides avoiding callback overhead,
@@ -3508,6 +3532,12 @@ export function ssrComponent(
 	try {
 		const explicitNamespace = NEXT_COMPONENT_NAMESPACE;
 		NEXT_COMPONENT_NAMESPACE = null;
+		if (activity) {
+			comp = renderActivityDescriptor;
+			// The generic component and inner Activity both own hydratable ranges.
+			// This mirrors the client even for a sole-root dynamic Activity tag.
+			inherit = false;
+		}
 		// Boundary builtins decline inherit through their component capability bit —
 		// mirrors componentSlot's
 		// client-side decline exactly (member/aliased/dynamic tags resolving to
@@ -3526,9 +3556,10 @@ export function ssrComponent(
 		// value-position call site (ssrHostElement's content path handles those), or
 		// a render FUNCTION from a template one.
 		if (typeof comp === 'string') {
+			const tag = comp;
 			const inheritedNamespace = explicitNamespace ?? FRAME?.namespace ?? 'html';
 			const childNamespace = parserNamespacesForTag(
-				comp.toLowerCase(),
+				tag.toLowerCase(),
 				inheritedNamespace,
 			).childrenNamespace;
 			return ssrInNamespace(childNamespace, () => {
@@ -3546,10 +3577,10 @@ export function ssrComponent(
 					// like renderComponentFramed normalizes a de-opt body's return.
 					const out = (kids as any)(undefined, parent);
 					const inner = typeof out === 'string' ? out : out == null ? '' : ssrChild(out, parent);
-					const html = ssrHostElement(comp, props, null, parent, inner);
+					const html = ssrHostElement(tag, props, null, parent, inner);
 					return inherit ? html : ssrBlock(html);
 				}
-				const html = ssrHostElement(comp, props, kids, parent);
+				const html = ssrHostElement(tag, props, kids, parent);
 				return inherit ? html : ssrBlock(html);
 			});
 		}
@@ -3585,7 +3616,7 @@ export function ssrComponent(
 		// transition (`<svg>`, `<math>`, or `<foreignObject>`) overrides it for the
 		// next component frame through ssrComponentNS.
 		frame.namespace = explicitNamespace ?? pf?.namespace;
-		return renderComponentFramed(comp, props, parent, frame, inherit);
+		return renderComponentFramed(comp as ServerComponent, props, parent, frame, inherit);
 	} finally {
 		if (identityScoped !== true) ASYNC_SCOPE = previousIdentityScope;
 	}
@@ -3596,7 +3627,7 @@ let NEXT_COMPONENT_NAMESPACE: 'html' | 'svg' | 'mathml' | null = null;
 /** Compiler ABI for a component call whose output is parsed in foreign content. */
 export function ssrComponentNS(
 	parent: SSRScope,
-	comp: ServerComponent | string,
+	comp: ServerComponent | string | typeof Activity,
 	props: any,
 	namespace: 'html' | 'svg' | 'mathml',
 	inherit?: boolean,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1939,8 +1939,8 @@ function rollbackTransitionJournal(checkpoint: number): void {
 // inventing a staged-mutation reconciler mode.
 //
 // Activation model (resolved at the end of the wrapped drain):
-//   enter  — a boundary block REGISTERED during the drain (subtree inserted).
-//   exit   — a pre-drain boundary block DISPOSED by the drain (subtree removed).
+//   enter  — a boundary gains visible hosts (subtree inserted or Activity revealed).
+//   exit   — a boundary loses its visible hosts (subtree removed or Activity hidden).
 //   update — a surviving boundary that was dirtied by a tracked mutation
 //            (setText under the boundary) or whose first element's rect moved.
 // Names: every pre-drain boundary is pre-named before the snapshot (a superset
@@ -2007,7 +2007,9 @@ export class ViewTransitionPseudoElement {
 		return document.documentElement.animate(keyframes, opts);
 	}
 	getAnimations(): Animation[] {
-		const all = document.documentElement.getAnimations?.() ?? [];
+		// Native transition pseudos belong to the document element's pseudo tree,
+		// not its own animation list. Include that subtree before selecting ours.
+		const all = document.documentElement.getAnimations?.({ subtree: true }) ?? [];
 		const out: Animation[] = [];
 		for (const a of all) {
 			const effect = a.effect as { pseudoElement?: string } | null;
@@ -2073,8 +2075,6 @@ interface ViewTransitionDriver {
 let VIEW_TRANSITION_DRIVER: ViewTransitionDriver | null = null;
 /** Mounted boundary blocks; pruned lazily (disposed) + on unmount. */
 const VT_REGISTRY = /* @__PURE__ */ new Set<Block>();
-/** Boundary blocks registered during the CURRENT wrapped drain (→ enter). */
-let VT_ENTERED: Block[] = [];
 /** Boundaries dirtied by tracked mutations during the current wrapped drain. */
 const VT_DIRTY = /* @__PURE__ */ new Set<Block>();
 /** True while the wrapped drain (the update callback's flushWork) runs. */
@@ -2128,18 +2128,30 @@ function vtMarkDirtyFromCurrentBlock(): void {
 	}
 }
 
-/** Top-level ELEMENT nodes of a boundary block's DOM range. */
+/** Whether a retained visibility boundary owns this host or one of its ancestors. */
+function vtHostVisible(element: Element): boolean {
+	if (hiddenDisplayNodes === 0) return true;
+	for (let node: Node | null = element; node !== null; node = node.parentNode) {
+		if (node.nodeType === 1 && HIDDEN_DISPLAYS.has(node as HTMLElement)) return false;
+	}
+	return true;
+}
+
+/** Top-level visible ELEMENT nodes of a boundary block's DOM range. */
 function vtRangeElements(block: Block): Element[] {
 	const els: Element[] = [];
+	if (inInactiveSubtree(block)) return els;
 	if (block.startMarker !== null && block.endMarker !== null) {
 		for (let n = block.startMarker.nextSibling; n !== null && n !== block.endMarker;) {
-			if (n.nodeType === 1) els.push(n as Element);
+			if (n.nodeType === 1 && vtHostVisible(n as Element)) els.push(n as Element);
 			n = n.nextSibling;
 		}
 	} else {
 		// Whole-container regime (root / owns-parent): every element child.
 		const kids = (block.parentNode as Element).children;
-		for (let i = 0; i < kids.length; i++) els.push(kids[i]);
+		for (let i = 0; i < kids.length; i++) {
+			if (vtHostVisible(kids[i])) els.push(kids[i]);
+		}
 	}
 	return els;
 }
@@ -2451,11 +2463,10 @@ function ensureViewTransitionDriver(): ViewTransitionDriver {
 		queueAllTransition,
 		renderBoundary(block, props) {
 			if (block.vt === null) {
-				// Registration during a wrapped drain is an enter activation; otherwise
-				// the block simply joins the mounted-boundary registry.
+				// Visibility snapshots decide activation: retained Activity boundaries
+				// can enter/exit without changing this mounted-boundary registration.
 				block.vt = props;
 				VT_REGISTRY.add(block);
-				if (VT_DRAIN) VT_ENTERED.push(block);
 			} else {
 				block.vt = props;
 			}
@@ -2878,6 +2889,7 @@ interface ScheduledVisibilityDriver {
 	find: typeof findHiddenRenderOwner;
 	reveal: typeof attemptHiddenReveal;
 	rehide: typeof rehideActivityAfterDescendantRender;
+	retryActivity: typeof renderHiddenActivity;
 }
 
 let SCHEDULED_VISIBILITY_DRIVER: ScheduledVisibilityDriver | null = null;
@@ -2887,6 +2899,7 @@ function ensureScheduledVisibilityDriver(): void {
 		find: findHiddenRenderOwner,
 		reveal: attemptHiddenReveal,
 		rehide: rehideActivityAfterDescendantRender,
+		retryActivity: renderHiddenActivity,
 	};
 }
 
@@ -2899,6 +2912,7 @@ function ensureScheduledVisibilityDriver(): void {
 // failed roots in one flush aggregate like React (AggregateError).
 function drainQueue(): { err: any } | null {
 	let pendingError: { err: any; all: any[] } | null = null;
+	let activitiesToRehide: Set<ActivitySlot> | null = null;
 	const drainId = ++DRAIN_ID;
 	if (QUEUE.length > 1) sortWaveByDepth(QUEUE);
 	// Iterate by index. A render may enqueue MORE work (e.g. a setState during
@@ -2934,6 +2948,19 @@ function drainQueue(): { err: any } | null {
 				block.nestedUpdateError = false;
 				throw maximumUpdateDepthError();
 			}
+			// Guarded render-phase updates (derived state) converge in a couple of
+			// passes; an unguarded one re-queues its own block forever. Cap per-block
+			// renders within one drain so the loop throws (catchable by @try /
+			// ErrorBoundary, like React's equivalent) instead of hanging. A hidden
+			// boundary retry must obey the same limit as an ordinary render.
+			if (block.drainStamp === drainId) {
+				if (++block.drainRenders > RENDER_PHASE_UPDATE_LIMIT) {
+					throw crossRenderUpdate ? maximumUpdateDepthError() : new Error(formatClientError(9));
+				}
+			} else {
+				block.drainStamp = drainId;
+				block.drainRenders = 1;
+			}
 			// An update to a block inside a SUSPENSE-HIDDEN subtree (its boundary's
 			// committed host content is hidden while the fallback shows) must retry
 			// the WHOLE boundary. The hidden render and fallback/reveal decision stay
@@ -2944,24 +2971,17 @@ function drainQueue(): { err: any } | null {
 				visibilityDriver!.reveal(hiddenTry, block.pendingMode ?? 'urgent');
 				continue;
 			}
-			// Guarded render-phase updates (derived state) converge in a couple of
-			// passes; an unguarded one re-queues its own block forever. Cap per-block
-			// renders within one drain so the loop throws (catchable by @try /
-			// ErrorBoundary, like React's equivalent) instead of hanging.
-			if (block.drainStamp === drainId) {
-				if (++block.drainRenders > RENDER_PHASE_UPDATE_LIMIT) {
-					throw crossRenderUpdate ? maximumUpdateDepthError() : new Error(formatClientError(9));
-				}
-			} else {
-				block.drainStamp = drainId;
-				block.drainRenders = 1;
+			if (hiddenActivity !== null && hiddenActivity.pendingThenable !== null) {
+				visibilityDriver!.retryActivity(hiddenActivity, true);
+				continue;
 			}
 			// An urgent render can install its first Suspense driver. Pair both
 			// hooks with the same captured driver rather than rereading it after render.
 			const transitionSwap = TRANSITION_SWAP_DRIVER;
 			const attempt = transitionSwap === null ? null : transitionSwap.begin(block);
 			try {
-				renderBlock(block);
+				if (hiddenActivity !== null) visibilityDriver!.retryActivity(hiddenActivity, false, block);
+				else renderBlock(block);
 			} finally {
 				if (transitionSwap !== null) transitionSwap.end(attempt);
 			}
@@ -2999,10 +3019,16 @@ function drainQueue(): { err: any } | null {
 			// A descendant render can replace an Activity's direct host root. The
 			// Activity itself did not render, so reapply its visual hide after the
 			// complete attempt (including a captured error or Suspense retry).
-			if (hiddenActivity !== null) visibilityDriver!.rehide(hiddenActivity);
+			if (hiddenActivity !== null) (activitiesToRehide ??= new Set()).add(hiddenActivity);
 		}
 	}
 	QUEUE.length = 0;
+	// Several sibling setters can share one hidden range. Re-scan it once after
+	// the complete render wave, before refs or layout effects can observe it.
+	// No Activity update means no collection/allocation on the ordinary path.
+	if (activitiesToRehide !== null) {
+		for (const activity of activitiesToRehide) SCHEDULED_VISIBILITY_DRIVER!.rehide(activity);
+	}
 	return pendingError;
 }
 
@@ -3420,13 +3446,16 @@ function vtFlush(work: () => void = flushWork): void {
 	// classes ALL resolve 'none' is left unnamed — the correct deactivation
 	// (a name in the old capture animates regardless).
 	const recs: VtRec[] = [];
+	const visibleBefore = new Set<Block>();
 	for (const b of VT_REGISTRY) {
 		if (b.disposed) {
 			VT_REGISTRY.delete(b);
 			continue;
 		}
-		if (vtAllNone(b.vt, types)) continue;
 		const els = vtRangeElements(b);
+		if (els.length === 0) continue;
+		visibleBefore.add(b);
+		if (vtAllNone(b.vt, types)) continue;
 		const rec: VtRec = { block: b, els, rect: null, name: '', cls: '' };
 		if (els.length > 0 && typeof els[0].getBoundingClientRect === 'function') {
 			const r = els[0].getBoundingClientRect();
@@ -3437,7 +3466,6 @@ function vtFlush(work: () => void = flushWork): void {
 		vtApplyStyles(rec, vtPreClass(b.vt, types));
 		recs.push(rec);
 	}
-	VT_ENTERED = [];
 	VT_DIRTY.clear();
 	VT_STATE = VT_PENDING_UPDATE;
 	VT_HANDLE = null;
@@ -3454,15 +3482,26 @@ function vtFlush(work: () => void = flushWork): void {
 			VT_DRAIN = false;
 		}
 		// Resolve activations from what the drain did.
+		// DOM lifetime is not visibility lifetime: Activity preserves both its
+		// ViewTransition blocks and hosts. Compare visible host contributions on
+		// both sides, including a ViewTransition wrapped AROUND an Activity.
+		const visibleAfter = new Map<Block, Element[]>();
+		for (const b of VT_REGISTRY) {
+			if (b.disposed) continue;
+			const els = vtRangeElements(b);
+			if (els.length > 0) visibleAfter.set(b, els);
+		}
+		const exited = (b: Block): boolean => visibleBefore.has(b) && !visibleAfter.has(b);
 		const exits: VtRec[] = [];
 		for (const rec of recs) {
-			if (rec.block.disposed) {
+			const after = visibleAfter.get(rec.block);
+			if (after === undefined) {
 				exits.push(rec);
 			} else {
 				// The drain may have replaced the boundary's elements — re-enumerate
 				// and re-assert the SAME name so the new capture pairs with the old.
 				const before = rec.els;
-				rec.els = vtRangeElements(rec.block);
+				rec.els = after;
 				const changed = VT_DIRTY.has(rec.block) || vtRectChanged(rec);
 				vtApplyStyles(rec, rec.cls === '' ? 'auto' : rec.cls);
 				if (
@@ -3479,17 +3518,19 @@ function vtFlush(work: () => void = flushWork): void {
 		// part of a subtree inserted as ONE unit — only the outermost animates
 		// (React's rule); nested ones stay silent unless they opt into the
 		// parent-enter relay (resolved after share pairing below).
-		const enteredSet = new Set(VT_ENTERED);
+		const enteredSet = new Set<Block>();
+		for (const b of visibleAfter.keys()) {
+			if (!visibleBefore.has(b)) enteredSet.add(b);
+		}
 		const enters: VtRec[] = [];
 		const nestedEntered: Block[] = [];
-		for (const b of VT_ENTERED) {
-			if (b.disposed) continue;
+		for (const b of enteredSet) {
 			const anc = vtNearestBoundaryAncestor(b);
 			if (anc !== null && enteredSet.has(anc)) {
 				nestedEntered.push(b);
 				continue;
 			}
-			const rec: VtRec = { block: b, els: vtRangeElements(b), rect: null, name: '', cls: '' };
+			const rec: VtRec = { block: b, els: visibleAfter.get(b)!, rect: null, name: '', cls: '' };
 			const cls = vtResolveClass(b.vt, 'enter', types);
 			// An explicit name always applies (it may pair a share); an unnamed
 			// 'none' enter is fully inert — skip naming and activation.
@@ -3543,7 +3584,7 @@ function vtFlush(work: () => void = flushWork): void {
 			// outermost fires (React's rule). Share pairing above still gets first
 			// claim (a named nested boundary may pair out of a removed unit).
 			const anc = vtNearestBoundaryAncestor(exitRec.block);
-			if (anc !== null && anc.disposed) continue;
+			if (anc !== null && exited(anc)) continue;
 			if (vtResolveClass(exitRec.block.vt, 'exit', types) !== 'none') {
 				acts.push({ kind: 'exit', rec: exitRec });
 			}
@@ -3558,7 +3599,7 @@ function vtFlush(work: () => void = flushWork): void {
 			if (!vtRelayParticipates(vt, 'parent-exit')) continue;
 			// A boundary consumed by a share pair never also parent-relays.
 			if (sharedBlocks.has(rec.block)) continue;
-			const outer = vtRelayOutermost(rec.block, 'parent-exit', (x) => x.disposed, types);
+			const outer = vtRelayOutermost(rec.block, 'parent-exit', exited, types);
 			if (outer === null || sharedBlocks.has(outer)) continue;
 			if (vtResolveClass(outer.vt, 'exit', types) === 'none') continue;
 			const cls = vtResolveClass(vt, 'parent-exit', types);
@@ -3572,7 +3613,7 @@ function vtFlush(work: () => void = flushWork): void {
 			if (vtResolveClass(outer.vt, 'enter', types) === 'none') continue;
 			const cls = vtResolveClass(b.vt, 'parent-enter', types);
 			if (cls === 'none') continue;
-			const rec: VtRec = { block: b, els: vtRangeElements(b), rect: null, name: '', cls: '' };
+			const rec: VtRec = { block: b, els: visibleAfter.get(b)!, rect: null, name: '', cls: '' };
 			vtApplyStyles(rec, cls);
 			recs.push(rec);
 			acts.push({ kind: 'parent-enter', rec });
@@ -3759,6 +3800,7 @@ const LAYOUT_CASCADE_LIMIT = 50;
  * hopping between elements never ends null, whichever binding updates first.
  */
 export function queueRefAttach(scope: Scope, ref: any, el: Element | FragmentInstance): void {
+	activityRefCreated?.(scope.block, el);
 	(WIP_CAPTURE !== null ? WIP_CAPTURE.refs : refAttachQueue).push({
 		ref,
 		el,
@@ -3791,6 +3833,8 @@ const refDetachQueue: any[] = [];
  */
 export function queueRefDetach(ref: any, el: Element | FragmentInstance | null): void {
 	if (ref == null || isRefDetachSuppressed(el)) return;
+	const activity = el === null ? undefined : activityRefState?.get(el);
+	if (activity?.hidden && activity.connected !== ref) return;
 	// Capture the active teardown boundary (if we're inside an unmount walk) so a
 	// throwing detach at drain time routes there — React's safelyDetachRef →
 	// captureCommitPhaseError (ReactErrorBoundaries:2782).
@@ -3895,6 +3939,11 @@ function drainRefAttaches(): void {
 		// re-run on a torn-down node — firing a callback ref on a dead element and
 		// resurrecting an object ref the cleanup just nulled.
 		if (blockSubtreeDisposed(r.block)) continue;
+		const activity = activityRefState?.get(r.el);
+		if (activity !== undefined && findHiddenActivity(r.block) !== null) {
+			activity.hidden = true;
+			continue;
+		}
 		try {
 			REF_CALLBACK_DEPTH++;
 			try {
@@ -6208,6 +6257,7 @@ function finishEffectRender(scope: Scope): void {
 	for (let i = 0; i < effects.length; i++) {
 		const effect = effects[i];
 		if (effect.renderVersion === CURRENT_EFFECT_RENDER_VERSION) continue;
+		if (effect.phase === INSERTION) invalidateInsertionReplay(effect);
 		if (!effect.active) continue;
 		// Reaching this call site again must recreate even when its authored deps
 		// are unchanged.
@@ -6226,12 +6276,17 @@ function finishEffectRender(scope: Scope): void {
 			phase: effect.phase,
 			seq: commitSeq++,
 		});
+		markEffectReconnectQueued(effect, effect.phase, target);
 	}
 }
 
 function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, phase: Phase): void {
 	const scope = CURRENT_SCOPE!;
 	const prev = scope.hooks?.get(slot) as EffectSlot | undefined;
+	if (phase === INSERTION) {
+		if (prev === undefined) activityInsertionEffectCreated?.(scope.block);
+		else invalidateInsertionReplay(prev);
+	}
 	const renderVersion = ensureEffectRenderVersion();
 	const firstReach = prev !== undefined && prev.renderVersion !== renderVersion;
 	if (firstReach) {
@@ -11319,6 +11374,18 @@ export function sibling(node: Node, n: number = 1): Node | null {
 // these helpers are unconditional "set this now" with internal data check.
 // ---------------------------------------------------------------------------
 
+// Optional visibility overlays must not add a WeakMap lookup to ordinary text
+// or style updates. Their writers are installed only while hidden hosts exist.
+let hiddenTextWriter: ((node: Text, value: string) => boolean) | null = null;
+let hiddenStyleWriter:
+	((el: HTMLElement | SVGElement, value: any, previous: any, property?: string) => boolean) | null =
+	null;
+
+function updateTextValue(node: Text, value: string): void {
+	if (hiddenTextWriter !== null && hiddenTextWriter(node, value)) return;
+	if (node.nodeValue !== value) node.nodeValue = value;
+}
+
 export function setText(node: Text, value: any): void {
 	// Unconditional write: the compiler's only emission site guards every call
 	// with `if (_b._prev$ !== _v)`, and `_prev` mirrors the node's current text
@@ -11336,7 +11403,9 @@ export function setText(node: Text, value: any): void {
 	// Write via `nodeValue` (a `Node`-level accessor) rather than `data` (which
 	// lives on `CharacterData` one prototype hop deeper) — it's measurably faster
 	// for the hot text-update path.
-	node.nodeValue = coerceText(value);
+	const text = coerceText(value);
+	if (hiddenTextWriter !== null && hiddenTextWriter(node, text)) return;
+	node.nodeValue = text;
 }
 
 /**
@@ -11565,7 +11634,41 @@ function dangerouslySetInnerHTMLOwnsChild(parent: Node, value: unknown): boolean
 const refCleanups = new WeakMap<(el: any) => unknown, WeakMap<object, () => void>>();
 const refLastCleanupTarget = new WeakMap<(el: any) => unknown, object>();
 
+interface ActivityRefState {
+	connected: any;
+	hidden: boolean;
+}
+
+// Record actual committed ref identities only when an Activity is in use. A
+// hidden render may already have replaced its manifest's ref before cleanup;
+// the committed identity is the one that must be disconnected exactly once.
+let activityRefState: WeakMap<Element | FragmentInstance, ActivityRefState> | null = null;
+let activityRefCreated: ((block: Block, target: Element | FragmentInstance) => void) | null = null;
+let activityInsertionEffectCreated: ((block: Block) => void) | null = null;
+let activityRefOwners: WeakMap<Block, boolean> | null = null;
+let liveActivityCount = 0;
+
 export function attachRef(
+	ref: any,
+	el: Element | FragmentInstance | null,
+	prevTarget?: Element | FragmentInstance | null,
+): void {
+	if (ref == null) return;
+	const target = el ?? prevTarget;
+	const activity = target == null ? undefined : activityRefState?.get(target);
+	if (activity !== undefined) {
+		if (el !== null) {
+			activity.hidden = false;
+			activity.connected = ref;
+		} else if (prevTarget != null) {
+			if (activity.hidden && activity.connected !== ref) return;
+			if (activity.connected === ref) activity.connected = null;
+		}
+	}
+	applyRefValue(ref, el, prevTarget);
+}
+
+function applyRefValue(
 	ref: any,
 	el: Element | FragmentInstance | null,
 	prevTarget?: Element | FragmentInstance | null,
@@ -11597,7 +11700,7 @@ export function attachRef(
 		return;
 	}
 	if (Array.isArray(ref)) {
-		for (let i = 0; i < ref.length; i++) attachRef(ref[i], el, prevTarget);
+		for (let i = 0; i < ref.length; i++) applyRefValue(ref[i], el, prevTarget);
 		return;
 	}
 	ref.current = el;
@@ -11639,13 +11742,29 @@ export const Fragment = Symbol.for('octane.Fragment') as unknown as (props: {
 	ref?: FragmentRefValue;
 }) => unknown;
 
-/**
- * React-19 `<Activity mode="hidden"|"visible">` sentinel. The compiler matches
- * the `Activity` tag by NAME (so this export is only needed so user imports
- * `import { Activity } from 'octane'` resolve); the runtime work happens in
- * `activityBlock`.
- */
-export const Activity: unique symbol = Symbol.for('octane.Activity');
+interface ActivityDescriptorDispatch {
+	type: symbol;
+	body: ComponentBody;
+}
+
+// Generic element reconciliation must not retain the optional Activity engine.
+// Importing the public sentinel installs its cold dispatch capability; direct
+// compiled Activities already call activityBlock and do not need this wrapper.
+let activityDescriptorDispatch: ActivityDescriptorDispatch | null = null;
+
+function initializeActivitySentinel(): symbol {
+	const type = Symbol.for('octane.Activity');
+	activityDescriptorDispatch = { type, body: renderActivityDescriptor };
+	return type;
+}
+
+/** Activity keeps its runtime sentinel identity while accepting ordinary JSX props. */
+export const Activity = /* @__PURE__ */ initializeActivitySentinel() as unknown as (props: {
+	mode?: 'visible' | 'hidden';
+	children?: unknown;
+	name?: string;
+	key?: string | number | bigint | null | undefined;
+}) => unknown;
 
 export class FragmentInstance {
 	/**
@@ -12976,6 +13095,7 @@ export function setStyle(el: HTMLElement | SVGElement, value: any, prev: any): v
 	// The whole style attribute, not the individual declarations applyStyleValue
 	// is about to touch: restoring the attribute text restores every one of them.
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'style');
+	if (hiddenStyleWriter !== null && hiddenStyleWriter(el, value, prev)) return;
 	applyStyleValue(el, style, value, prev);
 }
 
@@ -13002,6 +13122,7 @@ export function setStyleProperty(
 	// genuinely absent initial longhand from a preserved suspended-mount retry.
 	if (remove && previous === CURRENT_SCOPE) return;
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'style');
+	if (hiddenStyleWriter !== null && hiddenStyleWriter(el, value, previous, name)) return;
 	const style = (el as HTMLElement).style;
 	if (remove) style.removeProperty(styleName(name));
 	else applyStyleProperty(el, style, name, value);
@@ -16290,6 +16411,7 @@ function renderPortalState(
 			__profileTrackComponent(block, profilePortalComponent(rawBody));
 		}
 		state = { __kind: 'portalSlotSlot', block, target, start, end };
+		activityPortalCreated?.(block);
 		// Portal target hosts handlers stamped via the same `el.$$click = …`
 		// mechanism as the main tree, so it needs the delegated event listeners too.
 		// Refcounted: a target hosting two portals attaches once, detaches when the
@@ -17021,14 +17143,30 @@ export function componentSlot(
 	inherit?: boolean,
 	hasKey?: boolean,
 ): void {
-	if (typeof comp !== 'function' && typeof comp !== 'string') {
+	const dispatch = activityDescriptorDispatch;
+	const activity = dispatch !== null && (comp as unknown) === dispatch.type;
+	if (!activity && typeof comp !== 'function' && typeof comp !== 'string') {
 		throw invalidElementTypeError(comp);
 	}
 	// Dynamic JSX tags can resolve to a host STRING at runtime. Keep this
 	// descriptor/de-opt capability in the generic entry point: compiler-proven
 	// void component calls can then retain the function-only core without also
 	// retaining hostStringTagBody, generic attributes, or return reconciliation.
-	const body = typeof comp === 'string' ? (hostStringTagBody as unknown as ComponentBody) : comp;
+	const body = activity
+		? dispatch!.body
+		: typeof comp === 'string'
+			? (hostStringTagBody as unknown as ComponentBody)
+			: comp;
+	if (activity) {
+		// A runtime-selected sentinel cannot advertise compiler boundary flags.
+		// Keep its ordinary component frame symmetric with the server wrapper.
+		singleRoot = false;
+		inherit = false;
+		if (!hasKey && key === undefined && hasElementConfigKey(props)) {
+			key = props.key;
+			hasKey = true;
+		}
+	}
 	const renderProps =
 		typeof comp === 'string'
 			? ({
@@ -18540,7 +18678,7 @@ function reconcileDeoptNode(
 	if (t === 'string' || t === 'number' || t === 'bigint') {
 		const s = String(value);
 		if (prev !== null && prev.nodeType === 3 /* Text */) {
-			if ((prev as Text).nodeValue !== s) (prev as Text).nodeValue = s;
+			updateTextValue(prev as Text, s);
 			return prev;
 		}
 		return document.createTextNode(s);
@@ -19024,7 +19162,11 @@ function descNeedsBlocks(value: any): boolean {
 		// A Fragment descriptor is reconciled by childSlot's fragment-aware list
 		// path. If it appears below a host descriptor, keep that host on the Block
 		// path so the Fragment boundary is not mistaken for a raw host node.
-		if (value.type === Fragment) return true;
+		if (
+			value.type === Fragment ||
+			(activityDescriptorDispatch !== null && value.type === activityDescriptorDispatch.type)
+		)
+			return true;
 		// A component descriptor (function `type`) always needs a Block; a host
 		// descriptor needs one only if its own children do (recurse).
 		return typeof value.type === 'function' || descNeedsBlocks(value.children);
@@ -20295,10 +20437,12 @@ export function childSlot(
 		comp = value as ComponentBody;
 		isBodyFn = true;
 	} else if (isElementDescriptor(value)) {
-		if (typeof value.type !== 'function' && typeof value.type !== 'string') {
+		const dispatch = activityDescriptorDispatch;
+		const activity = dispatch !== null && (value.type as unknown) === dispatch.type;
+		if (!activity && typeof value.type !== 'function' && typeof value.type !== 'string') {
 			throw invalidElementTypeError(value.type);
 		}
-		comp = value.type as ComponentBody;
+		comp = activity ? dispatch!.body : (value.type as ComponentBody);
 		props = value.props;
 	}
 	if (comp !== null) {
@@ -20555,7 +20699,7 @@ export function childSlot(
 		return;
 	}
 	if (state.text !== null) {
-		if (state.text.nodeValue !== str) state.text.nodeValue = str;
+		updateTextValue(state.text, str);
 		return;
 	}
 	if (hydration !== null) {
@@ -20565,7 +20709,7 @@ export function childSlot(
 		if (n !== null && n !== state.end && n.nodeType === 3) {
 			state.text = n as Text;
 			hydration.node = n.nextSibling;
-			if ((n as Text).nodeValue !== str) (n as Text).nodeValue = str;
+			updateTextValue(n as Text, str);
 			return;
 		}
 	}
@@ -20617,7 +20761,7 @@ export function textSlot(
 	const str =
 		vt === 'string' ? (value as string) : vt === 'boolean' || value == null ? '' : String(value);
 	if (state.text !== null) {
-		if (state.text.nodeValue !== str) state.text.nodeValue = str;
+		updateTextValue(state.text, str);
 		return;
 	}
 	if (str === '') return;
@@ -20694,7 +20838,7 @@ export function childTextHole(
 			return null;
 		}
 		if (cachedNode !== null) {
-			if (cachedNode.nodeValue !== str) cachedNode.nodeValue = str;
+			updateTextValue(cachedNode, str);
 			return cachedNode;
 		}
 		const hydration = activeHydration();
@@ -21245,6 +21389,8 @@ interface SuspenseHiddenDom {
 // restore it only after the last owner reveals, independent of hide/reveal order.
 const HIDDEN_DISPLAYS = new WeakMap<HTMLElement, HiddenDisplay>();
 const HIDDEN_TEXTS = new WeakMap<Text, HiddenText>();
+let hiddenDisplayNodes = 0;
+let hiddenTextNodes = 0;
 let HIDDEN_ACTIVITY_NODES: WeakMap<Node, number> | null = null;
 let hiddenActivityNodeOwners = 0;
 
@@ -21275,16 +21421,75 @@ function fragmentHostVisible(node: Node): boolean {
 
 function enforceHiddenDisplay(el: HTMLElement): void {
 	const hidden = HIDDEN_DISPLAYS.get(el);
-	el.style.setProperty(
-		'display',
-		'none',
-		hidden !== undefined && hidden.importantOwners > 0 ? 'important' : '',
-	);
+	const priority = hidden !== undefined && hidden.importantOwners > 0 ? 'important' : '';
+	const style = el.style;
+	if (
+		style.getPropertyValue('display') !== 'none' ||
+		style.getPropertyPriority('display') !== priority
+	)
+		style.setProperty('display', 'none', priority);
+}
+
+function restoreHiddenDisplayValue(el: HTMLElement | SVGElement, display: HiddenDisplay): void {
+	if (display.value === '') el.style.removeProperty('display');
+	else el.style.setProperty('display', display.value, display.priority);
+	if (!display.hadStyle && el.getAttribute('style') === '') el.removeAttribute('style');
+}
+
+/** Apply an authored style against its real previous value, underneath the hide. */
+function writeHiddenStyle(
+	el: HTMLElement | SVGElement,
+	value: any,
+	previous: any,
+	property?: string,
+): boolean {
+	const hidden = HIDDEN_DISPLAYS.get(el as HTMLElement);
+	if (hidden === undefined) return false;
+	if (TRANSITION_JOURNAL !== null) {
+		TRANSITION_JOURNAL.push(
+			JOURNAL_PROP,
+			hidden,
+			'value',
+			hidden.value,
+			JOURNAL_PROP,
+			hidden,
+			'priority',
+			hidden.priority,
+			JOURNAL_PROP,
+			hidden,
+			'hadStyle',
+			hidden.hadStyle,
+		);
+	}
+	restoreHiddenDisplayValue(el, hidden);
+	try {
+		if (property === undefined) applyStyleValue(el, el.style, value, previous);
+		else if (value == null || typeof value === 'boolean')
+			el.style.removeProperty(styleName(property));
+		else applyStyleProperty(el, el.style, property, value);
+	} finally {
+		hidden.value = el.style.getPropertyValue('display');
+		hidden.priority = el.style.getPropertyPriority('display');
+		hidden.hadStyle = el.hasAttribute('style');
+		enforceHiddenDisplay(el as HTMLElement);
+	}
+	return true;
+}
+
+function writeHiddenText(node: Text, value: string): boolean {
+	const hidden = HIDDEN_TEXTS.get(node);
+	if (hidden === undefined) return false;
+	if (TRANSITION_JOURNAL !== null)
+		TRANSITION_JOURNAL.push(JOURNAL_PROP, hidden, 'data', hidden.data);
+	hidden.data = value;
+	return true;
 }
 
 function retainHiddenDisplay(el: HTMLElement, important: boolean): void {
 	const existing = HIDDEN_DISPLAYS.get(el);
 	if (existing === undefined) {
+		hiddenDisplayNodes++;
+		hiddenStyleWriter = writeHiddenStyle;
 		HIDDEN_DISPLAYS.set(el, {
 			owners: 1,
 			importantOwners: important ? 1 : 0,
@@ -21299,15 +21504,14 @@ function retainHiddenDisplay(el: HTMLElement, important: boolean): void {
 	enforceHiddenDisplay(el);
 }
 
-function releaseHiddenDisplay(el: HTMLElement, important: boolean): void {
+function releaseHiddenDisplay(el: HTMLElement, important: boolean, restore = true): void {
 	const display = HIDDEN_DISPLAYS.get(el);
 	if (display === undefined) return;
 	if (important) display.importantOwners--;
 	if (--display.owners === 0) {
 		HIDDEN_DISPLAYS.delete(el);
-		if (display.value === '') el.style.removeProperty('display');
-		else el.style.setProperty('display', display.value, display.priority);
-		if (!display.hadStyle && el.getAttribute('style') === '') el.removeAttribute('style');
+		if (--hiddenDisplayNodes === 0) hiddenStyleWriter = null;
+		if (restore) restoreHiddenDisplayValue(el, display);
 	} else {
 		enforceHiddenDisplay(el);
 	}
@@ -21319,16 +21523,20 @@ function enforceHiddenText(text: Text): void {
 
 function retainHiddenText(text: Text): void {
 	const existing = HIDDEN_TEXTS.get(text);
-	if (existing === undefined) HIDDEN_TEXTS.set(text, { owners: 1, data: text.data });
-	else existing.owners++;
+	if (existing === undefined) {
+		hiddenTextNodes++;
+		hiddenTextWriter = writeHiddenText;
+		HIDDEN_TEXTS.set(text, { owners: 1, data: text.data });
+	} else existing.owners++;
 }
 
-function releaseHiddenText(text: Text): void {
+function releaseHiddenText(text: Text, restore = true): void {
 	const saved = HIDDEN_TEXTS.get(text);
 	if (saved === undefined) return;
 	if (--saved.owners === 0) {
 		HIDDEN_TEXTS.delete(text);
-		text.data = saved.data;
+		if (--hiddenTextNodes === 0) hiddenTextWriter = null;
+		if (restore) text.data = saved.data;
 	} else {
 		enforceHiddenText(text);
 	}
@@ -22803,14 +23011,14 @@ function findHiddenActivity(block: Block | null): ActivitySlot | null {
  * the reveal (drop the pending arm, reactivate effects + refs — the
  * commitResume choreography) or hide it again and stay on the fallback.
  */
-function snapshotSubtreeEffectDeps(scope: Scope): EffectDepsSnapshot {
+function snapshotSubtreeEffectDeps(scope: Scope, phase?: Phase): EffectDepsSnapshot {
 	const snapshot: EffectDepsSnapshot = new Map();
 	const visit = (current: Scope): void => {
-		const hooks = current.hooks;
-		if (hooks !== null) {
-			for (const slot of hooks.values()) {
-				const effect = slot as EffectSlot | undefined;
-				if (effect?.effect === true) {
+		const effects = current.effectSlots;
+		if (effects !== null) {
+			for (let i = 0; i < effects.length; i++) {
+				const effect = effects[i];
+				if (phase === undefined || effect.phase === phase) {
 					snapshot.set(effect, {
 						deps: effect.deps,
 						revision: effect.revision,
@@ -22826,13 +23034,13 @@ function snapshotSubtreeEffectDeps(scope: Scope): EffectDepsSnapshot {
 }
 
 /** Roll hook-cell deps back after a speculative render whose captured commit was discarded. */
-function restoreSubtreeEffectDeps(scope: Scope, snapshot: EffectDepsSnapshot): void {
+function restoreSubtreeEffectDeps(scope: Scope, snapshot: EffectDepsSnapshot, phase?: Phase): void {
 	const visit = (current: Scope): void => {
-		const hooks = current.hooks;
-		if (hooks !== null) {
-			for (const slot of hooks.values()) {
-				const effect = slot as EffectSlot | undefined;
-				if (effect?.effect !== true) continue;
+		const effects = current.effectSlots;
+		if (effects !== null) {
+			for (let i = 0; i < effects.length; i++) {
+				const effect = effects[i];
+				if (phase !== undefined && effect.phase !== phase) continue;
 				const previous = snapshot.get(effect);
 				if (previous === undefined) {
 					// A slot created only by the discarded attempt remains reusable,
@@ -22852,14 +23060,24 @@ function restoreSubtreeEffectDeps(scope: Scope, snapshot: EffectDepsSnapshot): v
 	visit(scope);
 }
 
+type InsertionEffectReplays = Map<EffectSlot, PendingEffect[]>;
+
 interface EffectReconnectContext {
 	root: Block;
 	queues: [PendingEffect[], PendingEffect[], PendingEffect[]];
 	queuedSlots: Set<EffectSlot>;
+	insertionReplays: InsertionEffectReplays | null;
 	parent: EffectReconnectContext | null;
 }
 
 let EFFECT_RECONNECT_CONTEXT: EffectReconnectContext | null = null;
+
+/** A real hook reach/omission supersedes saved work, even when it queues nothing. */
+function invalidateInsertionReplay(effect: EffectSlot): void {
+	for (let context = EFFECT_RECONNECT_CONTEXT; context !== null; context = context.parent) {
+		context.insertionReplays?.delete(effect);
+	}
+}
 
 /** Keep nested reveal contexts aware of effects enqueued by an inner render. */
 function markEffectReconnectQueued(
@@ -22869,6 +23087,27 @@ function markEffectReconnectQueued(
 ): void {
 	for (let context = EFFECT_RECONNECT_CONTEXT; context !== null; context = context.parent) {
 		if (context.queues[phase] === target) context.queuedSlots.add(effect);
+	}
+}
+
+/** An inner suspended attempt must not leave an outer reveal's dedupe armed. */
+function forgetEffectReconnectQueued(
+	effects: Set<EffectSlot>,
+	phase: Phase,
+	target: PendingEffect[],
+): void {
+	for (let context = EFFECT_RECONNECT_CONTEXT; context !== null; context = context.parent) {
+		if (context.queues[phase] !== target) continue;
+		for (const effect of effects) context.queuedSlots.delete(effect);
+		// Work preceding the failed attempt still owns its queue position. Restore
+		// only entries that survived both queue truncation and hook-cell rollback.
+		for (let i = 0; i < target.length; i++) {
+			const entry = target[i];
+			const effect = entry.scope.hooks?.get(entry.slot) as EffectSlot | undefined;
+			if (effect !== undefined && effects.has(effect) && effect.revision === entry.revision) {
+				context.queuedSlots.add(effect);
+			}
+		}
 	}
 }
 
@@ -22883,19 +23122,21 @@ function reconnectBailedEffects(block: Block): void {
 	if (context === null || (block !== context.root && !blockIsAncestorOf(context.root, block)))
 		return;
 
-	const disconnected: Array<{ scope: Scope; effect: EffectSlot }> = [];
+	const disconnected: Array<{ scope: Scope; effect: EffectSlot; replay: PendingEffect[] | null }> =
+		[];
 	const visit = (scope: Scope): void => {
 		const effects = scope.effectSlots;
 		if (effects !== null) {
 			for (let i = 0; i < effects.length; i++) {
 				const effect = effects[i];
-				if (
-					effect.active &&
-					effect.disconnected &&
-					effect.connectedFn !== null &&
-					!context.queuedSlots.has(effect)
-				) {
-					disconnected.push({ scope, effect });
+				if (context.queuedSlots.has(effect)) continue;
+				const replay = context.insertionReplays?.get(effect);
+				if (replay !== undefined) {
+					disconnected.push({ scope, effect, replay });
+					continue;
+				}
+				if (effect.active && effect.disconnected && effect.connectedFn !== null) {
+					disconnected.push({ scope, effect, replay: null });
 				}
 			}
 		}
@@ -22907,23 +23148,43 @@ function reconnectBailedEffects(block: Block): void {
 	// staggered dependency updates would turn commit time into a false source-order
 	// key and reconnect earlier-declared effects after later ones.
 	for (let i = 0; i < disconnected.length; i++) {
-		const { scope, effect } = disconnected[i];
-		context.queues[effect.phase].push({
-			scope,
-			slot: effect.slot,
-			fn: effect.connectedFn!,
-			order: effect.order,
-			revision: effect.revision,
-			args: effect.connectedArgs,
-			phase: effect.phase,
-			seq: commitSeq++,
-		});
-		context.queuedSlots.add(effect);
+		const { scope, effect, replay } = disconnected[i];
+		const queue = context.queues[effect.phase];
+		if (replay !== null) {
+			// A completed memo/cached child can survive a later sibling's suspend.
+			// Its insertion effect has not committed, so replay the retained body at
+			// this bail position; a real rerender would have queued a fresher body.
+			const last = replay[replay.length - 1];
+			effect.active = last.fn !== null;
+			effect.deps = last.fn === null ? undefined : last.args;
+			const revision = ++effect.revision;
+			// Plain-TypeScript custom-hook composition can enqueue several bodies
+			// through one effective slot. They share a revision and all must commit.
+			for (let j = 0; j < replay.length; j++) {
+				queue.push({ ...replay[j], revision, seq: commitSeq++ });
+			}
+		} else {
+			queue.push({
+				scope,
+				slot: effect.slot,
+				fn: effect.connectedFn!,
+				order: effect.order,
+				revision: effect.revision,
+				args: effect.connectedArgs,
+				phase: effect.phase,
+				seq: commitSeq++,
+			});
+		}
+		markEffectReconnectQueued(effect, effect.phase, queue);
 	}
 }
 
 /** Render a reconnecting reveal while leaving ordinary renders allocation-free. */
-function renderWithEffectReconnect(block: Block, capture: OffscreenCapture | null): void {
+function renderWithEffectReconnect(
+	block: Block,
+	capture: OffscreenCapture | null,
+	insertionReplays: InsertionEffectReplays | null = null,
+): void {
 	const queues = capture === null ? effectQueues : capture.effects;
 	const queuedSlots = new Set<EffectSlot>();
 	for (let phase = 0; phase < queues.length; phase++) {
@@ -22931,11 +23192,11 @@ function renderWithEffectReconnect(block: Block, capture: OffscreenCapture | nul
 		for (let i = 0; i < queue.length; i++) {
 			const pending = queue[i];
 			const effect = pending.scope.hooks?.get(pending.slot) as EffectSlot | undefined;
-			if (effect?.effect === true) queuedSlots.add(effect);
+			if (effect?.effect === true && effect.revision === pending.revision) queuedSlots.add(effect);
 		}
 	}
 	const parent = EFFECT_RECONNECT_CONTEXT;
-	EFFECT_RECONNECT_CONTEXT = { root: block, queues, queuedSlots, parent };
+	EFFECT_RECONNECT_CONTEXT = { root: block, queues, queuedSlots, insertionReplays, parent };
 	try {
 		renderBlock(block);
 	} finally {
@@ -24627,6 +24888,25 @@ export function ifBlock(
 // preserved because the block is never disposed while toggling.
 // ---------------------------------------------------------------------------
 
+/** Cold descriptor/dynamic-tag path; direct compiled Activities call activityBlock. */
+function renderActivityDescriptor(props: any, scope: Scope): void {
+	const block = scope.block;
+	activityBlock(
+		scope,
+		0,
+		block.parentNode,
+		props?.mode ?? 'visible',
+		renderActivityChildren,
+		block.endMarker,
+	);
+}
+
+function renderActivityChildren(_props: unknown, scope: Scope): void {
+	const block = scope.block;
+	// Scoped children must resolve under the Activity, never in its caller.
+	childSlot(scope, 0, block.parentNode, block.parentBlock!.props?.children, block.endMarker);
+}
+
 interface ActivitySlot {
 	__kind: 'activityBlockSlot';
 	block: Block | null;
@@ -24637,14 +24917,135 @@ interface ActivitySlot {
 	commitVersion: number;
 	/** The visible effects still need their commit-phase deactivation. */
 	deactivationPending: boolean;
-	/** Direct child elements for which this Activity owns one shared hide. */
-	hiddenDisplays: Set<HTMLElement>;
-	/**
-	 * Direct child TEXT nodes for which this Activity owns one shared hide. Text
-	 * nodes have no box and can't take `display:none`, so a bare-text Activity child
-	 * (`<Activity mode="hidden">{'…'}</Activity>`) is hidden by blanking its data.
-	 */
-	hiddenTexts: Set<Text>;
+	/** A hidden Activity contains suspension without hiding its visible siblings. */
+	pendingThenable: TrackedThenable<unknown> | null;
+	suspend: ((thenable: TrackedThenable<unknown>) => void) | null;
+	/** Monotone gate: ref-free Activities never walk host-ref manifests. */
+	hasRefs: boolean;
+	/** Insertion-effect rollback is paid only by Activities that contain them. */
+	hasInsertionEffects: boolean;
+	pendingInsertions: InsertionEffectReplays | null;
+	/** Allocated on first hide; scratch sets are reused across visibility updates. */
+	hiddenDom: ActivityHiddenDom | null;
+	/** Logical portal descendants, including portals nested under host elements. */
+	portals: Set<Block> | null;
+}
+
+interface ActivityHiddenDom extends SuspenseHiddenDom {
+	nextDisplays: Set<HTMLElement>;
+	nextTexts: Set<Text>;
+}
+
+// Only applications using Activity retain portal visibility bookkeeping.
+let activityPortalCreated: ((block: Block) => void) | null = null;
+
+function retainActivityTracking(): void {
+	liveActivityCount++;
+	activityPortalCreated ??= registerActivityPortal;
+	activityRefCreated ??= registerActivityRef;
+	activityInsertionEffectCreated ??= registerActivityInsertionEffect;
+	activityRefState ??= new WeakMap();
+	activityRefOwners ??= new WeakMap();
+}
+
+function releaseActivityTracking(): void {
+	if (--liveActivityCount !== 0) return;
+	activityRefCreated = null;
+	activityInsertionEffectCreated = null;
+	activityPortalCreated = null;
+	const refs = activityRefState;
+	// The block's cleanup runs before descendant ref teardowns. Keep their
+	// committed records until this synchronous deletion/commit finishes, then
+	// remove the optional hooks entirely. A new Activity cancels this release.
+	queueMicrotask(() => {
+		if (liveActivityCount === 0 && activityRefState === refs) {
+			activityRefState = null;
+			activityRefOwners = null;
+		}
+	});
+}
+
+function findActivityRefOwners(block: Block): boolean {
+	let owned = false;
+	for (let current: Block | null = block; current !== null; current = current.parentBlock) {
+		const owner = (current as any).__activitySlot as ActivitySlot | undefined;
+		if (owner !== undefined && owner.block === current) {
+			owner.hasRefs = true;
+			owned = true;
+		}
+	}
+	return owned;
+}
+
+function registerActivityRef(block: Block, target: Element | FragmentInstance): void {
+	const refs = activityRefState!;
+	if (refs.has(target)) return;
+	const owners = activityRefOwners!;
+	let owned = owners.get(block);
+	if (owned === undefined) {
+		// A Block's logical parent is immutable. Cache both positive and negative
+		// ownership, so unrelated ref-heavy trees never repeat the ancestor walk.
+		owned = findActivityRefOwners(block);
+		owners.set(block, owned);
+	}
+	if (owned) refs.set(target, { connected: null, hidden: false });
+}
+
+function registerActivityInsertionEffect(block: Block): void {
+	for (let current: Block | null = block; current !== null; current = current.parentBlock) {
+		const owner = (current as any).__activitySlot as ActivitySlot | undefined;
+		if (owner !== undefined && owner.block === current) owner.hasInsertionEffects = true;
+	}
+}
+
+function registerActivityPortal(block: Block): void {
+	let owners: ActivitySlot[] | null = null;
+	for (let parent = block.parentBlock; parent !== null; parent = parent.parentBlock) {
+		const owner = (parent as any).__activitySlot as ActivitySlot | undefined;
+		if (owner === undefined || owner.block !== parent) continue;
+		(owner.portals ??= new Set()).add(block);
+		(owners ??= []).push(owner);
+	}
+	if (owners !== null) {
+		const retained = owners;
+		(block.cleanups ??= []).push(() => {
+			for (const owner of retained) owner.portals!.delete(block);
+		});
+	}
+}
+
+function hideActivityHostRange(block: Block, hidden: ActivityHiddenDom): void {
+	let node: ChildNode | null = block.startMarker!.nextSibling;
+	while (node !== null && node !== block.endMarker) {
+		// A foreign portal may target this same physical range. Its logical owner
+		// decides visibility; owned portal ranges are visited separately below.
+		const foreignEnd = (node as any).$$portalEnd as Node | undefined;
+		if (foreignEnd !== undefined) {
+			node = nodeAfterPortalRange(node, foreignEnd) as ChildNode | null;
+			continue;
+		}
+		if (node.nodeType === 1) {
+			const el = node as HTMLElement;
+			if (!hidden.nextDisplays.has(el)) {
+				hidden.nextDisplays.add(el);
+				if (!hidden.displays.has(el)) {
+					retainHiddenActivityNode(el);
+					retainHiddenDisplay(el, true);
+				} else enforceHiddenDisplay(el);
+			}
+		} else if (node.nodeType === 3) {
+			const text = node as Text;
+			if (!hidden.nextTexts.has(text)) {
+				hidden.nextTexts.add(text);
+				if (!hidden.texts.has(text)) {
+					retainHiddenActivityNode(text);
+					retainHiddenText(text);
+				}
+				enforceHiddenText(text);
+			}
+		}
+		node = node.nextSibling;
+	}
 }
 
 /**
@@ -24656,52 +25057,44 @@ interface ActivitySlot {
 function hideActivityRange(state: ActivitySlot): void {
 	const b = state.block;
 	if (!b) return;
+	const hidden = (state.hiddenDom ??= {
+		displays: new Set(),
+		texts: new Set(),
+		nextDisplays: new Set(),
+		nextTexts: new Set(),
+	});
 	if (!state.fragmentVisibilityCleanupRegistered) {
 		state.fragmentVisibilityCleanupRegistered = true;
-		(b.cleanups ??= []).push(() => {
-			for (const el of state.hiddenDisplays) releaseHiddenActivityNode(el);
-			for (const text of state.hiddenTexts) releaseHiddenActivityNode(text);
-		});
+		(b.cleanups ??= []).push(() => releaseActivityRange(state, false));
 	}
-	// Branch switches and HMR can replace direct roots while the Activity stays
-	// hidden. Drop detached entries now so a long-hidden, frequently updated
-	// boundary does not retain every outgoing host node until it reveals.
-	for (const el of state.hiddenDisplays) {
-		if (el.parentNode !== b.parentNode) {
-			state.hiddenDisplays.delete(el);
-			releaseHiddenActivityNode(el);
-			releaseHiddenDisplay(el, false);
+	hideActivityHostRange(b, hidden);
+	if (state.portals !== null) {
+		for (const portal of state.portals) {
+			if (!portal.disposed) hideActivityHostRange(portal, hidden);
 		}
 	}
-	for (const text of state.hiddenTexts) {
-		if (text.parentNode !== b.parentNode) {
-			state.hiddenTexts.delete(text);
+	// Reconcile ownership against the live ranges, not just parentNode. This
+	// releases replaced/moved roots and portal targets without retaining dead DOM.
+	for (const el of hidden.displays) {
+		if (!hidden.nextDisplays.has(el)) {
+			releaseHiddenActivityNode(el);
+			releaseHiddenDisplay(el, true);
+		}
+	}
+	for (const text of hidden.texts) {
+		if (!hidden.nextTexts.has(text)) {
 			releaseHiddenActivityNode(text);
 			releaseHiddenText(text);
 		}
 	}
-	let node: ChildNode | null = (b.startMarker as Comment).nextSibling;
-	while (node && node !== b.endMarker) {
-		if (node.nodeType === 1) {
-			const el = node as HTMLElement;
-			if (!state.hiddenDisplays.has(el)) {
-				state.hiddenDisplays.add(el);
-				retainHiddenActivityNode(el);
-				retainHiddenDisplay(el, false);
-			} else {
-				enforceHiddenDisplay(el);
-			}
-		} else if (node.nodeType === 3) {
-			const t = node as Text;
-			if (!state.hiddenTexts.has(t)) {
-				state.hiddenTexts.add(t);
-				retainHiddenActivityNode(t);
-				retainHiddenText(t);
-			}
-			enforceHiddenText(t);
-		}
-		node = node.nextSibling;
-	}
+	const displays = hidden.displays;
+	const texts = hidden.texts;
+	hidden.displays = hidden.nextDisplays;
+	hidden.texts = hidden.nextTexts;
+	hidden.nextDisplays = displays;
+	hidden.nextTexts = texts;
+	displays.clear();
+	texts.clear();
 }
 
 function rehideActivityAfterDescendantRender(state: ActivitySlot): void {
@@ -24714,16 +25107,167 @@ function rehideActivityAfterDescendantRender(state: ActivitySlot): void {
 
 /** Release this Activity's hide ownership, restoring nodes with no other owner. */
 function showActivityRange(state: ActivitySlot): void {
-	for (const el of state.hiddenDisplays) {
+	releaseActivityRange(state, true);
+}
+
+function releaseActivityRange(state: ActivitySlot, restore: boolean): void {
+	const hidden = state.hiddenDom;
+	if (hidden === null) return;
+	for (const el of hidden.displays) {
 		releaseHiddenActivityNode(el);
-		releaseHiddenDisplay(el, false);
+		releaseHiddenDisplay(el, true, restore);
 	}
-	state.hiddenDisplays.clear();
-	for (const text of state.hiddenTexts) {
+	hidden.displays.clear();
+	for (const text of hidden.texts) {
 		releaseHiddenActivityNode(text);
-		releaseHiddenText(text);
+		releaseHiddenText(text, restore);
 	}
-	state.hiddenTexts.clear();
+	hidden.texts.clear();
+}
+
+/** Disconnect the committed identities, including refs replaced by this render. */
+function hideActivityRefs(activity: ActivitySlot): void {
+	if (!activity.hasRefs) return;
+	const block = activity.block!;
+	const state = activityRefState!;
+	const refs: SuspenseRefEntry[] = [];
+	// A render can clear a ref prop before disappearance commits. Include its
+	// still-connected identity even when the current manifest now says null.
+	collectVisibleSubtreeRefs(block, refs, state);
+	for (const entry of refs) {
+		if (blockSubtreeDisposed(entry.scope.block)) continue;
+		let record = state.get(entry.el);
+		if (record === undefined) {
+			record = { connected: null, hidden: false };
+			state.set(entry.el, record);
+		}
+		const connected = record.connected;
+		// Publish hidden ownership before invoking user code: a cleanup may
+		// synchronously unmount this tree or an independent root.
+		record.hidden = true;
+		if (connected !== null) {
+			try {
+				REF_CALLBACK_DEPTH++;
+				try {
+					attachRef(connected, null, entry.el);
+				} finally {
+					REF_CALLBACK_DEPTH--;
+				}
+			} catch (err) {
+				if (err instanceof MaximumUpdateDepthError) throw err;
+				const handler = findTryHandler(entry.scope.block);
+				if (handler !== null) {
+					handler(err);
+					reportCaughtError(entry.scope.block, err);
+				} else if (!reportUncaughtError(entry.scope.block, err)) console.error(err);
+			}
+		}
+	}
+	discardSubtreeRefAttaches(block);
+}
+
+/** Reconnect current visible manifests, not stale attaches from hidden renders. */
+function queueCurrentActivityRefs(activity: ActivitySlot): void {
+	if (!activity.hasRefs) return;
+	const block = activity.block!;
+	if (inInactiveSubtree(block)) return;
+	discardSubtreeRefAttaches(block);
+	const state = activityRefState!;
+	const refs: SuspenseRefEntry[] = [];
+	const seen = new Set<Element | FragmentInstance>();
+	collectVisibleSubtreeRefs(block, refs);
+	for (const entry of refs) {
+		if (seen.has(entry.el) || inInactiveSubtree(entry.scope.block)) continue;
+		seen.add(entry.el);
+		const record = state.get(entry.el);
+		if (record !== undefined && !record.hidden && record.connected === entry.ref) continue;
+		queueRefAttach(
+			entry.scope,
+			entry.el instanceof FragmentInstance ? attachLiveFragmentRef : entry.ref,
+			entry.el,
+		);
+	}
+}
+
+function suspendHiddenActivity(state: ActivitySlot, thenable: TrackedThenable<unknown>): void {
+	if (state.pendingThenable === thenable) return;
+	state.pendingThenable = thenable;
+	const block = state.block!;
+	const retry = (): void => {
+		if (state.pendingThenable !== thenable || !state.hidden || blockSubtreeDisposed(block)) return;
+		scheduleRender(block);
+	};
+	thenable.then(retry, retry);
+}
+
+/** Hidden content is its own suspense boundary; visible content still propagates. */
+function renderHiddenActivity(state: ActivitySlot, replay = false, block = state.block!): void {
+	const previousReplay = RESUME_REPLAY;
+	if (replay) RESUME_REPLAY = true;
+	const insertionQueue = (WIP_CAPTURE === null ? effectQueues : WIP_CAPTURE.effects)[INSERTION];
+	const insertionCheckpoint = insertionQueue.length;
+	const insertionDeps = state.hasInsertionEffects
+		? snapshotSubtreeEffectDeps(block, INSERTION)
+		: null;
+	try {
+		if (state.pendingInsertions === null) renderBlock(block);
+		else renderWithEffectReconnect(block, WIP_CAPTURE, state.pendingInsertions);
+		state.pendingThenable = null;
+		state.pendingInsertions = null;
+	} catch (error) {
+		if (!isSuspenseException(error)) throw error;
+		// An independently scheduled descendant still belongs to its nearest
+		// Suspense boundary. Only capture here when this Activity owns the throw;
+		// nested Suspense keeps its normal fallback/retry transaction.
+		for (
+			let current: Block | null = block;
+			current !== null && current !== state.block;
+			current = current.parentBlock
+		) {
+			if ((current as any).__suspenseHandler) throw error;
+		}
+		let rolledBack: Set<EffectSlot> | null = null;
+		if (insertionQueue.length > insertionCheckpoint) {
+			const next: InsertionEffectReplays = new Map();
+			for (let i = insertionCheckpoint; i < insertionQueue.length; i++) {
+				const entry = insertionQueue[i];
+				const effect = entry.scope.hooks?.get(entry.slot) as EffectSlot | undefined;
+				if (effect?.effect !== true) continue;
+				if (EFFECT_RECONNECT_CONTEXT !== null) (rolledBack ??= new Set()).add(effect);
+				// A later render/presence transition may already have superseded an
+				// earlier enqueue in this attempt. Never revive that stale revision.
+				if (effect.revision !== entry.revision || blockSubtreeDisposed(entry.scope.block)) continue;
+				const entries = next.get(effect);
+				if (entries === undefined) next.set(effect, [entry]);
+				else entries.push(entry);
+			}
+			insertionQueue.length = insertionCheckpoint;
+			// A nested hidden Activity can take over work retained by an outer
+			// failed attempt. Its pending body now owns those entries; an ancestor
+			// memo/context-refresh walk must not replay them before this one resolves.
+			for (const effect of next.keys()) invalidateInsertionReplay(effect);
+			if (state.pendingInsertions === null) state.pendingInsertions = next.size === 0 ? null : next;
+			else for (const [effect, entries] of next) state.pendingInsertions.set(effect, entries);
+		}
+		if (insertionDeps !== null || state.pendingInsertions !== null) {
+			restoreSubtreeEffectDeps(block, insertionDeps ?? new Map(), INSERTION);
+		}
+		if (rolledBack !== null) forgetEffectReconnectQueued(rolledBack, INSERTION, insertionQueue);
+		suspendHiddenActivity(state, error.thenable);
+	} finally {
+		RESUME_REPLAY = previousReplay;
+	}
+}
+
+function setActivitySuspenseHandler(state: ActivitySlot, hidden: boolean): void {
+	const block = state.block!;
+	if (hidden) {
+		state.suspend ??= (thenable) => suspendHiddenActivity(state, thenable);
+		(block as any).__suspenseHandler = state.suspend;
+	} else {
+		state.pendingThenable = null;
+		(block as any).__suspenseHandler = null;
+	}
 }
 
 function queueActivityDeactivation(state: ActivitySlot, block: Block, commitVersion: number): void {
@@ -24745,6 +25289,9 @@ function queueActivityDeactivation(state: ActivitySlot, block: Block, commitVers
 		// Event bodies were published before commit actions drain. Destroy while
 		// the DOM is still connected, then hide the preserved range.
 		deactivateScope(block);
+		if (blockSubtreeDisposed(block) || state.block !== block) return;
+		hideActivityRefs(state);
+		if (blockSubtreeDisposed(block) || state.block !== block) return;
 		hideActivityRange(state);
 		state.deactivationPending = false;
 	});
@@ -24792,6 +25339,8 @@ export function activityBlock(
 			undefined,
 			env,
 		);
+		retainActivityTracking();
+		(b.cleanups ??= []).push(releaseActivityTracking);
 		state = {
 			__kind: 'activityBlockSlot',
 			block: b,
@@ -24799,8 +25348,13 @@ export function activityBlock(
 			fragmentVisibilityCleanupRegistered: false,
 			commitVersion: 0,
 			deactivationPending: false,
-			hiddenDisplays: new Set(),
-			hiddenTexts: new Set(),
+			pendingThenable: null,
+			suspend: null,
+			hasRefs: false,
+			hasInsertionEffects: false,
+			pendingInsertions: null,
+			hiddenDom: null,
+			portals: null,
 		};
 		// Activity is a rare boundary, so keep this back-reference off the
 		// monomorphic Block shape (matching the existing Suspense __trySlot tag).
@@ -24817,9 +25371,10 @@ export function activityBlock(
 		if (serverRangeEmpty && hydration !== null) {
 			b.inactive = wantHidden;
 			state.hidden = wantHidden;
+			if (wantHidden) setActivitySuspenseHandler(state, true);
 			hydration.deferredActivities.push(() => {
 				if (b.disposed) return;
-				hydration.suspend(() => renderBlock(b));
+				hydration.suspend(() => (state!.hidden ? renderHiddenActivity(state!) : renderBlock(b)));
 				if (state!.hidden) hideActivityRange(state!);
 			});
 			hydration.node = bEnd.nextSibling;
@@ -24829,9 +25384,10 @@ export function activityBlock(
 			// Mount while hidden: render children (creates state + DOM) but no
 			// effects — mark inactive BEFORE the render so enqueueEffect skips them.
 			b.inactive = true;
-			renderBlock(b);
-			hideActivityRange(state);
 			state.hidden = true;
+			setActivitySuspenseHandler(state, true);
+			renderHiddenActivity(state);
+			hideActivityRange(state);
 		} else {
 			renderBlock(b);
 		}
@@ -24852,8 +25408,9 @@ export function activityBlock(
 			b.inactive = true;
 			state.hidden = true;
 			state.deactivationPending = true;
+			setActivitySuspenseHandler(state, true);
 			queueActivityDeactivation(state, b, commitVersion);
-			renderBlock(b);
+			renderHiddenActivity(state);
 		} else {
 			// hidden → hidden: prerender (no effects), then hide any new children.
 			// If a prior visible→hidden attempt has not committed yet, replace its
@@ -24861,7 +25418,7 @@ export function activityBlock(
 			if (state.deactivationPending) {
 				queueActivityDeactivation(state, b, commitVersion);
 			}
-			renderBlock(b);
+			renderHiddenActivity(state);
 			if (!state.deactivationPending) hideActivityRange(state);
 		}
 	} else {
@@ -24872,7 +25429,10 @@ export function activityBlock(
 			b.inactive = false;
 			state.hidden = false;
 			state.deactivationPending = false;
-			renderWithEffectReconnect(b, null);
+			setActivitySuspenseHandler(state, false);
+			renderWithEffectReconnect(b, WIP_CAPTURE, state.pendingInsertions);
+			state.pendingInsertions = null;
+			queueCurrentActivityRefs(state);
 		} else {
 			// visible → visible: ordinary re-render in place.
 			renderBlock(b);
@@ -24930,9 +25490,9 @@ function forEachSubtreeChild(
 }
 
 // Detach every host ref in a subtree (object refs → null, callback refs called with
-// null), collecting {ref, el} for later re-attach. Used ONLY by the suspense-hide path
-// (NOT by <Activity>, which intentionally keeps refs) so React's "refs cycle null→node
-// across a suspend, like layout effects" contract holds even though octane preserves the
+// null), collecting {ref, el} for later re-attach. Suspense uses the detach walk;
+// Activity uses the same manifests with its committed-ref visibility tracking.
+// React's refs cycle null→node like layout effects even though Octane preserves the
 // DOM node. Compiled bodies with ref-carrying bindings stamp a REF MANIFEST on their
 // scope (`scope.refFields` — see the Scope interface): flat [kind, field, elField]
 // triads naming the binding-bag fields directly, so discovery is an indexed walk over
@@ -24945,12 +25505,14 @@ function detachSubtreeRefs(
 	shouldDetach: boolean = true,
 	includeHiddenTry: boolean = true,
 	uncommitted: UncommittedRefAttaches | null = null,
+	activityRefs: WeakMap<Element | FragmentInstance, ActivityRefState> | null = null,
 ): void {
 	// A block managing a de-opt host subtree (deoptItemBody / pure-host items):
 	// every node the de-opt reconciler built carries its descriptor (DEOPT_DESC),
 	// whose props may hold a ref — walk the DOM subtree for them.
 	const deoptRoot = (scope as any).deoptNode as Node | null | undefined;
-	if (deoptRoot != null) detachDeoptTreeRefs(deoptRoot, out, shouldDetach, scope, uncommitted);
+	if (deoptRoot != null)
+		detachDeoptTreeRefs(deoptRoot, out, shouldDetach, scope, uncommitted, activityRefs);
 	const rm = scope.refFields;
 	if (rm !== null) {
 		const bag = scope.slots[0];
@@ -24959,19 +25521,19 @@ function detachSubtreeRefs(
 				const kind = rm[j];
 				if (kind === 'r') {
 					// Element ref binding: field holds the ref, partner holds the element.
-					const ref = bag[rm[j + 1]];
-					if (ref == null) continue;
 					const el = bag[rm[j + 2]];
+					const ref = bag[rm[j + 1]] ?? activityRefs?.get(el)?.connected;
+					if (ref == null) continue;
 					out.push({ ref, el, scope });
 					if (shouldDetach && !refAttachWasDiscarded(uncommitted, el, ref)) {
 						attachRef(ref, null, el);
 					}
 				} else if (kind === 's') {
 					// Spread binding: the committed spread object may carry a ref.
-					const ref = bag[rm[j + 1]]?.ref;
-					if (ref == null) continue;
 					const el = bag[rm[j + 2]];
 					if (el == null) continue;
+					const ref = bag[rm[j + 1]]?.ref ?? activityRefs?.get(el)?.connected;
+					if (ref == null) continue;
 					out.push({ ref, el, scope });
 					if (shouldDetach && !refAttachWasDiscarded(uncommitted, el, ref)) {
 						attachRef(ref, null, el);
@@ -24980,10 +25542,12 @@ function detachSubtreeRefs(
 					// 'f' — <Fragment ref>: detach the FragmentInstance's current ref;
 					// reveal re-attaches the same instance.
 					const fi = bag[rm[j + 1]];
-					if (fi == null || fi._currentRef == null) continue;
-					out.push({ ref: fi._currentRef, el: fi, scope });
-					if (shouldDetach && !refAttachWasDiscarded(uncommitted, fi, fi._currentRef)) {
-						attachRef(fi._currentRef, null, fi);
+					if (fi == null) continue;
+					const ref = fi._currentRef ?? activityRefs?.get(fi)?.connected;
+					if (ref == null) continue;
+					out.push({ ref, el: fi, scope });
+					if (shouldDetach && !refAttachWasDiscarded(uncommitted, fi, ref)) {
+						attachRef(ref, null, fi);
 					}
 				}
 			}
@@ -24994,27 +25558,35 @@ function detachSubtreeRefs(
 		const s = slots[i];
 		if (s === null || typeof s !== 'object') continue;
 		// De-opt host element slot (value-position `<tag>` / motion-style): { el, anchor, ref }.
-		if (s.ref != null && s.anchor !== undefined && s.el instanceof Element) {
-			out.push({ ref: s.ref, el: s.el, scope });
-			if (shouldDetach && !refAttachWasDiscarded(uncommitted, s.el, s.ref)) {
-				attachRef(s.ref, null, s.el);
+		if (s.anchor !== undefined && s.el instanceof Element) {
+			const ref = s.ref ?? activityRefs?.get(s.el)?.connected;
+			if (ref != null) {
+				out.push({ ref, el: s.el, scope });
+				if (shouldDetach && !refAttachWasDiscarded(uncommitted, s.el, ref)) {
+					attachRef(ref, null, s.el);
+				}
 			}
 		}
 		// childSlot managing a pure-host de-opt node — same DEOPT_DESC walk.
 		if (s.__kind === 'childSlot' && s.hostNode != null) {
-			detachDeoptTreeRefs(s.hostNode, out, shouldDetach, scope, uncommitted);
+			detachDeoptTreeRefs(s.hostNode, out, shouldDetach, scope, uncommitted, activityRefs);
 		}
 	}
 	forEachSubtreeChild(
 		scope,
-		(child) => detachSubtreeRefs(child, out, shouldDetach, includeHiddenTry, uncommitted),
+		(child) =>
+			detachSubtreeRefs(child, out, shouldDetach, includeHiddenTry, uncommitted, activityRefs),
 		includeHiddenTry,
 	);
 }
 
 /** Collect the refs that belong to the subtree's CURRENT visible branches. */
-function collectVisibleSubtreeRefs(scope: Scope, out: SuspenseRefEntry[]): void {
-	detachSubtreeRefs(scope, out, false, false);
+function collectVisibleSubtreeRefs(
+	scope: Scope,
+	out: SuspenseRefEntry[],
+	activityRefs: WeakMap<Element | FragmentInstance, ActivityRefState> | null = null,
+): void {
+	detachSubtreeRefs(scope, out, false, false, null, activityRefs);
 }
 
 // Walk a de-opt-built DOM subtree detaching every stamped descriptor ref
@@ -25030,11 +25602,12 @@ function detachDeoptTreeRefs(
 	shouldDetach: boolean = true,
 	ownerScope?: Scope,
 	uncommitted: UncommittedRefAttaches | null = null,
+	activityRefs: WeakMap<Element | FragmentInstance, ActivityRefState> | null = null,
 ): void {
 	// No de-opt descriptor ref was ever stamped → nothing to detach or collect
 	// anywhere; skip the subtree scan. (Monotone flag — see noteDeoptRef.)
 	if (!DEOPT_REFS_STAMPED) return;
-	const ref = getDeoptDesc(node)?.props?.ref;
+	const ref = getDeoptDesc(node)?.props?.ref ?? activityRefs?.get(node as Element)?.connected;
 	if (ref != null) {
 		if (out !== null) {
 			// Suspense-hide: detach NOW (the caller re-attaches on reveal).
@@ -25064,7 +25637,7 @@ function detachDeoptTreeRefs(
 			c = nodeAfterPortalRange(c, rangeEnd);
 			continue;
 		}
-		detachDeoptTreeRefs(c, out, shouldDetach, ownerScope, uncommitted);
+		detachDeoptTreeRefs(c, out, shouldDetach, ownerScope, uncommitted, activityRefs);
 		c = c.nextSibling;
 	}
 }
@@ -25078,56 +25651,54 @@ function detachDeoptTreeRefs(
  * effects remain subscribed until actual deletion, matching React's
  * hidden-primary lifetime. A passive effect that never connected is not part of
  * that hidden primary and resets like a layout one (see below). State, DOM, and
- * blocks stay alive in either case. Refs remain attached for Activity; Suspense
- * cycles them separately via detachSubtreeRefs.
+ * blocks stay alive in either case. Both boundaries cycle refs separately from
+ * their effect cleanup walk.
  */
 function deactivateScope(scope: Scope, disconnectPassive: boolean = true): void {
-	const hooks = scope.hooks;
-	if (hooks) {
-		for (const slot of hooks.values()) {
-			if (slot && (slot as EffectSlot).effect === true) {
-				const e = slot as EffectSlot;
-				// INSERTION effects stay CONNECTED while hidden (React parity,
-				// Activity-test.js:1428): no cleanup on hide, deps kept so the
-				// reveal re-render doesn't re-fire them. They own injected styles
-				// that must persist while a tree is merely hidden; only a real
-				// unmount (unmountScope's effect-slot walk) tears them down.
-				//
-				// Suspense's `disconnectPassive=false` spares passive effects for the
-				// same reason — but only ones that ACTUALLY connected. `connectedFn` is
-				// set exclusively by runEffectBody, so a null one has never run: it
-				// belongs to a subtree the boundary rendered but never committed —
-				// siblings ahead of the call that suspended, or children introduced by a
-				// later attempt. There is no subscription to preserve, and its deps are
-				// already stamped from that aborted attempt, so sparing it would let the
-				// reveal re-render compare equal deps and skip the enqueue, stranding the
-				// mount effect — and its cleanup — forever. React fires every mount effect
-				// in the subtree when a suspended mount finally commits, so an
-				// unconnected passive slot resets exactly like a layout one.
-				if (
-					e.phase === INSERTION ||
-					(!disconnectPassive && e.phase === PASSIVE && e.connectedFn !== null)
-				) {
-					continue;
-				}
-				if (typeof e.cleanup === 'function') {
-					const cleanup = e.cleanup;
-					// Clear it BEFORE firing so unmountScope's effect-slot walk sees
-					// no cleanup and won't re-run it.
-					e.cleanup = undefined;
-					try {
-						runEffectCleanupCallback(cleanup);
-					} catch (err) {
-						if (err instanceof MaximumUpdateDepthError) throw err;
-						const handler = findTryHandler(scope.block);
-						if (handler !== null) handler(err);
-						else console.error(err);
-					}
-				}
-				// Force the setup to re-enqueue + re-fire when the subtree reactivates.
-				e.deps = undefined;
-				if (e.connectedFn !== null) e.disconnected = true;
+	const effects = scope.effectSlots;
+	if (effects !== null) {
+		for (let index = 0; index < effects.length; index++) {
+			const e = effects[index];
+			// INSERTION effects stay CONNECTED while hidden (React parity,
+			// Activity-test.js:1428): no cleanup on hide, deps kept so the
+			// reveal re-render doesn't re-fire them. They own injected styles
+			// that must persist while a tree is merely hidden; only a real
+			// unmount (unmountScope's effect-slot walk) tears them down.
+			//
+			// Suspense's `disconnectPassive=false` spares passive effects for the
+			// same reason — but only ones that ACTUALLY connected. `connectedFn` is
+			// set exclusively by runEffectBody, so a null one has never run: it
+			// belongs to a subtree the boundary rendered but never committed —
+			// siblings ahead of the call that suspended, or children introduced by a
+			// later attempt. There is no subscription to preserve, and its deps are
+			// already stamped from that aborted attempt, so sparing it would let the
+			// reveal re-render compare equal deps and skip the enqueue, stranding the
+			// mount effect — and its cleanup — forever. React fires every mount effect
+			// in the subtree when a suspended mount finally commits, so an
+			// unconnected passive slot resets exactly like a layout one.
+			if (
+				e.phase === INSERTION ||
+				(!disconnectPassive && e.phase === PASSIVE && e.connectedFn !== null)
+			) {
+				continue;
 			}
+			if (typeof e.cleanup === 'function') {
+				const cleanup = e.cleanup;
+				// Clear it BEFORE firing so unmountScope's effect-slot walk sees
+				// no cleanup and won't re-run it.
+				e.cleanup = undefined;
+				try {
+					runEffectCleanupCallback(cleanup);
+				} catch (err) {
+					if (err instanceof MaximumUpdateDepthError) throw err;
+					const handler = findTryHandler(scope.block);
+					if (handler !== null) handler(err);
+					else console.error(err);
+				}
+			}
+			// Force the setup to re-enqueue + re-fire when the subtree reactivates.
+			e.deps = undefined;
+			if (e.connectedFn !== null) e.disconnected = true;
 		}
 	}
 	forEachSubtreeChild(scope, (child) => deactivateScope(child, disconnectPassive));
@@ -27393,6 +27964,7 @@ export interface Root {
 	render(
 		element:
 			| ElementDescriptor
+			| PortalDescriptor
 			| string
 			| number
 			| bigint

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -2405,7 +2405,8 @@ function ownerSubtreeRetainable(owner: UniversalOwnerRecord): boolean {
 	if (
 		owner.updates.size !== 0 ||
 		owner.visibility !== 'visible' ||
-		(owner.isBoundary && (owner.hasBoundaryError || owner.boundaryThenable !== null)) ||
+		owner.boundaryThenable !== null ||
+		(owner.isBoundary && owner.hasBoundaryError) ||
 		(owner.component as any)?.__warm !== undefined ||
 		(owner.component !== null &&
 			universalComponentRevision(owner.component) !== owner.componentRevision)
@@ -2809,18 +2810,26 @@ function blueprintFromLogical(record: LogicalRecord): BlueprintNode {
 	};
 }
 
-function markDraftOwnerSuspenseHidden(owner: DraftOwner): void {
-	owner.visibility = 'suspense-hidden';
-	for (const child of owner.children) markDraftOwnerSuspenseHidden(child);
+function markDraftOwnerHidden(
+	owner: DraftOwner,
+	visibility: Exclude<UniversalVisibility, 'visible'>,
+): void {
+	// An Activity can retain a tree containing an independently suspended
+	// primary. Keep that stricter lifetime until its own boundary retries.
+	owner.visibility = owner.record.visibility === 'suspense-hidden' ? 'suspense-hidden' : visibility;
+	for (const child of owner.children) markDraftOwnerHidden(child, owner.visibility);
 }
 
-function markBlueprintSuspenseHidden(nodes: readonly BlueprintNode[]): void {
+function markBlueprintHidden(
+	nodes: readonly BlueprintNode[],
+	visibility: Exclude<UniversalVisibility, 'visible'>,
+): void {
 	for (const node of nodes) {
 		if (node.kind === 'host') {
-			node.visibility = 'suspense-hidden';
+			if (node.visibility !== 'suspense-hidden') node.visibility = visibility;
 			markUniversalTreeFeature(UNIVERSAL_TREE_HIDDEN);
 		}
-		markBlueprintSuspenseHidden(node.children);
+		markBlueprintHidden(node.children, visibility);
 	}
 }
 
@@ -2840,10 +2849,39 @@ function retainCommittedTryArm(owner: DraftOwner): BlueprintNode[] | null {
 	owner.claimedChildren.add(childRecord);
 	currentAttempt().owners.push(child);
 	retainCommittedOwnerTree(child);
-	markDraftOwnerSuspenseHidden(child);
+	markDraftOwnerHidden(child, 'suspense-hidden');
 	const nodes = ownerRange(child, range.children.map(blueprintFromLogical));
-	markBlueprintSuspenseHidden(nodes);
+	markBlueprintHidden(nodes, 'suspense-hidden');
 	return nodes;
+}
+
+/**
+ * A hidden Activity is its own suspension boundary. Restore only its accepted
+ * owner/host range, leaving the surrounding render free to commit. The failed
+ * draft stays in attempt.owners for memoized-promise replay; a fresh committed
+ * draft prevents its unapplied hook updates from being consumed by retention.
+ * This allocation and tree walk occur only when background work suspends.
+ */
+function retainCommittedActivity(owner: DraftOwner): BlueprintNode[] {
+	const attempt = currentAttempt();
+	const record = owner.record;
+	const parent = owner.parent!;
+	const range = record.mounted
+		? (record.range ?? findLogicalRange(attempt.root.rootRecordForRetention(), record.rangeKey))
+		: null;
+	resetDraftChildren(owner);
+	const retained = draftOwner(record, parent, owner.replayPath);
+	retained.visibility = owner.visibility;
+	retained.canHandleSuspense = owner.canHandleSuspense;
+	retained.boundaryThenable = owner.boundaryThenable;
+	parent.children[parent.children.indexOf(owner)] = retained;
+	attempt.owners.push(retained);
+	retainCommittedOwnerTree(retained);
+	const visibility = retained.visibility as Exclude<UniversalVisibility, 'visible'>;
+	for (const child of retained.children) markDraftOwnerHidden(child, visibility);
+	const nodes = range === null ? [] : range.children.map(blueprintFromLogical);
+	markBlueprintHidden(nodes, visibility);
+	return ownerRange(retained, nodes);
 }
 
 const OWNERLESS_LEAF_PLAN_CACHE = new WeakMap<UniversalPlan, UniversalHostPlan | null>();
@@ -3087,16 +3125,31 @@ function materializeValue(
 		const parent = CURRENT_OWNER;
 		if (parent === null) throw new Error('Universal Activity requires an owning component.');
 		const owner = claimChildOwner(parent, null, [...path, 'activity'], null);
+		const hidden = activity.mode === 'hidden';
+		owner.canHandleSuspense = hidden;
 		owner.visibility =
 			parent.visibility === 'suspense-hidden'
 				? 'suspense-hidden'
-				: parent.visibility === 'activity-hidden' || activity.mode === 'hidden'
+				: parent.visibility === 'activity-hidden' || hidden
 					? 'activity-hidden'
 					: 'visible';
-		const nodes = executeOwner(owner, () =>
-			materializeValue(activity.body(), expectedRenderer, null, [...path, 'activity-output']),
-		);
-		const range = ownerRange(owner, nodes);
+		const attempt = currentAttempt();
+		const universalIdCheckpoint = attempt.nextUniversalId;
+		let range: BlueprintNode[];
+		try {
+			if (owner.boundaryThenable !== null) throw new UniversalSuspense(owner.boundaryThenable);
+			const nodes = executeOwner(owner, () =>
+				materializeValue(activity.body(), expectedRenderer, null, [...path, 'activity-output']),
+			);
+			range = ownerRange(owner, nodes);
+		} catch (error) {
+			if (!hidden || !(error instanceof UniversalSuspense)) throw error;
+			attempt.nextUniversalId = universalIdCheckpoint;
+			// Routed renderer-region suspensions already installed a settlement
+			// callback; render-origin suspensions use the ordinary local replay.
+			if (owner.boundaryThenable === null) attempt.retryThenables.add(error.thenable);
+			range = retainCommittedActivity(owner);
+		}
 		return key === null ? range : [{ kind: 'range', key, children: range }];
 	}
 	if ((value as UniversalIfValue)?.$$kind === UNIVERSAL_IF) {
@@ -6661,7 +6714,7 @@ function routeUniversalOwnerSuspense(
 	thenable: PromiseLike<unknown>,
 ): boolean {
 	for (let current = owner.parent; current !== null; current = current.parent) {
-		if (!current.isBoundary || !current.canHandleSuspense || current.disposed) continue;
+		if (!current.canHandleSuspense || current.disposed) continue;
 		current.boundaryThenable = thenable;
 		current.boundaryError = undefined;
 		current.hasBoundaryError = false;
@@ -7032,7 +7085,13 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 	}
 
 	private attachHostRef(record: LogicalRecord): void {
-		if (this.hostAttachments?.registration == null || this.unmounted) return;
+		if (
+			this.hostAttachments?.registration == null ||
+			this.unmounted ||
+			record.visibility !== 'visible'
+		) {
+			return;
+		}
 		if (!this.readHostAttachment(record.id)) return;
 		const value = this.driver.getPublicInstance(this.container, record.id);
 		// A recycling-aware driver must not publish a ref until both its attachment
@@ -7088,7 +7147,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					records.get(record.id) !== record ||
 					record.ref == null ||
 					record.refAttached ||
-					record.visibility === 'suspense-hidden' ||
+					record.visibility !== 'visible' ||
 					!this.readHostAttachment(record.id)
 				) {
 					return;
@@ -8554,8 +8613,8 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		// already-active episode keeps its subtree on the full-root path.
 		for (let ancestor = target.parent; ancestor !== null; ancestor = ancestor.parent) {
 			if (
-				ancestor.isBoundary &&
-				(ancestor.hasBoundaryError || ancestor.boundaryThenable !== null)
+				ancestor.boundaryThenable !== null ||
+				(ancestor.isBoundary && ancestor.hasBoundaryError)
 			) {
 				return null;
 			}
@@ -8752,7 +8811,8 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			) {
 				if (
 					current === null ||
-					(current.isBoundary && (current.hasBoundaryError || current.boundaryThenable !== null))
+					current.boundaryThenable !== null ||
+					(current.isBoundary && current.hasBoundaryError)
 				) {
 					return undefined;
 				}
@@ -11092,16 +11152,14 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 				if (draft.record.kind !== 'host') return;
 				const blueprintHost = draft.blueprint as BlueprintHost;
 				const nextRef = blueprintHost.ref;
-				const suspenseHide =
-					draft.record.visibility !== 'suspense-hidden' &&
-					blueprintHost.visibility === 'suspense-hidden';
-				const suspenseReveal =
-					draft.record.visibility === 'suspense-hidden' &&
-					blueprintHost.visibility !== 'suspense-hidden';
+				const hide =
+					draft.record.visibility === 'visible' && blueprintHost.visibility !== 'visible';
+				const reveal =
+					draft.record.visibility !== 'visible' && blueprintHost.visibility === 'visible';
 				if (
 					!draft.isNew &&
 					draft.record.refAttached &&
-					(recreated.has(draft.record) || suspenseHide || !Object.is(draft.record.ref, nextRef))
+					(recreated.has(draft.record) || hide || !Object.is(draft.record.ref, nextRef))
 				) {
 					refDetaches.push({
 						record: draft.record,
@@ -11111,10 +11169,10 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 				}
 				if (
 					nextRef != null &&
-					blueprintHost.visibility !== 'suspense-hidden' &&
+					blueprintHost.visibility === 'visible' &&
 					(draft.isNew ||
 						recreated.has(draft.record) ||
-						suspenseReveal ||
+						reveal ||
 						!draft.record.refAttached ||
 						!Object.is(draft.record.ref, nextRef))
 				) {

--- a/packages/octane/tests/_fixtures/activity-authoring-returned.tsx
+++ b/packages/octane/tests/_fixtures/activity-authoring-returned.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource octane */
+import { Activity, useState, type OctaneNode } from 'octane';
+
+type Mode = 'visible' | 'hidden';
+
+interface ActivityProps {
+	mode: Mode;
+	label: string;
+	activityKey?: string;
+	config?: { mode?: Mode; key?: string; children?: OctaneNode };
+	boundary?: typeof Activity;
+}
+
+function Stateful(props: { label: string }) {
+	const [count, setCount] = useState(0);
+	return (
+		<button data-activity-child={props.label} onClick={() => setCount((value) => value + 1)}>
+			{props.label + ':' + count}
+		</button>
+	);
+}
+
+export function ReturnedActivity(props: ActivityProps) {
+	return (
+		<Activity {...props.config}>
+			<Stateful label={props.label} />
+		</Activity>
+	);
+}
+
+export function NestedReturnedActivity(props: ActivityProps) {
+	return (
+		<section>
+			<Activity key={props.activityKey} {...props.config}>
+				<Stateful label={props.label} />
+			</Activity>
+			<i data-activity-tail>tail</i>
+		</section>
+	);
+}
+
+export function ReturnedDynamicSpreadWinsActivity(props: ActivityProps) {
+	const Boundary = props.boundary ?? Activity;
+	return (
+		<Boundary key={props.activityKey} {...props.config}>
+			<Activity mode="visible">
+				<Stateful label={props.label} />
+			</Activity>
+		</Boundary>
+	);
+}
+
+export function ReturnedDynamicExplicitWinsActivity(props: ActivityProps) {
+	const Boundary = props.boundary ?? Activity;
+	return (
+		<Boundary {...props.config} key={props.activityKey}>
+			<Activity mode="visible">
+				<Stateful label={props.label} />
+			</Activity>
+		</Boundary>
+	);
+}
+
+export function ActivityConfigOrder(props: {
+	config: { mode?: Mode; key?: string };
+	readName(): string;
+	readKey(): string;
+	readMode(): Mode;
+	readLabel(): string;
+}) {
+	return (
+		<section>
+			<Activity
+				name={props.readName()}
+				{...props.config}
+				key={props.readKey()}
+				mode={props.readMode()}
+			>
+				<Stateful label={props.readLabel()} />
+			</Activity>
+		</section>
+	);
+}

--- a/packages/octane/tests/_fixtures/activity-authoring-shadowed.tsx
+++ b/packages/octane/tests/_fixtures/activity-authoring-shadowed.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource octane */
+import * as Octane from 'octane';
+import { Activity as PreservedActivity, type OctaneNode } from 'octane';
+
+function Ordinary(props: { mode?: string; children?: OctaneNode }) {
+	return <div data-ordinary-activity={props.mode}>{props.children}</div>;
+}
+
+const Activity = Ordinary;
+
+export function ModuleShadowedActivity() {
+	return (
+		<Activity mode="hidden">
+			<span>ordinary</span>
+		</Activity>
+	);
+}
+
+const moduleCallbackChildren = [Ordinary].map((PreservedActivity) => (
+	<PreservedActivity key="callback" mode="hidden">
+		<span>callback</span>
+	</PreservedActivity>
+));
+
+const namespaceCallbackChildren = [{ Activity: Ordinary }].map((Octane) => (
+	<Octane.Activity key="namespace" mode="hidden">
+		<span>namespace</span>
+	</Octane.Activity>
+));
+
+export function CallbackShadowedActivity() {
+	return (
+		<section>
+			{moduleCallbackChildren}
+			{namespaceCallbackChildren}
+		</section>
+	);
+}
+
+export function BlockShadowedActivity(props: { ordinary: boolean }) {
+	if (props.ordinary) {
+		const PreservedActivity = Ordinary;
+		return (
+			<PreservedActivity mode="hidden">
+				<span>block</span>
+			</PreservedActivity>
+		);
+	}
+	return (
+		<Octane.Activity mode="visible">
+			<span>builtin</span>
+		</Octane.Activity>
+	);
+}

--- a/packages/octane/tests/_fixtures/activity-authoring.tsrx
+++ b/packages/octane/tests/_fixtures/activity-authoring.tsrx
@@ -1,0 +1,164 @@
+import * as Octane from 'octane';
+import {
+	Activity,
+	Activity as PreservedActivity,
+	createElement,
+	use,
+	useEffect,
+	useState,
+	type OctaneNode,
+} from 'octane';
+
+type Mode = 'visible' | 'hidden';
+
+interface ChildProps {
+	label: string;
+	onEffect?: (event: string) => void;
+}
+
+interface ActivityProps extends ChildProps {
+	mode: Mode;
+	activityKey?: string;
+	config?: { mode?: Mode; key?: string; children?: OctaneNode };
+	boundary?: typeof Activity;
+}
+
+export function ActivityAuthoringChild(props: ChildProps) @{
+	const [count, setCount] = useState(0);
+	useEffect(() => {
+		props.onEffect?.('mount:' + props.label);
+		return () => props.onEffect?.('cleanup:' + props.label);
+	}, [props.label]);
+	<button data-activity-child={props.label} onClick={() => setCount((value) => value + 1)}>
+		{props.label + ':' + count}
+	</button>
+}
+
+export function DirectActivity(props: ActivityProps) @{
+	<Activity mode={props.mode}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Activity>
+}
+
+export function AliasedActivity(props: ActivityProps) @{
+	<PreservedActivity mode={props.mode}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</PreservedActivity>
+}
+
+export function NamespacedActivity(props: ActivityProps) @{
+	<Octane.Activity mode={props.mode}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Octane.Activity>
+}
+
+export function DynamicActivity(props: ActivityProps) @{
+	const Boundary = props.boundary ?? Activity;
+	<Boundary mode={props.mode}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Boundary>
+}
+
+export function DynamicSpreadActivity(props: ActivityProps) @{
+	const Boundary = props.boundary ?? Activity;
+	<Boundary {...props.config}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Boundary>
+}
+
+export function DynamicSpreadWinsActivity(props: ActivityProps) @{
+	const Boundary = props.boundary ?? Activity;
+	<Boundary key={props.activityKey} {...props.config}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Boundary>
+}
+
+export function DynamicExplicitWinsActivity(props: ActivityProps) @{
+	const Boundary = props.boundary ?? Activity;
+	<Boundary {...props.config} key={props.activityKey}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Boundary>
+}
+
+export function DynamicActivityConfigOrder(props: {
+	config: { mode?: Mode; key?: string };
+	readKey(): string;
+	readMode(): Mode;
+	readLabel(): string;
+}) @{
+	const Boundary = Activity;
+	<Boundary key={props.readKey()} {...props.config} mode={props.readMode()}>
+		<ActivityAuthoringChild label={props.readLabel()} />
+	</Boundary>
+}
+
+export function SpreadActivity(props: ActivityProps) @{
+	<Activity {...props.config}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Activity>
+}
+
+export function KeyedActivity(props: ActivityProps) @{
+	<Activity key={props.activityKey} mode={props.mode}>
+		<ActivityAuthoringChild label={props.label} onEffect={props.onEffect} />
+	</Activity>
+}
+
+export function ActivityChildrenProp(props: ActivityProps) @{
+	<Activity
+		mode={props.mode}
+		children={createElement(ActivityAuthoringChild, {
+			label: props.label,
+			onEffect: props.onEffect,
+		})}
+	/>
+}
+
+export function ActivityPropPrecedence(props: ActivityProps) @{
+	<div>
+		<Activity mode="hidden" {...props.config}>
+			<ActivityAuthoringChild label="spread-wins" />
+		</Activity>
+		<Activity {...props.config} mode="hidden">
+			<ActivityAuthoringChild label="explicit-wins" />
+		</Activity>
+		<Activity {...props.config} mode="visible">
+			<ActivityAuthoringChild label="nested-wins" />
+		</Activity>
+	</div>
+}
+
+export function OrdinaryActivity(props: { children?: OctaneNode; mode?: string }) @{
+	<div data-ordinary-activity={props.mode}>{props.children}</div>
+}
+
+export function ShadowedActivity(props: ChildProps) @{
+	const Activity = OrdinaryActivity;
+	<Activity mode="hidden">
+		<ActivityAuthoringChild label={props.label} />
+	</Activity>
+}
+
+export function ActivityDirectiveChildren(props: ActivityProps & { show: boolean }) @{
+	<Activity {...props.config}>
+		@if (props.show) {
+			<ActivityAuthoringChild label={props.label} />
+		} @else {
+			<span data-activity-empty>{'empty'}</span>
+		}
+	</Activity>
+}
+
+function ActivityRenderLoopChild(props: { pending?: Promise<never> }) @{
+	const [value, setValue] = useState(0);
+	// Bounded so a missing runtime guard fails the test instead of hanging it.
+	if (value < 80) setValue(value + 1);
+	if (props.pending !== undefined) use(props.pending);
+	<span>{value as number}</span>
+}
+
+export function ActivityRenderLoop(props: { pending?: Promise<never> }) @{
+	<Activity mode="hidden">
+		<ActivityRenderLoopChild pending={props.pending} />
+	</Activity>
+}

--- a/packages/octane/tests/activity-authoring.test.ts
+++ b/packages/octane/tests/activity-authoring.test.ts
@@ -532,6 +532,90 @@ describe('<Activity> server rendering and hydration', () => {
 		}
 	});
 
+	for (const initialMode of ['visible', 'hidden'] as const) {
+		for (const content of ['host', 'text'] as const) {
+			it(`hydrates initially ${initialMode} Activity ${content} children inside host descriptors without replacing DOM`, async () => {
+				function App(props: { mode: 'visible' | 'hidden'; label: string }) {
+					return createElement(
+						'main',
+						null,
+						createElement('input', { id: 'before-activity', defaultValue: 'before' }),
+						createElement(
+							'section',
+							null,
+							createElement(
+								Activity,
+								{ mode: props.mode },
+								content === 'host'
+									? createElement('span', { style: { display: 'inline-block' } }, props.label)
+									: props.label,
+							),
+						),
+						createElement('input', { id: 'after-activity', defaultValue: 'after' }),
+					);
+				}
+				const props = { mode: initialMode, label: 'initial' };
+				const host = container();
+				host.innerHTML = Server.renderToString(App, props).html;
+				const shell = host.querySelector('main') as HTMLElement;
+				const activityHost = host.querySelector('section') as HTMLElement;
+				const before = host.querySelector('#before-activity') as HTMLInputElement;
+				const after = host.querySelector('#after-activity') as HTMLInputElement;
+				before.value = 'edited before hydration';
+				after.value = 'edited after hydration';
+				function contentNode(): Node | null {
+					return content === 'host'
+						? activityHost.querySelector('span')
+						: (Array.from(activityHost.childNodes).find(
+								(node) => node.nodeType === Node.TEXT_NODE,
+							) ?? null);
+				}
+				const serverContent = contentNode();
+				if (initialMode === 'hidden') expect(serverContent).toBeNull();
+				else expect(serverContent?.textContent).toBe('initial');
+
+				const recoveries: unknown[] = [];
+				const root = hydrateRoot(host, App, props, {
+					onRecoverableError: (error) => recoveries.push(error),
+				});
+				roots.push(root);
+				flushSync(() => {});
+				await Promise.resolve();
+				expect(recoveries).toEqual([]);
+				const preservedContent = contentNode();
+				expect(preservedContent).not.toBeNull();
+				if (initialMode === 'visible') expect(preservedContent).toBe(serverContent);
+
+				function expectPreserved(mode: 'visible' | 'hidden', label: string) {
+					expect(host.querySelector('main')).toBe(shell);
+					expect(host.querySelector('section')).toBe(activityHost);
+					expect(host.querySelector('#before-activity')).toBe(before);
+					expect(host.querySelector('#after-activity')).toBe(after);
+					expect(Array.from(shell.children)).toEqual([before, activityHost, after]);
+					expect(before.value).toBe('edited before hydration');
+					expect(after.value).toBe('edited after hydration');
+					expect(contentNode()).toBe(preservedContent);
+					if (content === 'host') {
+						expect(preservedContent?.textContent).toBe(label);
+						expect((preservedContent as HTMLElement).style.display).toBe(
+							mode === 'hidden' ? 'none' : 'inline-block',
+						);
+					} else {
+						expect(preservedContent?.textContent).toBe(mode === 'hidden' ? '' : label);
+					}
+				}
+				expectPreserved(initialMode, 'initial');
+				flushSync(() => root.render(App, { mode: 'hidden', label: 'updated' }));
+				expectPreserved('hidden', 'updated');
+				flushSync(() => root.render(App, { mode: 'visible', label: 'updated' }));
+				expectPreserved('visible', 'updated');
+				root.unmount();
+				expect(host.querySelector('main')).toBeNull();
+				expect(host.textContent).toBe('');
+			});
+		}
+	}
+
 	it('hydrates generic hidden ranges without consuming a visible sibling', () => {
 		function serverApp() {
 			return Server.createElement(

--- a/packages/octane/tests/activity-authoring.test.ts
+++ b/packages/octane/tests/activity-authoring.test.ts
@@ -1,0 +1,576 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as React from 'react';
+import { renderToStaticMarkup as reactStaticMarkup } from 'react-dom/server';
+import * as Server from 'octane/server';
+import {
+	Activity,
+	createElement,
+	createPortal,
+	createRoot,
+	flushSync,
+	hydrateRoot,
+} from '../src/index.js';
+import { flushEffects, mount } from './_helpers.js';
+import { loadServerFixture } from './_server-fixture.js';
+import { collectPipeableStream, collectReadableStream } from './_server-stream.js';
+import * as Fixture from './_fixtures/activity-authoring.tsrx';
+import * as ReturnedFixture from './_fixtures/activity-authoring-returned.js';
+import {
+	BlockShadowedActivity,
+	CallbackShadowedActivity,
+	ModuleShadowedActivity,
+} from './_fixtures/activity-authoring-shadowed.js';
+
+const server = loadServerFixture('packages/octane/tests/_fixtures/activity-authoring.tsrx');
+const returnedServer = loadServerFixture(
+	'packages/octane/tests/_fixtures/activity-authoring-returned.tsx',
+);
+const shadowedServer = loadServerFixture(
+	'packages/octane/tests/_fixtures/activity-authoring-shadowed.tsx',
+);
+const roots: Array<{ unmount(): void }> = [];
+const containers: HTMLElement[] = [];
+
+function container(): HTMLElement {
+	const element = document.createElement('div');
+	document.body.appendChild(element);
+	containers.push(element);
+	return element;
+}
+
+function child(host: ParentNode, label: string): HTMLButtonElement {
+	return host.querySelector(`[data-activity-child="${label}"]`) as HTMLButtonElement;
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) root.unmount();
+	for (const element of containers.splice(0)) element.remove();
+});
+
+describe('<Activity> authoring forms', () => {
+	// ReactFizzServer renders REACT_ACTIVITY_TYPE by identity, not the identifier
+	// used at its JSX site. React's Activity-test.js also preserves child state
+	// when the mode changes while ordinary keyed identity still controls resets.
+	for (const name of [
+		'DirectActivity',
+		'AliasedActivity',
+		'NamespacedActivity',
+		'DynamicActivity',
+		'DynamicSpreadActivity',
+		'SpreadActivity',
+		'ActivityChildrenProp',
+	] as const) {
+		it(`${name} preserves state and DOM while hiding and revealing`, () => {
+			const Component = Fixture[name];
+			const effects: string[] = [];
+			const props = {
+				mode: 'visible' as const,
+				config: { mode: 'visible' as const },
+				label: 'child',
+				onEffect: (event: string) => effects.push(event),
+			};
+			const view = mount(Component, props);
+			roots.push(view);
+			flushEffects();
+			const button = child(view.container, 'child');
+			expect(button).not.toBeNull();
+			flushSync(() => button.click());
+			expect(button.textContent).toBe('child:1');
+			view.update(Component, { ...props, mode: 'hidden', config: { mode: 'hidden' } });
+			flushEffects();
+			expect(child(view.container, 'child')).toBe(button);
+			expect(button.style.display).toBe('none');
+			expect(effects).toEqual(['mount:child', 'cleanup:child']);
+			view.update(Component, props);
+			flushEffects();
+			expect(child(view.container, 'child')).toBe(button);
+			expect(button.style.display).toBe('');
+			expect(button.textContent).toBe('child:1');
+			expect(effects).toEqual(['mount:child', 'cleanup:child', 'mount:child']);
+		});
+	}
+
+	it('keeps an unrelated local component named Activity ordinary', () => {
+		const view = mount(Fixture.ShadowedActivity, { label: 'ordinary' });
+		roots.push(view);
+		const wrapper = view.container.querySelector('[data-ordinary-activity]') as HTMLElement;
+		expect(wrapper).not.toBeNull();
+		expect(wrapper.dataset.ordinaryActivity).toBe('hidden');
+		expect(wrapper.style.display).toBe('');
+		expect(child(wrapper, 'ordinary').textContent).toBe('ordinary:0');
+	});
+
+	it('merges spread props in source order and lets nested children override children props', () => {
+		const view = mount(Fixture.ActivityPropPrecedence, {
+			mode: 'visible',
+			label: 'unused',
+			config: { mode: 'visible', children: 'overridden' },
+		});
+		roots.push(view);
+		expect(child(view.container, 'spread-wins').style.display).toBe('');
+		expect(child(view.container, 'explicit-wins').style.display).toBe('none');
+		expect(child(view.container, 'nested-wins').textContent).toBe('nested-wins:0');
+		expect(view.container.textContent).not.toContain('overridden');
+	});
+
+	for (const name of ['KeyedActivity', 'SpreadActivity', 'DynamicSpreadActivity'] as const) {
+		it(`${name} resets child state when its key changes`, () => {
+			const Component = Fixture[name];
+			const props = {
+				mode: 'visible' as const,
+				activityKey: 'first',
+				config: { mode: 'visible' as const, key: 'first' },
+				label: 'keyed',
+			};
+			const view = mount(Component, props);
+			roots.push(view);
+			const original = child(view.container, 'keyed');
+			flushSync(() => original.click());
+			view.update(Component, {
+				...props,
+				mode: 'hidden',
+				config: { ...props.config, mode: 'hidden' },
+			});
+			view.update(Component, props);
+			expect(child(view.container, 'keyed')).toBe(original);
+			expect(original.textContent).toBe('keyed:1');
+			view.update(Component, {
+				...props,
+				activityKey: 'second',
+				config: { ...props.config, key: 'second' },
+			});
+			const replacement = child(view.container, 'keyed');
+			expect(replacement).not.toBe(original);
+			expect(replacement.textContent).toBe('keyed:0');
+		});
+	}
+
+	for (const [name, Component, ServerComponent, spreadWins] of [
+		[
+			'DynamicSpreadWinsActivity',
+			Fixture.DynamicSpreadWinsActivity,
+			server.DynamicSpreadWinsActivity,
+			true,
+		],
+		[
+			'DynamicExplicitWinsActivity',
+			Fixture.DynamicExplicitWinsActivity,
+			server.DynamicExplicitWinsActivity,
+			false,
+		],
+		[
+			'ReturnedDynamicSpreadWinsActivity',
+			ReturnedFixture.ReturnedDynamicSpreadWinsActivity,
+			returnedServer.ReturnedDynamicSpreadWinsActivity,
+			true,
+		],
+		[
+			'ReturnedDynamicExplicitWinsActivity',
+			ReturnedFixture.ReturnedDynamicExplicitWinsActivity,
+			returnedServer.ReturnedDynamicExplicitWinsActivity,
+			false,
+		],
+	] as const) {
+		it(`${name} reconciles by the last authored key after hydration`, () => {
+			const props = {
+				mode: 'visible' as const,
+				activityKey: 'explicit',
+				config: { mode: 'visible' as const, key: 'spread' },
+				label: 'ordered-key',
+			};
+			const host = container();
+			host.innerHTML = Server.renderToString(ServerComponent, props).html;
+			const original = child(host, props.label);
+			const root = hydrateRoot(host, Component, props);
+			roots.push(root);
+			flushSync(() => {});
+			expect(child(host, props.label)).toBe(original);
+			flushSync(() => original.click());
+
+			const changedLosingKey = spreadWins
+				? { ...props, activityKey: 'ignored-change' }
+				: { ...props, config: { ...props.config, key: 'ignored-change' } };
+			root.render(Component, changedLosingKey);
+			flushSync(() => {});
+			expect(child(host, props.label)).toBe(original);
+			expect(original.textContent).toBe('ordered-key:1');
+
+			root.render(Component, {
+				...changedLosingKey,
+				config: { ...changedLosingKey.config, mode: 'hidden' },
+			});
+			flushSync(() => {});
+			expect(child(host, props.label)).toBe(original);
+			expect(original.style.display).toBe('none');
+			root.render(Component, changedLosingKey);
+			flushSync(() => {});
+			expect(child(host, props.label)).toBe(original);
+			expect(original.style.display).toBe('');
+
+			const changedEffectiveKey = spreadWins
+				? { ...props, config: { ...props.config, key: 'replacement' } }
+				: { ...props, activityKey: 'replacement' };
+			root.render(Component, changedEffectiveKey);
+			flushSync(() => {});
+			expect(child(host, props.label)).not.toBe(original);
+			expect(child(host, props.label).textContent).toBe('ordered-key:0');
+		});
+	}
+
+	it('evaluates a dynamic tag’s explicit key before a later spread config', () => {
+		function propsFor(events: string[]) {
+			return {
+				config: {
+					get key() {
+						events.push('spread:key');
+						return 'effective';
+					},
+				},
+				readKey() {
+					events.push('key');
+					return 'overridden';
+				},
+				readMode() {
+					events.push('mode');
+					return 'visible' as const;
+				},
+				readLabel() {
+					events.push('child');
+					return 'ordered';
+				},
+			};
+		}
+		const expected = ['key', 'spread:key', 'mode', 'child'];
+		const clientEvents: string[] = [];
+		const view = mount(Fixture.DynamicActivityConfigOrder, propsFor(clientEvents));
+		roots.push(view);
+		expect(child(view.container, 'ordered').textContent).toBe('ordered:0');
+		expect(clientEvents).toEqual(expected);
+		const serverEvents: string[] = [];
+		expect(
+			Server.renderToStaticMarkup(server.DynamicActivityConfigOrder, propsFor(serverEvents)).html,
+		).toContain('ordered:0');
+		expect(serverEvents).toEqual(expected);
+	});
+
+	it('retains template directives inside a spread-configured Activity', () => {
+		const props = {
+			mode: 'hidden' as const,
+			config: { mode: 'hidden' as const },
+			label: 'branch',
+			show: true,
+		};
+		const view = mount(Fixture.ActivityDirectiveChildren, props);
+		roots.push(view);
+		expect(child(view.container, 'branch').style.display).toBe('none');
+		view.update(Fixture.ActivityDirectiveChildren, { ...props, show: false });
+		const empty = view.container.querySelector('[data-activity-empty]') as HTMLElement;
+		expect(empty.textContent).toBe('empty');
+		expect(empty.style.display).toBe('none');
+		view.update(Fixture.ActivityDirectiveChildren, {
+			...props,
+			config: { mode: 'visible' },
+			show: false,
+		});
+		expect(view.container.querySelector('[data-activity-empty]')).toBe(empty);
+		expect(empty.style.display).toBe('');
+	});
+
+	for (const suspends of [false, true]) {
+		it(`bounds render-phase update loops in hidden content${suspends ? ' that suspends' : ''}`, () => {
+			const pending = suspends ? new Promise<never>(() => {}) : undefined;
+			expect(() => {
+				const view = mount(Fixture.ActivityRenderLoop, { pending });
+				roots.push(view);
+			}).toThrow(/Too many re-renders|error #9/);
+		});
+	}
+});
+
+describe('<Activity> element descriptors', () => {
+	for (const placement of ['root', 'host', 'list', 'portal'] as const) {
+		it(`preserves descriptor children at a ${placement} position`, () => {
+			const host = container();
+			const portal = placement === 'portal' ? container() : host;
+			const root = createRoot(host);
+			roots.push(root);
+			function output(mode: 'visible' | 'hidden', key = 'saved') {
+				const activity = createElement(
+					Activity,
+					{ mode, key },
+					createElement(Fixture.ActivityAuthoringChild, { label: placement }),
+				);
+				if (placement === 'root') return activity;
+				if (placement === 'portal') return createPortal(activity, portal);
+				return createElement(
+					'section',
+					null,
+					placement === 'list' ? [activity, createElement('i', { key: 'tail' }, 'tail')] : activity,
+				);
+			}
+			root.render(output('visible'));
+			flushSync(() => {});
+			const button = child(portal, placement);
+			expect(button).not.toBeNull();
+			flushSync(() => button.click());
+			root.render(output('hidden'));
+			flushSync(() => {});
+			expect(child(portal, placement)).toBe(button);
+			expect(button.style.display).toBe('none');
+			root.render(output('visible'));
+			flushSync(() => {});
+			expect(child(portal, placement)).toBe(button);
+			expect(button.textContent).toBe(`${placement}:1`);
+			expect(button.style.display).toBe('');
+			root.render(output('visible', 'replacement'));
+			flushSync(() => {});
+			expect(child(portal, placement)).not.toBe(button);
+			expect(child(portal, placement).textContent).toBe(`${placement}:0`);
+		});
+	}
+});
+
+describe('<Activity> returned JSX', () => {
+	for (const name of ['ReturnedActivity', 'NestedReturnedActivity'] as const) {
+		it(`${name} preserves state, key precedence, and server node identity`, () => {
+			const Component = ReturnedFixture[name];
+			const props = {
+				mode: 'visible' as const,
+				label: 'returned',
+				activityKey: 'overridden',
+				config: { mode: 'visible' as const, key: 'effective' },
+			};
+			const host = container();
+			host.innerHTML = Server.renderToString(returnedServer[name], props).html;
+			const original = child(host, 'returned');
+			const tail = host.querySelector('[data-activity-tail]');
+			expect(original).not.toBeNull();
+			const root = hydrateRoot(host, Component, props);
+			roots.push(root);
+			flushSync(() => {});
+			expect(child(host, 'returned')).toBe(original);
+			flushSync(() => original.click());
+			root.render(Component, {
+				...props,
+				activityKey: 'still-overridden',
+				config: { ...props.config, mode: 'hidden' },
+			});
+			flushSync(() => {});
+			expect(child(host, 'returned')).toBe(original);
+			expect(original.style.display).toBe('none');
+			root.render(Component, props);
+			flushSync(() => {});
+			expect(child(host, 'returned')).toBe(original);
+			expect(original.textContent).toBe('returned:1');
+			root.render(Component, { ...props, config: { ...props.config, key: 'replacement' } });
+			flushSync(() => {});
+			expect(child(host, 'returned')).not.toBe(original);
+			expect(child(host, 'returned').textContent).toBe('returned:0');
+			if (tail !== null) expect(host.querySelector('[data-activity-tail]')).toBe(tail);
+		});
+	}
+
+	it('evaluates spread getters and explicit props in authored order', () => {
+		function propsFor(events: string[]) {
+			return {
+				config: {
+					get mode() {
+						events.push('spread:mode');
+						return 'hidden' as const;
+					},
+					get key() {
+						events.push('spread:key');
+						return 'overridden';
+					},
+				},
+				readName() {
+					events.push('name');
+					return 'instrumented';
+				},
+				readKey() {
+					events.push('key');
+					return 'effective';
+				},
+				readMode() {
+					events.push('mode');
+					return 'visible' as const;
+				},
+				readLabel() {
+					events.push('child');
+					return 'ordered';
+				},
+			};
+		}
+		const expected = ['name', 'spread:mode', 'spread:key', 'key', 'mode', 'child'];
+		const clientEvents: string[] = [];
+		const view = mount(ReturnedFixture.ActivityConfigOrder, propsFor(clientEvents));
+		roots.push(view);
+		expect(child(view.container, 'ordered').style.display).toBe('');
+		expect(clientEvents).toEqual(expected);
+		const serverEvents: string[] = [];
+		const html = Server.renderToStaticMarkup(
+			returnedServer.ActivityConfigOrder,
+			propsFor(serverEvents),
+		).html;
+		expect(html).toContain('ordered:0');
+		expect(serverEvents).toEqual(expected);
+	});
+
+	it('does not reserve a module-local Activity component name', () => {
+		const view = mount(ModuleShadowedActivity);
+		roots.push(view);
+		const wrapper = view.container.querySelector('[data-ordinary-activity]') as HTMLElement;
+		expect(wrapper).not.toBeNull();
+		expect(wrapper.style.display).toBe('');
+		expect(wrapper.textContent).toBe('ordinary');
+		expect(Server.renderToStaticMarkup(shadowedServer.ModuleShadowedActivity).html).toBe(
+			'<div data-ordinary-activity="hidden"><span>ordinary</span></div>',
+		);
+	});
+
+	it('resolves named and namespace imports through module callback scopes', () => {
+		const view = mount(CallbackShadowedActivity);
+		roots.push(view);
+		const wrappers = Array.from(
+			view.container.querySelectorAll<HTMLElement>('[data-ordinary-activity]'),
+		);
+		expect(wrappers.map((wrapper) => wrapper.textContent)).toEqual(['callback', 'namespace']);
+		expect(wrappers.every((wrapper) => wrapper.style.display === '')).toBe(true);
+		const html = Server.renderToStaticMarkup(shadowedServer.CallbackShadowedActivity).html;
+		expect(html).toContain('<div data-ordinary-activity="hidden"><span>callback</span></div>');
+		expect(html).toContain('<div data-ordinary-activity="hidden"><span>namespace</span></div>');
+	});
+
+	it('does not lower a block-scoped import shadow as the builtin', () => {
+		const view = mount(BlockShadowedActivity, { ordinary: true });
+		roots.push(view);
+		const wrapper = view.container.querySelector('[data-ordinary-activity]') as HTMLElement;
+		expect(wrapper).not.toBeNull();
+		expect(wrapper.textContent).toBe('block');
+		expect(wrapper.style.display).toBe('');
+		expect(
+			Server.renderToStaticMarkup(shadowedServer.BlockShadowedActivity, { ordinary: true }).html,
+		).toBe('<div data-ordinary-activity="hidden"><span>block</span></div>');
+		view.update(BlockShadowedActivity, { ordinary: false });
+		expect(view.container.querySelector('[data-ordinary-activity]')).toBeNull();
+		expect(view.container.textContent).toBe('builtin');
+	});
+});
+
+describe('<Activity> server rendering and hydration', () => {
+	// Per ReactDOMServerPartialHydrationActivity-test.internal.js:1083 and
+	// React's documented server Activity contract: hidden children are omitted.
+	for (const name of [
+		'DirectActivity',
+		'AliasedActivity',
+		'NamespacedActivity',
+		'DynamicActivity',
+		'DynamicSpreadActivity',
+		'SpreadActivity',
+		'KeyedActivity',
+		'ActivityChildrenProp',
+	] as const) {
+		it(`${name} omits hidden HTML and adopts visible server nodes`, () => {
+			const props = { mode: 'visible' as const, config: { mode: 'visible' as const }, label: name };
+			const visible = Server.renderToString(server[name], props).html;
+			const hidden = Server.renderToStaticMarkup(server[name], {
+				...props,
+				mode: 'hidden',
+				config: { mode: 'hidden' },
+			}).html;
+			expect(hidden).toBe('');
+			const host = container();
+			host.innerHTML = visible;
+			const button = child(host, name);
+			expect(button).not.toBeNull();
+			const root = hydrateRoot(host, Fixture[name], props);
+			roots.push(root);
+			flushSync(() => {});
+			expect(child(host, name)).toBe(button);
+			flushSync(() => button.click());
+			expect(button.textContent).toBe(`${name}:1`);
+		});
+	}
+
+	it('matches React static markup for a public Activity descriptor', () => {
+		for (const mode of ['visible', 'hidden'] as const) {
+			const expected = reactStaticMarkup(
+				React.createElement(React.Activity, {
+					mode,
+					children: React.createElement('span', null, 'child'),
+				}),
+			);
+			const actual = Server.renderToStaticMarkup(() =>
+				Server.createElement(
+					Server.Activity,
+					{ mode },
+					Server.createElement('span', null, 'child'),
+				),
+			).html;
+			expect(actual).toBe(expected);
+		}
+	});
+
+	it('finishes both stream transports without evaluating hidden descriptor children', async () => {
+		const fail = () => {
+			throw new Error('hidden child must not render');
+		};
+		const App = () =>
+			Server.createElement(
+				'main',
+				null,
+				Server.createElement(Server.Activity, { mode: 'hidden' }, Server.createElement(fail)),
+				Server.createElement('span', { id: 'visible-stream-tail' }, 'ready'),
+			);
+		for (const collect of [collectPipeableStream, collectReadableStream]) {
+			const result = await collect(App);
+			expect(result.errors).toEqual([]);
+			const host = container();
+			host.innerHTML = result.html;
+			expect(host.querySelector('#visible-stream-tail')?.textContent).toBe('ready');
+			expect(host.textContent).toBe('ready');
+		}
+	});
+
+	it('hydrates generic hidden ranges without consuming a visible sibling', () => {
+		function serverApp() {
+			return Server.createElement(
+				'section',
+				null,
+				Server.createElement(
+					Server.Activity,
+					{ mode: 'hidden' },
+					Server.createElement(server.ActivityAuthoringChild, { label: 'hidden' }),
+				),
+				Server.createElement('i', { id: 'descriptor-tail' }, 'tail'),
+			);
+		}
+		function clientApp(props: { mode: 'visible' | 'hidden' }) {
+			return createElement(
+				'section',
+				null,
+				createElement(
+					Activity,
+					{ mode: props.mode },
+					createElement(Fixture.ActivityAuthoringChild, { label: 'hidden' }),
+				),
+				createElement('i', { id: 'descriptor-tail' }, 'tail'),
+			);
+		}
+		const host = container();
+		host.innerHTML = Server.renderToString(serverApp).html;
+		const tail = host.querySelector('#descriptor-tail');
+		const root = hydrateRoot(host, clientApp, { mode: 'hidden' });
+		roots.push(root);
+		flushSync(() => {});
+		const button = child(host, 'hidden');
+		expect(button).not.toBeNull();
+		expect(button.style.display).toBe('none');
+		expect(host.querySelector('#descriptor-tail')).toBe(tail);
+		root.render(clientApp, { mode: 'visible' });
+		flushSync(() => {});
+		expect(child(host, 'hidden')).toBe(button);
+		expect(button.style.display).toBe('');
+		expect(host.querySelector('#descriptor-tail')).toBe(tail);
+	});
+});

--- a/packages/octane/tests/browser/activity-view-transition/activity-view-transition.test.ts
+++ b/packages/octane/tests/browser/activity-view-transition/activity-view-transition.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+import { launchBrowser } from '../../../../../test-utils/playwright-browser.js';
+import { createServer, type ViteDevServer } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+let browser: Browser;
+
+beforeAll(async () => {
+	browser = await launchBrowser({ headless: true });
+});
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+async function openPage(
+	mode: 'dev' | 'prod',
+	placement: 'inside' | 'outside',
+): Promise<{
+	failures: string[];
+	page: Page;
+	server: ViteDevServer;
+}> {
+	const server = await createServer({
+		cacheDir: resolve(
+			HERE,
+			`../../../../../node_modules/.vite/octane-activity-view-transition-${mode}`,
+		),
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		plugins: [octane(mode === 'prod' ? { hmr: false } : {})],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	const failures: string[] = [];
+	let page: Page | undefined;
+	try {
+		await server.listen();
+		const address = server.httpServer!.address();
+		if (!address || typeof address === 'string') throw new Error('Vite did not expose a TCP port');
+		page = await browser.newPage();
+		page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+		page.on('console', (message) => {
+			if (message.type() === 'error' || message.type() === 'warning') {
+				failures.push(`${message.type()}: ${message.text()}`);
+			}
+		});
+		await page.goto(`http://127.0.0.1:${address.port}/?placement=${placement}`);
+		await page.waitForFunction(() => Boolean(window.__activityViewTransition));
+		return { failures, page, server };
+	} catch (error) {
+		await Promise.allSettled([page?.close(), server.close()]);
+		throw error;
+	}
+}
+
+async function transition(page: Page, mode: 'visible' | 'hidden', text: string) {
+	const mark = await page.evaluate(
+		({ mode, text }) => window.__activityViewTransition.render(mode, text),
+		{ mode, text },
+	);
+	await page.waitForFunction(
+		({ mode, text }) => {
+			const panel = document.querySelector('#activity-transition-panel') as HTMLElement;
+			return (
+				panel.querySelector('span')!.textContent === text &&
+				(getComputedStyle(panel).display === 'none') === (mode === 'hidden')
+			);
+		},
+		{ mode, text },
+	);
+	return page.evaluate((mark) => window.__activityViewTransition.settle(mark), mark);
+}
+
+describe.sequential('Activity View Transitions in a real browser', () => {
+	it.each([
+		['dev', 'inside'],
+		['dev', 'outside'],
+		['prod', 'inside'],
+		['prod', 'outside'],
+	] as const)(
+		'%s preserves Activity %s ViewTransition across native enter/exit',
+		async (mode, placement) => {
+			const { failures, page, server } = await openPage(mode, placement);
+			try {
+				const initial = await page.evaluate(() => window.__activityViewTransition.snapshot());
+				expect(initial).toEqual({
+					connected: true,
+					hidden: true,
+					panelIdentity: true,
+					inputIdentity: true,
+					inputValue: 'draft',
+					text: 'initial',
+					transitionName: '',
+				});
+
+				const revealed = await transition(page, 'visible', 'initial');
+				expect(revealed).toMatchObject({ ...initial, hidden: false });
+				expect(revealed.events).toEqual([
+					{ kind: 'enter', name: 'activity-panel', hasAnimation: true },
+				]);
+				expect(revealed.nativeCalls).toEqual([
+					{ ready: 'fulfilled', update: 'fulfilled', finished: 'fulfilled' },
+				]);
+				await page.locator('#activity-transition-input').fill('preserved draft');
+
+				const updated = await transition(page, 'visible', 'longer visible content');
+				expect(updated).toMatchObject({
+					...initial,
+					hidden: false,
+					inputValue: 'preserved draft',
+					text: 'longer visible content',
+				});
+				expect(updated.events).toEqual([
+					{ kind: 'update', name: 'activity-panel', hasAnimation: true },
+				]);
+
+				const hidden = await transition(page, 'hidden', 'longer visible content');
+				expect(hidden).toMatchObject({
+					...initial,
+					inputValue: 'preserved draft',
+					text: 'longer visible content',
+				});
+				expect(hidden.events).toEqual([
+					{ kind: 'exit', name: 'activity-panel', hasAnimation: true },
+				]);
+				expect(hidden.nativeCalls).toEqual([
+					{ ready: 'fulfilled', update: 'fulfilled', finished: 'fulfilled' },
+				]);
+
+				const background = await transition(page, 'hidden', 'background content');
+				expect(background).toMatchObject({
+					...initial,
+					inputValue: 'preserved draft',
+					text: 'background content',
+				});
+				expect(background.events).toEqual([]);
+				// Skipping before the native API call is also valid. If a transition was
+				// started to apply this commit, native `ready` must reject (no animation)
+				// while the actual update and completion still succeed.
+				for (const call of background.nativeCalls) {
+					expect(call).toEqual({ ready: 'rejected', update: 'fulfilled', finished: 'fulfilled' });
+				}
+
+				const restored = await transition(page, 'visible', 'background content');
+				expect(restored).toMatchObject({
+					...initial,
+					hidden: false,
+					inputValue: 'preserved draft',
+					text: 'background content',
+				});
+				expect(restored.events).toEqual([
+					{ kind: 'enter', name: 'activity-panel', hasAnimation: true },
+				]);
+				expect(failures).toEqual([]);
+			} finally {
+				try {
+					await page.evaluate(() => window.__activityViewTransition.unmount());
+				} finally {
+					await Promise.allSettled([page.close(), server.close()]);
+				}
+			}
+		},
+	);
+});

--- a/packages/octane/tests/browser/activity-view-transition/index.html
+++ b/packages/octane/tests/browser/activity-view-transition/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane Activity View Transitions</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/activity-view-transition/main.ts
+++ b/packages/octane/tests/browser/activity-view-transition/main.ts
@@ -1,0 +1,134 @@
+import {
+	createRoot,
+	flushSync,
+	startTransition,
+	type ViewTransitionInstance,
+} from '../../../src/index.js';
+import {
+	ActivityTransitionApp,
+	WrappedActivityTransitionApp,
+	type ActivityTransitionProps,
+} from '../../conformance/_fixtures/view-transition.tsrx';
+
+type Status = 'pending' | 'fulfilled' | 'rejected';
+type Activation = 'enter' | 'exit' | 'update';
+interface NativeObservation {
+	ready: Status;
+	update: Status;
+	finished: Status;
+}
+
+const container = document.querySelector('#root') as HTMLElement;
+const Host =
+	new URLSearchParams(location.search).get('placement') === 'inside'
+		? WrappedActivityTransitionApp
+		: ActivityTransitionApp;
+const events: Array<{ kind: Activation; name: string; hasAnimation: boolean }> = [];
+const nativeCalls: NativeObservation[] = [];
+const pending: Promise<void>[] = [];
+const nativeStartViewTransition = document.startViewTransition;
+if (typeof nativeStartViewTransition !== 'function') {
+	throw new Error('This test requires the native document.startViewTransition API');
+}
+
+// Observe the browser boundary, but keep the native callback scheduling, capture,
+// promises and animation objects intact. No View Transition mock runs here.
+document.startViewTransition = function (...args) {
+	const transition = Reflect.apply(nativeStartViewTransition, document, args) as ViewTransition;
+	const observation: NativeObservation = {
+		ready: 'pending',
+		update: 'pending',
+		finished: 'pending',
+	};
+	nativeCalls.push(observation);
+	pending.push(
+		(async () => {
+			const outcomes = await Promise.allSettled([
+				transition.ready,
+				transition.updateCallbackDone,
+				transition.finished,
+			]);
+			observation.ready = outcomes[0].status;
+			observation.update = outcomes[1].status;
+			observation.finished = outcomes[2].status;
+		})(),
+	);
+	return transition;
+};
+
+function record(kind: Activation, instance: ViewTransitionInstance): void {
+	events.push({
+		kind,
+		name: instance.name,
+		hasAnimation: instance[kind === 'exit' ? 'old' : 'new'].getAnimations().length > 0,
+	});
+}
+
+const props: ActivityTransitionProps = {
+	mode: 'hidden',
+	text: 'initial',
+	onEnter: (instance) => record('enter', instance),
+	onExit: (instance) => record('exit', instance),
+	onUpdate: (instance) => record('update', instance),
+};
+const root = createRoot(container);
+root.render(Host, props);
+const initialPanel = container.querySelector('#activity-transition-panel') as HTMLElement;
+const initialInput = container.querySelector('#activity-transition-input') as HTMLInputElement;
+
+function snapshot() {
+	const panel = container.querySelector('#activity-transition-panel') as HTMLElement;
+	const input = container.querySelector('#activity-transition-input') as HTMLInputElement;
+	return {
+		connected: panel.isConnected && input.isConnected,
+		hidden: getComputedStyle(panel).display === 'none',
+		panelIdentity: panel === initialPanel,
+		inputIdentity: input === initialInput,
+		inputValue: input.value,
+		text: panel.querySelector('span')!.textContent,
+		transitionName: panel.style.viewTransitionName,
+	};
+}
+
+function render(mode: ActivityTransitionProps['mode'], text: string) {
+	const mark = { nativeStart: nativeCalls.length, eventStart: events.length };
+	startTransition(() => root.render(Host, { ...props, mode, text }));
+	return mark;
+}
+
+async function settle(mark: ReturnType<typeof render>) {
+	// The driver may skip a hidden-only update before or after calling the native
+	// API. The caller first observes the committed DOM, then waits for any native
+	// handles that actually exist, without assuming an internal flush count.
+	for (let i = mark.nativeStart; i < pending.length; i++) await pending[i];
+	return {
+		...snapshot(),
+		events: events.slice(mark.eventStart),
+		nativeCalls: nativeCalls.slice(mark.nativeStart),
+	};
+}
+
+window.__activityViewTransition = {
+	render,
+	settle,
+	snapshot,
+	async unmount() {
+		try {
+			flushSync(() => root.unmount());
+			await Promise.all(pending);
+		} finally {
+			document.startViewTransition = nativeStartViewTransition;
+		}
+	},
+};
+
+declare global {
+	interface Window {
+		__activityViewTransition: {
+			render: typeof render;
+			settle: typeof settle;
+			snapshot: typeof snapshot;
+			unmount(): Promise<void>;
+		};
+	}
+}

--- a/packages/octane/tests/conformance/_fixtures/activity-dom-insertion-helpers.ts
+++ b/packages/octane/tests/conformance/_fixtures/activity-dom-insertion-helpers.ts
@@ -1,0 +1,16 @@
+import { useInsertionEffect } from 'octane';
+
+function useSharedInsertion(label: string, log: (entry: string) => void): void {
+	useInsertionEffect(() => {
+		log('insertion shared mount:' + label);
+		return () => log('insertion shared cleanup:' + label);
+	}, [label, log]);
+}
+
+// Plain-TypeScript hook transforms slot the base hook but do not wrap these
+// nested custom-hook calls. Both enqueues share one effective slot, and both
+// bodies must remain observable when a completed memo child survives suspension.
+export function useRepeatedSharedInsertions(log: (entry: string) => void): void {
+	useSharedInsertion('first', log);
+	useSharedInsertion('second', log);
+}

--- a/packages/octane/tests/conformance/_fixtures/activity-dom.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/activity-dom.tsrx
@@ -1,0 +1,465 @@
+import {
+	Activity,
+	bindRendererRegionOwner,
+	createContext,
+	createElement,
+	createPortal,
+	memo,
+	use,
+	useEffect,
+	useInsertionEffect,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from 'octane';
+import { useRepeatedSharedInsertions } from './activity-dom-insertion-helpers.js';
+
+export type ActivityMode = 'visible' | 'hidden';
+export type InputReference = { current: HTMLInputElement | null };
+export type ButtonReference = (element: HTMLButtonElement | null) => void | (() => void);
+type Log = (entry: string) => void;
+
+interface RefProps {
+	mode: ActivityMode;
+	objectRef: InputReference;
+	callbackRef: ButtonReference | null;
+	log: Log;
+}
+
+function RefChild(props: RefProps) @{
+	useLayoutEffect(() => {
+		props.log('layout mount:' + (props.objectRef.current?.id ?? 'null'));
+		return () => {
+			props.log('layout cleanup:' + (props.objectRef.current?.id ?? 'null'));
+		};
+	}, []);
+	<>
+		<input id="activity-ref-input" defaultValue="draft" ref={props.objectRef} />
+		<button id="activity-ref-button" type="button" ref={props.callbackRef}>{'button'}</button>
+	</>
+}
+
+export function ActivityRefHost(props: RefProps) @{
+	<main>
+		<Activity mode={props.mode}>
+			<RefChild {...props} />
+		</Activity>
+	</main>
+}
+
+function DescriptorRefChild(props: RefProps) @{
+	useLayoutEffect(() => {
+		props.log('layout mount:' + (props.objectRef.current?.id ?? 'null'));
+		return () => {
+			props.log('layout cleanup:' + (props.objectRef.current?.id ?? 'null'));
+		};
+	}, []);
+	<>
+		{createElement('input', {
+			id: 'activity-ref-input',
+			defaultValue: 'draft',
+			ref: props.objectRef,
+		})}
+		{createElement(
+			'button',
+			{
+				id: 'activity-ref-button',
+				type: 'button',
+				ref: props.callbackRef,
+			},
+			'button',
+		)}
+	</>
+}
+
+export function ActivityDescriptorRefHost(props: RefProps) @{
+	<main>
+		<Activity mode={props.mode}>
+			<DescriptorRefChild {...props} />
+		</Activity>
+	</main>
+}
+
+export function NestedActivityRefHost(props: RefProps & { inner: ActivityMode }) @{
+	<main>
+		<Activity mode={props.mode}>
+			<Activity mode={props.inner}>
+				<RefChild {...props} />
+			</Activity>
+		</Activity>
+	</main>
+}
+
+interface Values {
+	display: string | undefined;
+	color: string;
+	text: string;
+}
+
+export function ActivityValuesHost(props: Values & { mode: ActivityMode }) @{
+	<main id="activity-values">
+		<Activity mode={props.mode}>
+			<section
+				id="activity-values-styled"
+				style={{ display: props.display, color: props.color }}
+			>{'styled'}</section>
+			{props.text as string}
+		</Activity>
+	</main>
+}
+
+function PortalItem(props: { id: string; display: string; log: Log }) @{
+	const [count, setCount] = useState(0);
+	useLayoutEffect(() => {
+		props.log('layout mount:' + props.id);
+		return () => props.log('layout cleanup:' + props.id);
+	}, []);
+	useEffect(() => {
+		props.log('passive mount:' + props.id);
+		return () => props.log('passive cleanup:' + props.id);
+	}, []);
+	<button
+		id={'activity-portal-' + props.id}
+		type="button"
+		style={{ display: props.display }}
+		onClick={() => setCount((value) => value + 1)}
+	>
+		{props.id + ':' + count}
+	</button>
+}
+
+interface PortalProps {
+	mode: ActivityMode;
+	target: Element;
+	secondTarget?: Element;
+	showPortal: boolean;
+	items: readonly string[];
+	display: string;
+	log: Log;
+}
+
+function PortalContents(props: PortalProps) @{
+	<>
+		@for (const id of props.items; key id) {
+			<PortalItem id={id} display={props.display} log={props.log} />
+		}
+		@if (props.secondTarget) {
+			<aside id="activity-portal-nested-host">{createPortal(
+				<PortalItem id="nested" display={props.display} log={props.log} />,
+				props.secondTarget,
+			)}</aside>
+		}
+	</>
+}
+
+export function ActivityPortalHost(props: PortalProps) @{
+	<main>
+		<Activity mode={props.mode}>
+			<section id="activity-portal-inline">
+				@if (props.showPortal) {
+					<div>{createPortal(<PortalContents {...props} />, props.target)}</div>
+				}
+			</section>
+		</Activity>
+	</main>
+}
+
+export function NestedPortalActivityHost(props: {
+	outer: ActivityMode;
+	inner: ActivityMode;
+	target: Element;
+}) @{
+	<main>
+		<Activity mode={props.outer}>
+			<section id="activity-portal-inline">{createPortal(
+				<Activity mode={props.inner}>
+					<button
+						id="activity-portal-nested"
+						type="button"
+						style="display: inline-flex"
+					>{'nested'}</button>
+				</Activity>,
+				props.target,
+			)}</section>
+		</Activity>
+	</main>
+}
+
+function MaybeSuspend(props: { pending: boolean; promise: Promise<string> }) @{
+	if (props.pending) use(props.promise);
+	<span id="activity-portal-ready">{'ready'}</span>
+}
+
+function PortalSuspense(props: {
+	promise: Promise<string>;
+	expose: (setter: (pending: boolean) => void) => void;
+}) @{
+	const [pending, setPending] = useState(false);
+	props.expose(setPending);
+	<>
+		@try {
+			<>
+				<strong id="activity-portal-primary" style="display: inline-flex">{'primary'}</strong>
+				<MaybeSuspend pending={pending} promise={props.promise} />
+			</>
+		} @pending {
+			<em id="activity-portal-pending">{'loading'}</em>
+		}
+	</>
+}
+
+export function ActivitySuspensePortalHost(props: {
+	mode: ActivityMode;
+	target: Element;
+	promise: Promise<string>;
+	expose: (setter: (pending: boolean) => void) => void;
+}) @{
+	<main>
+		<Activity mode={props.mode}>
+			<div>{createPortal(
+				<PortalSuspense promise={props.promise} expose={props.expose} />,
+				props.target,
+			)}</div>
+		</Activity>
+	</main>
+}
+
+function AsyncActivityChild(props: { promise: Promise<string>; log: Log }) @{
+	const value = use(props.promise);
+	useEffect(() => {
+		props.log('mount');
+		return () => props.log('cleanup');
+	}, []);
+	<span id="activity-async-child">{value as string}</span>
+}
+
+export function ActivityAsyncHost(props: {
+	mode: ActivityMode;
+	promise: Promise<string>;
+	log: Log;
+}) @{
+	<main>
+		@try {
+			<>
+				<b id="activity-async-sibling">{'visible sibling'}</b>
+				<Activity mode={props.mode}>
+					<AsyncActivityChild promise={props.promise} log={props.log} />
+				</Activity>
+			</>
+		} @pending {
+			<em id="activity-async-fallback">{'loading'}</em>
+		}
+	</main>
+}
+
+export function ActivityGuardedRefHost(props: {
+	mode: ActivityMode;
+	first: ButtonReference;
+	second: ButtonReference;
+}) @{
+	<main>
+		@try {
+			<Activity mode={props.mode}>
+				<button id="activity-guarded-first" ref={props.first}>{'first'}</button>
+				<button id="activity-guarded-second" ref={props.second}>{'second'}</button>
+			</Activity>
+		} @catch (error) {
+			<strong id="activity-guarded-error">{error.message as string}</strong>
+		}
+	</main>
+}
+
+interface StatefulAsyncProps {
+	mode: ActivityMode;
+	show: boolean;
+	promise: Promise<string>;
+	expose: (setter: (value: number) => void) => void;
+	log: Log;
+}
+
+function StatefulAsyncChild(props: StatefulAsyncProps) @{
+	const [count, setCount] = useState(0);
+	props.expose(setCount);
+	const value =
+		count === 1 ? use(props.promise) : 'ready';
+	useLayoutEffect(() => {
+		props.log('layout mount:' + count);
+		return () => props.log('layout cleanup:' + count);
+	}, [count]);
+	useEffect(() => {
+		props.log('passive mount:' + count);
+		return () => props.log('passive cleanup:' + count);
+	}, [count]);
+	<>
+		<input id="activity-stateful-input" defaultValue="draft" />
+		<span id="activity-stateful-value">{value + ':' + count}</span>
+	</>
+}
+
+export function ActivityStatefulAsyncHost(props: StatefulAsyncProps) @{
+	<main>
+		@try {
+			<>
+				<b id="activity-stateful-sibling">{'visible sibling'}</b>
+				@if (props.show) {
+					<Activity mode={props.mode}>
+						<StatefulAsyncChild {...props} />
+					</Activity>
+				}
+			</>
+		} @pending {
+			<em id="activity-stateful-pending">{'loading'}</em>
+		} @catch (error) {
+			<strong id="activity-stateful-error">{error.message as string}</strong>
+		}
+	</main>
+}
+
+function InsertionBeforeSuspend(props: { value: number; log: Log }) @{
+	useInsertionEffect(() => {
+		props.log('insertion mount:' + props.value);
+		return () => props.log('insertion cleanup:' + props.value);
+	}, [props.value]);
+	<i id="activity-insertion-before">{props.value as number}</i>
+}
+
+const MemoInsertionBeforeSuspend = memo(InsertionBeforeSuspend);
+type InsertionChildVariant = 'plain' | 'memo' | 'cached';
+
+function InsertionAsyncChildren(props: {
+	promise: Promise<string>;
+	initial: number;
+	variant: InsertionChildVariant;
+	expose: (setter: (value: number) => void) => void;
+	log: Log;
+}) @{
+	const [value, setValue] = useState(props.initial);
+	props.expose(setValue);
+	const cachedChild = useMemo(
+		() => createElement(InsertionBeforeSuspend, { value, log: props.log }),
+		[value, props.log],
+	);
+	<>
+		@switch (props.variant) {
+			@case 'memo': {
+				<MemoInsertionBeforeSuspend value={value} log={props.log} />
+			}
+			@case 'cached': {
+				{cachedChild}
+			}
+			@default: {
+				<InsertionBeforeSuspend value={value} log={props.log} />
+			}
+		}
+		<MaybeSuspend pending={value === 1} promise={props.promise} />
+	</>
+}
+
+export function ActivityInsertionAsyncHost(props: {
+	mode: ActivityMode;
+	promise: Promise<string>;
+	initial: number;
+	variant: InsertionChildVariant;
+	expose: (setter: (value: number) => void) => void;
+	log: Log;
+}) @{
+	<main>
+		@try {
+			<>
+				<b id="activity-insertion-sibling">{'visible sibling'}</b>
+				<Activity mode={props.mode}>
+					<InsertionAsyncChildren {...props} />
+				</Activity>
+			</>
+		} @pending {
+			<em id="activity-insertion-pending">{'loading'}</em>
+		}
+	</main>
+}
+
+function ConditionalInsertionBeforeSuspend(props: {
+	value: number;
+	enabled: boolean;
+	log: Log;
+}) @{
+	if (props.enabled) {
+		useInsertionEffect(() => {
+			props.log('insertion mount:' + props.value);
+			return () => props.log('insertion cleanup:' + props.value);
+		}, [props.value]);
+	}
+	<i id="activity-insertion-before">{props.value as number}</i>
+}
+
+const MemoConditionalInsertionBeforeSuspend = memo(ConditionalInsertionBeforeSuspend);
+
+export function ActivityInsertionRetryHost(props: {
+	value: number;
+	enabled: boolean;
+	pending: boolean;
+	promise: Promise<string>;
+	log: Log;
+}) @{
+	<Activity mode="hidden">
+		<MemoConditionalInsertionBeforeSuspend
+			value={props.value}
+			enabled={props.enabled}
+			log={props.log}
+		/>
+		<MaybeSuspend pending={props.pending} promise={props.promise} />
+	</Activity>
+}
+
+function RepeatedInsertionBeforeSuspend(props: { log: Log }) @{
+	useRepeatedSharedInsertions(props.log);
+	<i id="activity-insertion-repeated">{'repeated'}</i>
+}
+
+const MemoRepeatedInsertionBeforeSuspend = memo(RepeatedInsertionBeforeSuspend);
+
+export function ActivityRepeatedInsertionHost(props: {
+	pending: boolean;
+	promise: Promise<string>;
+	log: Log;
+}) @{
+	<Activity mode="hidden">
+		<MemoRepeatedInsertionBeforeSuspend log={props.log} />
+		<MaybeSuspend pending={props.pending} promise={props.promise} />
+	</Activity>
+}
+
+const InsertionRetryPhaseContext = createContext(0);
+
+function NestedInsertionRetryConsumer(props: { innerPromise: Promise<string>; log: Log }) @{
+	const phase = use(InsertionRetryPhaseContext);
+	<Activity mode={phase === 2 ? 'hidden' : 'visible'}>
+		<MemoInsertionBeforeSuspend value={phase === 0 ? 0 : 1} log={props.log} />
+		<MaybeSuspend pending={phase === 2} promise={props.innerPromise} />
+	</Activity>
+}
+
+function NestedInsertionRetryShell(props: { innerPromise: Promise<string>; log: Log }) @{
+	<NestedInsertionRetryConsumer {...props} />
+}
+
+const MemoNestedInsertionRetryShell = memo(NestedInsertionRetryShell);
+
+export function ActivityNestedInsertionRetryHost(props: {
+	phase: number;
+	innerPromise: Promise<string>;
+	outerPromise: Promise<string>;
+	log: Log;
+}) @{
+	<InsertionRetryPhaseContext.Provider value={props.phase}>
+		<Activity mode="hidden">
+			<MemoNestedInsertionRetryShell innerPromise={props.innerPromise} log={props.log} />
+			<MaybeSuspend pending={props.phase === 1} promise={props.outerPromise} />
+		</Activity>
+	</InsertionRetryPhaseContext.Provider>
+}
+
+export function ActivityRegionChild(props: { thenable: Promise<void> }) @{
+	bindRendererRegionOwner(props);
+	use(props.thenable);
+	<span id="activity-region-ready">{'ready'}</span>
+}

--- a/packages/octane/tests/conformance/_fixtures/view-transition.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/view-transition.tsrx
@@ -1,4 +1,4 @@
-import { ViewTransition, use } from 'octane';
+import { Activity, ViewTransition, use, type ViewTransitionProps } from 'octane';
 
 // Fixtures for conformance/view-transition.test.ts — ports of facebook/react
 // ReactDOMViewTransition-test.js (see the test file for per-`it` citations).
@@ -46,6 +46,48 @@ export function PlainApp(props) @{
 			</ViewTransition>
 		}
 	</>
+}
+
+export interface ActivityTransitionProps {
+	mode: 'visible' | 'hidden';
+	text: string;
+	onEnter?: ViewTransitionProps['onEnter'];
+	onExit?: ViewTransitionProps['onExit'];
+	onUpdate?: ViewTransitionProps['onUpdate'];
+}
+
+// Activity visibility changes retain the boundary and its hosts, but are still
+// enter/exit activations when committed inside a View Transition.
+export function ActivityTransitionApp(props: ActivityTransitionProps) @{
+	<Activity mode={props.mode}>
+		<ViewTransition
+			name="activity-panel"
+			onEnter={props.onEnter}
+			onExit={props.onExit}
+			onUpdate={props.onUpdate}
+		>
+			<section id="activity-transition-panel">
+				<input id="activity-transition-input" defaultValue="draft" />
+				<span>{props.text as string}</span>
+			</section>
+		</ViewTransition>
+	</Activity>
+}
+
+export function WrappedActivityTransitionApp(props: ActivityTransitionProps) @{
+	<ViewTransition
+		name="activity-panel"
+		onEnter={props.onEnter}
+		onExit={props.onExit}
+		onUpdate={props.onUpdate}
+	>
+		<Activity mode={props.mode}>
+			<section id="activity-transition-panel">
+				<input id="activity-transition-input" defaultValue="draft" />
+				<span>{props.text as string}</span>
+			</section>
+		</Activity>
+	</ViewTransition>
 }
 
 // Per ReactDOMViewTransition-test.js:425 — a ViewTransition around a Suspense

--- a/packages/octane/tests/conformance/activity-dom.test.ts
+++ b/packages/octane/tests/conformance/activity-dom.test.ts
@@ -1,0 +1,913 @@
+/**
+ * Activity DOM contracts from React 19.2.7's Activity-test.js and
+ * ReactFiberCommitWork.js, plus ReactDOMActivity-test.js at the repository's
+ * pinned canary b740af2510de1e19fcb399abb862af26ff95ac80.
+ * Hidden-work scheduling is intentionally different: Octane prerenders in the
+ * same pass. The assertions below concern committed visibility, refs, state,
+ * effects, and authored DOM values, not scheduler lanes or render counts.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRoot, flushSync, type ComponentBody } from '../../src/index.js';
+import { act, flushEffects, mount, type MountResult } from '../_helpers';
+import {
+	ActivityAsyncHost,
+	ActivityDescriptorRefHost,
+	ActivityGuardedRefHost,
+	ActivityInsertionAsyncHost,
+	ActivityInsertionRetryHost,
+	ActivityNestedInsertionRetryHost,
+	ActivityPortalHost,
+	ActivityRefHost,
+	ActivityRepeatedInsertionHost,
+	ActivitySuspensePortalHost,
+	ActivityStatefulAsyncHost,
+	ActivityValuesHost,
+	NestedActivityRefHost,
+	NestedPortalActivityHost,
+	type ActivityMode,
+	type ButtonReference,
+	type InputReference,
+} from './_fixtures/activity-dom.tsrx';
+
+const roots: MountResult[] = [];
+const targets: Element[] = [];
+
+function render<P>(body: ComponentBody<P>, props: P): MountResult {
+	const result = mount(body, props);
+	roots.push(result);
+	flushEffects();
+	return result;
+}
+
+function unmount(result: MountResult): void {
+	const index = roots.indexOf(result);
+	if (index !== -1) roots.splice(index, 1);
+	result.unmount();
+}
+
+function target(): HTMLDivElement {
+	const element = document.createElement('div');
+	document.body.appendChild(element);
+	targets.push(element);
+	return element;
+}
+
+function find<T extends HTMLElement = HTMLElement>(container: ParentNode, selector: string): T {
+	const element = container.querySelector(selector);
+	if (element === null) throw new Error(`Missing ${selector}`);
+	return element as T;
+}
+
+function directText(container: Element): string {
+	return Array.from(container.childNodes)
+		.filter((node): node is Text => node.nodeType === Node.TEXT_NODE)
+		.map((node) => node.data)
+		.join('');
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((done, fail) => {
+		resolve = done;
+		reject = fail;
+	});
+	return { promise, resolve, reject };
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) root.unmount();
+	for (const element of targets.splice(0)) element.remove();
+	flushEffects();
+});
+
+describe.each([
+	['compiled hosts', ActivityRefHost],
+	['element descriptors', ActivityDescriptorRefHost],
+] as const)('Activity refs — %s', (_label, Host) => {
+	// Per Activity-test.js:198 and ReactFiberCommitWork.js:2908/3098 (v19.2.7).
+	it('attaches initially hidden refs only when the preserved hosts become visible', () => {
+		const objectRef: InputReference = { current: null };
+		const calls: string[] = [];
+		const callbackRef: ButtonReference = (element) => {
+			if (element === null) {
+				calls.push('null');
+				return;
+			}
+			calls.push('attach');
+			return () => calls.push('cleanup');
+		};
+		const log: string[] = [];
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			objectRef,
+			callbackRef,
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(Host, props);
+		const input = find<HTMLInputElement>(result.container, '#activity-ref-input');
+		input.value = 'preserved draft';
+
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual([]);
+		expect(log).toEqual([]);
+		expect(input.style.display).toBe('none');
+
+		result.update(Host, { ...props, mode: 'visible' });
+		flushEffects();
+		expect(objectRef.current).toBe(input);
+		expect(input.value).toBe('preserved draft');
+		expect(calls).toEqual(['attach']);
+		expect(log).toEqual(['layout mount:activity-ref-input']);
+
+		unmount(result);
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual(['attach', 'cleanup']);
+	});
+
+	// Per Activity-test.js:433 and ReactFiberCommitWork.js:2953 (v19.2.7).
+	it('disconnects refs before hiding and reconnects only the latest refs on reveal', () => {
+		const objectRef: InputReference = { current: null };
+		const nextObjectRef: InputReference = { current: null };
+		const calls: string[] = [];
+		const callbackRef: ButtonReference = (element) => {
+			if (element === null) {
+				calls.push('old:null');
+				return;
+			}
+			calls.push('old:attach');
+			return () => {
+				calls.push(`old:cleanup:${element.isConnected}:${element.style.display}`);
+			};
+		};
+		const nextCallbackRef: ButtonReference = (element) => {
+			if (element === null) {
+				calls.push('next:null');
+				return;
+			}
+			calls.push('next:attach');
+			return () => calls.push('next:cleanup');
+		};
+		const log: string[] = [];
+		const props = {
+			mode: 'visible' as ActivityMode,
+			objectRef,
+			callbackRef,
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(Host, props);
+		const input = objectRef.current!;
+		const button = find<HTMLButtonElement>(result.container, '#activity-ref-button');
+		input.value = 'user draft';
+		calls.length = 0;
+		log.length = 0;
+
+		result.update(Host, { ...props, mode: 'hidden' });
+		flushEffects();
+		expect(log).toEqual(['layout cleanup:activity-ref-input']);
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual(['old:cleanup:true:']);
+		expect(button.style.display).toBe('none');
+		expect(find(result.container, '#activity-ref-input')).toBe(input);
+
+		const next = {
+			...props,
+			mode: 'hidden' as ActivityMode,
+			objectRef: nextObjectRef,
+			callbackRef: nextCallbackRef,
+		};
+		result.update(Host, next);
+		flushEffects();
+		expect(nextObjectRef.current).toBeNull();
+		expect(calls).toEqual(['old:cleanup:true:']);
+
+		result.update(Host, { ...next, mode: 'visible' });
+		flushEffects();
+		expect(objectRef.current).toBeNull();
+		expect(nextObjectRef.current).toBe(input);
+		expect(input.value).toBe('user draft');
+		expect(find(result.container, '#activity-ref-button')).toBe(button);
+		expect(calls).toEqual(['old:cleanup:true:', 'next:attach']);
+		expect(log).toEqual(['layout cleanup:activity-ref-input', 'layout mount:activity-ref-input']);
+
+		result.update(Host, next);
+		flushEffects();
+		expect(nextObjectRef.current).toBeNull();
+		expect(calls).toEqual(['old:cleanup:true:', 'next:attach', 'next:cleanup']);
+		unmount(result);
+		expect(calls).toEqual(['old:cleanup:true:', 'next:attach', 'next:cleanup']);
+	});
+
+	// Per ReactFiberCommitWork.js disappearLayoutEffects (v19.2.7).
+	it('disconnects the committed ref when the hide render replaces or removes it', () => {
+		const calls: string[] = [];
+		const oldRef: ButtonReference = (element) => {
+			if (element === null) return;
+			calls.push('old:attach');
+			return () => calls.push('old:cleanup:' + element.style.display);
+		};
+		const nextRef: ButtonReference = (element) => {
+			if (element === null) return;
+			calls.push('next:attach');
+			return () => calls.push('next:cleanup:' + element.style.display);
+		};
+		const props = {
+			mode: 'visible' as ActivityMode,
+			objectRef: { current: null } as InputReference,
+			callbackRef: oldRef,
+			log: () => {},
+		};
+		const result = render(Host, props);
+		const button = find(result.container, '#activity-ref-button');
+		result.update(Host, { ...props, mode: 'hidden', callbackRef: nextRef });
+		expect(calls).toEqual(['old:attach', 'old:cleanup:']);
+		expect(button.style.display).toBe('none');
+		result.update(Host, { ...props, callbackRef: nextRef });
+		expect(calls).toEqual(['old:attach', 'old:cleanup:', 'next:attach']);
+		result.update(Host, { ...props, mode: 'hidden', callbackRef: null });
+		expect(calls).toEqual(['old:attach', 'old:cleanup:', 'next:attach', 'next:cleanup:']);
+		result.update(Host, { ...props, callbackRef: null });
+		expect(find(result.container, '#activity-ref-button')).toBe(button);
+		unmount(result);
+		expect(calls).toEqual(['old:attach', 'old:cleanup:', 'next:attach', 'next:cleanup:']);
+	});
+});
+
+describe('Activity ref cleanup errors', () => {
+	// Per ReactErrorBoundaries-test.internal.js:2782 and Activity disappearance.
+	it('routes a throwing ref cleanup to its error boundary without skipping other refs', () => {
+		const container = target();
+		const error = new Error('Activity ref cleanup failed');
+		const reports: unknown[] = [];
+		const calls: string[] = [];
+		const root = createRoot(container, { onCaughtError: (value) => reports.push(value) });
+		const first: ButtonReference = (element) => {
+			if (element === null) return;
+			return () => {
+				calls.push('first:cleanup');
+				throw error;
+			};
+		};
+		const second: ButtonReference = (element) => {
+			if (element === null) return;
+			return () => calls.push('second:cleanup');
+		};
+		try {
+			flushSync(() => root.render(ActivityGuardedRefHost, { mode: 'visible', first, second }));
+			expect(() =>
+				flushSync(() =>
+					root.render(ActivityGuardedRefHost, {
+						mode: 'hidden',
+						first,
+						second,
+					}),
+				),
+			).not.toThrow();
+			expect(container.querySelector('#activity-guarded-error')?.textContent).toBe(error.message);
+			expect(container.querySelector('#activity-guarded-second')).toBeNull();
+			expect(calls).toEqual(['first:cleanup', 'second:cleanup']);
+			expect(reports).toEqual([error]);
+		} finally {
+			root.unmount();
+		}
+		expect(calls).toEqual(['first:cleanup', 'second:cleanup']);
+	});
+
+	// Disappearance cleanups may synchronously delete their own root.
+	it('finishes a reentrant unmount without repeating hidden ref cleanup', async () => {
+		const calls: string[] = [];
+		let result!: MountResult;
+		const first: ButtonReference = (element) => {
+			if (element === null) return;
+			return () => {
+				calls.push('first:cleanup');
+				unmount(result);
+			};
+		};
+		const second: ButtonReference = (element) => {
+			if (element === null) return;
+			return () => calls.push('second:cleanup');
+		};
+		result = render(ActivityGuardedRefHost, { mode: 'visible', first, second });
+		const container = result.container;
+		result.update(ActivityGuardedRefHost, { mode: 'hidden', first, second });
+		expect(container.isConnected).toBe(false);
+		expect(container.textContent).toBe('');
+		expect(calls).toEqual(['first:cleanup', 'second:cleanup']);
+		await act(async () => {});
+		const objectRef: InputReference = { current: null };
+		const next = render(ActivityRefHost, {
+			mode: 'hidden',
+			objectRef,
+			callbackRef: null,
+			log: () => {},
+		});
+		expect(objectRef.current).toBeNull();
+		next.update(ActivityRefHost, {
+			mode: 'visible',
+			objectRef,
+			callbackRef: null,
+			log: () => {},
+		});
+		expect(objectRef.current).toBe(find(next.container, '#activity-ref-input'));
+		unmount(next);
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual(['first:cleanup', 'second:cleanup']);
+	});
+});
+
+describe('Activity authored DOM values', () => {
+	// Per Activity-test.js:550 (v19.2.7): the boundary overrides visibility,
+	// while reveal must use the child's latest authored property value.
+	it('restores display updates made while the same host remains hidden', () => {
+		const props = {
+			mode: 'visible' as ActivityMode,
+			display: 'inline-flex',
+			color: 'red',
+			text: '',
+		};
+		const result = render(ActivityValuesHost, props);
+		const element = find(result.container, '#activity-values-styled');
+		result.update(ActivityValuesHost, { ...props, mode: 'hidden' });
+		result.update(ActivityValuesHost, {
+			...props,
+			mode: 'hidden',
+			display: 'grid',
+			color: 'blue',
+		});
+		expect(element.style.display).toBe('none');
+		expect(element.style.color).toBe('blue');
+
+		result.update(ActivityValuesHost, {
+			...props,
+			display: 'grid',
+			color: 'blue',
+		});
+		expect(find(result.container, '#activity-values-styled')).toBe(element);
+		expect(element.style.display).toBe('grid');
+		expect(element.style.color).toBe('blue');
+	});
+
+	// Per Activity-test.js:550 (v19.2.7).
+	it('preserves removal of an authored display value while hidden', () => {
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			display: 'inline-flex' as string | undefined,
+			color: 'red',
+			text: '',
+		};
+		const result = render(ActivityValuesHost, props);
+		const element = find(result.container, '#activity-values-styled');
+		result.update(ActivityValuesHost, { ...props, display: undefined });
+		expect(element.style.display).toBe('none');
+		result.update(ActivityValuesHost, { ...props, display: undefined, mode: 'visible' });
+		expect(element.style.display).toBe('');
+		expect(element.style.color).toBe('red');
+	});
+
+	// Per https://react.dev/reference/react/Activity#caveats (bare-text children).
+	it('restores the latest bare text after updates made while hidden', () => {
+		const props = {
+			mode: 'visible' as ActivityMode,
+			display: undefined,
+			color: 'red',
+			text: 'old text',
+		};
+		const result = render(ActivityValuesHost, props);
+		const host = find(result.container, '#activity-values');
+		expect(directText(host)).toBe('old text');
+		result.update(ActivityValuesHost, { ...props, mode: 'hidden' });
+		result.update(ActivityValuesHost, { ...props, mode: 'hidden', text: 'latest text' });
+		expect(directText(host)).toBe('');
+		result.update(ActivityValuesHost, { ...props, text: 'latest text' });
+		expect(directText(host)).toBe('latest text');
+	});
+});
+
+describe('nested Activity refs', () => {
+	// Per Activity-test.js:1362 and ReactFiberCommitWork.js:2962 (v19.2.7).
+	it('keeps refs disconnected until every enclosing Activity is visible', () => {
+		const objectRef: InputReference = { current: null };
+		const calls: string[] = [];
+		const callbackRef: ButtonReference = (element) => {
+			if (element === null) return;
+			calls.push('attach');
+			return () => calls.push('cleanup');
+		};
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			inner: 'hidden' as ActivityMode,
+			objectRef,
+			callbackRef,
+			log: () => {},
+		};
+		const result = render(NestedActivityRefHost, props);
+		const input = find<HTMLInputElement>(result.container, '#activity-ref-input');
+		expect(objectRef.current).toBeNull();
+		result.update(NestedActivityRefHost, { ...props, inner: 'visible' });
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual([]);
+		result.update(NestedActivityRefHost, { ...props, mode: 'visible', inner: 'visible' });
+		expect(objectRef.current).toBe(input);
+		expect(calls).toEqual(['attach']);
+
+		result.update(NestedActivityRefHost, props);
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual(['attach', 'cleanup']);
+		result.update(NestedActivityRefHost, { ...props, mode: 'visible' });
+		expect(objectRef.current).toBeNull();
+		expect(calls).toEqual(['attach', 'cleanup']);
+		result.update(NestedActivityRefHost, { ...props, mode: 'visible', inner: 'visible' });
+		expect(objectRef.current).toBe(input);
+		expect(calls).toEqual(['attach', 'cleanup', 'attach']);
+	});
+});
+
+describe('Activity portal visibility', () => {
+	// Per ReactDOMActivity-test.js:57/388 (React canary).
+	it('hides deeply nested portals and restores their DOM, state, and effects', () => {
+		const portalTarget = target();
+		const nestedTarget = target();
+		const log: string[] = [];
+		const props = {
+			mode: 'visible' as ActivityMode,
+			target: portalTarget,
+			secondTarget: nestedTarget,
+			showPortal: true,
+			items: ['a'],
+			display: 'inline-flex',
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityPortalHost, props);
+		const item = find<HTMLButtonElement>(portalTarget, '#activity-portal-a');
+		const nested = find(nestedTarget, '#activity-portal-nested');
+		flushSync(() => item.click());
+		expect(item.textContent).toBe('a:1');
+		log.length = 0;
+
+		result.update(ActivityPortalHost, { ...props, mode: 'hidden' });
+		flushEffects();
+		expect(find(result.container, '#activity-portal-inline').style.display).toBe('none');
+		expect(item.style.display).toBe('none');
+		expect(nested.style.display).toBe('none');
+		expect(log.sort()).toEqual([
+			'layout cleanup:a',
+			'layout cleanup:nested',
+			'passive cleanup:a',
+			'passive cleanup:nested',
+		]);
+		log.length = 0;
+
+		result.update(ActivityPortalHost, props);
+		flushEffects();
+		expect(find(portalTarget, '#activity-portal-a')).toBe(item);
+		expect(find(nestedTarget, '#activity-portal-nested')).toBe(nested);
+		expect(item.textContent).toBe('a:1');
+		expect(item.style.display).toBe('inline-flex');
+		expect(nested.style.display).toBe('inline-flex');
+		expect(log.sort()).toEqual([
+			'layout mount:a',
+			'layout mount:nested',
+			'passive mount:a',
+			'passive mount:nested',
+		]);
+	});
+
+	// Per ReactDOMActivity-test.js:152/218/437 (React canary).
+	it('keeps new portals and inserted portal children hidden until reveal', () => {
+		const portalTarget = target();
+		const log: string[] = [];
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			target: portalTarget,
+			showPortal: false,
+			items: ['a'],
+			display: 'inline-flex',
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityPortalHost, props);
+		expect(portalTarget.querySelector('#activity-portal-a')).toBeNull();
+		result.update(ActivityPortalHost, { ...props, showPortal: true });
+		flushEffects();
+		const item = find(portalTarget, '#activity-portal-a');
+		expect(item.style.display).toBe('none');
+		expect(log).toEqual([]);
+
+		const updated = { ...props, showPortal: true, items: ['a', 'b'], display: 'grid' };
+		result.update(ActivityPortalHost, updated);
+		flushEffects();
+		const added = find(portalTarget, '#activity-portal-b');
+		expect(item.style.display).toBe('none');
+		expect(added.style.display).toBe('none');
+		expect(log).toEqual([]);
+
+		result.update(ActivityPortalHost, { ...updated, mode: 'visible' });
+		flushEffects();
+		expect(find(portalTarget, '#activity-portal-a')).toBe(item);
+		expect(find(portalTarget, '#activity-portal-b')).toBe(added);
+		expect(item.style.display).toBe('grid');
+		expect(added.style.display).toBe('grid');
+		expect(log.sort()).toEqual([
+			'layout mount:a',
+			'layout mount:b',
+			'passive mount:a',
+			'passive mount:b',
+		]);
+	});
+
+	// Per ReactDOMActivity-test.js:102 (React canary).
+	it('does not reveal a portal until both nested Activity owners are visible', () => {
+		const portalTarget = target();
+		const props = {
+			outer: 'hidden' as ActivityMode,
+			inner: 'hidden' as ActivityMode,
+			target: portalTarget,
+		};
+		const result = render(NestedPortalActivityHost, props);
+		const item = find(portalTarget, '#activity-portal-nested');
+		expect(item.style.display).toBe('none');
+		result.update(NestedPortalActivityHost, { ...props, inner: 'visible' });
+		expect(item.style.display).toBe('none');
+		result.update(NestedPortalActivityHost, {
+			...props,
+			outer: 'visible',
+			inner: 'visible',
+		});
+		expect(item.style.display).toBe('inline-flex');
+
+		result.update(NestedPortalActivityHost, props);
+		result.update(NestedPortalActivityHost, { ...props, outer: 'visible' });
+		expect(item.style.display).toBe('none');
+		result.update(NestedPortalActivityHost, {
+			...props,
+			outer: 'visible',
+			inner: 'visible',
+		});
+		expect(item.style.display).toBe('inline-flex');
+	});
+
+	// Per ReactDOMActivity-test.js:288 (React canary).
+	it('keeps a portaled Suspense fallback and resumed primary hidden', () => {
+		const portalTarget = target();
+		let setPending!: (pending: boolean) => void;
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			target: portalTarget,
+			promise: new Promise<string>(() => {}),
+			expose: (setter: typeof setPending) => (setPending = setter),
+		};
+		const result = render(ActivitySuspensePortalHost, props);
+		const primary = find(portalTarget, '#activity-portal-primary');
+		expect(primary.style.display).toBe('none');
+		flushSync(() => setPending(true));
+		flushEffects();
+		expect(find(portalTarget, '#activity-portal-pending').style.display).toBe('none');
+
+		flushSync(() => setPending(false));
+		flushEffects();
+		expect(portalTarget.querySelector('#activity-portal-pending')).toBeNull();
+		expect(find(portalTarget, '#activity-portal-primary')).toBe(primary);
+		expect(primary.style.display).toBe('none');
+
+		result.update(ActivitySuspensePortalHost, { ...props, mode: 'visible' });
+		expect(primary.style.display).toBe('inline-flex');
+		expect(find(portalTarget, '#activity-portal-ready').style.display).toBe('');
+	});
+});
+
+describe('Activity background suspension', () => {
+	// Per ActivitySuspense-test.js:99 (v19.2.7).
+	it('does not replace visible siblings with a fallback when hidden content suspends', async () => {
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((done) => (resolve = done));
+		const log: string[] = [];
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			promise,
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityAsyncHost, props);
+		const sibling = find(result.container, '#activity-async-sibling');
+		expect(sibling.style.display).toBe('');
+		expect(result.container.querySelector('#activity-async-fallback')).toBeNull();
+		expect(log).toEqual([]);
+
+		await act(async () => {
+			resolve('ready');
+			await promise;
+		});
+		flushEffects();
+		const child = find(result.container, '#activity-async-child');
+		expect(child.textContent).toBe('ready');
+		expect(child.style.display).toBe('none');
+		expect(result.container.querySelector('#activity-async-fallback')).toBeNull();
+		expect(log).toEqual([]);
+
+		result.update(ActivityAsyncHost, { ...props, mode: 'visible' });
+		flushEffects();
+		expect(find(result.container, '#activity-async-sibling')).toBe(sibling);
+		expect(find(result.container, '#activity-async-child')).toBe(child);
+		expect(child.style.display).toBe('');
+		expect(log).toEqual(['mount']);
+	});
+
+	// Per ActivitySuspense-test.js:384 (v19.2.7).
+	it('retries hidden descendant state without revealing a fallback or losing preserved input state', async () => {
+		const pending = deferred<string>();
+		const log: string[] = [];
+		let setCount!: (value: number) => void;
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			show: true,
+			promise: pending.promise,
+			expose: (setter: typeof setCount) => (setCount = setter),
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityStatefulAsyncHost, props);
+		const input = find<HTMLInputElement>(result.container, '#activity-stateful-input');
+		const sibling = find(result.container, '#activity-stateful-sibling');
+		input.value = 'preserved edit';
+		flushSync(() => setCount(1));
+		expect(sibling.style.display).toBe('');
+		expect(result.container.querySelector('#activity-stateful-pending')).toBeNull();
+		expect(log).toEqual([]);
+
+		// A newer state can finish the hidden tree before its promise settles.
+		flushSync(() => setCount(2));
+		expect(find(result.container, '#activity-stateful-input')).toBe(input);
+		expect(input.value).toBe('preserved edit');
+		expect(find(result.container, '#activity-stateful-value').textContent).toBe('ready:2');
+		expect(input.style.display).toBe('none');
+		await act(async () => {
+			pending.resolve('obsolete');
+			await pending.promise;
+		});
+		expect(result.container.querySelector('#activity-stateful-pending')).toBeNull();
+		expect(log).toEqual([]);
+		result.update(ActivityStatefulAsyncHost, { ...props, mode: 'visible' });
+		flushEffects();
+		expect(find(result.container, '#activity-stateful-sibling')).toBe(sibling);
+		expect(input.value).toBe('preserved edit');
+		expect(input.style.display).toBe('');
+		expect(log).toEqual(['layout mount:2', 'passive mount:2']);
+	});
+
+	// Per ActivitySuspense-test.js:293 (v19.2.7).
+	it('can hide already-suspended visible content and re-suspend when revealed', async () => {
+		const pending = deferred<string>();
+		const log: string[] = [];
+		let setCount!: (value: number) => void;
+		const props = {
+			mode: 'visible' as ActivityMode,
+			show: true,
+			promise: pending.promise,
+			expose: (setter: typeof setCount) => (setCount = setter),
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityStatefulAsyncHost, props);
+		const input = find<HTMLInputElement>(result.container, '#activity-stateful-input');
+		const sibling = find(result.container, '#activity-stateful-sibling');
+		input.value = 'kept through suspense';
+		flushSync(() => setCount(1));
+		expect(find(result.container, '#activity-stateful-pending').textContent).toBe('loading');
+		result.update(ActivityStatefulAsyncHost, { ...props, mode: 'hidden' });
+		flushEffects();
+		expect(result.container.querySelector('#activity-stateful-pending')).toBeNull();
+		expect(sibling.style.display).toBe('');
+		expect(input.style.display).toBe('none');
+		expect(log).toEqual([
+			'layout mount:0',
+			'passive mount:0',
+			'layout cleanup:0',
+			'passive cleanup:0',
+		]);
+		result.update(ActivityStatefulAsyncHost, props);
+		expect(find(result.container, '#activity-stateful-pending').textContent).toBe('loading');
+		await act(async () => {
+			pending.resolve('resolved');
+			await pending.promise;
+		});
+		flushEffects();
+		expect(result.container.querySelector('#activity-stateful-pending')).toBeNull();
+		expect(find(result.container, '#activity-stateful-input')).toBe(input);
+		expect(input.value).toBe('kept through suspense');
+		expect(input.style.display).toBe('');
+		expect(find(result.container, '#activity-stateful-value').textContent).toBe('resolved:1');
+		expect(log.slice(-2)).toEqual(['layout mount:1', 'passive mount:1']);
+	});
+
+	// Per ActivitySuspense-test.js:99/384: hidden suspension is not an error boundary.
+	it('routes rejected hidden work to the enclosing error boundary', async () => {
+		const pending = deferred<string>();
+		const log: string[] = [];
+		let setCount!: (value: number) => void;
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			show: true,
+			promise: pending.promise,
+			expose: (setter: typeof setCount) => (setCount = setter),
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityStatefulAsyncHost, props);
+		flushSync(() => setCount(1));
+		expect(find(result.container, '#activity-stateful-sibling').style.display).toBe('');
+		expect(result.container.querySelector('#activity-stateful-pending')).toBeNull();
+		await act(async () => {
+			pending.reject(new Error('background request failed'));
+			await pending.promise.catch(() => {});
+		});
+		expect(find(result.container, '#activity-stateful-error').textContent).toBe(
+			'background request failed',
+		);
+		expect(result.container.querySelector('#activity-stateful-input')).toBeNull();
+		expect(log).toEqual([]);
+	});
+
+	// Per ActivitySuspense-test.js:99: deleting a prerender must cancel its retry.
+	it('does not resurrect removed hidden work when its promise resolves', async () => {
+		const pending = deferred<string>();
+		const log: string[] = [];
+		let setCount!: (value: number) => void;
+		const props = {
+			mode: 'hidden' as ActivityMode,
+			show: true,
+			promise: pending.promise,
+			expose: (setter: typeof setCount) => (setCount = setter),
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityStatefulAsyncHost, props);
+		flushSync(() => setCount(1));
+		expect(find(result.container, '#activity-stateful-sibling').style.display).toBe('');
+		result.update(ActivityStatefulAsyncHost, { ...props, show: false });
+		await act(async () => {
+			pending.resolve('too late');
+			await pending.promise;
+		});
+		expect(result.container.querySelector('#activity-stateful-input')).toBeNull();
+		expect(result.container.querySelector('#activity-stateful-pending')).toBeNull();
+		expect(find(result.container, '#activity-stateful-sibling').style.display).toBe('');
+		expect(log).toEqual([]);
+	});
+
+	// Stable React 19.2.7 oracle: an insertion effect ahead of a suspending
+	// sibling commits only after the hidden render completes, not on its attempt.
+	it.each([
+		['plain', 0],
+		['plain', 1],
+		['memo', 0],
+		['memo', 1],
+		['cached', 0],
+		['cached', 1],
+	] as const)(
+		'does not commit insertion effects from suspended hidden work (%s, initial %s)',
+		async (variant, initial) => {
+			const pending = deferred<string>();
+			const log: string[] = [];
+			let setValue!: (value: number) => void;
+			const props = {
+				mode: 'hidden' as ActivityMode,
+				promise: pending.promise,
+				initial,
+				variant,
+				expose: (setter: typeof setValue) => (setValue = setter),
+				log: (entry: string) => log.push(entry),
+			};
+			const result = render(ActivityInsertionAsyncHost, props);
+			if (initial === 0) {
+				expect(log).toEqual(['insertion mount:0']);
+				log.length = 0;
+				flushSync(() => setValue(1));
+			}
+			expect(find(result.container, '#activity-insertion-sibling').style.display).toBe('');
+			expect(result.container.querySelector('#activity-insertion-pending')).toBeNull();
+			expect(log).toEqual([]);
+			await act(async () => {
+				pending.resolve('ready');
+				await pending.promise;
+			});
+			expect(log).toEqual(
+				initial === 0 ? ['insertion cleanup:0', 'insertion mount:1'] : ['insertion mount:1'],
+			);
+			expect(find(result.container, '#activity-insertion-before').style.display).toBe('none');
+			result.update(ActivityInsertionAsyncHost, { ...props, mode: 'visible' });
+			expect(log).toEqual(
+				initial === 0 ? ['insertion cleanup:0', 'insertion mount:1'] : ['insertion mount:1'],
+			);
+			unmount(result);
+			expect(log.at(-1)).toBe('insertion cleanup:1');
+		},
+	);
+
+	// A completed child can supersede an aborted insertion effect without queuing
+	// a replacement: its deps match the committed effect, or its slot-keyed hook
+	// is omitted. A later memo bailout must not resurrect that abandoned body.
+	it.each(['same-deps', 'omitted-slot'] as const)(
+		'discards superseded insertion effects across hidden retries (%s)',
+		async (variant) => {
+			const first = deferred<string>();
+			const second = deferred<string>();
+			const log: string[] = [];
+			const props = {
+				value: 0,
+				enabled: variant === 'same-deps',
+				pending: false,
+				promise: first.promise,
+				log: (entry: string) => log.push(entry),
+			};
+			const result = render(ActivityInsertionRetryHost, props);
+			expect(log).toEqual(variant === 'same-deps' ? ['insertion mount:0'] : []);
+			log.length = 0;
+			result.update(ActivityInsertionRetryHost, {
+				...props,
+				value: 1,
+				enabled: true,
+				pending: true,
+			});
+			expect(log).toEqual([]);
+			result.update(ActivityInsertionRetryHost, {
+				...props,
+				pending: true,
+				promise: second.promise,
+			});
+			expect(log).toEqual([]);
+			await act(async () => {
+				second.resolve('ready');
+				await second.promise;
+			});
+			const before = find(result.container, '#activity-insertion-before');
+			expect(before.textContent).toBe('0');
+			expect(before.style.display).toBe('none');
+			expect(log).toEqual([]);
+			await act(async () => {
+				first.resolve('superseded');
+				await first.promise;
+			});
+			expect(log).toEqual([]);
+			unmount(result);
+			expect(log).toEqual(variant === 'same-deps' ? ['insertion cleanup:0'] : []);
+		},
+	);
+
+	it.each([false, true])(
+		'preserves repeated insertion effects through one custom-hook slot (pending %s)',
+		async (pending) => {
+			const request = deferred<string>();
+			const log: string[] = [];
+			const result = render(ActivityRepeatedInsertionHost, {
+				pending,
+				promise: request.promise,
+				log: (entry: string) => log.push(entry),
+			});
+			if (pending) {
+				expect(log).toEqual([]);
+				await act(async () => {
+					request.resolve('ready');
+					await request.promise;
+				});
+			}
+			expect(log).toEqual(['insertion shared mount:first', 'insertion shared mount:second']);
+			expect(find(result.container, '#activity-insertion-repeated').style.display).toBe('none');
+			unmount(result);
+			expect(log).toEqual([
+				'insertion shared mount:first',
+				'insertion shared mount:second',
+				'insertion shared cleanup:second',
+			]);
+		},
+	);
+
+	// Stable React 19.2.7 oracle: moving an aborted insertion update from an outer
+	// Activity to a pending inner Activity does not commit it when the outer work
+	// completes. A memo/context refresh must leave the inner retry responsible.
+	it('transfers pending insertion effects to a nested Activity without committing early', async () => {
+		const inner = deferred<string>();
+		const outer = deferred<string>();
+		const log: string[] = [];
+		const props = {
+			phase: 0,
+			innerPromise: inner.promise,
+			outerPromise: outer.promise,
+			log: (entry: string) => log.push(entry),
+		};
+		const result = render(ActivityNestedInsertionRetryHost, props);
+		expect(log).toEqual(['insertion mount:0']);
+		log.length = 0;
+		result.update(ActivityNestedInsertionRetryHost, { ...props, phase: 1 });
+		expect(log).toEqual([]);
+		result.update(ActivityNestedInsertionRetryHost, { ...props, phase: 2 });
+		expect(log).toEqual([]);
+		await act(async () => {
+			inner.resolve('inner ready');
+			await inner.promise;
+		});
+		expect(log).toEqual(['insertion cleanup:0', 'insertion mount:1']);
+		expect(find(result.container, '#activity-insertion-before').style.display).toBe('none');
+		await act(async () => {
+			outer.resolve('superseded outer request');
+			await outer.promise;
+		});
+		expect(log).toEqual(['insertion cleanup:0', 'insertion mount:1']);
+		unmount(result);
+		expect(log).toEqual(['insertion cleanup:0', 'insertion mount:1', 'insertion cleanup:1']);
+	});
+});

--- a/packages/octane/tests/conformance/fragment-refs-activity.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-activity.test.ts
@@ -28,17 +28,42 @@ function renderGroup(mode: 'visible' | 'hidden') {
 	const innerRef: { current: FragmentInstance | null } = { current: null };
 	const wrappedRef: { current: FragmentInstance | null } = { current: null };
 	const props = { mode, fragmentRef, innerRef, wrappedRef };
-	mounted = mount(ActivityFragmentGroup, props);
+	mounted = mount(ActivityFragmentGroup, { ...props, mode: 'visible' });
+	const fragment = fragmentRef.current!;
+	const inner = innerRef.current!;
+	const wrapped = wrappedRef.current!;
+	if (mode === 'hidden') {
+		mounted.update(ActivityFragmentGroup, props);
+		expect(fragmentRef.current).toBe(fragment);
+		expect(innerRef.current).toBeNull();
+		expect(wrappedRef.current).toBeNull();
+	}
 	return {
 		result: mounted,
 		props,
-		fragment: fragmentRef.current!,
-		inner: innerRef.current!,
-		wrapped: wrappedRef.current!,
+		fragment,
+		inner,
+		wrapped,
 	};
 }
 
 describe('Fragment refs and Activity visibility', () => {
+	it('defers initially hidden Fragment refs until their Activity reveals', () => {
+		const fragmentRef: { current: FragmentInstance | null } = { current: null };
+		const innerRef: { current: FragmentInstance | null } = { current: null };
+		const wrappedRef: { current: FragmentInstance | null } = { current: null };
+		const props = { mode: 'hidden' as const, fragmentRef, innerRef, wrappedRef };
+		mounted = mount(ActivityFragmentGroup, props);
+		const outer = fragmentRef.current;
+		expect(outer).toBeInstanceOf(FragmentInstance);
+		expect(innerRef.current).toBeNull();
+		expect(wrappedRef.current).toBeNull();
+		mounted.update(ActivityFragmentGroup, { ...props, mode: 'visible' });
+		expect(fragmentRef.current).toBe(outer);
+		expect(innerRef.current).toBeInstanceOf(FragmentInstance);
+		expect(wrappedRef.current).toBeInstanceOf(FragmentInstance);
+	});
+
 	// Per ReactDOMFragmentRefs-test.js:959.
 	it('excludes hidden Activity children from listeners and fragment ownership', () => {
 		const { result, fragment, inner, wrapped } = renderGroup('hidden');

--- a/packages/octane/tests/conformance/fragment-refs-descriptors.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-descriptors.test.ts
@@ -324,7 +324,9 @@ describe('Fragment refs on public createElement descriptors', () => {
 		]);
 	});
 
-	it('keeps descriptor refs attached while Activity hides and reveals their hosts', () => {
+	// Per ReactFiberCommitWork.js disappearLayoutEffects/reappearLayoutEffects
+	// (React canary b740af2510de1e19fcb399abb862af26ff95ac80).
+	it('disconnects descriptor refs while Activity preserves and reveals their hosts', () => {
 		const fragmentRef: FragmentReference = { current: null };
 		const host = render(
 			createElement(ActivityDescriptorFragment, { fragmentRef, mode: 'visible' as const }),
@@ -337,7 +339,7 @@ describe('Fragment refs on public createElement descriptors', () => {
 		expect(child.reactFragments?.has(fragment)).toBe(true);
 
 		render(createElement(ActivityDescriptorFragment, { fragmentRef, mode: 'hidden' as const }));
-		expect(fragmentRef.current).toBe(fragment);
+		expect(fragmentRef.current).toBeNull();
 		expect(host.querySelector('#descriptor-activity-child')).toBe(child);
 		expect(child.style.display).toBe('none');
 		expect(child.reactFragments?.has(fragment)).toBe(false);

--- a/packages/octane/tests/conformance/view-transition.test.ts
+++ b/packages/octane/tests/conformance/view-transition.test.ts
@@ -27,6 +27,9 @@ import {
 	ExitApp,
 	UpdateApp,
 	PlainApp,
+	ActivityTransitionApp,
+	WrappedActivityTransitionApp,
+	type ActivityTransitionProps,
 	ShareApp,
 	SuspenseRevealApp,
 	NestedUnitApp,
@@ -155,6 +158,86 @@ describe('ReactDOMViewTransition (ported)', () => {
 			expect(exits.length).toBe(1);
 			expect(container.textContent).toBe('');
 		});
+
+		// Per https://react.dev/reference/react/Activity#caveats.
+		it.each([
+			['inside ViewTransition', WrappedActivityTransitionApp],
+			['outside ViewTransition', ActivityTransitionApp],
+		] as const)(
+			'activates enter and exit when Activity %s reveals and hides preserved content',
+			async (_label, Host) => {
+				const calls: string[] = [];
+				const props: ActivityTransitionProps = {
+					mode: 'hidden',
+					text: 'initial',
+					onEnter: () => {
+						calls.push('enter');
+					},
+					onExit: () => {
+						calls.push('exit');
+					},
+					onUpdate: () => {
+						calls.push('update');
+					},
+				};
+				await act(() => root.render(Host, props));
+				const panel = container.querySelector('#activity-transition-panel') as HTMLElement;
+				const input = container.querySelector('#activity-transition-input') as HTMLInputElement;
+				input.value = 'preserved draft';
+				expect(panel.style.display).toBe('none');
+				expect(calls).toEqual([]);
+
+				await act(() =>
+					startTransition(() =>
+						root.render(Host, {
+							...props,
+							mode: 'visible',
+						}),
+					),
+				);
+				expect(calls).toEqual(['enter']);
+				expect(panel.style.display).toBe('');
+				expect(container.querySelector('#activity-transition-input')).toBe(input);
+				expect(input.value).toBe('preserved draft');
+
+				await act(() =>
+					startTransition(() =>
+						root.render(Host, {
+							...props,
+							mode: 'visible',
+							text: 'longer visible content',
+						}),
+					),
+				);
+				expect(calls).toEqual(['enter', 'update']);
+				await act(() => startTransition(() => root.render(Host, props)));
+				expect(calls).toEqual(['enter', 'update', 'exit']);
+				expect(panel.style.display).toBe('none');
+
+				await act(() =>
+					startTransition(() =>
+						root.render(Host, {
+							...props,
+							text: 'background content',
+						}),
+					),
+				);
+				expect(calls).toEqual(['enter', 'update', 'exit']);
+				expect(panel.style.display).toBe('none');
+				await act(() =>
+					startTransition(() =>
+						root.render(Host, {
+							...props,
+							mode: 'visible',
+							text: 'background content',
+						}),
+					),
+				);
+				expect(calls).toEqual(['enter', 'update', 'exit', 'enter']);
+				expect(container.querySelector('#activity-transition-panel')).toBe(panel);
+				expect(input.value).toBe('preserved draft');
+			},
+		);
 
 		// Per ReactDOMViewTransition-test.js:324
 		it('fires onUpdate when content inside a ViewTransition changes', async () => {

--- a/packages/octane/tests/ssr-production-bundle.test.ts
+++ b/packages/octane/tests/ssr-production-bundle.test.ts
@@ -59,12 +59,39 @@ async function productionServerModule<T extends Record<string, unknown>>(
 					],
 	});
 
+	// A runtime failure should name the entry, not print the entire base64 bundle
+	// in every stack frame.
+	const code = result.outputFiles[0].text + '\n//# sourceURL=octane-production-server-bundle.js';
 	return import(
-		`data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+		`data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
 	) as Promise<T>;
 }
 
 describe('production-bundled server rendering', () => {
+	it('renders public client Activity descriptors without retaining the server sentinel export', async () => {
+		const { visible, hidden } = await productionServerModule<{
+			visible: string;
+			hidden: string;
+		}>(`
+import { Activity, createElement } from 'octane';
+import { renderToStaticMarkup } from 'octane/server';
+
+function HiddenChild() {
+	throw new Error('Hidden Activity children must not render on the server');
+}
+
+export const visible = renderToStaticMarkup(() =>
+	createElement(Activity, null, createElement('span', null, 'visible')),
+).html;
+export const hidden = renderToStaticMarkup(() =>
+	createElement(Activity, { mode: 'hidden' }, createElement(HiddenChild)),
+).html;
+`);
+
+		expect(visible).toBe('<span>visible</span>');
+		expect(hidden).toBe('');
+	});
+
 	it('preserves permanent-static markup alongside an explicitly retained deferred boundary', async () => {
 		const component = `
 import { Hydrate } from 'octane';

--- a/packages/octane/tests/universal-activity.test.ts
+++ b/packages/octane/tests/universal-activity.test.ts
@@ -1,27 +1,42 @@
 import { describe, expect, it } from 'vitest';
+import { type ComponentBody } from '../src/index.js';
 import {
+	type ObjectHostContainer,
 	type ObjectHostInstance,
+	type UniversalHostAttachmentBatch,
+	type UniversalHostDriver,
+	type UniversalRenderable,
 	createObjectContainer,
 	createObjectDriver,
 	createUniversalRoot,
 	defineUniversalComponent,
+	isRendererRegion,
+	rendererRegion,
 	universalActivity,
 	universalComponent,
 	universalPlan,
 	universalProps,
+	universalTry,
 	universalValue,
+	use,
 	useEffect,
 	useInsertionEffect,
 	useLayoutEffect,
 	useState,
 } from '../src/universal.js';
+import { mount as mountDom } from './_helpers';
 import { CompiledUniversalActivity } from './_fixtures/universal-activity.object.tsrx';
+import { ActivityRegionChild } from './conformance/_fixtures/activity-dom.tsrx';
 
 const hostPlan = universalPlan('object', {
 	kind: 'host',
 	type: 'node',
 	propsSlot: 0,
 });
+
+function labeledHost(label: string) {
+	return universalValue(hostPlan, [universalProps([['set', 'label', label]])]);
+}
 
 async function flushUniversalWork(count = 3) {
 	for (let index = 0; index < count; index++) await Promise.resolve();
@@ -37,7 +52,7 @@ describe('universal Activity visibility', () => {
 		root.render(CompiledUniversalActivity, { mode: 'hidden', hostRef });
 		const instance = container.children[0];
 		expect(instance.visible).toBe(false);
-		expect(refs).toEqual([instance]);
+		expect(refs).toEqual([]);
 		root.render(CompiledUniversalActivity, { mode: 'visible', hostRef });
 		expect(container.children[0]).toBe(instance);
 		expect(instance.visible).toBe(true);
@@ -45,7 +60,7 @@ describe('universal Activity visibility', () => {
 		root.unmount();
 	});
 
-	it('preserves the host, state, and ref while disconnecting effects and events', async () => {
+	it('preserves the host and state while disconnecting refs, effects, and events', async () => {
 		const container = createObjectContainer();
 		const root = createUniversalRoot(container, createObjectDriver());
 		const log: string[] = [];
@@ -107,7 +122,7 @@ describe('universal Activity visibility', () => {
 		await flushUniversalWork();
 		const instance = container.children[0];
 		expect(instance.visible).toBe(false);
-		expect(refs).toEqual([instance]);
+		expect(refs).toEqual([]);
 		expect(log).toEqual(['render:0', 'insertion mount:0']);
 		expect(() => container.dispatchEvent(instance, 'press', undefined)).toThrow(
 			/no "press" listener/,
@@ -142,7 +157,7 @@ describe('universal Activity visibility', () => {
 		expect(container.children[0]).toBe(instance);
 		expect(instance.props.value).toBe(1);
 		expect(instance.visible).toBe(false);
-		expect(refs).toEqual([instance]);
+		expect(refs).toEqual([instance, null]);
 		expect(log).toEqual(['render:1', 'layout cleanup', 'passive cleanup']);
 		expect(() => container.dispatchEvent(instance, 'press', undefined)).toThrow(
 			/no "press" listener/,
@@ -150,7 +165,7 @@ describe('universal Activity visibility', () => {
 
 		root.unmount();
 		await flushUniversalWork();
-		expect(refs.at(-1)).toBeNull();
+		expect(refs).toEqual([instance, null]);
 		expect(log.at(-1)).toBe('insertion cleanup:1');
 	});
 
@@ -158,7 +173,7 @@ describe('universal Activity visibility', () => {
 		const container = createObjectContainer();
 		const root = createUniversalRoot(container, createObjectDriver());
 		const log: string[] = [];
-		const effectComponent = (name: string, child: (() => unknown) | null = null) =>
+		const effectComponent = (name: string, child: (() => UniversalRenderable) | null = null) =>
 			defineUniversalComponent('object', () => {
 				useLayoutEffect(
 					() => {
@@ -277,6 +292,326 @@ describe('universal Activity visibility', () => {
 		root.unmount();
 	});
 
+	// Per ReactFiberCommitWork.js:2908/3098 (React 19.2.7).
+	it('reconnects the latest ref after hidden updates without repeating old cleanups', () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const calls: string[] = [];
+		const firstObject = { current: null as ObjectHostInstance | null };
+		const nextObject = { current: null as ObjectHostInstance | null };
+		const first = (value: ObjectHostInstance | null) => {
+			if (value === null) {
+				calls.push('first:null');
+				return;
+			}
+			calls.push('first:attach');
+			return () => calls.push('first:cleanup');
+		};
+		const next = (value: ObjectHostInstance | null) => {
+			if (value === null) {
+				calls.push('next:null');
+				return;
+			}
+			calls.push('next:attach');
+			return () => calls.push('next:cleanup');
+		};
+		const Scene = defineUniversalComponent(
+			'object',
+			(props: { mode: 'visible' | 'hidden'; ref: unknown }) =>
+				universalActivity(props.mode, () =>
+					universalValue(hostPlan, [universalProps([['set', 'ref', props.ref]])]),
+				),
+		);
+
+		root.render(Scene, { mode: 'visible', ref: [firstObject, first] });
+		const instance = container.children[0];
+		expect(firstObject.current).toBe(instance);
+		root.render(Scene, { mode: 'hidden', ref: [firstObject, first] });
+		expect(firstObject.current).toBeNull();
+		expect(calls).toEqual(['first:attach', 'first:cleanup']);
+		root.render(Scene, { mode: 'hidden', ref: [nextObject, next] });
+		expect(nextObject.current).toBeNull();
+		expect(calls).toEqual(['first:attach', 'first:cleanup']);
+
+		const abandoned = root.prepare(Scene, { mode: 'visible', ref: [nextObject, next] });
+		expect(abandoned.status).toBe('prepared');
+		abandoned.abort();
+		expect(nextObject.current).toBeNull();
+		expect(instance.visible).toBe(false);
+		root.render(Scene, { mode: 'visible', ref: [nextObject, next] });
+		expect(container.children[0]).toBe(instance);
+		expect(nextObject.current).toBe(instance);
+		expect(calls).toEqual(['first:attach', 'first:cleanup', 'next:attach']);
+
+		root.render(Scene, { mode: 'hidden', ref: [nextObject, next] });
+		root.unmount();
+		expect(nextObject.current).toBeNull();
+		expect(calls).toEqual(['first:attach', 'first:cleanup', 'next:attach', 'next:cleanup']);
+	});
+
+	// A native recycling driver may attach a preserved host while its logical
+	// Activity is hidden. Physical attachment alone must not publish a UI ref.
+	it('keeps refs disconnected across hidden physical attachment notifications', () => {
+		const container = createObjectContainer();
+		let notify!: (batch: UniversalHostAttachmentBatch) => void;
+		const driver: UniversalHostDriver<ObjectHostContainer, ObjectHostInstance> = {
+			...createObjectDriver(),
+			attachments: {
+				subscribe(_target, onChange) {
+					notify = onChange;
+					return { isAttached: () => true, unsubscribe() {} };
+				},
+			},
+		};
+		const root = createUniversalRoot(container, driver);
+		const calls: Array<ObjectHostInstance | null> = [];
+		const ref = (value: ObjectHostInstance | null) => calls.push(value);
+		const Scene = defineUniversalComponent('object', (props: { mode: 'visible' | 'hidden' }) =>
+			universalActivity(props.mode, () =>
+				universalValue(hostPlan, [universalProps([['set', 'ref', ref]])]),
+			),
+		);
+
+		root.render(Scene, { mode: 'hidden' });
+		const instance = container.children[0];
+		expect(calls).toEqual([]);
+		notify({ detached: [instance.id], attached: [instance.id] });
+		expect(calls).toEqual([]);
+		root.render(Scene, { mode: 'visible' });
+		expect(calls).toEqual([instance]);
+		root.render(Scene, { mode: 'hidden' });
+		expect(calls).toEqual([instance, null]);
+		notify({ detached: [instance.id], attached: [instance.id] });
+		expect(calls).toEqual([instance, null]);
+		root.unmount();
+		expect(calls).toEqual([instance, null]);
+	});
+
+	// Per ActivitySuspense-test.js:99/224 (React 19.2.7).
+	it('contains hidden suspension and retries without replacing the visible shell', async () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((done) => (resolve = done));
+		const log: string[] = [];
+		const Child = defineUniversalComponent('object', () => {
+			const value = use(promise);
+			useEffect(
+				() => {
+					log.push('mount');
+					return () => log.push('cleanup');
+				},
+				[],
+				'effect',
+			);
+			return labeledHost(value);
+		});
+		const Scene = defineUniversalComponent('object', (props: { mode: 'visible' | 'hidden' }) =>
+			universalTry(
+				() => [
+					labeledHost('shell'),
+					universalActivity(props.mode, () => universalComponent('object', Child, {})),
+				],
+				() => labeledHost('fallback'),
+			),
+		);
+
+		root.render(Scene, { mode: 'hidden' });
+		const shell = container.children[0];
+		expect(container.children.map((instance) => instance.props.label)).toEqual(['shell']);
+		expect(shell.visible).toBe(true);
+		expect(log).toEqual([]);
+
+		root.render(Scene, { mode: 'visible' });
+		expect(
+			container.children.some(
+				(instance) => instance.props.label === 'fallback' && instance.visible,
+			),
+		).toBe(true);
+		root.render(Scene, { mode: 'hidden' });
+		expect(container.children.map((instance) => instance.props.label)).toEqual(['shell']);
+		expect(container.children[0]).toBe(shell);
+		expect(shell.visible).toBe(true);
+
+		resolve('ready');
+		await promise;
+		await flushUniversalWork(6);
+		const child = container.children[1];
+		expect(container.children.map((instance) => instance.props.label)).toEqual(['shell', 'ready']);
+		expect(child.visible).toBe(false);
+		expect(log).toEqual([]);
+		root.render(Scene, { mode: 'visible' });
+		await flushUniversalWork();
+		expect(container.children).toEqual([shell, child]);
+		expect(child.visible).toBe(true);
+		expect(log).toEqual(['mount']);
+		root.unmount();
+	});
+
+	// Per ActivitySuspense-test.js:293/384 (React 19.2.7).
+	it.each(['component', 'Activity body'] as const)(
+		'preserves accepted hidden hosts and queued state when a later render suspends (%s)',
+		async (stateOwner) => {
+			const container = createObjectContainer();
+			const root = createUniversalRoot(container, createObjectDriver());
+			let pending: Promise<string> | null = null;
+			let resolve!: (value: string) => void;
+			let setCount!: (value: number) => void;
+			const log: string[] = [];
+			const renderChild = () => {
+				const [count, update] = useState(0, 'count');
+				setCount = update;
+				const value = pending === null ? 'ready' : use(pending);
+				useEffect(
+					() => {
+						log.push('mount');
+						return () => log.push('cleanup');
+					},
+					[],
+					'effect',
+				);
+				return labeledHost(`${value}:${count}`);
+			};
+			const Child = defineUniversalComponent('object', renderChild);
+			const Scene = defineUniversalComponent('object', (props: { mode: 'visible' | 'hidden' }) =>
+				universalTry(
+					() => [
+						labeledHost('shell'),
+						universalActivity(props.mode, () =>
+							stateOwner === 'component' ? universalComponent('object', Child, {}) : renderChild(),
+						),
+					],
+					() => labeledHost('fallback'),
+				),
+			);
+
+			root.render(Scene, { mode: 'visible' });
+			await flushUniversalWork();
+			setCount(3);
+			await flushUniversalWork();
+			const [shell, child] = container.children;
+			expect(child.props.label).toBe('ready:3');
+			const abandonedPromise = new Promise<string>((done) => (resolve = done));
+			pending = abandonedPromise;
+			const abandoned = root.prepare(Scene, { mode: 'hidden' });
+			expect(abandoned.status).toBe('prepared');
+			expect(child.visible).toBe(true);
+			expect(log).toEqual(['mount']);
+			abandoned.abort();
+			resolve('abandoned');
+			await abandonedPromise;
+			await flushUniversalWork();
+			expect(container.children).toEqual([shell, child]);
+			expect(child.visible).toBe(true);
+			expect(child.props.label).toBe('ready:3');
+			expect(log).toEqual(['mount']);
+
+			pending = new Promise<string>((done) => (resolve = done));
+			root.render(Scene, { mode: 'hidden' });
+			await flushUniversalWork();
+			expect(container.children).toEqual([shell, child]);
+			expect(shell.visible).toBe(true);
+			expect(child.visible).toBe(false);
+			expect(log).toEqual(['mount', 'cleanup']);
+
+			setCount(4);
+			await flushUniversalWork();
+			expect(container.children).toEqual([shell, child]);
+			expect(child.props.label).toBe('ready:3');
+			resolve('settled');
+			await pending;
+			await flushUniversalWork(6);
+			expect(container.children).toEqual([shell, child]);
+			expect(child.visible).toBe(false);
+			expect(child.props.label).toBe('settled:4');
+			expect(log).toEqual(['mount', 'cleanup']);
+			root.render(Scene, { mode: 'visible' });
+			await flushUniversalWork();
+			expect(child.visible).toBe(true);
+			expect(log).toEqual(['mount', 'cleanup', 'mount']);
+			root.unmount();
+		},
+	);
+
+	// Per ActivitySuspense-test.js:99 (React 19.2.7). Activity contains promises,
+	// not errors: rejection still belongs to the enclosing error boundary.
+	it('routes a rejected hidden render to the enclosing catch boundary', async () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		let reject!: (error: Error) => void;
+		const promise = new Promise<string>((_resolve, fail) => (reject = fail));
+		const Child = defineUniversalComponent('object', () => labeledHost(use(promise)));
+		const Scene = defineUniversalComponent('object', () =>
+			universalTry(
+				() => [
+					labeledHost('shell'),
+					universalActivity('hidden', () => universalComponent('object', Child, {})),
+				],
+				() => labeledHost('fallback'),
+				(error) => labeledHost(`caught:${(error as Error).message}`),
+			),
+		);
+
+		root.render(Scene, undefined);
+		expect(container.children.map((instance) => instance.props.label)).toEqual(['shell']);
+		reject(new Error('background failed'));
+		await promise.catch(() => undefined);
+		await flushUniversalWork(6);
+		expect(container.children.map((instance) => instance.props.label)).toEqual([
+			'caught:background failed',
+		]);
+		expect(container.children[0].visible).toBe(true);
+		root.unmount();
+	});
+
+	it('contains renderer-region suspension inside the owning hidden Activity', async () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		let resolve!: () => void;
+		const thenable = new Promise<void>((done) => (resolve = done));
+		const regionPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'html-region',
+			bindings: [['region', 0]],
+		});
+		const Region = defineUniversalComponent('object', () =>
+			universalValue(regionPlan, [
+				rendererRegion('object', 'dom', ActivityRegionChild, { thenable }),
+			]),
+		);
+		const Scene = defineUniversalComponent('object', (props: { mode: 'visible' | 'hidden' }) =>
+			universalTry(
+				() => [
+					labeledHost('shell'),
+					universalActivity(props.mode, () => universalComponent('object', Region, {})),
+				],
+				() => labeledHost('fallback'),
+			),
+		);
+
+		root.render(Scene, { mode: 'hidden' });
+		const [shell, regionHost] = container.children;
+		const region = regionHost.props.region;
+		if (!isRendererRegion(region)) throw new Error('Expected a committed DOM renderer region.');
+		const dom = mountDom(region.component as ComponentBody<unknown>, region.props);
+		try {
+			await flushUniversalWork(6);
+			expect(container.children).toEqual([shell, regionHost]);
+			expect(shell.visible).toBe(true);
+			expect(regionHost.visible).toBe(false);
+			resolve();
+			await thenable;
+			await flushUniversalWork(6);
+			expect(container.children).toEqual([shell, regionHost]);
+			expect(regionHost.visible).toBe(false);
+			root.render(Scene, { mode: 'visible' });
+			expect(regionHost.visible).toBe(true);
+		} finally {
+			dom.unmount();
+			root.unmount();
+		}
+	});
+
 	it('publishes a hidden recreate atomically after an apply fault and reconnects it on reveal', () => {
 		const container = createObjectContainer();
 		const baseDriver = createObjectDriver();
@@ -383,14 +718,13 @@ describe('universal Activity visibility', () => {
 		expect(replacement).not.toBe(accepted);
 		expect(replacement.id).toBe(acceptedId);
 		expect(replacement.visible).toBe(false);
-		expect(currentRef).toBe(replacement);
+		expect(currentRef).toBeNull();
 		expect(log).toEqual([
 			`attach-cleanup:accepted:current:visible`,
 			`attach:replacement:${acceptedId}:hidden`,
 			'layout:cleanup',
 			'ref:null:accepted',
 			`update:replacement:${acceptedId}:hidden`,
-			`ref:replacement:${acceptedId}:hidden`,
 		]);
 		expect(() => container.dispatchEvent(replacement, 'press', undefined)).toThrow(
 			/no "press" listener/,
@@ -401,7 +735,7 @@ describe('universal Activity visibility', () => {
 		expect(container.children[0]).toBe(replacement);
 		expect(replacement.visible).toBe(true);
 		expect(currentRef).toBe(replacement);
-		expect(log).toEqual(['layout:mount']);
+		expect(log).toEqual([`ref:replacement:${acceptedId}:visible`, 'layout:mount']);
 		container.dispatchEvent(replacement, 'press', undefined);
 		expect(log.at(-1)).toBe('press');
 


### PR DESCRIPTION
## Summary

- Correct observable Activity behavior across the DOM and universal runtimes, compiler authoring forms, SSR, hydration, and ViewTransition integration.
- Batch hidden descendant visibility work once per render wave, removing a quadratic range scan.
- Add a same-source production React/Octane benchmark suite, 32 deterministic regression guards, focused conformance coverage, an audit report, and an `octane` patch changeset.

## Why

The initial new DOM suite failed all 26 development/production cases on the original runtime: hidden refs remained attached, authored display/text could restore stale values, deep portals remained visible, and hidden suspension activated an enclosing visible fallback. The benchmark independently measured 256 full range scans and 65,536 display checks for one batch of 256 hidden row updates.

## Changes

- Disconnect/reconnect the current public host and Fragment refs across Activity visibility, including cleanup-bearing callbacks, ref changes while hidden, nested ownership, teardown errors, and reentrancy.
- Preserve the latest authored display/text under overlapping Activity/Suspense hides; track logical portal ownership and newly inserted or retried portal content.
- Contain hidden suspension, retain pending state, and replay insertion effects safely through memo/cached-child bailouts, repeated custom-hook enqueues, superseding/omitted hooks, and nested Activity ownership. Keep render-loop guards active during retries.
- Support aliases, namespaces, dynamic tags, `createElement(Activity, ...)`, spreads, children props, and authored key precedence. Preserve the direct mode-only compiler output and lazy hidden-child omission on the server.
- Correct ViewTransition enter/exit classification for both nesting orders and expose native pseudo-element animations through the public transition instance.
- Keep optional Activity descriptor dispatch tree-shakeable; gate ref manifests and insertion snapshots, cache negative ref ownership, and disable ref tracking after the last Activity unmounts.

Full findings and reproduction commands: [`docs/activity-audit.md`](https://github.com/octanejs/octane/blob/codex/activity-parity-performance-pr/docs/activity-audit.md) and [`benchmarks/activity/README.md`](https://github.com/octanejs/octane/blob/codex/activity-parity-performance-pr/benchmarks/activity/README.md).

## Performance

Same-machine, same-toolchain production browser measurements; the repeat ran in reverse order with 16 samples. These are benchmark steady-window scores, not full-sample means.

| Measurement | Original | Candidate |
| --- | ---: | ---: |
| 256 hidden descendant updates, completed work | 9.271 ms | 0.286 ms (~32x faster) |
| Range scans / display checks for that batch | 256 / 65,536 | 1 / 256 |
| Eight hide/reveal cycles | 2.957 ms | 4.300 ms (+45%) |
| Eight nested visibility cycles | 5.786 ms | 7.671 ms (+33%) |
| Twelve plain-tree prop updates | 1.729 ms | 1.943 ms (+12%; no added named Activity helper work) |

All state writes and retained identities are verified. Hidden setter batches add no style writes or row churn; both toggle workloads retain the original 4,096 style writes. Ordinary ref controls pass before, after, and alongside a separate hidden Activity. The five ordinary bundle controls exclude the optional Activity implementation, but shared correctness changes add 311–538 gzip bytes. Direct Activity/ref-control compiler outputs remain byte-identical.

The 32 guards protect deterministic work, DOM retention, cold paths, and optional implementation reachability. The original baseline fails exactly the three quadratic-work guards; the candidate passes all 32. No wall-clock ceiling was introduced and no existing absolute bundle-size budget was loosened.

## Validation

- [x] `pnpm run sync` — passed with process-local `COREPACK_ENABLE_NETWORK=0 pnpm_config_verify_deps_before_run=false` to avoid automatic reinstallation of borrowed dependency links; no generated tracked diff.
- [x] Scoped Prettier over all changed/new files and `git diff --check`.
- [x] Final focused Activity/compiler/SSR/hydration/Fragment/Suspense/ViewTransition/conditional-hook run: **971 tests across 57 files**, development and production where configured; rerun on the clean PR branch.
- [x] Universal neighboring suites: **652 tests across 34 files**.
- [x] Native Chromium Activity/ViewTransition: **4 cases**, both nesting orders and both compiler modes, including native animation handles and retained edited input.
- [x] Strict core `tsgo`, narrowed Activity `tsrx-tsc`, benchmark `tsrx-tsc`, and compiler syntax checks.
- [x] Unified Activity benchmark: **32/32 guards**; shared precise-work tests: **6/6**.
- [ ] `pnpm format:check` — repository-wide command not run; scoped check passed.
- [ ] `pnpm typecheck` — normal full-workspace gate not established; real dependency declaration overlays were used for the strict/scoped checks. The broader changed-file graph retains pre-existing universal-object and ViewTransition fixture typing diagnostics.
- [ ] `pnpm test` — normal native-parser/full-workspace gate not established. The locked `oxc-tsrx` installation returned HTTP 403, so the audit used the supported JavaScript parser adapter and explicit worktree aliases.

The broad core run plus corrected root-equivalent differential/profile/language-service cohorts accounts for **13,639 passed assertions across 861 file executions**. Six environment-failed executions/eight assertions remain for the unavailable native parser or incomplete installed workspace-package layout. Frozen/candidate controls agree; this aggregate is **not** a single green full-suite invocation. No fake packages, ambient TSRX modules, manifest changes, or lockfile changes were used.

## Risk / follow-ups

- This is **not** a claim of complete React parity or universal performance improvement. Toggle workloads are slower, and shared bundle bytes increase as recorded above.
- General atomic deletion during a suspended hidden render remains the existing per-swap structural-transaction limitation. Queue rollback cannot undo an already-executed unmount cleanup; a general fix requires owner-state staging across branch, descriptor, key/component, list, and portal mutations.
- Synchronous hidden work, no React offscreen/idle lane, and no selective-hydration scheduling remain intentional differences.
- Repeat the normal native-parser, full-workspace, and authoritative bundle-budget gates in a complete installation before readiness. Audit timings used Node 26.4.0, Chromium 149, React 19.2.7, Vite 8.1.5, esbuild 0.28.1, and the same supported JS-parser fallback for both revisions.
- The PR is isolated onto public upstream baseline `2d2f638b5da4ccb9a5ec46c5cea7b9c52c059192`. Its runtime/compiler, package manifest, and lockfile match the local merge used for the audit; three unrelated inherited test/changeset files are excluded. Integrate the live base and repeat required checks before marking ready.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core Activity commit, refs, Suspense containment, compiler lowering, and SSR/hydration. Visibility and identity bugs here can leak hidden UI or drop retained state.
> 
> **Overview**
> Fixes observable `<Activity>` behavior so hide/reveal matches the intended React contract: disconnect/reconnect public refs, restore latest authored display/text, hide logically owned portals, and keep hidden suspension from activating a visible outer fallback. Insertion effects now replay safely after suspended hidden renders (including memoized children and nested boundaries).
> 
> Coalesces hidden descendant visibility into **one range scan per render wave** (256 scans / 65,536 display checks → 1 / 256 for a 256-row setter batch). Optional Activity implementation and ref tracking stay off ordinary trees; hide/reveal itself is slower.
> 
> Compiler still uses the direct mode-only fast path, but aliases, namespaces, spreads, children props, and ordered keys now resolve to the same boundary. SSR/hydration omit hidden children; ViewTransition enter/exit covers both nesting orders.
> 
> Adds a same-source Octane/React production benchmark, 32 deterministic work/ref/bundle guards, and `docs/activity-audit.md`. Synchronous hidden scheduling and the existing per-swap structural-deletion limit are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32694f86ea5fbe23aea86fe53e9fa408b199405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789899786&installation_model_id=432790&pr_number=816&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F816&signature=2bad7a8b67087ac2e689800411d041f82f8e94f74f5ce209b3fbdf48ed4d1690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->