### PR TITLE
feat: share binding hook sub-slots

### DIFF
--- a/.changeset/shared-hook-subslots.md
+++ b/.changeset/shared-hook-subslots.md
@@ -1,0 +1,45 @@
+---
+'@octanejs/alien-signals': patch
+'@octanejs/animejs': patch
+'@octanejs/aria': patch
+'@octanejs/base-ui': patch
+'@octanejs/dexie': patch
+'@octanejs/dnd-kit': patch
+'@octanejs/electron': patch
+'@octanejs/floating-ui': patch
+'@octanejs/gsap': patch
+'@octanejs/i18next': patch
+'@octanejs/input-otp': patch
+'@octanejs/jotai': patch
+'@octanejs/lexical': patch
+'@octanejs/livestore': patch
+'@octanejs/mcp-server': patch
+'@octanejs/mobx': patch
+'@octanejs/radix': patch
+'@octanejs/react-error-boundary': patch
+'@octanejs/recharts': patch
+'@octanejs/redux': patch
+'@octanejs/remix-router': patch
+'@octanejs/rxjs': patch
+'@octanejs/solana-react': patch
+'@octanejs/tanstack-db': patch
+'@octanejs/tanstack-query': patch
+'@octanejs/tanstack-router': patch
+'@octanejs/tanstack-store': patch
+'@octanejs/tanstack-virtual': patch
+'@octanejs/tauri': patch
+'@octanejs/three': patch
+'@octanejs/tiptap': patch
+'@octanejs/usehooks-ts': patch
+'@octanejs/valtio': patch
+'@octanejs/vaul': patch
+'@octanejs/wagmi': patch
+'@octanejs/window': patch
+'@octanejs/xstate': patch
+'@octanejs/xstate-store': patch
+'@octanejs/zag': patch
+'@octanejs/zustand': patch
+'octane': patch
+---
+
+Deduplicate binding hook sub-slot derivation behind Octane's shared helper while preserving each binding's slotless and symbol-identity behavior.

--- a/packages/alien-signals/src/internal.ts
+++ b/packages/alien-signals/src/internal.ts
@@ -1,29 +1,9 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/alien-signals:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:alien-signals:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({
+	tagPrefix: ':alien-signals:',
+	slotlessPrefix: '@octanejs/alien-signals:',
+});
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/animejs/src/internal.ts
+++ b/packages/animejs/src/internal.ts
@@ -1,4 +1,4 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
+import { createSubSlot } from 'octane';
 
 export function splitSlot<T>(args: T[]): [T[], symbol | undefined] {
 	const tail = args[args.length - 1];
@@ -6,17 +6,4 @@ export function splitSlot<T>(args: T[]): [T[], symbol | undefined] {
 	return [slot === undefined ? args : args.slice(0, -1), slot];
 }
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let slots = subSlotCache.get(slot);
-	if (slots === undefined) {
-		slots = new Map();
-		subSlotCache.set(slot, slots);
-	}
-	let child = slots.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:animejs:${tag}`);
-		slots.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ tagPrefix: ':animejs:' });

--- a/packages/aria/src/internal.ts
+++ b/packages/aria/src/internal.ts
@@ -9,22 +9,9 @@
 //     const slot = restSlot(args) ?? S('useHover');
 // (Same pattern as the other @octanejs bindings; see packages/floating-ui.)
 
-// Derive a stable, distinct sub-slot from a wrapper's slot, namespaced per hook.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+import { subSlot } from 'octane';
+
+export { subSlot };
 
 // Split the compiler-injected trailing slot off a hook's args. Needed when a
 // public hook takes optional user args, so the slot can't be located positionally.

--- a/packages/base-ui/src/internal.ts
+++ b/packages/base-ui/src/internal.ts
@@ -5,22 +5,9 @@
 // its trailing argument and derives a distinct sub-slot for every base hook it composes.
 // (Same pattern as @octanejs/floating-ui and the other bindings.)
 
-// Derive a stable, distinct sub-slot from a wrapper's slot, namespaced per hook.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+import { subSlot } from 'octane';
+
+export { subSlot };
 
 // Split the compiler-injected trailing slot off a hook's args. Needed because the public
 // hooks take optional args, so the slot can't be located positionally.

--- a/packages/dexie/src/internal.ts
+++ b/packages/dexie/src/internal.ts
@@ -1,20 +1,6 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		byTag.set(tag, (derived = Symbol.for((slot.description ?? '') + ':' + tag)));
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 export function splitSlot(args: any[]): [any[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/dnd-kit/src/internal.ts
+++ b/packages/dnd-kit/src/internal.ts
@@ -2,16 +2,6 @@
 // trailing call-site slot and derive distinct slots for every base hook they
 // compose. This keeps multiple draggable/sortable hooks in one component
 // isolated while preserving upstream's stable hook identities.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		derived = Symbol((slot.description ?? '') + ':' + tag);
-		byTag.set(tag, derived);
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({ global: false });

--- a/packages/electron/src/renderer/internal.ts
+++ b/packages/electron/src/renderer/internal.ts
@@ -1,23 +1,8 @@
 import { OCTANE_ELECTRON_GLOBAL } from '../common/channels';
 import type { OctaneElectronAPI } from '../common/types';
+import { createSubSlot } from 'octane';
 
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
-
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		byTag.set(tag, (derived = Symbol.for((slot.description ?? '') + ':' + tag)));
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 export function splitSlot(args: any[]): [any[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/floating-ui/src/internal.ts
+++ b/packages/floating-ui/src/internal.ts
@@ -7,22 +7,9 @@
 // interaction hooks so they need no slot of their own. (Same pattern as the other
 // @octanejs bindings.)
 
-// Derive a stable, distinct sub-slot from a wrapper's slot, namespaced per hook.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+import { subSlot } from 'octane';
+
+export { subSlot };
 
 // Split the compiler-injected trailing slot off a hook's args. Needed because the
 // public hooks take optional args, so the slot can't be located positionally.

--- a/packages/gsap/src/internal.ts
+++ b/packages/gsap/src/internal.ts
@@ -1,21 +1,9 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareSlotCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareSlotCache.get(tag);
-		if (bare === undefined) bareSlotCache.set(tag, (bare = Symbol.for('@octanejs/gsap:' + tag)));
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		byTag.set(tag, (derived = Symbol.for((slot.description ?? '@octanejs/gsap') + ':' + tag)));
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({
+	parentDescriptionFallback: '@octanejs/gsap',
+	slotlessPrefix: '@octanejs/gsap:',
+});
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/i18next/src/internal.js
+++ b/packages/i18next/src/internal.js
@@ -3,24 +3,9 @@
 // composed base hook gets a deterministic sub-slot. Tag-only symbols cover
 // renderHook and other slotless callers while remaining distinct inside the
 // runtime's ambient withSlot path.
-const subSlotCache = new Map();
-const bareTagCache = new Map();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot, tag) {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(`:${tag}`)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let symbol = byTag.get(tag);
-	if (symbol === undefined) {
-		symbol = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, symbol);
-	}
-	return symbol;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 export function splitSlot(args) {
 	const tail = args[args.length - 1];

--- a/packages/input-otp/src/use-previous.ts
+++ b/packages/input-otp/src/use-previous.ts
@@ -1,21 +1,10 @@
-import { useEffect, useRef } from 'octane';
+import { createSubSlot, useEffect, useRef } from 'octane';
 
-const childSlots = new Map<symbol, Map<string, symbol>>();
-
-function subSlot(slot: symbol | undefined, key: string): symbol | undefined {
-	if (!slot) return undefined;
-	let slots = childSlots.get(slot);
-	if (!slots) {
-		slots = new Map();
-		childSlots.set(slot, slots);
-	}
-	let child = slots.get(key);
-	if (!child) {
-		child = Symbol(`input-otp:usePrevious:${key}`);
-		slots.set(key, child);
-	}
-	return child;
-}
+const subSlot = createSubSlot({
+	parentPrefix: 'input-otp:usePrevious',
+	includeParentDescription: false,
+	global: false,
+});
 
 /** Returns the value observed during the previous committed render. */
 export function usePrevious<T>(value: T, slot?: symbol): T | undefined {

--- a/packages/input-otp/src/use-pwm-badge.ts
+++ b/packages/input-otp/src/use-pwm-badge.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'octane';
+import { createSubSlot, useCallback, useEffect, useMemo, useState } from 'octane';
 
 import type { OTPInputProps } from './types';
 
@@ -13,22 +13,11 @@ export const PASSWORD_MANAGERS_SELECTORS = [
 	'[style$="2147483647 !important;"]',
 ].join(',');
 
-const childSlots = new Map<symbol, Map<string, symbol>>();
-
-function subSlot(slot: symbol | undefined, key: string): symbol | undefined {
-	if (!slot) return undefined;
-	let children = childSlots.get(slot);
-	if (!children) {
-		children = new Map();
-		childSlots.set(slot, children);
-	}
-	let child = children.get(key);
-	if (!child) {
-		child = Symbol(`input-otp:usePasswordManagerBadge:${key}`);
-		children.set(key, child);
-	}
-	return child;
-}
+const subSlot = createSubSlot({
+	parentPrefix: 'input-otp:usePasswordManagerBadge',
+	includeParentDescription: false,
+	global: false,
+});
 
 export function usePasswordManagerBadge(
 	options: {

--- a/packages/jotai/src/internal.ts
+++ b/packages/jotai/src/internal.ts
@@ -6,27 +6,11 @@
 
 // Memoized: subSlot runs on EVERY hook call every render; the cache returns the
 // identical Symbol.for-interned value without the concat + registry lookup.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-// Tag-only symbols for the slotless-caller case (see below).
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	// No inherited slot (the caller was NOT compiled — e.g. a vendored wrapper
-	// hook): return a stable TAG-ONLY symbol rather than undefined. The runtime
-	// combines it with the ambient withSlot path, so sibling base hooks inside
-	// one composed hook stay DISTINCT per tag. Returning undefined here made
-	// them all resolve to the bare path — one shared slot, state collision.
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+// A stable tag-only symbol keeps sibling base hooks distinct when an
+// uncompiled caller relies on the ambient withSlot path.
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 // Split the compiler-injected trailing slot off a hook's runtime args, returning
 // the user args (everything before it) and the slot.

--- a/packages/lexical/src/shared/internal.ts
+++ b/packages/lexical/src/shared/internal.ts
@@ -4,23 +4,9 @@
 // NOT compiled — so a hook here receives the caller's slot as its trailing argument
 // and derives a distinct sub-slot for each base hook it composes.
 
-// Derive a stable, distinct sub-slot from a wrapper's slot, namespaced per hook so
-// composing multiple base hooks gives each its own identity.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+import { subSlot } from 'octane';
+
+export { subSlot };
 
 // Split the compiler-injected trailing slot off a hook's args. Needed for hooks
 // with OPTIONAL user args, where the slot can't be located positionally (the

--- a/packages/livestore/src/internal.ts
+++ b/packages/livestore/src/internal.ts
@@ -1,29 +1,6 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/livestore:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/livestore:' });
 
 export function splitSlot(
 	args: unknown[],

--- a/packages/mobx/src/internal.ts
+++ b/packages/mobx/src/internal.ts
@@ -1,26 +1,8 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/mobx:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol(`${slot.description ?? '@octanejs/mobx'}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({
+	parentDescriptionFallback: '@octanejs/mobx',
+	slotlessPrefix: '@octanejs/mobx:',
+	global: false,
+	slotlessGlobal: true,
+});

--- a/packages/octane-mcp-server/skills/bridge-react-package.md
+++ b/packages/octane-mcp-server/skills/bridge-react-package.md
@@ -128,11 +128,7 @@ So a bridge never means "run the React package unchanged". It means:
    the official bindings:
 
    ```ts
-   import { useMemo, useRef } from 'octane';
-
-   export function subSlot(slot: symbol | undefined, tag: string) {
-   	return slot !== undefined ? Symbol.for((slot.description ?? '') + ':' + tag) : undefined;
-   }
+   import { subSlot, useMemo, useRef } from 'octane';
 
    export function useControllableState(opts, slot?: symbol) {
    	const valueRef = useRef(opts.defaultValue, subSlot(slot, 'value'));

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -6,6 +6,13 @@ export { initializeHydrationEventCapture } from './hydration/event-capture.js';
 // behavior-only consumers never retain component or hydration machinery.
 export { attachBehaviorRoot } from './behavior-root.js';
 export type * from './behavior-root.js';
+export {
+	createSubSlot,
+	subSlot,
+	type SubSlot,
+	type SlotlessSubSlot,
+	type SubSlotOptions,
+} from './sub-slot.js';
 
 // Profiling's application API and compiler ABI live at `octane/profiling`;
 // neither belongs on the React-shaped main namespace.

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -22,6 +22,13 @@
  */
 
 export { executeServerFunction } from './rpc.js';
+export {
+	createSubSlot,
+	subSlot,
+	type SubSlot,
+	type SlotlessSubSlot,
+	type SubSlotOptions,
+} from '../sub-slot.js';
 
 // Semi-public compiler target for inferred method-call dependencies — the
 // same helper the client entry ships, because inferred dependency arrays are

--- a/packages/octane/src/sub-slot.ts
+++ b/packages/octane/src/sub-slot.ts
@@ -1,0 +1,74 @@
+/**
+ * Formatting and identity options for binding-owned hook sub-slots.
+ *
+ * The defaults preserve the long-standing `parent:tag` global-symbol shape.
+ * Bindings with an uncompiled-caller fallback can opt into a stable tag-only
+ * symbol with `slotlessPrefix`; bindings that must distinguish two parent
+ * symbols with the same description can set `global` to `false`.
+ */
+export interface SubSlotOptions {
+	/** Text before the parent slot description. */
+	parentPrefix?: string;
+	/** Text between the parent slot description and the child tag. */
+	tagPrefix?: string;
+	/** Description used when a parent symbol has no description. */
+	parentDescriptionFallback?: string;
+	/** Text before a tag-only child; omitting it preserves an undefined parent. */
+	slotlessPrefix?: string;
+	/** Include the parent symbol's description in the child description. */
+	includeParentDescription?: boolean;
+	/** Use `Symbol.for`; set to false for factory-local child identities. */
+	global?: boolean;
+	/** Override global/local identity for tag-only children. */
+	slotlessGlobal?: boolean;
+}
+
+export type SubSlot = (slot: symbol | undefined, tag: string) => symbol | undefined;
+export type SlotlessSubSlot = (slot: symbol | undefined, tag: string) => symbol;
+
+export function createSubSlot(
+	options: SubSlotOptions & { slotlessPrefix: string },
+): SlotlessSubSlot;
+export function createSubSlot(options?: SubSlotOptions): SubSlot;
+export function createSubSlot(options: SubSlotOptions = {}): SubSlot {
+	const childSlots = new Map<symbol, Map<string, symbol>>();
+	const slotlessSlots = options.slotlessPrefix === undefined ? null : new Map<string, symbol>();
+	const parentPrefix = options.parentPrefix ?? '';
+	const tagPrefix = options.tagPrefix ?? ':';
+	const parentDescriptionFallback = options.parentDescriptionFallback ?? '';
+	const includeParentDescription = options.includeParentDescription !== false;
+	const makeSymbol: (description: string) => symbol =
+		options.global === false ? Symbol : Symbol.for;
+	const makeSlotlessSymbol: (description: string) => symbol =
+		options.slotlessGlobal === false ||
+		(options.slotlessGlobal === undefined && options.global === false)
+			? Symbol
+			: Symbol.for;
+
+	return (slot, tag) => {
+		if (slot === undefined) {
+			if (slotlessSlots === null) return undefined;
+			let child = slotlessSlots.get(tag);
+			if (child === undefined) {
+				child = makeSlotlessSymbol(options.slotlessPrefix! + tag);
+				slotlessSlots.set(tag, child);
+			}
+			return child;
+		}
+
+		let byTag = childSlots.get(slot);
+		if (byTag === undefined) childSlots.set(slot, (byTag = new Map()));
+		let child = byTag.get(tag);
+		if (child === undefined) {
+			const parentDescription = includeParentDescription
+				? (slot.description ?? parentDescriptionFallback)
+				: '';
+			child = makeSymbol(parentPrefix + parentDescription + tagPrefix + tag);
+			byTag.set(tag, child);
+		}
+		return child;
+	};
+}
+
+/** Default binding helper: global `parent:tag` children and no slotless fallback. */
+export const subSlot = createSubSlot();

--- a/packages/octane/src/universal-native.ts
+++ b/packages/octane/src/universal-native.ts
@@ -7,6 +7,13 @@
  * do not provide DOM globals.
  */
 export * from './universal-core.js';
+export {
+	createSubSlot,
+	subSlot,
+	type SubSlot,
+	type SlotlessSubSlot,
+	type SubSlotOptions,
+} from './sub-slot.js';
 
 import {
 	universalContext,

--- a/packages/octane/src/universal.ts
+++ b/packages/octane/src/universal.ts
@@ -6,6 +6,13 @@
  * retains Octane's existing DOM `createContext` identity.
  */
 export * from './universal-core.js';
+export {
+	createSubSlot,
+	subSlot,
+	type SubSlot,
+	type SlotlessSubSlot,
+	type SubSlotOptions,
+} from './sub-slot.js';
 
 export { createContext } from './runtime.js';
 export {

--- a/packages/octane/tests/sub-slot.test.ts
+++ b/packages/octane/tests/sub-slot.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { createSubSlot, subSlot } from '../src/index.js';
+import * as Server from '../src/server/index.js';
+import * as Universal from '../src/universal.js';
+import * as UniversalNative from '../src/universal-native.js';
+
+describe('binding hook-slot composition', () => {
+	it('derives stable, distinct child slots while preserving a missing parent', () => {
+		const parent = Symbol.for('test:binding-hook');
+		const state = subSlot(parent, 'state');
+
+		expect(state).toBe(subSlot(parent, 'state'));
+		expect(state).not.toBe(subSlot(parent, 'effect'));
+		expect(subSlot(undefined, 'state')).toBeUndefined();
+	});
+
+	it('supports stable slotless children and binding namespaces', () => {
+		const namespaced = createSubSlot({
+			parentPrefix: '@octanejs/example:',
+			tagPrefix: ':hook:',
+			slotlessPrefix: '@octanejs/example:bare:',
+		});
+		const parent = Symbol.for('component');
+
+		expect(Symbol.keyFor(namespaced(parent, 'state'))).toBe(
+			'@octanejs/example:component:hook:state',
+		);
+		expect(Symbol.keyFor(namespaced(undefined, 'state'))).toBe('@octanejs/example:bare:state');
+		expect(namespaced(undefined, 'state')).toBe(namespaced(undefined, 'state'));
+	});
+
+	it('can keep child identity local to each parent symbol', () => {
+		const local = createSubSlot({ global: false });
+		const firstParent = Symbol('same-description');
+		const secondParent = Symbol('same-description');
+		const first = local(firstParent, 'state');
+
+		expect(first).toBe(local(firstParent, 'state'));
+		expect(first).not.toBe(local(secondParent, 'state'));
+		expect(Symbol.keyFor(first!)).toBeUndefined();
+	});
+
+	it('can preserve global slotless identity with parent-local children', () => {
+		const mixed = createSubSlot({
+			global: false,
+			slotlessGlobal: true,
+			slotlessPrefix: '@octanejs/example:',
+		});
+
+		expect(Symbol.keyFor(mixed(undefined, 'state'))).toBe('@octanejs/example:state');
+		expect(Symbol.keyFor(mixed(Symbol('parent'), 'state'))).toBeUndefined();
+	});
+
+	it('supports fixed and fallback parent descriptions', () => {
+		const fallback = createSubSlot({
+			parentPrefix: '@octanejs/example:',
+			parentDescriptionFallback: 'anonymous',
+		});
+		const fixed = createSubSlot({
+			parentPrefix: '@octanejs/example',
+			includeParentDescription: false,
+		});
+
+		expect(Symbol.keyFor(fallback(Symbol(), 'state')!)).toBe('@octanejs/example:anonymous:state');
+		expect(Symbol.keyFor(fixed(Symbol('ignored'), 'state')!)).toBe('@octanejs/example:state');
+	});
+
+	it('is available from every runtime entry used by bindings', () => {
+		expect(Server.subSlot).toBe(subSlot);
+		expect(Server.createSubSlot).toBe(createSubSlot);
+		expect(Universal.subSlot).toBe(subSlot);
+		expect(Universal.createSubSlot).toBe(createSubSlot);
+		expect(UniversalNative.subSlot).toBe(subSlot);
+		expect(UniversalNative.createSubSlot).toBe(createSubSlot);
+	});
+});

--- a/packages/radix/src/internal.ts
+++ b/packages/radix/src/internal.ts
@@ -5,22 +5,9 @@
 // its trailing argument and derives a distinct sub-slot for every base hook it composes.
 // (Same pattern as @octanejs/floating-ui and the other bindings.)
 
-// Derive a stable, distinct sub-slot from a wrapper's slot, namespaced per hook.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+import { subSlot } from 'octane';
+
+export { subSlot };
 
 // Split the compiler-injected trailing slot off a hook's args. Needed because the public
 // hooks take optional args, so the slot can't be located positionally.

--- a/packages/react-error-boundary/src/internal.ts
+++ b/packages/react-error-boundary/src/internal.ts
@@ -1,21 +1,6 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareSlotCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareSlotCache.get(tag);
-		if (bare === undefined)
-			bareSlotCache.set(tag, (bare = Symbol.for('react-error-boundary:' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		byTag.set(
-			tag,
-			(derived = Symbol.for((slot.description ?? 'react-error-boundary') + ':' + tag)),
-		);
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({
+	parentDescriptionFallback: 'react-error-boundary',
+	slotlessPrefix: 'react-error-boundary:',
+});

--- a/packages/recharts/src/internal.ts
+++ b/packages/recharts/src/internal.ts
@@ -6,27 +6,11 @@
 
 // Memoized: subSlot runs on EVERY hook call every render; the cache returns the
 // identical Symbol.for-interned value without the concat + registry lookup.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-// Tag-only symbols for the slotless-caller case (see below).
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	// No inherited slot (the caller was NOT compiled — e.g. a vendored wrapper
-	// hook): return a stable TAG-ONLY symbol rather than undefined. The runtime
-	// combines it with the ambient withSlot path, so sibling base hooks inside
-	// one composed hook stay DISTINCT per tag. Returning undefined here made
-	// them all resolve to the bare path — one shared slot, state collision.
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+// A stable tag-only symbol keeps sibling base hooks distinct when an
+// uncompiled caller relies on the ambient withSlot path.
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 // Split the compiler-injected trailing slot off a hook's runtime args, returning
 // the user args (everything before it) and the slot.

--- a/packages/redux/src/internal.ts
+++ b/packages/redux/src/internal.ts
@@ -6,27 +6,11 @@
 
 // Memoized: subSlot runs on EVERY hook call every render; the cache returns the
 // identical Symbol.for-interned value without the concat + registry lookup.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-// Tag-only symbols for the slotless-caller case (see below).
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	// No inherited slot (the caller was NOT compiled — e.g. a vendored wrapper
-	// hook): return a stable TAG-ONLY symbol rather than undefined. The runtime
-	// combines it with the ambient withSlot path, so sibling base hooks inside
-	// one composed hook stay DISTINCT per tag. Returning undefined here made
-	// them all resolve to the bare path — one shared slot, state collision.
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+// A stable tag-only symbol keeps sibling base hooks distinct when an
+// uncompiled caller relies on the ambient withSlot path.
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 // Split the compiler-injected trailing slot off a hook's runtime args, returning
 // the user args (everything before it) and the slot.

--- a/packages/remix-router/src/internal.ts
+++ b/packages/remix-router/src/internal.ts
@@ -6,27 +6,11 @@
 
 // Memoized: subSlot runs on EVERY hook call every render; the cache returns the
 // identical Symbol.for-interned value without the concat + registry lookup.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-// Tag-only symbols for the slotless-caller case (see below).
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	// No inherited slot (the caller was NOT compiled — e.g. a vendored wrapper
-	// hook): return a stable TAG-ONLY symbol rather than undefined. The runtime
-	// combines it with the ambient withSlot path, so sibling base hooks inside
-	// one composed hook stay DISTINCT per tag. Returning undefined here made
-	// them all resolve to the bare path — one shared slot, state collision.
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+// A stable tag-only symbol keeps sibling base hooks distinct when an
+// uncompiled caller relies on the ambient withSlot path.
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 // Split the compiler-injected trailing slot off a hook's runtime args, returning
 // the user args (everything before it) and the slot.

--- a/packages/rxjs/src/internal.ts
+++ b/packages/rxjs/src/internal.ts
@@ -1,20 +1,6 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(`:rxjs:${tag}`)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		byTag.set(tag, (derived = Symbol.for(`${slot.description ?? ''}:rxjs:${tag}`)));
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({ tagPrefix: ':rxjs:', slotlessPrefix: ':rxjs:' });
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/solana-react/src/internal.ts
+++ b/packages/solana-react/src/internal.ts
@@ -1,15 +1,6 @@
-const slots = new Map<symbol, Map<string, symbol>>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (!slot) return Symbol.for(`@octanejs/solana-react:${tag}`);
-	let children = slots.get(slot);
-	if (!children) slots.set(slot, (children = new Map()));
-	let child = children.get(tag);
-	if (!child) {
-		children.set(
-			tag,
-			(child = Symbol.for(`${slot.description ?? '@octanejs/solana-react'}:${tag}`)),
-		);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({
+	parentDescriptionFallback: '@octanejs/solana-react',
+	slotlessPrefix: '@octanejs/solana-react:',
+});

--- a/packages/tanstack-db/src/slot.ts
+++ b/packages/tanstack-db/src/slot.ts
@@ -1,20 +1,6 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
+import { subSlot } from 'octane';
 
-/**
- * Derive a stable sub-slot from a wrapper's compiler-injected slot so nested
- * Octane hooks inside a custom hook each get distinct call-site identity.
- */
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) {
-		sym = Symbol.for(`${slot.description ?? ``}:${tag}`);
-		byTag.set(tag, sym);
-	}
-	return sym;
-}
+export { subSlot };
 
 /** Split a compiler-injected trailing slot symbol off hook runtime args. */
 export function splitTrailingSlot<T extends Array<unknown>>(

--- a/packages/tanstack-query/src/internal.ts
+++ b/packages/tanstack-query/src/internal.ts
@@ -1,25 +1,8 @@
 // Shared internals for the binding hooks.
 import { shouldThrowError } from '@tanstack/query-core';
-import { use, useRef } from 'octane';
+import { subSlot, use, useRef } from 'octane';
 
-// Derive a stable, distinct sub-slot from a wrapper's compiler-injected slot, so
-// a hook composing multiple base hooks gives each one its own identity. Tags are
-// namespaced per hook (e.g. ':oq:obs', ':ms:cb') to avoid cross-hook collisions.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+export { subSlot };
 
 // Split the compiler-injected trailing slot off a hook's runtime args, returning
 // the user args (everything before it) and the slot.

--- a/packages/tanstack-router/src/internal.ts
+++ b/packages/tanstack-router/src/internal.ts
@@ -4,23 +4,9 @@
 // a hook here receives the caller's slot as its trailing argument and derives a
 // distinct sub-slot for each base hook it composes.
 
-// Derive a stable, distinct sub-slot from a wrapper's slot, namespaced per hook so
-// composing multiple base hooks gives each its own identity.
-// Memoized: subSlot runs on EVERY hook call every render, and the naive form
-// pays a string concat + global symbol-registry lookup each time. The cache is
-// keyed by the slot symbol itself; the minted value is byte-identical to the
-// uncached Symbol.for result, so identity is preserved across HMR re-evals and
-// the per-package copies of this helper. Key universe is bounded: slots are
-// per-call-site module constants (never minted per render).
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+import { subSlot } from 'octane';
+
+export { subSlot };
 
 // Split the compiler-injected (or .ts-forwarded) trailing slot off a hook's args,
 // returning the user args (everything before it) and the slot.

--- a/packages/tanstack-store/src/internal.ts
+++ b/packages/tanstack-store/src/internal.ts
@@ -2,32 +2,9 @@
 // per-call-site Symbol into calls made by compiled components; the binding
 // forwards that symbol and derives a distinct sub-slot for each hook it
 // composes.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/tanstack-store:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/tanstack-store:' });
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/tanstack-virtual/src/internal.ts
+++ b/packages/tanstack-virtual/src/internal.ts
@@ -6,27 +6,11 @@
 
 // Memoized: subSlot runs on EVERY hook call every render; the cache returns the
 // identical Symbol.for-interned value without the concat + registry lookup.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-// Tag-only symbols for the slotless-caller case (see below).
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	// No inherited slot (the caller was NOT compiled — e.g. a vendored wrapper
-	// hook): return a stable TAG-ONLY symbol rather than undefined. The runtime
-	// combines it with the ambient withSlot path, so sibling base hooks inside
-	// one composed hook stay DISTINCT per tag. Returning undefined here made
-	// them all resolve to the bare path — one shared slot, state collision.
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined) byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':' + tag)));
-	return sym;
-}
+// A stable tag-only symbol keeps sibling base hooks distinct when an
+// uncompiled caller relies on the ambient withSlot path.
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 // Split the compiler-injected trailing slot off a hook's runtime args, returning
 // the user args (everything before it) and the slot.

--- a/packages/tauri/src/internal.ts
+++ b/packages/tauri/src/internal.ts
@@ -1,22 +1,8 @@
 import type { InvokeArgs } from '@tauri-apps/api/core';
 
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) bareTagCache.set(tag, (bare = Symbol.for(':' + tag)));
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let derived = byTag.get(tag);
-	if (derived === undefined) {
-		byTag.set(tag, (derived = Symbol.for((slot.description ?? '') + ':' + tag)));
-	}
-	return derived;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: ':' });
 
 export function splitSlot(args: any[]): [any[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/three/src/core/hooks.ts
+++ b/packages/three/src/core/hooks.ts
@@ -8,6 +8,7 @@
  */
 import * as THREE from 'three';
 import {
+	createSubSlot,
 	useContext,
 	useLayoutEffect,
 	useMemo,
@@ -39,25 +40,9 @@ export interface RefObject<T> {
 type EqualityFn<T> = (previous: T, next: T) => boolean;
 type Selector<T> = (state: RootState) => T;
 
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-
-function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	// Universal hooks allocate an owner-local implicit slot when an uncompiled
-	// caller provides no symbol. Preserve that fallback; a shared tag-only symbol
-	// would make two direct calls to the same composed hook collide.
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-	let result = byTag.get(tag);
-	if (result === undefined) {
-		result = Symbol.for(`${slot.description ?? ''}:@octanejs/three:${tag}`);
-		byTag.set(tag, result);
-	}
-	return result;
-}
+// Universal hooks preserve their owner-local implicit fallback when an
+// uncompiled caller provides no symbol.
+const subSlot = createSubSlot({ tagPrefix: ':@octanejs/three:' });
 
 function splitSlot(args: readonly unknown[]): [readonly unknown[], symbol | undefined] {
 	const tail = args.at(-1);

--- a/packages/tiptap/src/internal.ts
+++ b/packages/tiptap/src/internal.ts
@@ -3,32 +3,12 @@
 // custom-hook call. Binding hooks split that argument from their public
 // options and derive one stable sub-slot for each base hook they compose.
 
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareSlotCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareSlotCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/tiptap:${tag}`);
-			bareSlotCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let result = byTag.get(tag);
-	if (result === undefined) {
-		result = Symbol.for(`${slot.description ?? ''}:@octanejs/tiptap:${tag}`);
-		byTag.set(tag, result);
-	}
-	return result;
-}
+export const subSlot = createSubSlot({
+	tagPrefix: ':@octanejs/tiptap:',
+	slotlessPrefix: '@octanejs/tiptap:',
+});
 
 /** Split a compiler-owned trailing slot from a custom hook's user arguments. */
 export function splitSlot(args: readonly unknown[]): [readonly unknown[], symbol | undefined] {

--- a/packages/usehooks-ts/src/internal.ts
+++ b/packages/usehooks-ts/src/internal.ts
@@ -1,5 +1,4 @@
-const childSlots = new Map<symbol, Map<string, symbol>>();
-const childSlotNamespace = '@octanejs/usehooks-ts';
+import { createSubSlot } from 'octane';
 
 export function splitSlot<T>(args: T[]): { args: T[]; slot: symbol | undefined } {
 	const tail = args.at(-1);
@@ -8,17 +7,4 @@ export function splitSlot<T>(args: T[]): { args: T[]; slot: symbol | undefined }
 		: { args, slot: undefined };
 }
 
-export function subSlot(slot: symbol | undefined, key: string): symbol | undefined {
-	if (!slot) return undefined;
-	let slots = childSlots.get(slot);
-	if (!slots) {
-		slots = new Map();
-		childSlots.set(slot, slots);
-	}
-	let child = slots.get(key);
-	if (!child) {
-		child = Symbol.for(`${childSlotNamespace}:${slot.description ?? ''}:${key}`);
-		slots.set(key, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ parentPrefix: '@octanejs/usehooks-ts:' });

--- a/packages/valtio/src/internal.ts
+++ b/packages/valtio/src/internal.ts
@@ -1,26 +1,3 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/valtio:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/valtio:' });

--- a/packages/vaul/src/internal.ts
+++ b/packages/vaul/src/internal.ts
@@ -1,13 +1,3 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let value = byTag.get(tag);
-	if (value === undefined) {
-		value = Symbol.for(`@octanejs/vaul:${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, value);
-	}
-	return value;
-}
+export const subSlot = createSubSlot({ parentPrefix: '@octanejs/vaul:' });

--- a/packages/wagmi/src/internal.ts
+++ b/packages/wagmi/src/internal.ts
@@ -1,21 +1,6 @@
-import { createContext } from 'octane';
+import { createContext, subSlot } from 'octane';
+
+export { subSlot };
 import type { ResolvedRegister } from '@wagmi/core';
 
 export const WagmiContext = createContext<ResolvedRegister['config'] | undefined>(undefined);
-
-const slots = new Map<symbol, Map<string, symbol>>();
-
-export function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (!slot) return undefined;
-	let children = slots.get(slot);
-	if (!children) {
-		children = new Map();
-		slots.set(slot, children);
-	}
-	let child = children.get(tag);
-	if (!child) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		children.set(tag, child);
-	}
-	return child;
-}

--- a/packages/window/src/internal.ts
+++ b/packages/window/src/internal.ts
@@ -1,8 +1,9 @@
 // Octane appends a compiler-owned hook slot to public hook calls. Binding
 // internals derive stable child slots so composed hooks and sibling
 // virtualizers never share state.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
+
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/window:' });
 
 export function getSlot(args: unknown[]): symbol | undefined {
 	const slot = args.at(-1);
@@ -12,26 +13,4 @@ export function getSlot(args: unknown[]): symbol | undefined {
 export function getPublicArgument(args: unknown[], index: number): unknown {
 	const publicLength = getSlot(args) === undefined ? args.length : args.length - 1;
 	return index < publicLength ? args[index] : undefined;
-}
-
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/window:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
 }

--- a/packages/xstate-store/src/internal.ts
+++ b/packages/xstate-store/src/internal.ts
@@ -4,32 +4,9 @@
 // composes. This package declares `octane.hookSlots.manual` for `src`, so the
 // compiler's plain-`.ts` slotting pass skips these modules and the forwarding
 // below is the only thing that keeps two call sites of the same hook apart.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/xstate-store:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/xstate-store:' });
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/xstate/src/internal.ts
+++ b/packages/xstate/src/internal.ts
@@ -4,32 +4,9 @@
 // composes. This package declares `octane.hookSlots.manual` for `src`, so the
 // compiler's plain-`.ts` slotting pass skips these modules and the forwarding
 // below is the only thing that keeps two call sites of the same hook apart.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareTagCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareTagCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/xstate:${tag}`);
-			bareTagCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/xstate:' });
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/zag/src/internal.ts
+++ b/packages/zag/src/internal.ts
@@ -1,29 +1,6 @@
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-const bareSlotCache = new Map<string, symbol>();
+import { createSubSlot } from 'octane';
 
-export function subSlot(slot: symbol | undefined, tag: string): symbol {
-	if (slot === undefined) {
-		let bare = bareSlotCache.get(tag);
-		if (bare === undefined) {
-			bare = Symbol.for(`@octanejs/zag:${tag}`);
-			bareSlotCache.set(tag, bare);
-		}
-		return bare;
-	}
-
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) {
-		byTag = new Map();
-		subSlotCache.set(slot, byTag);
-	}
-
-	let child = byTag.get(tag);
-	if (child === undefined) {
-		child = Symbol.for(`${slot.description ?? ''}:${tag}`);
-		byTag.set(tag, child);
-	}
-	return child;
-}
+export const subSlot = createSubSlot({ slotlessPrefix: '@octanejs/zag:' });
 
 export function splitSlot(args: unknown[]): [unknown[], symbol | undefined] {
 	const tail = args[args.length - 1];

--- a/packages/zustand/src/traditional.ts
+++ b/packages/zustand/src/traditional.ts
@@ -15,7 +15,7 @@
 //
 // Note: v5 recommends `useShallow` over this equality-fn pattern for object
 // slices; `traditional` exists for code that still uses it.
-import { useSyncExternalStore, useRef } from 'octane';
+import { createSubSlot, useSyncExternalStore, useRef } from 'octane';
 import { createStore } from 'zustand/vanilla';
 import type { StateCreator, StoreApi } from 'zustand/vanilla';
 
@@ -24,21 +24,7 @@ type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 's
 
 const identity = <T>(arg: T): T => arg;
 
-// Derive a stable, distinct sub-slot from the wrapper's slot. `Symbol.for` interns
-// by description, so the same call site always yields the same sub-slot; the
-// `:wsel:` namespace keeps it clear of useSyncExternalStore's `:uses:` slots.
-// Memoized — subSlot runs per hook call per render; the cache returns the
-// identical Symbol.for-interned value without the concat + registry lookup.
-const subSlotCache = new Map<symbol, Map<string, symbol>>();
-function subSlot(slot: symbol | undefined, tag: string): symbol | undefined {
-	if (slot === undefined) return undefined;
-	let byTag = subSlotCache.get(slot);
-	if (byTag === undefined) subSlotCache.set(slot, (byTag = new Map()));
-	let sym = byTag.get(tag);
-	if (sym === undefined)
-		byTag.set(tag, (sym = Symbol.for((slot.description ?? '') + ':wsel:' + tag)));
-	return sym;
-}
+const subSlot = createSubSlot({ tagPrefix: ':wsel:' });
 
 interface SelectionCell<U> {
 	hasValue: boolean;


### PR DESCRIPTION
## Summary

- add shared `subSlot` and `createSubSlot` helpers to Octane's client, server, and universal entry points
- replace binding-local copies while preserving each binding's slotless fallback, namespace, and global/local symbol identity
- document the shared helper in the binding bridge guidance and add a patch changeset

Closes #810.

## Implementation

`createSubSlot` keeps the hot cache-hit path to parent/tag map lookups and supports the small set of compatibility policies already present across bindings. The default `subSlot` preserves the common `parent:tag` global-symbol behavior; configured factories cover namespaced descriptions, stable slotless children, and factory-local symbols.

The migration removes all remaining binding-owned `function subSlot` implementations without changing hook call sites.

## Validation

- `pnpm typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm test` — 2,262 files and 22,727 tests passed
- `pnpm format:files:check`
- focused `sub-slot.test.ts` run in development and production projects — 12 tests passed
- `node benchmarks/bench.mjs --quick hook-store-composition` — semantic checksums, lifecycle counts, and hook-work counts unchanged; no quick-run regression signal
- `pnpm sync`

## Risk

Low. The helper is pure symbol derivation with per-factory caches, and the migration retains each binding's prior symbol-description and identity policy. Client, server, universal, and universal-native exports are covered.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789933621&installation_model_id=432790&pr_number=818&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F818&signature=a73f30ab33b3353e86ffedf3a3ff8b1f3a87ae3a59a58ae407aef5eaf186c799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hook slot identity is load-bearing for composed binding state. The migration is intended to preserve each package’s prior symbol policy, but a mismatch would collide hook state across many bindings.
> 
> **Overview**
> Adds shared `subSlot` / `createSubSlot` helpers on Octane’s client, server, and universal entries, then replaces every binding-local copy with that factory.
> 
> Bindings keep their existing slotless fallbacks, namespaces, and global vs local symbol identity via options (`slotlessPrefix`, `tagPrefix`, `global`, etc.). Hook call sites are unchanged.
> 
> Also updates the React-bridge skill to import `subSlot` from `octane` instead of inlining a naive `Symbol.for` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f4b5baab08bacd2c1203180da1fdf8a9bd9f893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->