### PR TITLE
fix(octane): report inline boundary errors after commit

### DIFF
--- a/.changeset/committed-boundary-error-callbacks.md
+++ b/.changeset/committed-boundary-error-callbacks.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Fix missing root `onCaughtError` reports for first-mount and parent-driven error
+boundary catches in non-suspending renders. Publish inline reports after the
+fallback's refs and layout effects commit, preserve the original error, and
+discard abandoned reports without duplicating existing scheduled-error reports.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -911,6 +911,11 @@ routing and report through the same callbacks: boundary-claimed →
 `onCaughtError`, unclaimed → `onUncaughtError` (else the default
 `console.error`).
 
+In non-suspending renders, first-mount and parent-driven catches report the
+original error once after the fallback commits, including its refs and layout
+effects. Inline reports retained by Suspense or Activity wait for reveal, and
+are discarded if their catch is abandoned before that commit.
+
 ## Refs are props
 
 Components receive refs as ordinary props; there is no `forwardRef` wrapper:

--- a/packages/octane/audit/root-caught-error-reporting-performance.md
+++ b/packages/octane/audit/root-caught-error-reporting-performance.md
@@ -1,0 +1,139 @@
+# Root caught-error reporting: performance evidence
+
+Measured on 2026-08-22 against baseline commit
+`f1a78026e19f9db5c524b185f3a51cdd5a88e7cd`, archived before implementation.
+
+- Baseline `runtime.ts` SHA-256: `704d023c6d47728817fd590a54c83a8f60f2de7ea6bdf8ce4726cd44216cc667`.
+- Candidate `runtime.ts` SHA-256: `4efe7af4b0c2b8aae8a736d392676ee918d1c68b9b154a08205f4584666ba97f`.
+- Environment: macOS arm64, Node 26.4.0, esbuild 0.28.1, `@tsrx/core` 0.1.58,
+  esrap 2.3.2, and happy-dom 20.11.0.
+
+The configured registry blocked the native parser package before installation
+finished its links and repository-declared patches. Initial exploratory runs
+preceded that setup repair and are not the final evidence below. Both revisions
+were rerun after completing task-local dependency/workspace links and applying
+the already-committed patches by copy-on-write, without changing shared caches.
+The final measurements use the same locked benchmark dependencies, including the
+declared `@tsrx/core` patch; a second baseline execution reproduces all three JSON
+results exactly.
+
+Compilation selects the repository's shipped browser parser through its default
+package-import condition. No alternative registry or blocked package was used.
+These are browser-parser measurements, not native-parser validation.
+
+## Cost and lifetime
+
+Ordinary component renders gain no fields, closures, or arrays. The existing
+commit-action drain keeps its empty fast path, adds a result check per existing
+action, and supplies a commit-local report list checked after layout. Visible
+Activity updates and teardown add a reveal-storage lookup. Those constant checks
+are real costs that source-creation counters do not measure.
+
+Configured inline catches allocate one registration closure. Hidden catches also
+register a cleanup on first parking; disposing that catch removes its exact
+action even when its hidden owner survives. Reports reuse the existing reveal
+storage, extended to Activity, rather than adding a per-component map. Owner
+disposal, fresh primary mounts, and terminal catches clear retained work.
+Reconnect-context and ancestor searches run only while registering an actual
+caught error. Activity reveal wrappers are allocated only for parked actions.
+Only a surviving visible action creates a report record, and only commits with
+reports allocate the local report list. Identity/disposal checks cancel obsolete
+catches; commit-local lists prevent nested commits from publishing another
+commit's reports before its refs and layout effects.
+
+## Deterministic work
+
+All **993 non-bundle hook-memo metrics** are unchanged, including compiled fixture
+sizes and source-creation counters. Output, value, callback identity, and
+clean-versus-observed controls pass. Fixture, entry, observer, runner, and toolchain
+metadata match between revisions.
+
+A focused healthy-boundary probe reuses the unchanged hook-memo observer after
+production compilation and bundler tree shaking. It covers a plain leaf control,
+catch-only `@try`, `@try/@pending/@catch`, literal `<ErrorBoundary>`, and
+`createElement(ErrorBoundary)`, each with and without `onCaughtError`. Every
+configuration creates a root, mounts, performs 64 value-changing parent renders,
+and unmounts. Every render checks output, surviving leaf/section identity, absence
+of fallback content, and zero caught-error reports; teardown empties the root.
+Clean and observed executions agree.
+
+All **320 counters across those 40 phases** are identical. During each 64-update
+sequence, plain and compiled boundaries create no observed runtime functions or
+arrays. Compiled boundary caller plumbing retains its existing 64 application
+arrays; descriptor boundaries retain their existing 128 runtime functions and
+192 runtime rest arrays. Configuring the root callback does not change those
+update counts. These are source-creation events, not a complete heap-allocation
+census; object literals and allocations inside native built-ins are not counted.
+
+All 32 compiler files and `runtime.server.ts` are byte-identical. The observer's
+own value, lexical-closure, naming, and copy-on-write controls pass **2/2**.
+
+## Production bytes
+
+| Retained surface / fixture | Minified bytes, before → after | Gzip bytes, before → after | Gzip delta |
+| --- | ---: | ---: | ---: |
+| `attachBehaviorRoot` | 12,044 → 12,044 | 3,748 → 3,748 | 0 |
+| `createRoot` | 112,578 → 112,832 | 36,501 → 36,588 | +87 |
+| Root + state | 115,340 → 115,594 | 37,484 → 37,565 | +81 |
+| Root + compiler `errorBlock` | 115,754 → 116,970 | 37,523 → 37,903 | +380 |
+| Root + public `ErrorBoundary` | 138,344 → 139,778 | 44,312 → 44,770 | +458 |
+| Root + Suspense | 138,137 → 139,571 | 44,224 → 44,686 | +462 |
+| hook-memo runtime-form fixture | 141,616 → 141,880 | 44,875 → 44,958 | +83 |
+| hook-memo inline fixture | 143,283 → 143,547 | 45,417 → 45,499 | +82 |
+| Healthy-boundary fixture | 154,913 → 156,423 | 48,780 → 49,211 | +431 |
+
+The behavior-only bundle is byte-identical and excludes `runtime.ts`. Export
+surfaces use esbuild bundling, minification, tree shaking, ESM/browser/ESNext,
+production mode, disabled profiling, and gzip level 9. Root combinations also
+retain `createElement`, except the compiler-helper probe. They are retained export
+surfaces, not representative application bundles. Fixture sizes come from clean
+unobserved bundles; their bundle target is ES2022.
+
+## Commands and raw evidence
+
+Local runners, fixtures, source snapshots, manifests, and JSON results are under
+`/private/tmp/octane-824-perf-20260822-o6b3aceo`. Its `baseline` and `candidate-final`
+directories preserve the measured sources; `performance-comparison.json` records
+all deltas and verifies source/provenance equality. The baseline manifest includes
+the exact Git commit and per-file SHA-256 values.
+
+Run each source root with the same installed dependency root and result path:
+
+```sh
+OCTANE_MEMO_ROOT="$BENCH_SOURCE_ROOT" \
+OCTANE_MEMO_EXTERNAL_ROOT="$BENCH_DEPENDENCY_ROOT" \
+BENCH_JSON="$BENCH_RESULT_JSON" \
+node --import /private/tmp/octane-824-callbacks-browser-parser.mjs benchmarks/hook-memo/run.mjs
+
+node --import /private/tmp/octane-824-callbacks-browser-parser.mjs \
+  /private/tmp/octane-824-perf-20260822-o6b3aceo/healthy-boundaries.mjs \
+  "$BENCH_SOURCE_ROOT" "$BENCH_DEPENDENCY_ROOT" "$BENCH_RESULT_JSON"
+
+node /private/tmp/octane-824-perf-20260822-o6b3aceo/bundle-surfaces.mjs \
+  "$BENCH_SOURCE_ROOT" "$BENCH_DEPENDENCY_ROOT" "$BENCH_RESULT_JSON"
+
+python3 /private/tmp/octane-824-perf-20260822-o6b3aceo/compare-performance.py
+node --test benchmarks/hook-memo/instrument.test.mjs
+```
+
+Each probe has `-baseline.json`, `-baseline-recheck.json`, and `-candidate.json`
+results. The supported parser loader SHA-256 is
+`eef9d084eac53e4b09075364d8688e5fa1439512b885654061993be0e43a5fd6`;
+the unchanged lockfile SHA-256 is
+`047dfc5585e0dc60fbc9c3e3622af61d52bbb45dbc64ac717d9dd1bbdce91372`.
+The declared core patch SHA-256 is
+`1ce4d5ad217fbae79df568fcb088bb50bef3478506b420b8084c4f1e8df6c5b2`;
+its patched `src/transform/jsx/index.js` SHA-256 is
+`99feeaf7920877c55330e013caeeee9ff6d0950e8fe6f285909c5cc8e28826ac`.
+`dependency-repair-report.json` records the verified copy-on-write repair, while
+`pre-repair-evidence` preserves the superseded exploratory results separately.
+
+## Limits
+
+No latency, garbage-collection, or universal no-regression claim is made.
+Error-heavy throughput, Activity lookup overhead, reconnect-owner searches,
+long-lived hidden-report retention, and browser hydration throughput were not
+timed. SSR throughput was not repeated because the server runtime and compiler
+are unchanged. This audit establishes unchanged measured healthy-render work and
+the added production-byte cost; behavioral regression tests and current-head CI
+remain separate correctness gates.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2512,8 +2512,10 @@ const effectEventQueue: PendingEffectEvent[] = [];
 // Commit actions that must run after the callback bodies above publish. Activity
 // uses this for visible→hidden deactivation+DOM hiding so its cleanup sees the
 // fresh body while the range is still connected. Actions share the render/WIP
-// transaction below, so an aborted enclosing render drops them.
-const effectEventCommitActions: Array<() => void> = [];
+// transaction below, so an aborted enclosing render drops them. An inline catch
+// can return a report for this commit's post-layout phase, after its refs connect.
+type EffectEventCommitAction = () => InlineCaughtErrorReport | void;
+const effectEventCommitActions: EffectEventCommitAction[] = [];
 let passiveScheduled = false;
 // Monotonic enqueue counter — tags each PendingEffect with its DFS pre-order position
 // so the effect drains can reconstruct React's post-order (see comparePostOrder).
@@ -2612,7 +2614,7 @@ function attachLiveFragmentRef(instance: FragmentInstance): void {
 interface OffscreenCapture {
 	effects: [PendingEffect[], PendingEffect[], PendingEffect[]];
 	events: PendingEffectEvent[];
-	eventActions: Array<() => void>;
+	eventActions: EffectEventCommitAction[];
 	refs: RefAttach[];
 	// uSES store-syncs enqueued during this off-screen render (see storeSyncQueue).
 	// Spliced into the live queue on commit, dropped on dispose — a WIP that never
@@ -4098,7 +4100,7 @@ function commitEffects(): void {
 	// Activity visible→hidden work is transactionally deferred until the event
 	// bodies above publish. Its layout cleanup therefore sees the fresh body while
 	// the preserved DOM range is still connected, then the action hides that range.
-	drainEffectEventCommitActions();
+	const caughtReports = drainEffectEventCommitActions();
 	// Controlled-form commit work FIRST: select projections must see the
 	// options this render just built, and the dev missing-onInput check must
 	// see the element's full listener set (see drainControlledSyncs).
@@ -4117,6 +4119,7 @@ function commitEffects(): void {
 	// cleanup already fired in the mutation walk, ref attaches just landed, so a
 	// layout body sees populated refs and connected DOM.
 	if (mutationBatch !== null) runLayoutEffects(mutationBatch);
+	if (caughtReports !== null) publishInlineCaughtErrorReports(caughtReports);
 	// After layout effects (so a sibling layout effect that mutates+notifies the
 	// store has already run), reconcile each uSES consumer's committed snapshot
 	// against the store and re-render any that tore. Mirrors React draining its
@@ -4506,16 +4509,19 @@ function drainPassivePhase(): void {
 	}
 }
 
-function drainEffectEventCommitActions(): void {
-	if (effectEventCommitActions.length === 0) return;
+function drainEffectEventCommitActions(): InlineCaughtErrorReport[] | null {
+	if (effectEventCommitActions.length === 0) return null;
 	const q = effectEventCommitActions.splice(0);
+	let reports: InlineCaughtErrorReport[] | null = null;
 	for (let i = 0; i < q.length; i++) {
 		try {
-			q[i]();
+			const report = q[i]();
+			if (report !== undefined) (reports ??= []).push(report);
 		} catch (err) {
 			console.error(err);
 		}
 	}
+	return reports;
 }
 
 // Passive destroys of DELETED scopes, deferred past the sync phase (React
@@ -4892,7 +4898,7 @@ function enqueueEffectEventUpdate(entry: PendingEffectEvent): void {
 	EFFECT_EVENT_RENDER_TARGET.push(entry);
 }
 
-function enqueueEffectEventCommitAction(action: () => void): void {
+function enqueueEffectEventCommitAction(action: EffectEventCommitAction): void {
 	EFFECT_EVENT_ACTION_TARGET.push(action);
 }
 
@@ -5877,21 +5883,41 @@ interface LinkedStateSlot<Source, Value> {
 type LinkedStateTuple<Value> = [Value, StateSetter<Value>, () => Value];
 
 // A sibling may finish before another sibling suspends their shared boundary.
-// Keep linked-state publication and caught-error reports with that boundary:
-// their completed bodies may bail when the preserved primary finally reveals.
-let SUSPENSE_REVEAL_ACTIONS: WeakMap<TrySlot, Array<() => void>> | null = null;
+// Keep linked-state publication and caught-error reports with their hidden owner
+// (Suspense or Activity): completed bodies may bail when that owner reveals.
+let HIDDEN_REVEAL_ACTIONS: WeakMap<HiddenRenderOwner, EffectEventCommitAction[]> | null = null;
 
-function deferSuspenseRevealAction(boundary: TrySlot, action: () => void): void {
-	const deferred = (SUSPENSE_REVEAL_ACTIONS ??= new WeakMap());
+function deferHiddenRevealAction(
+	boundary: HiddenRenderOwner,
+	action: EffectEventCommitAction,
+): void {
+	const deferred = (HIDDEN_REVEAL_ACTIONS ??= new WeakMap());
 	const actions = deferred.get(boundary);
 	if (actions === undefined) deferred.set(boundary, [action]);
 	else actions.push(action);
 }
 
-function publishSuspenseRevealActions(boundary: TrySlot): void {
-	const actions = SUSPENSE_REVEAL_ACTIONS?.get(boundary);
+function publishHiddenRevealActions(boundary: HiddenRenderOwner): void {
+	const actions = HIDDEN_REVEAL_ACTIONS?.get(boundary);
 	if (actions === undefined) return;
-	SUSPENSE_REVEAL_ACTIONS!.delete(boundary);
+	if (boundary.__kind === 'activityBlockSlot') {
+		// A visible Activity render can still be discarded by an outer Suspense.
+		// Keep its parked work until a surviving commit consumes it; a retry may
+		// already see visible mode even though the first reveal never committed.
+		for (let i = 0; i < actions.length; i++) {
+			const action = actions[i];
+			enqueueEffectEventCommitAction(() => {
+				if (HIDDEN_REVEAL_ACTIONS?.get(boundary) !== actions) return;
+				const index = actions.indexOf(action);
+				if (index === -1) return;
+				actions.splice(index, 1);
+				if (actions.length === 0) HIDDEN_REVEAL_ACTIONS!.delete(boundary);
+				return action();
+			});
+		}
+		return;
+	}
+	HIDDEN_REVEAL_ACTIONS!.delete(boundary);
 	for (let i = 0; i < actions.length; i++) enqueueEffectEventCommitAction(actions[i]);
 }
 
@@ -5945,7 +5971,7 @@ export function useLinkedState<Source, Value>(
 						const publish = state!.renderPublish;
 						if (hiddenBoundary !== null && publish !== undefined) {
 							state!.renderParked = true;
-							deferSuspenseRevealAction(hiddenBoundary, publish);
+							deferHiddenRevealAction(hiddenBoundary, publish);
 							updatingParkedDraft = true;
 						}
 					}
@@ -6052,7 +6078,7 @@ export function useLinkedState<Source, Value>(
 		const hiddenBoundary = findSuspenseHiddenTry(block);
 		if (hiddenBoundary !== null) {
 			current.renderParked = true;
-			deferSuspenseRevealAction(hiddenBoundary, publish);
+			deferHiddenRevealAction(hiddenBoundary, publish);
 			return;
 		}
 		current.source = current.renderSource as Source;
@@ -21830,7 +21856,7 @@ function releaseHiddenText(text: Text, restore = true): void {
 // The visible arm must still unmount before its preserved hidden primary.
 function teardownTrySlot(state: TrySlot, detachDom: boolean): void {
 	cancelSuspenseRetry(state);
-	SUSPENSE_REVEAL_ACTIONS?.delete(state);
+	HIDDEN_REVEAL_ACTIONS?.delete(state);
 	if (state.block !== null) unmountBlock(state.block, detachDom);
 	discardOffscreenCapture(state.stagedCapture);
 	state.stagedCapture = null;
@@ -22005,7 +22031,7 @@ function clearPassthroughTry(state: TrySlot): void {
 	state.tryBlock = null;
 }
 
-function mountPassthroughCatch(state: TrySlot, error: unknown): void {
+function mountPassthroughCatch(state: TrySlot, error: unknown, reportInline = false): void {
 	clearPassthroughTry(state);
 	state.pendingThenable = null;
 	setTryBranch(state, 0);
@@ -22022,7 +22048,11 @@ function mountPassthroughCatch(state: TrySlot, error: unknown): void {
 		state.env,
 	);
 	state.block = block;
-	renderBlock(block);
+	try {
+		renderBlock(block);
+	} finally {
+		if (reportInline) enqueueInlineCaughtError(state);
+	}
 }
 
 function mountPassthroughPending(state: TrySlot, thenable: TrackedThenable<unknown>): void {
@@ -22110,7 +22140,7 @@ function renderPassthroughTry(state: TrySlot): void {
 			if (state.propagateSuspense) throw error;
 			mountPassthroughPending(state, error.thenable);
 		} else {
-			mountPassthroughCatch(state, error);
+			mountPassthroughCatch(state, error, true);
 		}
 	}
 }
@@ -22197,7 +22227,7 @@ export function errorBlock(
 			renderBlock(current);
 		} catch (error) {
 			if (isHostContextRequest(error) || isSuspenseException(error)) throw error;
-			switchErrorToCatch(state, error);
+			switchErrorToCatch(state, error, true);
 		}
 		return state.reset;
 	}
@@ -22253,6 +22283,7 @@ export function errorBlock(
 		switchErrorToCatch(
 			state,
 			error,
+			true,
 			adoptServerCatch && start !== null ? start : undefined,
 			adoptServerCatch && end !== null ? end : undefined,
 		);
@@ -22263,6 +22294,7 @@ export function errorBlock(
 function switchErrorToCatch(
 	state: ErrorSlot,
 	error: any,
+	reportInline = false,
 	adoptedStart?: Node,
 	adoptedEnd?: Node,
 ): void {
@@ -22331,6 +22363,8 @@ function switchErrorToCatch(
 		const parent = findTryHandler(state.parentBlock);
 		if (parent !== null) parent(propagated);
 		else console.error('catch body threw, no outer tryBlock:', nextError);
+	} finally {
+		if (reportInline) enqueueInlineCaughtError(state);
 	}
 }
 
@@ -22480,7 +22514,7 @@ export function tryBlock(
 			if (isSuspenseException(err)) {
 				if (s.propagateSuspense) throw err;
 				handleSuspense(s, err.thenable, s.tryBlock, journalCheckpoint);
-			} else switchToCatch(s, err);
+			} else switchToCatch(s, err, true);
 		} finally {
 			disarmTransitionJournal(journalCheckpoint);
 		}
@@ -22518,7 +22552,7 @@ function createTryBody(state: TrySlot, start: Node, end: Node): Block {
 
 /** New inputs abandon an initial primary that has never committed, not its fallback. */
 function restartUncommittedTry(state: TrySlot): Block | null {
-	SUSPENSE_REVEAL_ACTIONS?.delete(state);
+	HIDDEN_REVEAL_ACTIONS?.delete(state);
 	const old = state.tryBlock!;
 	const refs: SuspenseRefEntry[] = [];
 	collectVisibleSubtreeRefs(old, refs);
@@ -22546,7 +22580,7 @@ function mountHiddenTryBody(state: TrySlot): Block {
 
 function mountTry(state: TrySlot): void {
 	cancelSuspenseRetry(state);
-	SUSPENSE_REVEAL_ACTIONS?.delete(state);
+	HIDDEN_REVEAL_ACTIONS?.delete(state);
 	const wasPending = state.branch === 2;
 	const hydration = activeHydration();
 	discardOffscreenCapture(state.stagedCapture);
@@ -22677,6 +22711,7 @@ function mountTry(state: TrySlot): void {
 			switchToCatch(
 				state,
 				err,
+				true,
 				adoptServerCatch ? bStart : undefined,
 				adoptServerCatch ? bEnd : undefined,
 			);
@@ -23257,7 +23292,7 @@ function commitResumeInner(state: TrySlot): void {
 			}
 			if (state.branch === 1) {
 				if (wasPending) recordSuspenseCommit(state);
-				publishSuspenseRevealActions(state);
+				publishHiddenRevealActions(state);
 				// Reveal: re-attach the host refs detached on hide (same preserved nodes),
 				// before commitEffects fires recreated layout effects. Enumerating now
 				// ensures an aborted A→B hidden retry never resurrects stale ref A.
@@ -23735,7 +23770,7 @@ function attemptHiddenRevealInner(
 		state.pendingThenable = null;
 		spliceOffscreenCapture(hiddenCapture);
 		recordSuspenseCommit(state);
-		publishSuspenseRevealActions(state);
+		publishHiddenRevealActions(state);
 		queueCurrentHiddenRefs(state);
 		if (state.transitionTimeoutId !== null) {
 			clearTimeout(state.transitionTimeoutId);
@@ -24540,9 +24575,15 @@ function forwardFallbackSuspension(fallbackBlock: Block, error: unknown): boolea
 	return true;
 }
 
-function switchToCatch(state: TrySlot, err: any, adoptedStart?: Node, adoptedEnd?: Node): void {
+function switchToCatch(
+	state: TrySlot,
+	err: any,
+	reportInline = false,
+	adoptedStart?: Node,
+	adoptedEnd?: Node,
+): void {
 	cancelSuspenseRetry(state);
-	SUSPENSE_REVEAL_ACTIONS?.delete(state);
+	HIDDEN_REVEAL_ACTIONS?.delete(state);
 	const hydration = activeHydration();
 	discardOffscreenCapture(state.stagedCapture);
 	state.stagedCapture = null;
@@ -24704,6 +24745,8 @@ function switchToCatch(state: TrySlot, err: any, adoptedStart?: Node, adoptedEnd
 		const parent = findTryHandler(state.parentBlock);
 		if (parent) parent(propagated);
 		else console.error('catch body threw, no outer tryBlock:', e2);
+	} finally {
+		if (reportInline) enqueueInlineCaughtError(state);
 	}
 }
 
@@ -25549,6 +25592,7 @@ function showActivityRange(state: ActivitySlot): void {
 }
 
 function releaseActivityRange(state: ActivitySlot, restore: boolean): void {
+	if (!restore) HIDDEN_REVEAL_ACTIONS?.delete(state);
 	const hidden = state.hiddenDom;
 	if (hidden === null) return;
 	for (const el of hidden.displays) {
@@ -25874,6 +25918,7 @@ export function activityBlock(
 			// visible → visible: ordinary re-render in place.
 			renderBlock(b);
 		}
+		publishHiddenRevealActions(state);
 	}
 }
 
@@ -28452,6 +28497,9 @@ export interface RootOptions {
 	 * stacks are not part of Octane's API, matching the SSR `onError` shape).
 	 * Deletion-phase teardown errors report here too once their enclosing
 	 * boundary claims them (the routing itself is unchanged).
+	 * First-mount and parent-driven catches in non-suspending renders report
+	 * after their fallback's refs and layout effects commit. Retained hidden
+	 * reports wait for reveal; abandoning their catch cancels them.
 	 */
 	onCaughtError?: (error: unknown) => void;
 	/**
@@ -28534,16 +28582,116 @@ function reportCaughtError(block: Block | null, err: unknown, caught?: Block | n
 				if (caught.disposed) return;
 				const stillHidden = findSuspenseHiddenTry(caught);
 				if (stillHidden !== null) {
-					deferSuspenseRevealAction(stillHidden, publish);
+					deferHiddenRevealAction(stillHidden, publish);
 					return;
 				}
 				invokeRootErrorHandler(h, err);
 			};
-			deferSuspenseRevealAction(hiddenBoundary, publish);
+			deferHiddenRevealAction(hiddenBoundary, publish);
 			return;
 		}
 	}
 	invokeRootErrorHandler(h, err);
+}
+
+interface InlineCaughtErrorReport {
+	state: TrySlot | ErrorSlot;
+	block: Block;
+	error: unknown;
+	handler: (error: unknown) => void;
+	resume: EffectEventCommitAction;
+}
+
+/** Retained catches belong to the reveal even while its retry temporarily shows DOM. */
+function inlineCaughtErrorOwner(block: Block): HiddenRenderOwner | null {
+	const hidden = findHiddenRenderOwner(block, true);
+	if (hidden !== null) return hidden;
+	// A reconnecting primary is temporarily visible during speculative render.
+	// Keep its catch with that owner until reveal, even if a later sibling suspends.
+	for (let context = EFFECT_RECONNECT_CONTEXT; context !== null; context = context.parent) {
+		const root = context.root;
+		if (root !== block && !blockIsAncestorOf(root, block)) continue;
+		const suspense = (root as any).__trySlot as TrySlot | undefined;
+		if (suspense !== undefined && suspense.tryBlock === root) return suspense;
+		const activity = (root as any).__activitySlot as ActivitySlot | undefined;
+		if (activity !== undefined && activity.block === root) return activity;
+	}
+	if (!block.mounted) {
+		// An incomplete fallback may be unwinding a suspension to its enclosing
+		// Suspense, before that owner has hidden its primary. An ordinary fallback
+		// error instead disposes this catch and cancels its parked report.
+		for (let parent = block.parentBlock; parent !== null; parent = parent.parentBlock) {
+			const suspense = (parent as any).__trySlot as TrySlot | undefined;
+			if (suspense !== undefined && suspense.tryBlock === parent && !suspense.propagateSuspense) {
+				return suspense;
+			}
+		}
+	}
+	return null;
+}
+
+/** Inline boundary catches have no scheduled-error caller to report for them. */
+function enqueueInlineCaughtError(state: TrySlot | ErrorSlot): void {
+	if (ROOT_ERROR_HANDLERS === null || state.branch !== 0) return;
+	const block = state.block;
+	if (block === null) return;
+	const handler = rootErrorHandlersFor(block)?.onCaughtError;
+	if (handler === undefined) return;
+	const error = state.err;
+	let parkedOwner: HiddenRenderOwner | null = null;
+	let cleanupRegistered = false;
+	// Reuse render/WIP rollback: a later sibling can still abandon this catch.
+	// The returned record belongs to one commit's local list, so a nested commit
+	// during another action cannot publish it before this fallback's refs/layout.
+	const action = (owner?: HiddenRenderOwner): InlineCaughtErrorReport | void => {
+		parkedOwner = null;
+		if (block.disposed || state.block !== block) return;
+		const hidden = owner ?? findHiddenRenderOwner(block, true);
+		if (hidden !== null) {
+			parkedOwner = hidden;
+			if (!cleanupRegistered) {
+				cleanupRegistered = true;
+				// A child can be replaced while its hidden owner stays alive. Release
+				// this report then, rather than retaining it until a future reveal.
+				(block.cleanups ??= []).push(() => {
+					const owner = parkedOwner;
+					parkedOwner = null;
+					if (owner === null) return;
+					const actions = HIDDEN_REVEAL_ACTIONS?.get(owner);
+					if (actions === undefined) return;
+					const index = actions.indexOf(action);
+					if (index !== -1) actions.splice(index, 1);
+					if (actions.length === 0) HIDDEN_REVEAL_ACTIONS!.delete(owner);
+				});
+			}
+			deferHiddenRevealAction(hidden, action);
+			return;
+		}
+		return { state, block, error, handler, resume: action };
+	};
+	const owner = inlineCaughtErrorOwner(block);
+	if (owner !== null) {
+		// The fallback or a later sibling can suspend again. Keep this report with
+		// its reveal owner, outside the discarded retry's commit-action checkpoint.
+		action(owner);
+	} else {
+		enqueueEffectEventCommitAction(action);
+	}
+}
+
+function publishInlineCaughtErrorReports(reports: InlineCaughtErrorReport[]): void {
+	for (let i = 0; i < reports.length; i++) {
+		const report = reports[i];
+		if (report.block.disposed || report.state.block !== report.block) continue;
+		const hidden = findHiddenRenderOwner(report.block, true);
+		if (hidden !== null) {
+			report.resume();
+			continue;
+		}
+		// A layout effect may request reset without replacing this committed arm.
+		// Report the captured error, not the slot's now-reset branch or error value.
+		invokeRootErrorHandler(report.handler, report.error);
+	}
 }
 
 /** True when the owning root's onUncaughtError consumed the report (callers skip their default). */

--- a/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
+++ b/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
@@ -2,7 +2,216 @@
 // onUncaughtError on createRoot/hydrateRoot). Each host pairs a thrower with
 // (or without) a boundary so the tests can drive both report channels through
 // the render and passive-effect paths.
-import { ErrorBoundary, useEffect, useState } from 'octane';
+import {
+	Activity,
+	createElement,
+	ErrorBoundary,
+	HYDRATION_RANGE_BOUNDARY,
+	Suspense as CaughtSuspense,
+	use,
+	useEffect,
+	useLayoutEffect,
+	useState,
+} from 'octane';
+import type { ComponentBody } from 'octane';
+
+interface CaughtFallbackOptions {
+	fallbackRef?: { current: HTMLSpanElement | null };
+	onFallbackLayout?: () => void;
+	fallbackError?: Error;
+}
+
+export interface ParentErrorProps extends CaughtFallbackOptions {
+	error: Error | null;
+}
+
+function ParentDrivenThrower(props: ParentErrorProps) @{
+	if (props.error !== null) throw props.error;
+	<span>ok</span>
+}
+
+function caughtRenderText(error: unknown): string {
+	return 'caught:' + (error as Error).message;
+}
+
+export function CaughtRenderFallback(props: { error: unknown } & CaughtFallbackOptions) @{
+	if (props.fallbackError !== undefined) throw props.fallbackError;
+	useLayoutEffect(() => props.onFallbackLayout?.(), [props.onFallbackLayout]);
+	<span data-error-fallback ref={props.fallbackRef}>{caughtRenderText(props.error) as string}</span>
+}
+
+function renderCaughtFallback(error: unknown, props: CaughtFallbackOptions) {
+	return createElement(CaughtRenderFallback, {
+		error,
+		fallbackRef: props.fallbackRef,
+		onFallbackLayout: props.onFallbackLayout,
+		fallbackError: props.fallbackError,
+	});
+}
+
+export function LiteralCaughtParentError(props: ParentErrorProps) @{
+	<ErrorBoundary fallback={(error: unknown) => renderCaughtFallback(error, props)}>
+		<ParentDrivenThrower error={props.error} />
+	</ErrorBoundary>
+}
+
+export function DescriptorCaughtParentError(props: ParentErrorProps) {
+	return createElement(ErrorBoundary, {
+		fallback: (error: unknown) => renderCaughtFallback(error, props),
+		children: createElement(ParentDrivenThrower, { error: props.error }),
+	});
+}
+
+export function InlineCaughtParentError(props: ParentErrorProps) @{
+	@try {
+		<ParentDrivenThrower error={props.error} />
+	} @catch (error: unknown, _reset: () => void) {
+		<CaughtRenderFallback
+			error={error}
+			fallbackRef={props.fallbackRef}
+			onFallbackLayout={props.onFallbackLayout}
+			fallbackError={props.fallbackError}
+		/>
+	}
+}
+
+export function PassthroughCaughtRoot(props: ParentErrorProps) @{
+	<InlineCaughtParentError {...props} />
+}
+
+PassthroughCaughtRoot[HYDRATION_RANGE_BOUNDARY] = 'passthrough';
+
+export function ParentDrivenCaughtHost(
+	props: {
+		boundary: ComponentBody<ParentErrorProps>;
+		error: Error;
+		initiallyThrow: boolean;
+		tailError?: Error;
+	} & CaughtFallbackOptions,
+) @{
+	const [bang, setBang] = useState(props.initiallyThrow);
+	const Boundary = props.boundary;
+	<main>
+		<button data-trigger="boundary-error" onClick={() => setBang(true)}>trigger</button>
+		<Boundary
+			error={bang ? props.error : null}
+			fallbackRef={props.fallbackRef}
+			onFallbackLayout={props.onFallbackLayout}
+			fallbackError={props.fallbackError}
+		/>
+		<CaughtHostTail failed={bang} error={props.tailError} />
+	</main>
+}
+
+function CaughtHostTail(props: { failed: boolean; error?: Error }) @{
+	if (props.failed && props.error !== undefined) throw props.error;
+	<span>
+		{props.failed ? 'tail:failed' : 'tail:ready'}
+	</span>
+}
+
+export function LayoutResetCaughtHost(props: { error: Error } & CaughtFallbackOptions) @{
+	const [failed, setFailed] = useState(true);
+	<main>
+		<ErrorBoundary
+			fallback={(error: unknown, reset: () => void) => renderCaughtFallback(error, {
+				fallbackRef: props.fallbackRef,
+				onFallbackLayout: () => {
+					props.onFallbackLayout?.();
+					setFailed(false);
+					reset();
+				},
+			})}
+		>
+			<ParentDrivenThrower error={failed ? props.error : null} />
+		</ErrorBoundary>
+		<CaughtHostTail failed={failed} />
+	</main>
+}
+
+export interface HiddenCaughtActions {
+	fail: () => void;
+	wait: () => void;
+}
+
+interface HiddenCaughtProps extends CaughtFallbackOptions {
+	api: HiddenCaughtActions;
+	error: Error;
+	initial: Promise<string>;
+	pending: Promise<string>;
+}
+
+function IndependentlyCaughtOwner(props: HiddenCaughtProps) @{
+	const [failed, setFailed] = useState(false);
+	props.api.fail = () => setFailed(true);
+	@try {
+		<ParentDrivenThrower error={failed ? props.error : null} />
+	} @catch (error: unknown, _reset: () => void) {
+		<CaughtRenderFallback
+			error={error}
+			fallbackRef={props.fallbackRef}
+			onFallbackLayout={props.onFallbackLayout}
+		/>
+	}
+}
+
+function IndependentlyPendingSibling(props: HiddenCaughtProps) @{
+	const [promise, setPromise] = useState(props.initial);
+	props.api.wait = () => setPromise(props.pending);
+	const value = use(promise);
+	<span>{value as string}</span>
+}
+
+export function HiddenInlineCaughtHost(props: HiddenCaughtProps) @{
+	@try {
+		<main>
+			<IndependentlyCaughtOwner {...props} />
+			<span>|</span>
+			<IndependentlyPendingSibling {...props} />
+		</main>
+	} @pending {
+		<span>outer loading</span>
+	}
+}
+
+interface InterruptedActivityCaughtProps extends ParentErrorProps {
+	mode: 'hidden' | 'visible';
+	promise: Promise<string> | null;
+	siblingOutside: boolean;
+}
+
+function ActivityCaughtPendingSibling(props: { promise: Promise<string> | null }) @{
+	const value =
+		props.promise === null ? 'initial' : use(props.promise);
+	<span>{'|' + value as string}</span>
+}
+
+function ActivityCaughtContents(props: InterruptedActivityCaughtProps) @{
+	<section>
+		<DescriptorCaughtParentError
+			error={props.error}
+			fallbackRef={props.fallbackRef}
+			onFallbackLayout={props.onFallbackLayout}
+		/>
+		@if (!props.siblingOutside) {
+			<ActivityCaughtPendingSibling promise={props.promise} />
+		}
+	</section>
+}
+
+export function InterruptedActivityCaughtHost(props: InterruptedActivityCaughtProps) @{
+	<CaughtSuspense fallback={<span>outer loading</span>}>
+		<main>
+			<span>shell|</span>
+			<Activity mode={props.mode}>
+				<ActivityCaughtContents {...props} />
+			</Activity>
+			@if (props.siblingOutside) {
+				<ActivityCaughtPendingSibling promise={props.promise} />
+			}
+		</main>
+	</CaughtSuspense>
+}
 
 let bumpRender: (() => void) | null = null;
 export function triggerRenderThrow(): void {
@@ -19,7 +228,7 @@ function RenderThrower() @{
 }
 
 export function CaughtHost() @{
-	<ErrorBoundary fallback={(e) => 'caught:' + (e as Error).message}>
+	<ErrorBoundary fallback={(e: unknown) => 'caught:' + (e as Error).message}>
 		<RenderThrower />
 	</ErrorBoundary>
 }

--- a/packages/octane/tests/differential/suspense-timing.test.ts
+++ b/packages/octane/tests/differential/suspense-timing.test.ts
@@ -1055,16 +1055,37 @@ describe.each<Runtime>(['react', 'octane'])('%s suspending fallback renders', (r
 				return setup;
 			}
 
-			it('suspends an error fallback to an outer Suspense with no outer error boundary', async () => {
-				const { fallback, props } = errorResources();
-				let root!: TimingRoot;
-				await act(runtime, async () => {
-					root = mount(runtime, 'ErrorFallbackBoundary', props);
-				});
-				expect(visible(root)).toBe('outer loading');
-				await act(runtime, async () => fallback.resolve('fallback ready'));
-				expect(visible(root)).toBe('fallback ready:0');
-			});
+			it.each(['first mount', 'parent update'] as const)(
+				'reports a %s error only after its suspended fallback commits',
+				async (entry) => {
+					const { primary, fallback, props } = errorResources();
+					const layouts: string[] = [];
+					const reportedLayouts: string[][] = [];
+					props.onFallbackLayout = (value) => layouts.push(value);
+					if (entry === 'parent update') primary.resolve('primary ready');
+					let root!: TimingRoot;
+					await act(runtime, async () => {
+						root = mount(
+							runtime,
+							'ErrorFallbackBoundary',
+							{ ...props, primaryError: entry === 'first mount' ? props.primaryError : undefined },
+							{ onCaughtError: () => reportedLayouts.push([...layouts]) },
+						);
+					});
+					if (entry === 'parent update') {
+						expect(visible(root)).toBe('primary ready');
+						await act(runtime, async () => root.update(props));
+					}
+					expect(visible(root)).toBe('outer loading');
+					expect(root.caughtErrors).toEqual([]);
+					expect(layouts).toEqual([]);
+					await act(runtime, async () => fallback.resolve('fallback ready'));
+					expect(visible(root)).toBe('fallback ready:0');
+					expect(root.caughtErrors).toHaveLength(1);
+					expect(root.caughtErrors[0]).toBe(props.primaryError);
+					expect(reportedLayouts).toEqual([['fallback ready']]);
+				},
+			);
 
 			it('preserves committed error fallback state when refreshed data suspends', async () => {
 				const { props } = errorResources('fallback initial');
@@ -1131,22 +1152,38 @@ describe.each<Runtime>(['react', 'octane'])('%s suspending fallback renders', (r
 				expect(root.caughtErrors[0]).toBe(fallbackError);
 			});
 
-			it.each(['unmount', 'replacement'] as const)(
-				'discards a detached error report on %s before its fallback resolves',
-				async (cancellation) => {
+			it.each([
+				['unmount', 'first mount'],
+				['replacement', 'first mount'],
+				['unmount', 'parent update'],
+				['replacement', 'parent update'],
+				['unmount', 'scheduled rejection'],
+				['replacement', 'scheduled rejection'],
+			] as const)(
+				'discards an error report on %s before its fallback resolves (%s)',
+				async (cancellation, entry) => {
 					const { primary, fallback, props } = errorResources();
-					const suspendedProps = { ...props, primaryError: undefined };
+					const initialProps = {
+						...props,
+						primaryError: entry === 'first mount' ? props.primaryError : undefined,
+					};
+					if (entry === 'parent update') primary.resolve('primary ready');
 					let root!: TimingRoot;
 					await act(runtime, async () => {
-						root = mount(runtime, 'ErrorFallbackBoundary', suspendedProps);
+						root = mount(runtime, 'ErrorFallbackBoundary', initialProps);
 					});
-					expect(visible(root)).toBe('primary loading');
-					await act(runtime, async () => primary.reject(new Error('primary failed')));
+					if (entry === 'parent update') {
+						expect(visible(root)).toBe('primary ready');
+						await act(runtime, async () => root.update(props));
+					} else if (entry === 'scheduled rejection') {
+						expect(visible(root)).toBe('primary loading');
+						await act(runtime, async () => primary.reject(props.primaryError!));
+					}
 					expect(visible(root)).toBe('outer loading');
 					expect(root.caughtErrors).toEqual([]);
 					await act(runtime, async () => {
 						if (cancellation === 'unmount') root.unmount();
-						else root.update({ ...suspendedProps, replacement: 'replacement ready' });
+						else root.update({ ...props, replacement: 'replacement ready' });
 					});
 					const expected = cancellation === 'unmount' ? '' : 'replacement ready';
 					expect(visible(root)).toBe(expected);

--- a/packages/octane/tests/root-error-callbacks.test.ts
+++ b/packages/octane/tests/root-error-callbacks.test.ts
@@ -11,11 +11,15 @@
 // Roots created WITHOUT the options keep today's behavior byte-for-byte; the
 // control tests below pin that.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderToString } from 'octane/server';
+import { loadServerFixture } from './_server-fixture.js';
 import {
 	act,
+	Activity,
 	createRoot,
 	createContext,
 	createElement,
+	ErrorBoundary,
 	hydrateRoot,
 	flushSync,
 } from '../src/index.js';
@@ -30,10 +34,49 @@ import {
 	CleanupHost,
 	CaughtCleanupHost,
 	RefCleanupHost,
+	ParentDrivenCaughtHost,
+	LiteralCaughtParentError,
+	DescriptorCaughtParentError,
+	InlineCaughtParentError,
+	PassthroughCaughtRoot,
+	CaughtRenderFallback,
+	LayoutResetCaughtHost,
+	HiddenInlineCaughtHost,
+	InterruptedActivityCaughtHost,
+	type ParentErrorProps,
+	type HiddenCaughtActions,
 	triggerRenderThrow,
 	triggerEffectThrow,
 	triggerCleanupThrowerRemoval,
 } from './_fixtures/root-error-callbacks.tsrx';
+
+function visibleText(node: Node): string {
+	if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
+	if (node instanceof HTMLElement && (node.hidden || node.style.display === 'none')) return '';
+	return [...node.childNodes].map(visibleText).join('');
+}
+
+function observeCaughtCommit(container: HTMLElement) {
+	const fallbackRef = { current: null as HTMLSpanElement | null };
+	let layoutDone = false;
+	const observedCommit: Array<{
+		content: string;
+		refConnected: boolean;
+		layoutDone: boolean;
+	}> = [];
+	const onFallbackLayout = vi.fn(() => {
+		layoutDone = true;
+	});
+	const onCaughtError = vi.fn((_reported: unknown) => {
+		observedCommit.push({
+			content: visibleText(container),
+			refConnected: fallbackRef.current?.isConnected === true,
+			layoutDone,
+		});
+	});
+	const onUncaughtError = vi.fn();
+	return { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit };
+}
 
 describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 	let container: HTMLElement;
@@ -47,6 +90,452 @@ describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 		container.remove();
 		errSpy.mockRestore();
 	});
+
+	it('onCaughtError reports a direct root ErrorBoundary descriptor after its fallback commits', async () => {
+		const failure = new Error('direct-root-boom');
+		const reportedViews: Array<string | null> = [];
+		const onCaughtError = vi.fn((_reported: unknown) => {
+			reportedViews.push(container.textContent);
+		});
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onCaughtError, onUncaughtError });
+		try {
+			await act(() => {
+				root.render(
+					createElement(ErrorBoundary, {
+						fallback: 'caught',
+						children: createElement(() => {
+							throw failure;
+						}),
+					}),
+				);
+			});
+			expect(container.textContent).toBe('caught');
+			expect(onCaughtError).toHaveBeenCalledTimes(1);
+			expect(onCaughtError.mock.calls[0][0]).toBe(failure);
+			expect(reportedViews).toEqual(['caught']);
+			expect(onUncaughtError).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	describe.each([
+		['literal ErrorBoundary', LiteralCaughtParentError],
+		['createElement ErrorBoundary', DescriptorCaughtParentError],
+		['inline @try/@catch', InlineCaughtParentError],
+	] as const)('%s', (_name, boundary) => {
+		it.each(['first mount', 'parent-owned state update'] as const)(
+			'onCaughtError reports a %s error once after the fallback commits',
+			async (entry) => {
+				const error = new Error('parent-boom');
+				const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+					observeCaughtCommit(container);
+				const root = createRoot(container, { onCaughtError, onUncaughtError });
+				try {
+					await act(() => {
+						root.render(ParentDrivenCaughtHost, {
+							boundary,
+							error,
+							initiallyThrow: entry === 'first mount',
+							fallbackRef,
+							onFallbackLayout,
+						});
+					});
+					if (entry === 'parent-owned state update') {
+						expect(container.textContent).toBe('triggeroktail:ready');
+						expect(onCaughtError).not.toHaveBeenCalled();
+						await act(() => {
+							container
+								.querySelector<HTMLButtonElement>('[data-trigger="boundary-error"]')!
+								.click();
+						});
+					}
+					expect(container.textContent).toBe('triggercaught:parent-boomtail:failed');
+					expect(onCaughtError).toHaveBeenCalledTimes(1);
+					expect(onCaughtError.mock.calls[0][0]).toBe(error);
+					// Reporting sees the completed fallback commit, including its ref
+					// and layout effect, not a partially rendered parent replacement.
+					expect(observedCommit).toEqual([
+						{
+							content: 'triggercaught:parent-boomtail:failed',
+							refConnected: true,
+							layoutDone: true,
+						},
+					]);
+					expect(onUncaughtError).not.toHaveBeenCalled();
+				} finally {
+					root.unmount();
+				}
+			},
+		);
+
+		it('reports only the outer catch when an inner error fallback throws', async () => {
+			const primaryError = new Error('primary-boom');
+			const fallbackError = new Error('fallback-boom');
+			const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+				observeCaughtCommit(container);
+			const NestedBoundary = (props: ParentErrorProps) =>
+				createElement(ErrorBoundary, {
+					fallback: (error: unknown) =>
+						createElement(CaughtRenderFallback, {
+							error,
+							fallbackRef: props.fallbackRef,
+							onFallbackLayout: props.onFallbackLayout,
+						}),
+					children: createElement(boundary, { ...props, fallbackError }),
+				});
+			const root = createRoot(container, { onCaughtError, onUncaughtError });
+			try {
+				await act(() => {
+					root.render(ParentDrivenCaughtHost, {
+						boundary: NestedBoundary,
+						error: primaryError,
+						initiallyThrow: true,
+						fallbackRef,
+						onFallbackLayout,
+					});
+				});
+				expect(container.textContent).toBe('triggercaught:fallback-boomtail:failed');
+				expect(onCaughtError).toHaveBeenCalledTimes(1);
+				expect(onCaughtError.mock.calls[0][0]).toBe(fallbackError);
+				expect(observedCommit).toEqual([
+					{
+						content: 'triggercaught:fallback-boomtail:failed',
+						refConnected: true,
+						layoutDone: true,
+					},
+				]);
+				expect(onUncaughtError).not.toHaveBeenCalled();
+			} finally {
+				root.unmount();
+			}
+		});
+	});
+
+	it('reports the committed error even when its fallback layout requests a reset', async () => {
+		const error = new Error('reset-boom');
+		const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+			observeCaughtCommit(container);
+		const root = createRoot(container, { onCaughtError, onUncaughtError });
+		try {
+			await act(() => root.render(LayoutResetCaughtHost, { error, fallbackRef, onFallbackLayout }));
+			expect(container.textContent).toBe('oktail:ready');
+			expect(onCaughtError).toHaveBeenCalledTimes(1);
+			expect(onCaughtError.mock.calls[0][0]).toBe(error);
+			expect(observedCommit).toEqual([
+				{ content: 'caught:reset-boomtail:failed', refConnected: true, layoutDone: true },
+			]);
+			expect(onUncaughtError).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not report a caught initial render unmounted before its first commit', async () => {
+		const onCaughtError = vi.fn();
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onCaughtError, onUncaughtError });
+		await act(() => {
+			root.render(ParentDrivenCaughtHost, {
+				boundary: LiteralCaughtParentError,
+				error: new Error('abandoned-boom'),
+				initiallyThrow: true,
+			});
+			root.unmount();
+		});
+		expect(container.textContent).toBe('');
+		expect(onCaughtError).not.toHaveBeenCalled();
+		expect(onUncaughtError).not.toHaveBeenCalled();
+	});
+
+	it('does not report an inner catch abandoned by a later sibling error', async () => {
+		const primaryError = new Error('primary-boom');
+		const siblingError = new Error('sibling-boom');
+		const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+			observeCaughtCommit(container);
+		const root = createRoot(container, { onCaughtError, onUncaughtError });
+		try {
+			await act(() => {
+				root.render(
+					createElement(ErrorBoundary, {
+						fallback: (error: unknown) =>
+							createElement(CaughtRenderFallback, { error, fallbackRef, onFallbackLayout }),
+						children: createElement(ParentDrivenCaughtHost, {
+							boundary: LiteralCaughtParentError,
+							error: primaryError,
+							initiallyThrow: true,
+							tailError: siblingError,
+						}),
+					}),
+				);
+			});
+			expect(container.textContent).toBe('caught:sibling-boom');
+			expect(onCaughtError).toHaveBeenCalledTimes(1);
+			expect(onCaughtError.mock.calls[0][0]).toBe(siblingError);
+			expect(observedCommit).toEqual([
+				{ content: 'caught:sibling-boom', refConnected: true, layoutDone: true },
+			]);
+			expect(onUncaughtError).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([
+		['literal ErrorBoundary', LiteralCaughtParentError, 'LiteralCaughtParentError'],
+		['passthrough @try', PassthroughCaughtRoot, 'PassthroughCaughtRoot'],
+	] as const)(
+		'onCaughtError reports a client %s hydration catch after its fallback commits',
+		async (_kind, body, serverName) => {
+			const server = loadServerFixture('packages/octane/tests/_fixtures/root-error-callbacks.tsrx');
+			container.innerHTML = renderToString(server[serverName], { error: null }).html;
+			expect(container.textContent).toBe('ok');
+			const error = new Error('hydration-boom');
+			const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+				observeCaughtCommit(container);
+			let root: ReturnType<typeof hydrateRoot> | undefined;
+			try {
+				await act(() => {
+					root = hydrateRoot(
+						container,
+						body,
+						{ error, fallbackRef, onFallbackLayout },
+						{ onCaughtError, onUncaughtError },
+					);
+				});
+				expect(container.textContent).toBe('caught:hydration-boom');
+				expect(onCaughtError).toHaveBeenCalledTimes(1);
+				expect(onCaughtError.mock.calls[0][0]).toBe(error);
+				expect(observedCommit).toEqual([
+					{ content: 'caught:hydration-boom', refConnected: true, layoutDone: true },
+				]);
+				expect(onUncaughtError).not.toHaveBeenCalled();
+			} finally {
+				root?.unmount();
+			}
+		},
+	);
+
+	it.each([
+		['reveal', 'same update'],
+		['replacement', 'same update'],
+		['unmount', 'same update'],
+		['reveal', 'already hidden'],
+		['replacement', 'already hidden'],
+		['unmount', 'already hidden'],
+	] as const)(
+		'keeps a catch unreported under a suspended sibling before %s (%s)',
+		async (outcome, timing) => {
+			const error = new Error('hidden-boom');
+			let resolveSibling!: (value: string) => void;
+			const pending = new Promise<string>((resolve) => {
+				resolveSibling = resolve;
+			});
+			const api: HiddenCaughtActions = { fail() {}, wait() {} };
+			const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+				observeCaughtCommit(container);
+			const root = createRoot(container, { onCaughtError, onUncaughtError });
+			try {
+				await act(() => {
+					root.render(HiddenInlineCaughtHost, {
+						api,
+						error,
+						initial: Promise.resolve('sibling initial'),
+						pending,
+						fallbackRef,
+						onFallbackLayout,
+					});
+				});
+				expect(visibleText(container)).toBe('ok|sibling initial');
+				if (timing === 'already hidden') {
+					await act(() => api.wait());
+					expect(visibleText(container)).toBe('outer loading');
+					await act(() => api.fail());
+				} else {
+					await act(() => {
+						api.fail();
+						api.wait();
+					});
+				}
+				expect(visibleText(container)).toBe('outer loading');
+				expect(onCaughtError).not.toHaveBeenCalled();
+				expect(fallbackRef.current).toBeNull();
+				expect(onFallbackLayout).not.toHaveBeenCalled();
+				if (outcome === 'replacement') {
+					await act(() => root.render(createElement('span', null, 'replacement')));
+				} else if (outcome === 'unmount') {
+					await act(() => root.unmount());
+				}
+				await act(() => resolveSibling('sibling ready'));
+				if (outcome === 'reveal') {
+					expect(visibleText(container)).toBe('caught:hidden-boom|sibling ready');
+					expect(onCaughtError).toHaveBeenCalledTimes(1);
+					expect(onCaughtError.mock.calls[0][0]).toBe(error);
+					expect(observedCommit).toEqual([
+						{
+							content: 'caught:hidden-boom|sibling ready',
+							refConnected: true,
+							layoutDone: true,
+						},
+					]);
+				} else {
+					expect(visibleText(container)).toBe(outcome === 'replacement' ? 'replacement' : '');
+					expect(onCaughtError).not.toHaveBeenCalled();
+					expect(onFallbackLayout).not.toHaveBeenCalled();
+				}
+				expect(onUncaughtError).not.toHaveBeenCalled();
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it.each(['reveal', 'replacement', 'unmount'] as const)(
+		'keeps an Activity catch unreported while hidden before %s',
+		async (outcome) => {
+			const error = new Error('activity-boom');
+			const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+				observeCaughtCommit(container);
+			const renderCaughtChild = () =>
+				createElement(DescriptorCaughtParentError, {
+					error,
+					fallbackRef,
+					onFallbackLayout,
+				});
+			const root = createRoot(container, { onCaughtError, onUncaughtError });
+			try {
+				await act(() => {
+					root.render(createElement(Activity, { mode: 'hidden', children: renderCaughtChild() }));
+				});
+				// Activity prerenders the fallback, but its visible commit has not
+				// happened: neither refs, layout effects, nor reports may publish.
+				expect(container.querySelector('[data-error-fallback]')).not.toBeNull();
+				expect(visibleText(container)).toBe('');
+				expect(onCaughtError).not.toHaveBeenCalled();
+				expect(fallbackRef.current).toBeNull();
+				expect(onFallbackLayout).not.toHaveBeenCalled();
+				if (outcome === 'reveal') {
+					await act(() => {
+						root.render(
+							createElement(Activity, { mode: 'visible', children: renderCaughtChild() }),
+						);
+					});
+					expect(visibleText(container)).toBe('caught:activity-boom');
+					expect(onCaughtError).toHaveBeenCalledTimes(1);
+					expect(onCaughtError.mock.calls[0][0]).toBe(error);
+					expect(observedCommit).toEqual([
+						{ content: 'caught:activity-boom', refConnected: true, layoutDone: true },
+					]);
+				} else {
+					if (outcome === 'replacement') {
+						const replacement = createElement('span', null, 'replacement');
+						await act(() => {
+							root.render(createElement(Activity, { mode: 'hidden', children: replacement }));
+						});
+						// The Activity survives; replacing its hidden caught subtree must
+						// cancel that subtree's report before the Activity later reveals.
+						await act(() => {
+							root.render(createElement(Activity, { mode: 'visible', children: replacement }));
+						});
+					} else {
+						await act(() => root.unmount());
+					}
+					expect(visibleText(container)).toBe(outcome === 'replacement' ? 'replacement' : '');
+					expect(onCaughtError).not.toHaveBeenCalled();
+					expect(onFallbackLayout).not.toHaveBeenCalled();
+				}
+				expect(onUncaughtError).not.toHaveBeenCalled();
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it.each([
+		['inside', 'synchronous'],
+		['inside', 'suspending'],
+		['outside', 'synchronous'],
+		['outside', 'suspending'],
+	] as const)(
+		'reports a hidden Activity catch once after an interrupted reveal with a sibling %s Activity (%s initial render)',
+		async (placement, initialRender) => {
+			const error = new Error('activity-interrupted');
+			let resolveSibling!: (value: string) => void;
+			const pending = new Promise<string>((resolve) => {
+				resolveSibling = resolve;
+			});
+			const { fallbackRef, onFallbackLayout, onCaughtError, onUncaughtError, observedCommit } =
+				observeCaughtCommit(container);
+			const props = {
+				error,
+				fallbackRef,
+				onFallbackLayout,
+				siblingOutside: placement === 'outside',
+			};
+			const root = createRoot(container, { onCaughtError, onUncaughtError });
+			try {
+				// The hidden catch may finish synchronously or survive an initial
+				// pending sibling; neither path publishes before a visible commit.
+				await act(() => {
+					root.render(InterruptedActivityCaughtHost, {
+						...props,
+						mode: 'hidden',
+						promise: initialRender === 'suspending' ? Promise.resolve('initial') : null,
+					});
+				});
+				expect(visibleText(container)).toBe(placement === 'inside' ? 'shell|' : 'shell||initial');
+				expect(container.querySelector('[data-error-fallback]')).not.toBeNull();
+				expect(fallbackRef.current).toBeNull();
+				expect(onFallbackLayout).not.toHaveBeenCalled();
+				expect(onCaughtError).not.toHaveBeenCalled();
+
+				// The catch already exists in the hidden Activity. Showing it does
+				// not commit that catch while its later sibling is still suspended.
+				await act(() => {
+					root.render(InterruptedActivityCaughtHost, {
+						...props,
+						mode: 'visible',
+						promise: pending,
+					});
+				});
+				expect(visibleText(container)).toBe('outer loading');
+				expect(fallbackRef.current).toBeNull();
+				expect(onFallbackLayout).not.toHaveBeenCalled();
+				expect(onCaughtError).not.toHaveBeenCalled();
+
+				await act(() => resolveSibling('ready'));
+				expect(visibleText(container)).toBe('shell|caught:activity-interrupted|ready');
+				expect(fallbackRef.current?.isConnected).toBe(true);
+				expect(onFallbackLayout).toHaveBeenCalledTimes(1);
+				expect(onCaughtError).toHaveBeenCalledTimes(1);
+				expect(onCaughtError.mock.calls[0][0]).toBe(error);
+				expect(observedCommit).toEqual([
+					{
+						content: 'shell|caught:activity-interrupted|ready',
+						refConnected: true,
+						layoutDone: true,
+					},
+				]);
+
+				await act(() => {
+					root.render(InterruptedActivityCaughtHost, {
+						...props,
+						mode: 'visible',
+						promise: pending,
+					});
+				});
+				expect(visibleText(container)).toBe('shell|caught:activity-interrupted|ready');
+				expect(fallbackRef.current?.isConnected).toBe(true);
+				expect(onCaughtError).toHaveBeenCalledTimes(1);
+				expect(onUncaughtError).not.toHaveBeenCalled();
+			} finally {
+				await act(() => root.unmount());
+			}
+			expect(container.textContent).toBe('');
+			expect(fallbackRef.current).toBeNull();
+		},
+	);
 
 	it('onCaughtError fires once when a boundary claims a render error', async () => {
 		const onCaughtError = vi.fn();


### PR DESCRIPTION
## Summary

Fixes #824.

- Report first-mount and parent-driven catches for literal `<ErrorBoundary>`, public `createElement` descriptors, and inline `@try/@catch`.
- Deliver the original error exactly once after the surviving fallback's refs and layout effects commit. Abandoned catches stay silent, and existing scheduled-error reporting is not duplicated.
- Retain reports through covered Suspense retries and Activity reveals, including a fallback that suspends and a catch formed during an already-hidden retry.
- Add an `octane` patch changeset, public contract documentation, behavioral regressions, and performance evidence.

## Why

Inline catches did not have the scheduler caller that reports descendant-only errors. They rendered the right fallback but skipped the root callback. The fix uses the existing render/WIP commit actions and reveal storage, keeps post-layout reports local to their commit, and validates catch identity and ownership before publication.

## Validation

Current-head verification: [CI run](https://github.com/octanejs/octane/actions/runs/32563254745) passed for `7f5cccfc1` (26 successful jobs). Cursor Bugbot passed; there are no unresolved review threads. The PR is ready for maintainer review.

Local compilation used Octane's shipped browser parser. The configured registry explicitly blocks the pinned `oxc-tsrx` package; no alternative registry or blocked-package download was used. The interrupted install's task-local links and existing repository-declared patches were restored without changing package versions, manifests, or the lockfile.

| Check | Result |
| --- | --- |
| Complete affected suites, development + production | **492/492 passed**, no skipped tests |
| Error-boundary binding, differential, and SSR suites | **21/21 passed** |
| Broad core suite, development + production | **14,397 passed**; 6 native-parser-dependent tests and 2 native-dependent suite collections could not run successfully locally |
| Core source and public API type programs (`tsgo`) | Passed |
| Changed authored fixture (`tsrx-tsc`) | Passed |
| Scoped formatting, changesets, and test-marker checks | Passed |
| Repository sync and React parity metadata validation | Passed; generated files unchanged |

The baseline reproduces correct fallback DOM with missing callbacks, including the direct root-descriptor entry point. The regression matrix covers original-error identity, mount/parent-update entry, nested fallback failure, reset reentrancy, hydration, hidden/revealed catches, replacement, and unmount.

Scoped test-program typechecking still encounters three existing React DOM declaration-resolution errors and the shared server-fixture helper's undeclared `slot-hooks.js` import. The new hydration tests make that existing helper diagnostic reachable; the authored fixture and core/API programs pass. Full repository-wide `pnpm test`, `pnpm typecheck`, and `pnpm format:check` are not claimed locally green. Current-head CI is a separate gate.

Commands used the normal Vitest project configuration with a task-local selector for the existing browser parser:

```sh
node --import /private/tmp/octane-824-callbacks-browser-parser.mjs node_modules/vitest/vitest.mjs run packages/octane/tests \
  --config /private/tmp/octane-824-callbacks-vitest.config.mjs --configLoader native \
  --project octane --project octane-prod --maxWorkers=4
node node_modules/@typescript/native-preview/bin/tsgo --noEmit -p packages/octane/tsconfig.json
node node_modules/@typescript/native-preview/bin/tsgo --noEmit -p packages/octane/typetests/tsconfig.json
pnpm_config_verify_deps_before_run=warn NODE_OPTIONS='--import=/private/tmp/octane-824-callbacks-browser-parser.mjs' pnpm sync
```

The `pnpm` environment option prevents automatic reinstall attempts against the blocked dependency and leaves the missing-install-metadata warning visible; it does not alter security policy.

## Performance and review

[Performance evidence](https://github.com/openai-oss-forks/octane/blob/7f5cccfc1546ccfa4d53c8f375cca62919cc42a4/packages/octane/audit/root-caught-error-reporting-performance.md) compares the final source with current main `f1a78026e19f9db5c524b185f3a51cdd5a88e7cd` using the same repaired, lock-pinned inputs. All **993 non-bundle hook metrics** and **320 healthy-boundary creation counters** are unchanged, with semantic/identity controls passing. The retained compiler-boundary and public-boundary surfaces add **380 and 458 gzip bytes** respectively; the behavior-only bundle is identical. No latency improvement or universal allocation claim is made.

Adversarial review tightened incomplete-fallback and reconnect ownership, including ancestry guards for independent roots. It retained the existing scheduled-error path and generic rollback machinery instead of introducing a new per-component queue or effect lifecycle.

## Risk / follow-ups

- This fixes #824's explicitly non-suspending mount/parent-update scope. It does not change scheduled-report timing or redesign transition retention.
- Separate scratch probes confirmed two pre-existing Suspense cases on both base and candidate: a synchronous catch preceding a later sibling's initial suspension can still lose its report, and a held-transition error can expose its fallback before the later sibling resolves. Those broader behaviors are not claimed fixed here; no assertions were weakened in existing tests.
- Native-parser validation must pass in current-head CI before this PR is considered verified.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789980195&installation_model_id=432790&pr_number=828&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F828&signature=8aead3b8ec070637287a0f48976b308e63e94458e14de99cb4847150cb42bcd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches commit-phase error reporting, Suspense/Activity reveal queues, and catch-switch paths in the client runtime. Behavior is reporting-only and covered by new regressions, but a mistake could drop, duplicate, or mistime root callbacks.
> 
> **Overview**
> Fixes #824: first-mount and parent-driven `@try`/`ErrorBoundary` catches now fire root `onCaughtError` with the original error, once, after the fallback’s refs and layout effects commit.
> 
> Inline catches enqueue a commit-local report (no extra scheduled-error path). Hidden work parks on the existing reveal queue, now shared by Suspense and Activity, and is dropped if the catch is abandoned, replaced, or unmounted before a visible commit. Nested fallback throws, layout-time reset, hydration, and interrupted Activity reveals are covered; healthy-render counters stay unchanged with a modest production-byte cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f5cccfc1546ccfa4d53c8f375cca62919cc42a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->