### PR TITLE
fix: adopt framed primitive text during hydration

### DIFF
--- a/.changeset/fix-framed-primitive-hydration.md
+++ b/.changeset/fix-framed-primitive-hydration.md
@@ -1,0 +1,8 @@
+---
+"octane": patch
+---
+
+Fix duplicated text when hydrating a sole primitive child that the server framed,
+including spread-bearing hosts and conditional children. Reuse the server Text
+node while preserving hydration mismatch suppression, native events, and later
+child updates.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -10798,6 +10798,18 @@ class HydrationCapability {
 			}
 			return first as Text;
 		}
+		// A sole primitive can be framed by the server (e.g. a spread or ternary
+		// child). Unwrap only an exact text-only frame, then use the same adoption,
+		// mismatch and suppression behavior as bare text, without child-slot state.
+		if (this.isOpen(first)) {
+			const child = first.nextSibling;
+			const end = child?.nextSibling ?? null;
+			if (child?.nodeType === 3 && this.isClose(end) && end.nextSibling === null) {
+				first.remove();
+				end.remove();
+				return this.htext(el, text, loc);
+			}
+		}
 		const created = document.createTextNode(text);
 		el.appendChild(created);
 		return created;

--- a/packages/octane/tests/hydration/_fixtures/markerless-text.tsx
+++ b/packages/octane/tests/hydration/_fixtures/markerless-text.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'octane';
+/** @jsxImportSource octane */
+import { useLayoutEffect, useState, type OctaneNode } from 'octane';
 
 // A React-style `.tsx` only-child bare `{expr}` value hole (NOT `{… as string}`).
 // It lowers MARKERLESS — a single Text node appended to the host, no `<!>`
@@ -14,4 +15,36 @@ export function Counter() {
 	const [n, setN] = useState(0);
 	_bump = () => setN((x) => x + 1);
 	return <span id="c">{n}</span>;
+}
+
+export function SpreadButton({
+	children,
+	...props
+}: {
+	children?: OctaneNode;
+	title?: string;
+	onClick?: (event: MouseEvent) => void;
+	dangerouslySetInnerHTML?: { __html: string };
+	suppressHydrationWarning?: boolean;
+}) {
+	return <button {...props}>{children}</button>;
+}
+
+export function StatefulLabel({ onCleanup }: { onCleanup: () => void }) {
+	const [count, setCount] = useState(0);
+	useLayoutEffect(() => onCleanup, [onCleanup]);
+	return <span onClick={() => setCount((n) => n + 1)}>{'Child ' + count}</span>;
+}
+
+export function SpreadButtonPair({ first, second }: { first: OctaneNode; second: OctaneNode }) {
+	return (
+		<div>
+			<SpreadButton title="first">{first}</SpreadButton>
+			<SpreadButton title="second">{second}</SpreadButton>
+		</div>
+	);
+}
+
+export function ConditionalChild(props: { on: boolean; label: string }) {
+	return <div>{props.on ? <b>yes</b> : props.label}</div>;
 }

--- a/packages/octane/tests/hydration/markerless-text-hydrate.test.ts
+++ b/packages/octane/tests/hydration/markerless-text-hydrate.test.ts
@@ -1,34 +1,27 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { join } from 'node:path';
-import { compile } from 'octane/compiler';
-import { hydrateRoot, flushSync } from '../../src/index.js';
+import { createElement, createRoot, hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
-import { Counter, bump } from './_fixtures/markerless-text.tsx';
+import { loadServerFixture } from '../_server-fixture';
+import {
+	Counter,
+	ConditionalChild,
+	SpreadButton,
+	SpreadButtonPair,
+	StatefulLabel,
+	bump,
+} from './_fixtures/markerless-text.tsx';
 
-// An only-child bare `{expr}` value hole lowers MARKERLESS on both sides: the
-// server emits the host's bare text (no `<!--[-->…<!--]-->`), the client mounts a
-// plain Text node, and hydration ADOPTS that text node (same node, interactive)
-// — full parity with a `.tsrx` `{… as string}` text hole.
+// A sole renderable child must adopt the existing server text, whether the
+// host has static attributes or forwards a spread of component props.
 
 const FIXTURE = join(
 	process.cwd(),
 	'packages/octane/tests/hydration/_fixtures/markerless-text.tsx',
 );
 
-function serverModule(): Record<string, any> {
-	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'markerless-text.tsx', { mode: 'server' });
-	code = code.replace(
-		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
-	);
-	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
-	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
-	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
-}
-
-describe('hydrateRoot — markerless only-child `{expr}` value hole', () => {
-	const server = serverModule();
+describe('hydrateRoot — only-child renderable text', () => {
+	const server = loadServerFixture(FIXTURE, { id: 'markerless-text.tsx' });
 	let container: HTMLElement;
 	beforeEach(() => {
 		container = document.createElement('div');
@@ -36,40 +29,266 @@ describe('hydrateRoot — markerless only-child `{expr}` value hole', () => {
 	});
 	afterEach(() => container.remove());
 
-	it('compiles markerless: client uses childTextHole, server uses ssrChildText', () => {
-		const client = compile(readFileSync(FIXTURE, 'utf8'), 'markerless-text.tsx', {
-			mode: 'client',
-		}).code;
-		const srv = compile(readFileSync(FIXTURE, 'utf8'), 'markerless-text.tsx', {
-			mode: 'server',
-		}).code;
-		expect(client).toContain('childTextHole(');
-		expect(client).not.toContain('<!>'); // no placeholder baked into the template
-		expect(srv).toContain('ssrChildText(');
-	});
-
-	it('SSR is markerless and the client adopts the text node (interactive)', async () => {
+	it('adopts and updates the server text in a host without a spread', () => {
 		const { html } = ServerRT.renderToString(server.Counter, {});
-		// Bare text inside the span — no childSlot block range.
-		expect(html).toContain('<span id="c">0</span>');
-		expect(html).not.toContain('<!--[-->');
-
 		container.innerHTML = html;
 		const span = container.querySelector('#c') as HTMLElement;
-		const textNode = span.firstChild; // the server's bare text node
-		expect(textNode?.nodeType).toBe(3);
-
-		hydrateRoot(container, Counter, {});
-		flushSync(() => {});
-
-		// Adopted, not rebuilt: same span AND same text node.
-		expect(container.querySelector('#c')).toBe(span);
-		expect(span.firstChild).toBe(textNode);
+		const textNode = Array.from(span.childNodes).find((node) => node.nodeType === 3)!;
+		expect(textNode).toBeDefined();
 		expect(span.textContent).toBe('0');
 
-		// The markerless text binding is live.
-		flushSync(() => bump());
-		expect(span.textContent).toBe('1');
-		expect(span.firstChild).toBe(textNode); // updated in place, still the same node
+		const root = hydrateRoot(container, Counter, {});
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('#c')).toBe(span);
+			expect(span.contains(textNode)).toBe(true);
+			expect(span.textContent).toBe('0');
+
+			flushSync(() => bump());
+			expect(span.textContent).toBe('1');
+			expect(span.contains(textNode)).toBe(true);
+		} finally {
+			root.unmount();
+		}
 	});
+
+	it.each([
+		{ label: 'a string', children: 'Open', expected: 'Open' },
+		{ label: 'escaped text', children: 'Open & <close>', expected: 'Open & <close>' },
+		{ label: 'parser-normalized text', children: 'Open\r\nnext', expected: 'Open\nnext' },
+		{ label: 'an empty string', children: '', expected: '' },
+		{ label: 'false', children: false, expected: '' },
+		{ label: 'true', children: true, expected: '' },
+		{ label: 'null', children: null, expected: '' },
+		{ label: 'undefined', children: undefined, expected: '' },
+		{ label: 'zero', children: 0, expected: '0' },
+		{ label: 'a number', children: 42, expected: '42' },
+	])('adopts and updates a spread-bearing host from $label', ({ children, expected }) => {
+		const props = { children, title: 'server' };
+		container.innerHTML = ServerRT.renderToString(server.SpreadButton, props).html;
+		const button = container.querySelector('button')!;
+		const text = Array.from(button.childNodes).find((node) => node.nodeType === 3);
+		expect(button.textContent).toBe(expected);
+		if (expected !== '') expect(text).toBeDefined();
+		const root = hydrateRoot(container, SpreadButton, props);
+		try {
+			expect(container.querySelector('button')).toBe(button);
+			expect(button.textContent).toBe(expected);
+			if (text) expect(button.contains(text)).toBe(true);
+
+			flushSync(() => root.render(SpreadButton, { children: 'Updated', title: 'client' }));
+			expect(container.querySelector('button')).toBe(button);
+			expect(button.textContent).toBe('Updated');
+			expect(button.title).toBe('client');
+			if (text) {
+				expect(button.contains(text)).toBe(true);
+				expect(text.textContent).toBe('Updated');
+			}
+
+			for (const empty of ['', false, true, undefined, null]) {
+				flushSync(() => root.render(SpreadButton, { children: empty }));
+				expect(button.textContent).toBe('');
+				flushSync(() => root.render(SpreadButton, { children: 0 }));
+				expect(button.textContent).toBe('0');
+			}
+		} finally {
+			root.unmount();
+		}
+		expect(container.innerHTML).toBe('');
+	});
+
+	it.each(['render', 'hydrate'] as const)(
+		'keeps renderable mode changes, delegated events and cleanup live after %s',
+		(mode) => {
+			const originalClick = vi.fn();
+			const updatedClick = vi.fn();
+			const cleanup = vi.fn();
+			const props = { children: 'Open', onClick: originalClick };
+			if (mode === 'hydrate') {
+				container.innerHTML = ServerRT.renderToString(server.SpreadButton, props).html;
+			}
+			const root =
+				mode === 'hydrate' ? hydrateRoot(container, SpreadButton, props) : createRoot(container);
+			if (mode === 'render') root.render(SpreadButton, props);
+			const button = container.querySelector('button')!;
+			try {
+				expect(button.textContent).toBe('Open');
+				flushSync(() => button.click());
+				expect(originalClick).toHaveBeenCalledTimes(1);
+
+				flushSync(() =>
+					root.render(SpreadButton, {
+						children: createElement('strong', null, 'Bold'),
+						onClick: updatedClick,
+					}),
+				);
+				const strong = button.querySelector('strong')!;
+				expect(button.textContent).toBe('Bold');
+				const click = new MouseEvent('click', { bubbles: true });
+				flushSync(() => strong.dispatchEvent(click));
+				expect(originalClick).toHaveBeenCalledTimes(1);
+				expect(updatedClick).toHaveBeenCalledTimes(1);
+				expect(updatedClick.mock.calls[0][0]).toBe(click);
+
+				flushSync(() => root.render(SpreadButton, { children: 'Text' }));
+				expect(button.textContent).toBe('Text');
+				expect(strong.isConnected).toBe(false);
+				flushSync(() => button.click());
+				expect(updatedClick).toHaveBeenCalledTimes(1);
+
+				flushSync(() =>
+					root.render(SpreadButton, {
+						children: ['Back ', createElement('em', { key: 'label' }, 'again')],
+					}),
+				);
+				const emphasis = button.querySelector('em')!;
+				expect(button.textContent).toBe('Back again');
+				flushSync(() =>
+					root.render(SpreadButton, {
+						children: [createElement('em', { key: 'label' }, 'Again'), ' back'],
+					}),
+				);
+				expect(button.textContent).toBe('Again back');
+				expect(button.querySelector('em')).toBe(emphasis);
+
+				flushSync(() => root.render(SpreadButton, { children: 'Text again' }));
+				expect(button.textContent).toBe('Text again');
+				expect(emphasis.isConnected).toBe(false);
+
+				const componentProps = {
+					children: createElement(StatefulLabel, { onCleanup: cleanup }),
+					onClick: updatedClick,
+				};
+				flushSync(() => root.render(SpreadButton, componentProps));
+				const label = button.querySelector('span')!;
+				expect(button.textContent).toBe('Child 0');
+				flushSync(() => label.click());
+				expect(button.textContent).toBe('Child 1');
+				expect(updatedClick).toHaveBeenCalledTimes(2);
+				flushSync(() => root.render(SpreadButton, { ...componentProps, title: 'retained' }));
+				expect(button.querySelector('span')).toBe(label);
+				expect(button.textContent).toBe('Child 1');
+				expect(cleanup).not.toHaveBeenCalled();
+
+				flushSync(() => root.render(SpreadButton, { children: null }));
+				expect(button.textContent).toBe('');
+				expect(label.isConnected).toBe(false);
+				expect(cleanup).toHaveBeenCalledTimes(1);
+				flushSync(() => root.render(SpreadButton, componentProps));
+				expect(button.textContent).toBe('Child 0');
+				expect(container.querySelector('button')).toBe(button);
+			} finally {
+				root.unmount();
+			}
+			expect(cleanup).toHaveBeenCalledTimes(2);
+			expect(container.innerHTML).toBe('');
+			expect(button.isConnected).toBe(false);
+		},
+	);
+
+	it('adopts spread-bearing siblings without replacing either host or text', () => {
+		const props = { first: 'Open', second: 'Close' };
+		container.innerHTML = ServerRT.renderToString(server.SpreadButtonPair, props).html;
+		const buttons = Array.from(container.querySelectorAll('button'));
+		const texts = buttons.map((button) =>
+			Array.from(button.childNodes).find((node) => node.nodeType === 3),
+		);
+		const root = hydrateRoot(container, SpreadButtonPair, props);
+		try {
+			expect(container.textContent).toBe('OpenClose');
+			flushSync(() => root.render(SpreadButtonPair, { first: 'First', second: 'Second' }));
+			const updatedButtons = Array.from(container.querySelectorAll('button'));
+			expect(buttons.map((button) => button.textContent)).toEqual(['First', 'Second']);
+			for (let i = 0; i < buttons.length; i++) {
+				expect(updatedButtons[i]).toBe(buttons[i]);
+				expect(buttons[i].contains(texts[i]!)).toBe(true);
+			}
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('adopts a conditional primitive child and switches to and from an element', () => {
+		const props = { on: false, label: 'first' };
+		container.innerHTML = ServerRT.renderToString(server.ConditionalChild, props).html;
+		const div = container.querySelector('div')!;
+		const text = Array.from(div.childNodes).find((node) => node.nodeType === 3)!;
+		expect(div.textContent).toBe('first');
+		const root = hydrateRoot(container, ConditionalChild, props);
+		try {
+			expect(container.querySelector('div')).toBe(div);
+			expect(div.textContent).toBe('first');
+			expect(div.contains(text)).toBe(true);
+			flushSync(() => root.render(ConditionalChild, { on: false, label: 'second' }));
+			expect(div.textContent).toBe('second');
+			expect(text.textContent).toBe('second');
+			expect(div.contains(text)).toBe(true);
+			flushSync(() => root.render(ConditionalChild, { on: true, label: 'second' }));
+			const bold = div.querySelector('b')!;
+			expect(div.textContent).toBe('yes');
+			expect(text.isConnected).toBe(false);
+			flushSync(() => root.render(ConditionalChild, { on: false, label: 'last' }));
+			expect(div.textContent).toBe('last');
+			expect(bold.isConnected).toBe(false);
+			expect(container.querySelector('div')).toBe(div);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([false, true])(
+		'adopts mismatched spread text with suppressHydrationWarning=%s',
+		(suppressHydrationWarning) => {
+			const props = { children: 'Server', suppressHydrationWarning };
+			container.innerHTML = ServerRT.renderToString(server.SpreadButton, props).html;
+			const button = container.querySelector('button')!;
+			const text = Array.from(button.childNodes).find((node) => node.nodeType === 3)!;
+			const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				const root = hydrateRoot(container, SpreadButton, { ...props, children: 'Client' });
+				try {
+					flushSync(() => {});
+					expect(button.textContent).toBe(suppressHydrationWarning ? 'Server' : 'Client');
+					expect(button.contains(text)).toBe(true);
+					if (suppressHydrationWarning) {
+						expect(errors).not.toHaveBeenCalled();
+					} else if (process.env.OCTANE_TEST_COMPILE_MODE !== 'prod') {
+						expect(
+							errors.mock.calls.some(([message]) => String(message).includes('hydration mismatch')),
+						).toBe(true);
+					}
+					flushSync(() => root.render(SpreadButton, { ...props, children: 'Updated' }));
+					expect(button.textContent).toBe('Updated');
+					expect(button.contains(text)).toBe(true);
+				} finally {
+					root.unmount();
+				}
+			} finally {
+				errors.mockRestore();
+			}
+		},
+	);
+
+	it.each(['', false, true, undefined, 'Open'])(
+		'resumes children after raw HTML takes ownership of a hydrated host from %j',
+		(children) => {
+			container.innerHTML = ServerRT.renderToString(server.SpreadButton, { children }).html;
+			const root = hydrateRoot(container, SpreadButton, { children });
+			const button = container.querySelector('button')!;
+			try {
+				flushSync(() =>
+					root.render(SpreadButton, {
+						children: null,
+						dangerouslySetInnerHTML: { __html: '<b>Raw</b>' },
+					}),
+				);
+				expect(button.querySelector('b')?.textContent).toBe('Raw');
+				flushSync(() => root.render(SpreadButton, { children: 'Back' }));
+				expect(button.textContent).toBe('Back');
+				expect(container.querySelector('button')).toBe(button);
+			} finally {
+				root.unmount();
+			}
+		},
+	);
 });


### PR DESCRIPTION
## Summary

- Fix duplicated primitive text when hydrating a host whose server-rendered child has a frame, including spread-bearing hosts and conditional children.
- Unwrap only an exact sole-text frame in `HydrationCapability.htext`, then reuse normal Text adoption, mismatch handling, suppression, and parser normalization. No retained child-slot state or compiler changes.
- Extend the existing markerless hydration suite and add an `octane` patch changeset.

## Why

This valid component can server-render a framed primitive child:

```tsx
function Button({ children, ...props }) {
  return <button {...props}>{children}</button>;
}
```

Hydrating `children="Open"` saw the opening comment instead of a first-child Text node and appended another Text, producing `OpenOpen`. The same mismatch affects a sole conditional child such as `{on ? <b>yes</b> : label}`.

## Validation

- [x] Regression red/green: 20 failures before the fix; all 44 regression cases pass afterward across compiler dev/prod projects.
- [x] 770 tests passed: all core hydration tests, plus `innerhtml-spread.test.ts`, `generic-child-transitions.test.ts`, and `ternary-mixed-arms.test.ts`.
- [x] Coverage includes original host/Text identity, strings and parser-normalized text, empty/boolean/null/number values, subsequent updates, element/array/component switches, native delegated events, raw-HTML round trips, mismatch suppression, and unmount cleanup.
- [x] Public compile → SSR → hydrate proof in minified production Chromium for both spread and conditional shapes.
- [x] Core and changed-file `tsrx-tsc --noEmit` checks.
- [x] Changed-file Prettier, changeset validation, and `git diff --check`.
- [x] Full direct-Node equivalent of the repository sync command; no generated diff.
- [ ] Full monorepo format, typecheck, and test commands were not run locally; targeted checks above were used.

Local validation used `oxc-tsrx@0.4.0` and repository-patched `@tsrx/core@0.1.58` because the pinned `oxc-tsrx@0.5.0` was unavailable. Dependency manifests and lockfiles are unchanged.

## Performance

The existing production news control retained identical HTML, pre/post DOM census, host identity, and interactions. Hydration score was 2.25 → 2.31 ms (+2.8%, with reported score RME of 5.3–5.6%): inconclusive, with no speedup claim. The client bundle changed by +169 raw / +42 gzip / +105 brotli bytes. This is an unaffected markerless-hydration control, not a comparison treating the previously broken case as equivalent work.

## Risk / follow-ups

- Only a host filled by an opening frame comment, exactly one Text, and a final closing frame comment is normalized. Other shapes keep the existing path.
- The separate, pre-existing initial-null → raw HTML → text `NotFoundError` remains out of scope; it reproduces with and without this fix.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hydration DOM adoption in the runtime, which can cause visible mismatches if the unwrap is too aggressive. The change is small, shape-gated, and covered by expanded hydrate tests.
> 
> **Overview**
> Stops duplicated text when hydrating a sole primitive child that the server wrapped in a frame (spread-bearing hosts and conditionals like `{on ? <b>yes</b> : label}`). Previously `htext` saw the opening comment, appended a second Text node, and produced `OpenOpen`.
> 
> `HydrationCapability.htext` now unwraps only an exact open-comment / Text / close-comment host, then reuses the existing Text adoption path (mismatch, `suppressHydrationWarning`, parser-normalized text). Other shapes are unchanged; no compiler or child-slot state.
> 
> Hydration tests cover spread children, sibling hosts, ternary switches, events, raw HTML round-trips, and mismatch suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3178666006d45bfac0b367c6e474aeccd9277b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789946153&installation_model_id=432790&pr_number=823&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F823&signature=2357c3248963a4e556588840e501028080a4f4e08d3a3929ffbbbafaac0f7c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->