### PR TITLE
docs: require task worktrees and green CI

### DIFF
--- a/.agents/skills/create-a-pr/SKILL.md
+++ b/.agents/skills/create-a-pr/SKILL.md
@@ -17,14 +17,25 @@ Use this when asked to prepare a branch and pull request for an Octane change.
    git diff --stat
    ```
 2. Read `AGENTS.md` and `docs/packages.md`.
-3. Confirm no unrelated local changes are included.
+3. For a new task, fetch the remote default branch and create a dedicated new
+   worktree and non-default branch from it. For an existing pull request, use
+   its already-dedicated worktree.
+4. Verify the task worktree is not the primary checkout and its current branch
+   is neither `main` nor `master`.
+5. Confirm no unrelated local changes are included.
+
+The primary checkout and local default branches are read-only. Never implement,
+install dependencies, generate artifacts, test with commands that write files,
+stage, or commit there. Preserve any state already present and move to the task
+worktree before doing work.
 
 ## Branch and implementation hygiene
 
 - Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
 - Keep commits focused.
 - Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
-- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+- If changing RuleSync source, edit `.rulesync/rules/*` or
+  `.rulesync/skills/*` and run `pnpm rules:generate`.
 
 ## Validation checklist
 
@@ -98,7 +109,7 @@ review the resulting diff. Include every relevant generated change in the
 commit:
 
 ```bash
-git checkout -b <branch>
+git branch --show-current
 pnpm sync
 git status --short
 git add <files>
@@ -118,15 +129,15 @@ both labels as a bot, which does.
 ## Draft and readiness gates
 
 Open every PR as a draft. Nothing has run against the pushed diff yet, and the
-draft state is what says so. By default, leave readiness and merging to a
-maintainer. When the user explicitly authorizes the agent to mark the PR ready,
-check every gate below against the current head and live base. The required-check
-gate has one bootstrap exception: when Actions has produced no required checks
-for the current head because the PR is still a draft, the first transition to
-ready is allowed after every non-CI gate and all relevant local validation pass.
+draft state is what says so. A request to create a PR through completion
+authorizes the agent to mark it ready after every non-CI gate below and all
+relevant local validation pass, unless the user explicitly asks to leave it as
+a draft. The required-check gate has this bootstrap exception: when Actions has
+produced no required checks for the current head because the PR is still a
+draft, the first transition to ready is allowed after every non-CI gate passes.
 That transition starts CI; it is not evidence that CI passed.
 
-- every required check is terminal and successful;
+- every required and relevant CI check is terminal and successful;
 - every actionable review comment and review thread is resolved on the current head;
 - no reviewer or bot review is still in progress or expected for an older head;
 - the head contains the live base branch, not merely the base SHA cached when the PR opened;
@@ -136,17 +147,20 @@ That transition starts CI; it is not evidence that CI passed.
 These are independent gates. Green checks do not prove that review feedback is
 resolved, and resolved feedback does not prove that the branch still merges.
 After the bootstrap transition, keep the PR ready while required checks run. Do
-not describe it as fully ready or merge-ready until those checks are terminal
-and successful; if a required check fails, address it and restart the gates.
+not describe the work as done, complete, fully ready, or merge-ready until every
+required and relevant CI check for the current pushed head is terminal and
+successful; if a check fails, address it, push the fix, and restart the gates.
 Re-check mergeability and the live base after the last push and immediately
 before `gh pr ready`. If the base moved, incorporate it without rewriting a
 published branch, rerun sync and validation, push, and start the gates again.
 
-Unless the user explicitly requested monitoring, do not sit on `gh pr checks --watch`. Repository CI intentionally skips
-every job while the pull request is a draft and starts on the
-`ready_for_review` event. Cursor Bugbot still reviews every pull request,
-including drafts, outside Actions, so people can watch and respond to its issue
-comments before making a draft ready. Vercel may also report separately.
+Monitor required and relevant CI checks after the PR is ready and continue
+through failures until the current pushed head is green. Use bounded polling
+intervals so status updates can still be shared. Repository CI intentionally
+skips every job while the pull request is a draft and starts on the
+`ready_for_review` event, so a draft-only skipped result is not green. Cursor
+Bugbot still reviews every pull request, including drafts, outside Actions;
+Vercel may also report separately.
 
 ## Declare provenance in the PR body
 
@@ -182,5 +196,6 @@ issues.
 ## Final response
 
 Return PR URL, branch, commit summary, provenance declared, and validation
-evidence.
-The PR stays a draft.
+evidence, including required and relevant CI results for the current pushed
+head and the PR's final draft/readiness state. Do not say the work is done or
+complete unless required and relevant CI is green.

--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -17,14 +17,25 @@ Use this when asked to prepare a branch and pull request for an Octane change.
    git diff --stat
    ```
 2. Read `AGENTS.md` and `docs/packages.md`.
-3. Confirm no unrelated local changes are included.
+3. For a new task, fetch the remote default branch and create a dedicated new
+   worktree and non-default branch from it. For an existing pull request, use
+   its already-dedicated worktree.
+4. Verify the task worktree is not the primary checkout and its current branch
+   is neither `main` nor `master`.
+5. Confirm no unrelated local changes are included.
+
+The primary checkout and local default branches are read-only. Never implement,
+install dependencies, generate artifacts, test with commands that write files,
+stage, or commit there. Preserve any state already present and move to the task
+worktree before doing work.
 
 ## Branch and implementation hygiene
 
 - Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
 - Keep commits focused.
 - Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
-- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+- If changing RuleSync source, edit `.rulesync/rules/*` or
+  `.rulesync/skills/*` and run `pnpm rules:generate`.
 
 ## Validation checklist
 
@@ -98,7 +109,7 @@ review the resulting diff. Include every relevant generated change in the
 commit:
 
 ```bash
-git checkout -b <branch>
+git branch --show-current
 pnpm sync
 git status --short
 git add <files>
@@ -118,15 +129,15 @@ both labels as a bot, which does.
 ## Draft and readiness gates
 
 Open every PR as a draft. Nothing has run against the pushed diff yet, and the
-draft state is what says so. By default, leave readiness and merging to a
-maintainer. When the user explicitly authorizes the agent to mark the PR ready,
-check every gate below against the current head and live base. The required-check
-gate has one bootstrap exception: when Actions has produced no required checks
-for the current head because the PR is still a draft, the first transition to
-ready is allowed after every non-CI gate and all relevant local validation pass.
+draft state is what says so. A request to create a PR through completion
+authorizes the agent to mark it ready after every non-CI gate below and all
+relevant local validation pass, unless the user explicitly asks to leave it as
+a draft. The required-check gate has this bootstrap exception: when Actions has
+produced no required checks for the current head because the PR is still a
+draft, the first transition to ready is allowed after every non-CI gate passes.
 That transition starts CI; it is not evidence that CI passed.
 
-- every required check is terminal and successful;
+- every required and relevant CI check is terminal and successful;
 - every actionable review comment and review thread is resolved on the current head;
 - no reviewer or bot review is still in progress or expected for an older head;
 - the head contains the live base branch, not merely the base SHA cached when the PR opened;
@@ -136,17 +147,20 @@ That transition starts CI; it is not evidence that CI passed.
 These are independent gates. Green checks do not prove that review feedback is
 resolved, and resolved feedback does not prove that the branch still merges.
 After the bootstrap transition, keep the PR ready while required checks run. Do
-not describe it as fully ready or merge-ready until those checks are terminal
-and successful; if a required check fails, address it and restart the gates.
+not describe the work as done, complete, fully ready, or merge-ready until every
+required and relevant CI check for the current pushed head is terminal and
+successful; if a check fails, address it, push the fix, and restart the gates.
 Re-check mergeability and the live base after the last push and immediately
 before `gh pr ready`. If the base moved, incorporate it without rewriting a
 published branch, rerun sync and validation, push, and start the gates again.
 
-Unless the user explicitly requested monitoring, do not sit on `gh pr checks --watch`. Repository CI intentionally skips
-every job while the pull request is a draft and starts on the
-`ready_for_review` event. Cursor Bugbot still reviews every pull request,
-including drafts, outside Actions, so people can watch and respond to its issue
-comments before making a draft ready. Vercel may also report separately.
+Monitor required and relevant CI checks after the PR is ready and continue
+through failures until the current pushed head is green. Use bounded polling
+intervals so status updates can still be shared. Repository CI intentionally
+skips every job while the pull request is a draft and starts on the
+`ready_for_review` event, so a draft-only skipped result is not green. Cursor
+Bugbot still reviews every pull request, including drafts, outside Actions;
+Vercel may also report separately.
 
 ## Declare provenance in the PR body
 
@@ -182,5 +196,6 @@ issues.
 ## Final response
 
 Return PR URL, branch, commit summary, provenance declared, and validation
-evidence.
-The PR stays a draft.
+evidence, including required and relevant CI results for the current pushed
+head and the PR's final draft/readiness state. Do not say the work is done or
+complete unless required and relevant CI is green.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -47,10 +47,15 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
-asserts human); never apply PR labels. Existing PR body edits must merge,
-preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
-byte-for-byte, refetch before writing, and verify after.
+## Worktrees and CI
+
+New tasks use a dedicated worktree/non-default branch from the remote
+default. Primary checkout and local `main`/`master` are read-only; existing work
+stays in its worktree.
+
+A pushed PR is not done. Run current-head CI; fix failures until
+required/relevant checks pass. If drafts skip CI, mark ready unless asked to
+leave it draft. Never claim done before green CI. See `create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -49,13 +49,13 @@ read that path directly if your tool cannot load a skill by name.
 
 ## Worktrees and CI
 
-New tasks use a dedicated worktree/non-default branch from the remote
-default. Primary checkout and local `main`/`master` are read-only; existing work
-stays in its worktree.
+New tasks use a dedicated worktree/non-default branch. Primary checkout and
+local `main`/`master` are read-only.
 
-A pushed PR is not done. Run current-head CI; fix failures until
-required/relevant checks pass. If drafts skip CI, mark ready unless asked to
-leave it draft. Never claim done before green CI. See `create-a-pr`.
+A pushed PR is not done. Run current-head CI; fix failures until relevant checks
+pass. If draft CI skips, mark ready unless asked not to. Never claim done before
+green CI. Preserve `<!-- CURSOR_SUMMARY -->`…`<!-- /CURSOR_SUMMARY -->`; see
+`create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -14,14 +14,25 @@ Use this when asked to prepare a branch and pull request for an Octane change.
    git diff --stat
    ```
 2. Read `AGENTS.md` and `docs/packages.md`.
-3. Confirm no unrelated local changes are included.
+3. For a new task, fetch the remote default branch and create a dedicated new
+   worktree and non-default branch from it. For an existing pull request, use
+   its already-dedicated worktree.
+4. Verify the task worktree is not the primary checkout and its current branch
+   is neither `main` nor `master`.
+5. Confirm no unrelated local changes are included.
+
+The primary checkout and local default branches are read-only. Never implement,
+install dependencies, generate artifacts, test with commands that write files,
+stage, or commit there. Preserve any state already present and move to the task
+worktree before doing work.
 
 ## Branch and implementation hygiene
 
 - Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
 - Keep commits focused.
 - Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
-- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+- If changing RuleSync source, edit `.rulesync/rules/*` or
+  `.rulesync/skills/*` and run `pnpm rules:generate`.
 
 ## Validation checklist
 
@@ -95,7 +106,7 @@ review the resulting diff. Include every relevant generated change in the
 commit:
 
 ```bash
-git checkout -b <branch>
+git branch --show-current
 pnpm sync
 git status --short
 git add <files>
@@ -115,15 +126,15 @@ both labels as a bot, which does.
 ## Draft and readiness gates
 
 Open every PR as a draft. Nothing has run against the pushed diff yet, and the
-draft state is what says so. By default, leave readiness and merging to a
-maintainer. When the user explicitly authorizes the agent to mark the PR ready,
-check every gate below against the current head and live base. The required-check
-gate has one bootstrap exception: when Actions has produced no required checks
-for the current head because the PR is still a draft, the first transition to
-ready is allowed after every non-CI gate and all relevant local validation pass.
+draft state is what says so. A request to create a PR through completion
+authorizes the agent to mark it ready after every non-CI gate below and all
+relevant local validation pass, unless the user explicitly asks to leave it as
+a draft. The required-check gate has this bootstrap exception: when Actions has
+produced no required checks for the current head because the PR is still a
+draft, the first transition to ready is allowed after every non-CI gate passes.
 That transition starts CI; it is not evidence that CI passed.
 
-- every required check is terminal and successful;
+- every required and relevant CI check is terminal and successful;
 - every actionable review comment and review thread is resolved on the current head;
 - no reviewer or bot review is still in progress or expected for an older head;
 - the head contains the live base branch, not merely the base SHA cached when the PR opened;
@@ -133,17 +144,20 @@ That transition starts CI; it is not evidence that CI passed.
 These are independent gates. Green checks do not prove that review feedback is
 resolved, and resolved feedback does not prove that the branch still merges.
 After the bootstrap transition, keep the PR ready while required checks run. Do
-not describe it as fully ready or merge-ready until those checks are terminal
-and successful; if a required check fails, address it and restart the gates.
+not describe the work as done, complete, fully ready, or merge-ready until every
+required and relevant CI check for the current pushed head is terminal and
+successful; if a check fails, address it, push the fix, and restart the gates.
 Re-check mergeability and the live base after the last push and immediately
 before `gh pr ready`. If the base moved, incorporate it without rewriting a
 published branch, rerun sync and validation, push, and start the gates again.
 
-Unless the user explicitly requested monitoring, do not sit on `gh pr checks --watch`. Repository CI intentionally skips
-every job while the pull request is a draft and starts on the
-`ready_for_review` event. Cursor Bugbot still reviews every pull request,
-including drafts, outside Actions, so people can watch and respond to its issue
-comments before making a draft ready. Vercel may also report separately.
+Monitor required and relevant CI checks after the PR is ready and continue
+through failures until the current pushed head is green. Use bounded polling
+intervals so status updates can still be shared. Repository CI intentionally
+skips every job while the pull request is a draft and starts on the
+`ready_for_review` event, so a draft-only skipped result is not green. Cursor
+Bugbot still reviews every pull request, including drafts, outside Actions;
+Vercel may also report separately.
 
 ## Declare provenance in the PR body
 
@@ -179,5 +193,6 @@ issues.
 ## Final response
 
 Return PR URL, branch, commit summary, provenance declared, and validation
-evidence.
-The PR stays a draft.
+evidence, including required and relevant CI results for the current pushed
+head and the PR's final draft/readiness state. Do not say the work is done or
+complete unless required and relevant CI is green.

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -17,14 +17,25 @@ Use this when asked to prepare a branch and pull request for an Octane change.
    git diff --stat
    ```
 2. Read `AGENTS.md` and `docs/packages.md`.
-3. Confirm no unrelated local changes are included.
+3. For a new task, fetch the remote default branch and create a dedicated new
+   worktree and non-default branch from it. For an existing pull request, use
+   its already-dedicated worktree.
+4. Verify the task worktree is not the primary checkout and its current branch
+   is neither `main` nor `master`.
+5. Confirm no unrelated local changes are included.
+
+The primary checkout and local default branches are read-only. Never implement,
+install dependencies, generate artifacts, test with commands that write files,
+stage, or commit there. Preserve any state already present and move to the task
+worktree before doing work.
 
 ## Branch and implementation hygiene
 
 - Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
 - Keep commits focused.
 - Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
-- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+- If changing RuleSync source, edit `.rulesync/rules/*` or
+  `.rulesync/skills/*` and run `pnpm rules:generate`.
 
 ## Validation checklist
 
@@ -98,7 +109,7 @@ review the resulting diff. Include every relevant generated change in the
 commit:
 
 ```bash
-git checkout -b <branch>
+git branch --show-current
 pnpm sync
 git status --short
 git add <files>
@@ -118,15 +129,15 @@ both labels as a bot, which does.
 ## Draft and readiness gates
 
 Open every PR as a draft. Nothing has run against the pushed diff yet, and the
-draft state is what says so. By default, leave readiness and merging to a
-maintainer. When the user explicitly authorizes the agent to mark the PR ready,
-check every gate below against the current head and live base. The required-check
-gate has one bootstrap exception: when Actions has produced no required checks
-for the current head because the PR is still a draft, the first transition to
-ready is allowed after every non-CI gate and all relevant local validation pass.
+draft state is what says so. A request to create a PR through completion
+authorizes the agent to mark it ready after every non-CI gate below and all
+relevant local validation pass, unless the user explicitly asks to leave it as
+a draft. The required-check gate has this bootstrap exception: when Actions has
+produced no required checks for the current head because the PR is still a
+draft, the first transition to ready is allowed after every non-CI gate passes.
 That transition starts CI; it is not evidence that CI passed.
 
-- every required check is terminal and successful;
+- every required and relevant CI check is terminal and successful;
 - every actionable review comment and review thread is resolved on the current head;
 - no reviewer or bot review is still in progress or expected for an older head;
 - the head contains the live base branch, not merely the base SHA cached when the PR opened;
@@ -136,17 +147,20 @@ That transition starts CI; it is not evidence that CI passed.
 These are independent gates. Green checks do not prove that review feedback is
 resolved, and resolved feedback does not prove that the branch still merges.
 After the bootstrap transition, keep the PR ready while required checks run. Do
-not describe it as fully ready or merge-ready until those checks are terminal
-and successful; if a required check fails, address it and restart the gates.
+not describe the work as done, complete, fully ready, or merge-ready until every
+required and relevant CI check for the current pushed head is terminal and
+successful; if a check fails, address it, push the fix, and restart the gates.
 Re-check mergeability and the live base after the last push and immediately
 before `gh pr ready`. If the base moved, incorporate it without rewriting a
 published branch, rerun sync and validation, push, and start the gates again.
 
-Unless the user explicitly requested monitoring, do not sit on `gh pr checks --watch`. Repository CI intentionally skips
-every job while the pull request is a draft and starts on the
-`ready_for_review` event. Cursor Bugbot still reviews every pull request,
-including drafts, outside Actions, so people can watch and respond to its issue
-comments before making a draft ready. Vercel may also report separately.
+Monitor required and relevant CI checks after the PR is ready and continue
+through failures until the current pushed head is green. Use bounded polling
+intervals so status updates can still be shared. Repository CI intentionally
+skips every job while the pull request is a draft and starts on the
+`ready_for_review` event, so a draft-only skipped result is not green. Cursor
+Bugbot still reviews every pull request, including drafts, outside Actions;
+Vercel may also report separately.
 
 ## Declare provenance in the PR body
 
@@ -182,5 +196,6 @@ issues.
 ## Final response
 
 Return PR URL, branch, commit summary, provenance declared, and validation
-evidence.
-The PR stays a draft.
+evidence, including required and relevant CI results for the current pushed
+head and the PR's final draft/readiness state. Do not say the work is done or
+complete unless required and relevant CI is green.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,13 +44,13 @@ read that path directly if your tool cannot load a skill by name.
 
 ## Worktrees and CI
 
-New tasks use a dedicated worktree/non-default branch from the remote
-default. Primary checkout and local `main`/`master` are read-only; existing work
-stays in its worktree.
+New tasks use a dedicated worktree/non-default branch. Primary checkout and
+local `main`/`master` are read-only.
 
-A pushed PR is not done. Run current-head CI; fix failures until
-required/relevant checks pass. If drafts skip CI, mark ready unless asked to
-leave it draft. Never claim done before green CI. See `create-a-pr`.
+A pushed PR is not done. Run current-head CI; fix failures until relevant checks
+pass. If draft CI skips, mark ready unless asked not to. Never claim done before
+green CI. Preserve `<!-- CURSOR_SUMMARY -->`…`<!-- /CURSOR_SUMMARY -->`; see
+`create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,10 +42,15 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
-asserts human); never apply PR labels. Existing PR body edits must merge,
-preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
-byte-for-byte, refetch before writing, and verify after.
+## Worktrees and CI
+
+New tasks use a dedicated worktree/non-default branch from the remote
+default. Primary checkout and local `main`/`master` are read-only; existing work
+stays in its worktree.
+
+A pushed PR is not done. Run current-head CI; fix failures until
+required/relevant checks pass. If drafts skip CI, mark ready unless asked to
+leave it draft. Never claim done before green CI. See `create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -17,14 +17,25 @@ Use this when asked to prepare a branch and pull request for an Octane change.
    git diff --stat
    ```
 2. Read `AGENTS.md` and `docs/packages.md`.
-3. Confirm no unrelated local changes are included.
+3. For a new task, fetch the remote default branch and create a dedicated new
+   worktree and non-default branch from it. For an existing pull request, use
+   its already-dedicated worktree.
+4. Verify the task worktree is not the primary checkout and its current branch
+   is neither `main` nor `master`.
+5. Confirm no unrelated local changes are included.
+
+The primary checkout and local default branches are read-only. Never implement,
+install dependencies, generate artifacts, test with commands that write files,
+stage, or commit there. Preserve any state already present and move to the task
+worktree before doing work.
 
 ## Branch and implementation hygiene
 
 - Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
 - Keep commits focused.
 - Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
-- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+- If changing RuleSync source, edit `.rulesync/rules/*` or
+  `.rulesync/skills/*` and run `pnpm rules:generate`.
 
 ## Validation checklist
 
@@ -98,7 +109,7 @@ review the resulting diff. Include every relevant generated change in the
 commit:
 
 ```bash
-git checkout -b <branch>
+git branch --show-current
 pnpm sync
 git status --short
 git add <files>
@@ -118,15 +129,15 @@ both labels as a bot, which does.
 ## Draft and readiness gates
 
 Open every PR as a draft. Nothing has run against the pushed diff yet, and the
-draft state is what says so. By default, leave readiness and merging to a
-maintainer. When the user explicitly authorizes the agent to mark the PR ready,
-check every gate below against the current head and live base. The required-check
-gate has one bootstrap exception: when Actions has produced no required checks
-for the current head because the PR is still a draft, the first transition to
-ready is allowed after every non-CI gate and all relevant local validation pass.
+draft state is what says so. A request to create a PR through completion
+authorizes the agent to mark it ready after every non-CI gate below and all
+relevant local validation pass, unless the user explicitly asks to leave it as
+a draft. The required-check gate has this bootstrap exception: when Actions has
+produced no required checks for the current head because the PR is still a
+draft, the first transition to ready is allowed after every non-CI gate passes.
 That transition starts CI; it is not evidence that CI passed.
 
-- every required check is terminal and successful;
+- every required and relevant CI check is terminal and successful;
 - every actionable review comment and review thread is resolved on the current head;
 - no reviewer or bot review is still in progress or expected for an older head;
 - the head contains the live base branch, not merely the base SHA cached when the PR opened;
@@ -136,17 +147,20 @@ That transition starts CI; it is not evidence that CI passed.
 These are independent gates. Green checks do not prove that review feedback is
 resolved, and resolved feedback does not prove that the branch still merges.
 After the bootstrap transition, keep the PR ready while required checks run. Do
-not describe it as fully ready or merge-ready until those checks are terminal
-and successful; if a required check fails, address it and restart the gates.
+not describe the work as done, complete, fully ready, or merge-ready until every
+required and relevant CI check for the current pushed head is terminal and
+successful; if a check fails, address it, push the fix, and restart the gates.
 Re-check mergeability and the live base after the last push and immediately
 before `gh pr ready`. If the base moved, incorporate it without rewriting a
 published branch, rerun sync and validation, push, and start the gates again.
 
-Unless the user explicitly requested monitoring, do not sit on `gh pr checks --watch`. Repository CI intentionally skips
-every job while the pull request is a draft and starts on the
-`ready_for_review` event. Cursor Bugbot still reviews every pull request,
-including drafts, outside Actions, so people can watch and respond to its issue
-comments before making a draft ready. Vercel may also report separately.
+Monitor required and relevant CI checks after the PR is ready and continue
+through failures until the current pushed head is green. Use bounded polling
+intervals so status updates can still be shared. Repository CI intentionally
+skips every job while the pull request is a draft and starts on the
+`ready_for_review` event, so a draft-only skipped result is not green. Cursor
+Bugbot still reviews every pull request, including drafts, outside Actions;
+Vercel may also report separately.
 
 ## Declare provenance in the PR body
 
@@ -182,5 +196,6 @@ issues.
 ## Final response
 
 Return PR URL, branch, commit summary, provenance declared, and validation
-evidence.
-The PR stays a draft.
+evidence, including required and relevant CI results for the current pushed
+head and the PR's final draft/readiness state. Do not say the work is done or
+complete unless required and relevant CI is green.

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -49,10 +49,15 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
-asserts human); never apply PR labels. Existing PR body edits must merge,
-preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
-byte-for-byte, refetch before writing, and verify after.
+## Worktrees and CI
+
+New tasks use a dedicated worktree/non-default branch from the remote
+default. Primary checkout and local `main`/`master` are read-only; existing work
+stays in its worktree.
+
+A pushed PR is not done. Run current-head CI; fix failures until
+required/relevant checks pass. If drafts skip CI, mark ready unless asked to
+leave it draft. Never claim done before green CI. See `create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -51,13 +51,13 @@ read that path directly if your tool cannot load a skill by name.
 
 ## Worktrees and CI
 
-New tasks use a dedicated worktree/non-default branch from the remote
-default. Primary checkout and local `main`/`master` are read-only; existing work
-stays in its worktree.
+New tasks use a dedicated worktree/non-default branch. Primary checkout and
+local `main`/`master` are read-only.
 
-A pushed PR is not done. Run current-head CI; fix failures until
-required/relevant checks pass. If drafts skip CI, mark ready unless asked to
-leave it draft. Never claim done before green CI. See `create-a-pr`.
+A pushed PR is not done. Run current-head CI; fix failures until relevant checks
+pass. If draft CI skips, mark ready unless asked not to. Never claim done before
+green CI. Preserve `<!-- CURSOR_SUMMARY -->`…`<!-- /CURSOR_SUMMARY -->`; see
+`create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -16,14 +16,25 @@ Use this when asked to prepare a branch and pull request for an Octane change.
    git diff --stat
    ```
 2. Read `AGENTS.md` and `docs/packages.md`.
-3. Confirm no unrelated local changes are included.
+3. For a new task, fetch the remote default branch and create a dedicated new
+   worktree and non-default branch from it. For an existing pull request, use
+   its already-dedicated worktree.
+4. Verify the task worktree is not the primary checkout and its current branch
+   is neither `main` nor `master`.
+5. Confirm no unrelated local changes are included.
+
+The primary checkout and local default branches are read-only. Never implement,
+install dependencies, generate artifacts, test with commands that write files,
+stage, or commit there. Preserve any state already present and move to the task
+worktree before doing work.
 
 ## Branch and implementation hygiene
 
 - Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
 - Keep commits focused.
 - Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
-- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+- If changing RuleSync source, edit `.rulesync/rules/*` or
+  `.rulesync/skills/*` and run `pnpm rules:generate`.
 
 ## Validation checklist
 
@@ -97,7 +108,7 @@ review the resulting diff. Include every relevant generated change in the
 commit:
 
 ```bash
-git checkout -b <branch>
+git branch --show-current
 pnpm sync
 git status --short
 git add <files>
@@ -117,15 +128,15 @@ both labels as a bot, which does.
 ## Draft and readiness gates
 
 Open every PR as a draft. Nothing has run against the pushed diff yet, and the
-draft state is what says so. By default, leave readiness and merging to a
-maintainer. When the user explicitly authorizes the agent to mark the PR ready,
-check every gate below against the current head and live base. The required-check
-gate has one bootstrap exception: when Actions has produced no required checks
-for the current head because the PR is still a draft, the first transition to
-ready is allowed after every non-CI gate and all relevant local validation pass.
+draft state is what says so. A request to create a PR through completion
+authorizes the agent to mark it ready after every non-CI gate below and all
+relevant local validation pass, unless the user explicitly asks to leave it as
+a draft. The required-check gate has this bootstrap exception: when Actions has
+produced no required checks for the current head because the PR is still a
+draft, the first transition to ready is allowed after every non-CI gate passes.
 That transition starts CI; it is not evidence that CI passed.
 
-- every required check is terminal and successful;
+- every required and relevant CI check is terminal and successful;
 - every actionable review comment and review thread is resolved on the current head;
 - no reviewer or bot review is still in progress or expected for an older head;
 - the head contains the live base branch, not merely the base SHA cached when the PR opened;
@@ -135,17 +146,20 @@ That transition starts CI; it is not evidence that CI passed.
 These are independent gates. Green checks do not prove that review feedback is
 resolved, and resolved feedback does not prove that the branch still merges.
 After the bootstrap transition, keep the PR ready while required checks run. Do
-not describe it as fully ready or merge-ready until those checks are terminal
-and successful; if a required check fails, address it and restart the gates.
+not describe the work as done, complete, fully ready, or merge-ready until every
+required and relevant CI check for the current pushed head is terminal and
+successful; if a check fails, address it, push the fix, and restart the gates.
 Re-check mergeability and the live base after the last push and immediately
 before `gh pr ready`. If the base moved, incorporate it without rewriting a
 published branch, rerun sync and validation, push, and start the gates again.
 
-Unless the user explicitly requested monitoring, do not sit on `gh pr checks --watch`. Repository CI intentionally skips
-every job while the pull request is a draft and starts on the
-`ready_for_review` event. Cursor Bugbot still reviews every pull request,
-including drafts, outside Actions, so people can watch and respond to its issue
-comments before making a draft ready. Vercel may also report separately.
+Monitor required and relevant CI checks after the PR is ready and continue
+through failures until the current pushed head is green. Use bounded polling
+intervals so status updates can still be shared. Repository CI intentionally
+skips every job while the pull request is a draft and starts on the
+`ready_for_review` event, so a draft-only skipped result is not green. Cursor
+Bugbot still reviews every pull request, including drafts, outside Actions;
+Vercel may also report separately.
 
 ## Declare provenance in the PR body
 
@@ -181,5 +195,6 @@ issues.
 ## Final response
 
 Return PR URL, branch, commit summary, provenance declared, and validation
-evidence.
-The PR stays a draft.
+evidence, including required and relevant CI results for the current pushed
+head and the PR's final draft/readiness state. Do not say the work is done or
+complete unless required and relevant CI is green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,13 @@ read that path directly if your tool cannot load a skill by name.
 
 ## Worktrees and CI
 
-New tasks use a dedicated worktree/non-default branch from the remote
-default. Primary checkout and local `main`/`master` are read-only; existing work
-stays in its worktree.
+New tasks use a dedicated worktree/non-default branch. Primary checkout and
+local `main`/`master` are read-only.
 
-A pushed PR is not done. Run current-head CI; fix failures until
-required/relevant checks pass. If drafts skip CI, mark ready unless asked to
-leave it draft. Never claim done before green CI. See `create-a-pr`.
+A pushed PR is not done. Run current-head CI; fix failures until relevant checks
+pass. If draft CI skips, mark ready unless asked not to. Never claim done before
+green CI. Preserve `<!-- CURSOR_SUMMARY -->`…`<!-- /CURSOR_SUMMARY -->`; see
+`create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,15 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
-asserts human); never apply PR labels. Existing PR body edits must merge,
-preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
-byte-for-byte, refetch before writing, and verify after.
+## Worktrees and CI
+
+New tasks use a dedicated worktree/non-default branch from the remote
+default. Primary checkout and local `main`/`master` are read-only; existing work
+stays in its worktree.
+
+A pushed PR is not done. Run current-head CI; fix failures until
+required/relevant checks pass. If drafts skip CI, mark ready unless asked to
+leave it draft. Never claim done before green CI. See `create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,13 @@ read that path directly if your tool cannot load a skill by name.
 
 ## Worktrees and CI
 
-New tasks use a dedicated worktree/non-default branch from the remote
-default. Primary checkout and local `main`/`master` are read-only; existing work
-stays in its worktree.
+New tasks use a dedicated worktree/non-default branch. Primary checkout and
+local `main`/`master` are read-only.
 
-A pushed PR is not done. Run current-head CI; fix failures until
-required/relevant checks pass. If drafts skip CI, mark ready unless asked to
-leave it draft. Never claim done before green CI. See `create-a-pr`.
+A pushed PR is not done. Run current-head CI; fix failures until relevant checks
+pass. If draft CI skips, mark ready unless asked not to. Never claim done before
+green CI. Preserve `<!-- CURSOR_SUMMARY -->`…`<!-- /CURSOR_SUMMARY -->`; see
+`create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,15 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
-asserts human); never apply PR labels. Existing PR body edits must merge,
-preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
-byte-for-byte, refetch before writing, and verify after.
+## Worktrees and CI
+
+New tasks use a dedicated worktree/non-default branch from the remote
+default. Primary checkout and local `main`/`master` are read-only; existing work
+stays in its worktree.
+
+A pushed PR is not done. Run current-head CI; fix failures until
+required/relevant checks pass. If drafts skip CI, mark ready unless asked to
+leave it draft. Never claim done before green CI. See `create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -64,13 +64,13 @@ read that path directly if your tool cannot load a skill by name.
 
 ## Worktrees and CI
 
-New tasks use a dedicated worktree/non-default branch from the remote
-default. Primary checkout and local `main`/`master` are read-only; existing work
-stays in its worktree.
+New tasks use a dedicated worktree/non-default branch. Primary checkout and
+local `main`/`master` are read-only.
 
-A pushed PR is not done. Run current-head CI; fix failures until
-required/relevant checks pass. If drafts skip CI, mark ready unless asked to
-leave it draft. Never claim done before green CI. See `create-a-pr`.
+A pushed PR is not done. Run current-head CI; fix failures until relevant checks
+pass. If draft CI skips, mark ready unless asked not to. Never claim done before
+green CI. Preserve `<!-- CURSOR_SUMMARY -->`…`<!-- /CURSOR_SUMMARY -->`; see
+`create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -62,10 +62,15 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
-asserts human); never apply PR labels. Existing PR body edits must merge,
-preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
-byte-for-byte, refetch before writing, and verify after.
+## Worktrees and CI
+
+New tasks use a dedicated worktree/non-default branch from the remote
+default. Primary checkout and local `main`/`master` are read-only; existing work
+stays in its worktree.
+
+A pushed PR is not done. Run current-head CI; fix failures until
+required/relevant checks pass. If drafts skip CI, mark ready unless asked to
+leave it draft. Never claim done before green CI. See `create-a-pr`.
 
 ## Your React instincts are the main failure mode here
 


### PR DESCRIPTION
## Summary

- Require every new task to use a dedicated worktree and non-default branch.
- Treat the primary checkout and local `main`/`master` branches as read-only.
- Require current-head CI to be green before agent-authored PR work is described as done.

## Why

- Isolate concurrent agent work from the primary checkout and unrelated local changes.
- Make CI completion an explicit outcome instead of stopping after a push or PR creation.

## Changes

- Add the concise always-loaded worktree and CI policy to the root RuleSync rule.
- Expand the `create-a-pr` source skill with worktree preflight, ready-state CI bootstrap, monitoring, failure handling, and final-reporting requirements.
- Regenerate all RuleSync agent instruction and skill targets.

## Validation

- [ ] `pnpm format:check` (not run; targeted formatting used)
- [ ] `pnpm typecheck` (not run; documentation/agent-instruction-only change)
- [ ] `pnpm test` (not run; documentation/agent-instruction-only change)
- [x] targeted tests: `pnpm sync`, `pnpm rules:check`, `pnpm context:budget:check`, and targeted `pnpm format:files:check`

## Risk / follow-ups

- Policy-only change with no package or runtime impact. Repository CI will provide the broader validation gate.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title, with the type-prefixed head branch as a
fallback. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated agent-instruction only; no runtime, package, or CI workflow code changes.
> 
> **Overview**
> Tightens agent PR workflow so new work happens in a dedicated worktree on a non-default branch, with the primary checkout and local `main`/`master` treated as read-only.
> 
> Creating a PR through completion now authorizes marking it ready (unless asked to stay draft), then monitoring required/relevant CI until the current head is green. Agents must not call the work done until those checks pass, and must report CI results plus draft/readiness in the final response.
> 
> Also notes that RuleSync skill sources live under `.rulesync/skills/*` as well as rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed2591ed4c121a27cbbaea46243a23e75125bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789941033&installation_model_id=432790&pr_number=820&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F820&signature=52352e37253987f0bda5783a572ffb6721c6cd07769711172d1828d5dd27316b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->