### PR TITLE
perf(octane): reduce streaming replay and descriptor update work

### DIFF
--- a/.changeset/streaming-replay-checkpoints.md
+++ b/.changeset/streaming-replay-checkpoints.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Reduce streaming server-render work by checkpointing changed Suspense boundaries instead of copying the entire boundary registry for every component. Preserve render-phase retry state, discovery order, hydration seeds, and error handling.
+
+Avoid general keyed-child bookkeeping for a single owned text node, and avoid reclassifying host subtrees that already require component reconciliation. Keep text identity, foreign DOM ownership, and interrupted-update rollback unchanged.

--- a/benchmarks/chat-stream/README.md
+++ b/benchmarks/chat-stream/README.md
@@ -1,6 +1,6 @@
 # chat-stream benchmark
 
-The modern workload: a ChatGPT/Claude-style chat interface — conversation
+The modern workload: a streaming chat interface — conversation
 tabs, a keyed message list of role bubbles with mixed text/code segments, a
 CONTROLLED composer — streaming **predefined token sequences** into the UI.
 Seven frameworks implement the same DOM contract and state model; the harness
@@ -99,3 +99,51 @@ pnpm --dir benchmarks/chat-stream bench:work
 `TARGET_URL` overrides the preview address, and `WORK_JSON` saves the measured
 counts. The work build is deliberately unminified; the normal benchmark keeps
 its minified production bundle.
+
+## Runtime-descriptor streaming sidecar
+
+The compiled `.tsrx` fixture above does not exercise the generic host-tree
+renderer used by Markdown libraries. The sidecar projects the same eight
+`SCRIPTED_REPLIES` into one growing, multi-section document with headings,
+paragraphs, and code blocks. Each arrival creates fresh `createElement`
+descriptors, as a Markdown-to-JSX projection does. It deliberately excludes
+Markdown parsing, syntax highlighting, network pacing, and layout/paint: its
+metric is synchronous elapsed rendering and descriptor-projection time for the
+complete token stream in a production build.
+
+```bash
+pnpm --dir benchmarks/chat-stream bench:descriptors
+node benchmarks/chat-stream/descriptor-stream.mjs 16
+node benchmarks/chat-stream/descriptor-stream.mjs --build-only
+BENCH_JSON=/tmp/descriptor-stream.json node benchmarks/chat-stream/descriptor-stream.mjs 16
+```
+
+The runner builds a temporary production bundle, starts a loopback-only server
+on an available port, launches Chromium, and cleans both up. No separately
+running application or dependency installation is needed. Cases are:
+
+- `hosts_fine`: raw host descriptors in 8-token batches.
+- `hosts_coarse`: the same document in 64-token batches.
+- `components_fine`: the same document with a stateful component-backed Copy
+  button, exercising hosts whose descendants require reconciled Blocks.
+- `text_control`: the same visible text as a scalar return, bypassing generic
+  host-child reconciliation; host-tree optimizations should not help this case.
+
+Mount and the first batch are outside the timed window. An untimed pass verifies
+every subsequent chunk, checks surviving DOM identity, interacts with the Copy
+button and checks its state survives later arrivals, and verifies teardown.
+Three complete warmup streams precede the samples. Every timed sample then
+checks final content and survivor identity outside its timed window. The
+composer is left unchanged throughout. The JSON includes raw sample durations,
+shared benchmark statistics, semantic-content hashes, stream length, browser
+and Node versions, and source/fixture/corpus/compiler/lockfile/bundle hashes.
+
+`DESCRIPTOR_STREAM_ROOT` selects another checkout's Octane runtime source;
+`DESCRIPTOR_STREAM_EXTERNAL_ROOT` selects the checkout providing installed
+dependencies and the fixture's hook compiler. Both default to this runner's
+checkout. Use the same runner, corpus, dependencies, hook compiler, iteration
+count, and machine state for before/after measurements. Runtime source hashes
+include uncommitted changes; the Git commit alone is not the candidate identity.
+
+This sidecar measures Octane's generic descriptor renderer. It does not measure
+end-to-end application latency or the compiled `.tsrx` fixture's update path.

--- a/benchmarks/chat-stream/descriptor-entry.ts
+++ b/benchmarks/chat-stream/descriptor-entry.ts
@@ -1,0 +1,201 @@
+import { createElement, createRoot, flushSync, useState } from 'octane';
+import { SCRIPTED_REPLIES, segText } from './octane-tsrx/src/data.js';
+
+type Mode = 'hosts' | 'components' | 'text';
+const TITLE = 'Streaming response';
+let total = 0;
+const sections = SCRIPTED_REPLIES.map((reply, index) => {
+	const section = { ...reply, start: total, title: `Part ${index + 1}`, index };
+	total += reply.total;
+	return section;
+});
+const container = document.querySelector('#root') as HTMLElement;
+let root: ReturnType<typeof createRoot> | null = null;
+let updateProgress: (done: number) => void;
+let progress = 0;
+let currentMode: Mode = 'hosts';
+let copied = 0;
+let survivors = new Map<string, Element>();
+let scalarNode: ChildNode | null = null;
+
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(`descriptor-stream: ${message}`);
+}
+
+function CopyButton() {
+	const [count, setCount] = useState(0);
+	return createElement(
+		'button',
+		{ 'data-stable': 'copy', onClick: () => setCount(count + 1) },
+		`Copy (${count})`,
+	);
+}
+
+// This is the projection stage of a Markdown renderer, not a Markdown parser:
+// every arrival produces fresh descriptors for the currently visible document.
+// The source blocks/tokens and settled segment-string cache are chat-stream's.
+function Document({ mode }: { mode: Mode }) {
+	const [done, setDone] = useState(0);
+	const [copyCount, setCopyCount] = useState(0);
+	updateProgress = setDone;
+	const children = [];
+	let text = TITLE;
+	if (mode !== 'text') {
+		children.push(createElement('h1', { key: 'heading', 'data-stable': 'heading' }, TITLE));
+	}
+	for (const section of sections) {
+		const localDone = done - section.start;
+		if (localDone <= 0) break;
+		const blocks = [];
+		text += section.title;
+		for (const segment of section.segments) {
+			if (localDone <= segment.start) break;
+			const content = segText(segment, localDone);
+			if (mode === 'text') {
+				text += content;
+				continue;
+			}
+			const props = { key: segment.id, 'data-stable': `segment-${segment.id}` };
+			blocks.push(
+				segment.type === 'code'
+					? createElement(
+							'pre',
+							props,
+							createElement('code', { 'data-stable': `code-${segment.id}` }, content),
+						)
+					: createElement('p', props, content),
+			);
+		}
+		if (mode !== 'text') {
+			children.push(
+				createElement(
+					'section',
+					{ key: section.index, 'data-stable': `section-${section.index}` },
+					createElement('h2', { 'data-stable': `title-${section.index}` }, section.title),
+					createElement('div', { 'data-stable': `body-${section.index}` }, blocks),
+				),
+			);
+		}
+	}
+	if (mode === 'text') return text + 'Copy (0)';
+	children.push(
+		mode === 'components'
+			? createElement(CopyButton, { key: 'copy' })
+			: createElement(
+					'button',
+					{
+						key: 'copy',
+						'data-stable': 'copy',
+						onClick: () => setCopyCount(copyCount + 1),
+					},
+					`Copy (${copyCount})`,
+				),
+	);
+	return createElement('article', { 'data-stable': 'document' }, children);
+}
+
+// Independent content oracle: join the authored token arrays directly rather
+// than using the renderer's segText helper or its descriptor projection.
+function expectedText(done: number, copyCount: number): string {
+	let expected = TITLE;
+	for (const section of sections) {
+		if (done <= section.start) break;
+		expected += section.title;
+		for (const segment of section.segments) {
+			const count = Math.max(
+				0,
+				Math.min(segment.tokens.length, done - section.start - segment.start),
+			);
+			expected += segment.tokens.slice(0, count).join('');
+		}
+	}
+	return expected + `Copy (${copyCount})`;
+}
+
+function verify(): void {
+	assert(
+		container.textContent === expectedText(progress, copied),
+		`incorrect text at token ${progress}`,
+	);
+	if (currentMode === 'text') {
+		assert(
+			scalarNode !== null && scalarNode.parentNode === container,
+			'the scalar stream replaced its text node',
+		);
+	} else {
+		const next = new Map<string, Element>();
+		for (const node of container.querySelectorAll('[data-stable]')) {
+			const key = node.getAttribute('data-stable')!;
+			assert(!next.has(key), `duplicate document node ${key}`);
+			if (survivors.has(key)) assert(survivors.get(key) === node, `replaced surviving ${key}`);
+			next.set(key, node);
+		}
+		for (const key of survivors.keys()) assert(next.has(key), `removed surviving ${key}`);
+		survivors = next;
+	}
+	const composer = document.querySelector('#composer') as HTMLTextAreaElement;
+	assert(composer.value === 'a draft kept while the response streams', 'changed the composer');
+}
+
+function advance(batch: number): void {
+	progress = Math.min(total, progress + batch);
+	flushSync(() => updateProgress(progress));
+}
+
+function prepare(mode: Mode, batch: number): void {
+	root?.unmount();
+	assert(container.childNodes.length === 0, 'teardown left rendered content');
+	currentMode = mode;
+	progress = 0;
+	copied = 0;
+	survivors = new Map();
+	root = createRoot(container);
+	root.render(Document, { mode });
+	// Mount and the first token batch are not sustained-stream work. Capturing
+	// those first live nodes lets every timed sample protect survivor identity.
+	advance(batch);
+	scalarNode = Array.from(container.childNodes).find((node) => node.nodeType === 3) ?? null;
+	verify();
+}
+
+function semanticPass(mode: Mode, batch: number) {
+	prepare(mode, batch);
+	let chunks = 0;
+	while (progress < total) {
+		advance(batch);
+		chunks++;
+		if (chunks === 1 && mode !== 'text') {
+			const button = container.querySelector('button') as HTMLButtonElement;
+			flushSync(() => button.click());
+			copied = 1;
+		}
+		verify();
+	}
+	const result = {
+		tokens: total,
+		chunks,
+		text: container.textContent,
+		blocks: sections.reduce((count, section) => count + section.segments.length, 0),
+	};
+	root!.unmount();
+	root = null;
+	assert(container.childNodes.length === 0, 'final teardown left rendered content');
+	return result;
+}
+
+function sample(mode: Mode, batch: number) {
+	prepare(mode, batch);
+	(window as Window & { gc?: () => void }).gc?.();
+	let chunks = 0;
+	const start = performance.now();
+	while (progress < total) {
+		advance(batch);
+		chunks++;
+	}
+	const ms = performance.now() - start;
+	// No DOM queries, content comparisons, or identity bookkeeping are timed.
+	verify();
+	return { ms, chunks };
+}
+
+(window as any).__descriptorStream = { semanticPass, sample };

--- a/benchmarks/chat-stream/descriptor-stream.mjs
+++ b/benchmarks/chat-stream/descriptor-stream.mjs
@@ -1,0 +1,226 @@
+// Production browser sidecar for runtime-descriptor streaming. The compiled
+// cross-framework chat fixture remains unchanged and serves as a separate guard.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const HERE = import.meta.dirname;
+const RUNNER_REPO = path.resolve(HERE, '../..');
+const SOURCE_REPO = path.resolve(process.env.DESCRIPTOR_STREAM_ROOT || RUNNER_REPO);
+const DEPENDENCY_REPO = path.resolve(process.env.DESCRIPTOR_STREAM_EXTERNAL_ROOT || RUNNER_REPO);
+const OCTANE = path.join(SOURCE_REPO, 'packages/octane');
+const ENTRY = path.join(HERE, 'descriptor-entry.ts');
+const BUILD_ONLY = process.argv.includes('--build-only');
+const ITERATIONS = Number(process.argv.slice(2).find((arg) => arg !== '--build-only') || 12);
+assert(Number.isInteger(ITERATIONS) && ITERATIONS > 0, 'iterations must be a positive integer');
+const WARMUPS = 3;
+const OPS = [
+	{ name: 'hosts_fine', mode: 'hosts', batch: 8 },
+	{ name: 'hosts_coarse', mode: 'hosts', batch: 64 },
+	{ name: 'components_fine', mode: 'components', batch: 8 },
+	{ name: 'text_control', mode: 'text', batch: 8 },
+];
+const requireDependencies = createRequire(
+	path.join(DEPENDENCY_REPO, 'packages/octane/package.json'),
+);
+const { build, version: esbuildVersion } = requireDependencies('esbuild');
+const { chromium } = createRequire(
+	path.join(DEPENDENCY_REPO, 'benchmarks/chat-stream/package.json'),
+)('playwright');
+// Keep this fixture's hook transformation and dependencies fixed when selecting
+// another runtime checkout; the source-root override measures runtime changes.
+const compilerFile = path.join(DEPENDENCY_REPO, 'packages/octane/src/compiler/slot-hooks.js');
+const { slotHooks } = await import(pathToFileURL(compilerFile).href);
+const exportsMap = JSON.parse(fs.readFileSync(path.join(OCTANE, 'package.json'), 'utf8')).exports;
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+
+function sourceHash(directory) {
+	const hash = createHash('sha256');
+	function visit(current) {
+		const entries = fs
+			.readdirSync(current, { withFileTypes: true })
+			.sort((a, b) => a.name.localeCompare(b.name));
+		for (const entry of entries) {
+			const filename = path.join(current, entry.name);
+			if (entry.isDirectory()) visit(filename);
+			else if (entry.isFile()) {
+				hash.update(path.relative(directory, filename));
+				hash.update('\0');
+				hash.update(fs.readFileSync(filename));
+				hash.update('\0');
+			}
+		}
+	}
+	visit(directory);
+	return hash.digest('hex');
+}
+
+function sourceCommit() {
+	try {
+		return execFileSync('git', ['-C', SOURCE_REPO, 'rev-parse', 'HEAD'], {
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		}).trim();
+	} catch {
+		return null;
+	}
+}
+
+async function bundle(outfile) {
+	await build({
+		entryPoints: [ENTRY],
+		absWorkingDir: RUNNER_REPO,
+		outfile,
+		bundle: true,
+		minify: true,
+		format: 'esm',
+		platform: 'browser',
+		target: 'es2022',
+		logLevel: 'silent',
+		define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+		nodePaths: [
+			path.join(DEPENDENCY_REPO, 'packages/octane/node_modules'),
+			path.join(DEPENDENCY_REPO, 'node_modules'),
+		],
+		plugins: [
+			{
+				name: 'descriptor-stream-runtime',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => {
+						const entry =
+							exportsMap[request === 'octane' ? '.' : './' + request.slice('octane/'.length)];
+						const target = typeof entry === 'string' ? entry : entry?.import || entry?.default;
+						assert.equal(typeof target, 'string', `unmapped runtime import ${request}`);
+						return { path: path.resolve(OCTANE, target) };
+					});
+					plugin.onLoad({ filter: /descriptor-entry\.ts$/ }, ({ path: filename }) => {
+						if (filename !== ENTRY) return null;
+						const source = fs.readFileSync(filename, 'utf8');
+						const slotted = slotHooks(source, filename, {
+							environment: 'client',
+							hmr: false,
+							profile: false,
+						});
+						return { contents: slotted?.code ?? source, loader: 'ts', resolveDir: HERE };
+					});
+				},
+			},
+		],
+	});
+}
+
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-descriptor-stream-'));
+let browser;
+let server;
+try {
+	const output = path.join(directory, 'entry.js');
+	await bundle(output);
+	const code = fs.readFileSync(output);
+	const meta = {
+		node: process.version,
+		esbuild: esbuildVersion,
+		sourceCommit: sourceCommit(),
+		sourceRoot: SOURCE_REPO,
+		dependencyRoot: DEPENDENCY_REPO,
+		sourceSha256: sourceHash(path.join(OCTANE, 'src')),
+		entrySha256: sha256(fs.readFileSync(ENTRY)),
+		runnerSha256: sha256(fs.readFileSync(import.meta.filename)),
+		corpusSha256: sha256(fs.readFileSync(path.join(HERE, 'octane-tsrx/src/data.js'))),
+		compilerSha256: sha256(fs.readFileSync(compilerFile)),
+		lockfileSha256: sha256(fs.readFileSync(path.join(DEPENDENCY_REPO, 'pnpm-lock.yaml'))),
+		bundleSha256: sha256(code),
+		bundleBytes: code.length,
+		warmups: WARMUPS,
+		measurement:
+			'synchronous elapsed rendering and descriptor-projection time for a complete production stream, excluding mount, first chunk, parsing, paint, network pacing and semantic checks',
+	};
+	if (BUILD_ONLY) {
+		console.log(
+			JSON.stringify({ suite: 'chat-stream-descriptors', buildOnly: true, meta }, null, '\t'),
+		);
+	} else {
+		const html =
+			'<!doctype html><html><body><textarea id="composer">a draft kept while the response streams</textarea><main id="root"></main><script type="module" src="/entry.js"></script></body></html>';
+		server = http.createServer((request, response) => {
+			if (request.url === '/entry.js') {
+				response.writeHead(200, { 'content-type': 'text/javascript' });
+				response.end(code);
+			} else if (request.url === '/') {
+				response.writeHead(200, { 'content-type': 'text/html' });
+				response.end(html);
+			} else {
+				response.writeHead(404);
+				response.end();
+			}
+		});
+		await new Promise((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(0, '127.0.0.1', resolve);
+		});
+		browser = await chromium.launch({
+			headless: true,
+			args: ['--disable-extensions', '--js-flags=--expose-gc'],
+		});
+		meta.chromium = browser.version();
+		const results = {};
+		const semantics = {};
+		for (const op of OPS) {
+			const context = await browser.newContext();
+			try {
+				const page = await context.newPage();
+				const errors = [];
+				page.on('pageerror', (error) => errors.push(error.message));
+				await page.goto(`http://127.0.0.1:${server.address().port}/`, { waitUntil: 'load' });
+				const semantic = await page.evaluate(
+					({ mode, batch }) => window.__descriptorStream.semanticPass(mode, batch),
+					op,
+				);
+				semantics[op.name] = { ...semantic, text: undefined, textSha256: sha256(semantic.text) };
+				for (let i = 0; i < WARMUPS; i++) {
+					await page.evaluate(
+						({ mode, batch }) => window.__descriptorStream.sample(mode, batch),
+						op,
+					);
+				}
+				const samples = [];
+				for (let i = 0; i < ITERATIONS; i++) {
+					const measured = await page.evaluate(({ mode, batch }) => {
+						return window.__descriptorStream.sample(mode, batch);
+					}, op);
+					assert.equal(measured.chunks, semantic.chunks, 'sample changed the stream length');
+					samples.push(measured.ms);
+				}
+				assert.deepEqual(errors, [], 'production browser reported errors');
+				const stat = summarizeSamples(samples);
+				results[op.name] = { ...timingStatForJson(stat), rawSamplesMs: samples };
+				console.log(
+					`${op.name.padEnd(18)} ${stat.median.toFixed(2).padStart(8)} ms median; ${stat.score.toFixed(2)} ms score, ${stat.scoreRme.toFixed(1)}% RME`,
+				);
+			} finally {
+				await context.close();
+			}
+		}
+		const payload = {
+			suite: 'chat-stream-descriptors',
+			iterations: ITERATIONS,
+			targets: [{ name: 'octane', results, meta: { ...meta, semantics, ops: OPS } }],
+		};
+		if (process.env.BENCH_JSON) {
+			fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');
+			console.log(`BENCH_JSON written to ${process.env.BENCH_JSON}`);
+		}
+	}
+} finally {
+	await browser?.close();
+	if (server?.listening) await new Promise((resolve) => server.close(resolve));
+	fs.rmSync(directory, { recursive: true, force: true });
+}

--- a/benchmarks/chat-stream/package.json
+++ b/benchmarks/chat-stream/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "bench": "node run.mjs",
     "bench:long": "node run.mjs 16",
-    "bench:work": "node work.mjs"
+    "bench:work": "node work.mjs",
+    "bench:descriptors": "node descriptor-stream.mjs"
   },
   "dependencies": {
     "playwright": "catalog:default"

--- a/benchmarks/streaming-ssr/README.md
+++ b/benchmarks/streaming-ssr/README.md
@@ -41,10 +41,19 @@ deterministic `setTimeout` schedule:
   streaming-shape scenario: every framework's `totalTime` is floored at ~50ms
   by the schedule itself, so the numbers that matter are `shellTTFB` and the
   chunk framing.
-- **all-fast** — every card resolves at ~1ms. Data latency vanishes, so
-  per-chunk engine overhead dominates; this is the throughput scenario
+- **all-fast** — every card resolves at ~1ms. Data latency shrinks, so
+  per-chunk engine overhead is more visible; this is the throughput scenario
   (**renders/sec**, sequential, from mean `totalTime` — the ~1ms timer floor
   is included and identical for all targets).
+
+Three additional **Octane-only CPU controls** reuse the exact compiled page:
+`cpu-10` and `cpu-100` release 10 or 100 cards immediately after the consumer
+accepts the shell; `cpu-waves-50` releases 50 cards in reverse-discovery groups
+of five, advancing the producer when each response chunk is accepted. No data
+timers are added. The runtime's normal coalescing, full passes, serialization,
+and consumer acceptance remain in the measurement. These cases isolate
+per-component/per-boundary cost from a network or timer floor; they do not
+represent application token-streaming latency or a cross-framework comparison.
 
 ## Metrics (medians over the iteration count, after 5 warmup renders)
 
@@ -64,31 +73,28 @@ deterministic `setTimeout` schedule:
   `runFullFramedPass` + shell flush). This should stay near the top: it's one
   sync pass with no scheduler.
 - **octane `totalTime` / `chunkCount`** — the streaming engine's **pass-based
-  round model** (`runStream`): each round `settleSuspended`s **all** currently
-  suspended thenables (`Promise.all`), then re-runs a **full page pass**. With
-  10 independent boundaries that means the staggered schedule produces exactly
-  **2 chunks** (shell, then one segment batch after the *slowest* promise) —
-  octane does not flush card 0 at 5ms the way React/Preact/Solid/Ripple do. The
-  metrics here can't see per-boundary latency directly, but `chunkCount` = 2
-  is its fingerprint, and any regression that adds rounds (or passes per
-  round) shows up in `total_staggered` tail and `total_allfast`.
+  wave model** (`runStream`): `settleFirstOfWave` waits for the first unresolved
+  thenable, coalesces settlements from the same event-loop turn, then re-runs
+  a **full page pass**. A staggered boundary can flush before a slower sibling;
+  simultaneous settlements share a pass. Chunk counts describe the observed
+  coalescing, not a fixed shell-plus-one-batch contract.
 - **octane all-fast `renders/sec`** — the cost of (passes × full-tree
-  serialization): the all-fast render is shell pass + 1 settle + 1 full
-  re-pass + segment flush. If N boundaries with distinct resolve ticks ever
-  stop coalescing into one round, this crashes first. Don't tune the runtime
-  from this suite alone — profile `runStream`'s re-pass loop.
-- **React / Preact / Solid / Ripple** — reference engines measured on the same clock;
-  their per-boundary flushing is the granularity octane's round model trades
-  away.
+  serialization): the all-fast render normally coalesces into a shell pass
+  plus one full re-pass and segment flush. Separately resolving boundaries
+  legitimately require more waves. The controlled CPU cases make the cost of
+  those waves and boundary-count scaling measurable without the 1ms data floor.
+- **React / Preact / Solid / Ripple** — reference engines measured on the same
+  clock; their scheduling and flush policies can differ. Compare the output
+  gates and observed chunk counts alongside timing.
 
 ## Fairness notes / genuine semantic differences
 
 - Same DOM shape, same data schedule, promises created at render start for
   every target; the suspending read lives in a child component of the
   boundary in all five fixtures.
-- **octane**: per-round full re-passes (documented divergence from React Fizz
-  in `runtime.server.ts`) — batches all boundaries that resolve in the same
-  round into one chunk, and re-renders the whole page each round. Resolved
+- **octane**: per-wave full re-passes (documented divergence from React Fizz
+  in `runtime.server.ts`) — batches boundaries that resolve in the same
+  event-loop wave into one chunk, and re-renders the whole page each wave. Resolved
   boundary markup travels in parser-safe JSON data scripts so trusted raw HTML
   cannot close a protocol carrier early; the correctness gate decodes those
   carriers before inspecting the semantic page shape.
@@ -109,12 +115,15 @@ deterministic `setTimeout` schedule:
   Treat its numbers as a slightly-lighter-duty reference, not a strict
   apples-to-apples engine comparison.
 
-The harness correctness gate asserts semantics only (shell exactly once, all
-10 card payloads present, and — for staggered — the first chunk flushed before
-the slowest data could resolve and the stream outlived the 50ms schedule).
+The harness correctness gate asserts the shell appears exactly once and all
+requested card payloads are present (10 cards in the shared scenarios). For
+staggered, the first chunk must flush before the slowest data could resolve and
+the stream must outlive the 50ms schedule.
 Protocol payload decoding is confined to this verification pass; measured
-bytes, chunks, and timings always use the original wire output. Chunk framing
-is deliberately NOT gated; it's part of the result.
+bytes, chunks, and timings always use the original wire output. The shared
+timer-based scenarios do not fix chunk framing; it is part of the result. The
+controlled CPU cases additionally require the same chunk count in every timed
+sample, because consumer acceptance drives their producer schedule.
 
 ## Run
 
@@ -128,3 +137,9 @@ TARGETS=octane,react node benchmarks/streaming-ssr/run.mjs 10 --no-build
 `BENCH_JSON` ops per target: `shell_staggered`, `total_staggered`,
 `shell_allfast`, `total_allfast` (the latter carries `opsPerSec`); chunk
 counts, bytes, skeleton counts and all-fast renders/sec land in `meta`.
+Octane additionally reports `shell_cpu_10`, `total_cpu_10`, `shell_cpu_100`,
+`total_cpu_100`, `shell_cpu_waves_50`, and `total_cpu_waves_50`, with the actual
+card/group sizes, chunks, and bytes in `meta.controlledCpu`. Every CPU case
+passes the same complete-card-output gate and checks that the shell precedes
+the controlled data. Increase the iteration count for sub-millisecond cases;
+quick smoke runs establish correctness, not a performance claim.

--- a/benchmarks/streaming-ssr/octane/src/entry-server.ts
+++ b/benchmarks/streaming-ssr/octane/src/entry-server.ts
@@ -1,6 +1,6 @@
 import { renderToPipeableStream } from 'octane/server';
 import { App } from './App.tsrx';
-import { makeCards, type Scenario } from './data';
+import { cardData, makeCards, type CardData, type CardSlot, type Scenario } from './data';
 
 // Streaming SSR entry — octane target. The harness (../run.mjs) imports the
 // BUILT bundle of this module and times renderStream(): data promises start at
@@ -28,6 +28,38 @@ export function renderStream(scenario: Scenario, onChunk: (chunk: string) => voi
 		);
 		pipe({
 			write: onChunk,
+			end: resolve,
+		});
+	});
+}
+
+// CPU/scaling control for the same compiled page, without the data timers of
+// the cross-framework schedule. The producer releases a group only after the
+// previous response chunk is accepted, so the shell remains genuinely streamed
+// and the runtime's own wave/coalescing work stays inside the measurement.
+export function renderControlledStream(
+	cardCount: number,
+	waveSize: number,
+	onChunk: (chunk: string) => void,
+): Promise<void> {
+	const resolveCards: Array<() => void> = [];
+	const cards: CardSlot[] = Array.from({ length: cardCount }, (_, id) => ({
+		id,
+		promise: new Promise<CardData>((resolve) => resolveCards.push(() => resolve(cardData(id)))),
+	}));
+	let remaining = cardCount;
+	return new Promise((resolve, reject) => {
+		const stream = renderToPipeableStream(
+			App,
+			{ cards },
+			{ onShellError: reject, onError: reject },
+		);
+		stream.pipe({
+			write(chunk) {
+				onChunk(chunk);
+				for (let i = Math.min(waveSize, remaining); i > 0; i--) resolveCards[--remaining]();
+				return true;
+			},
 			end: resolve,
 		});
 	});

--- a/benchmarks/streaming-ssr/run.mjs
+++ b/benchmarks/streaming-ssr/run.mjs
@@ -65,6 +65,11 @@ const TARGETS = [
 	{ name: 'ripple', dir: 'ripple' },
 ];
 const SCENARIOS = ['staggered', 'all-fast'];
+const CPU_SCENARIOS = [
+	{ name: 'cpu-10', cards: 10, waveSize: 10 },
+	{ name: 'cpu-100', cards: 100, waveSize: 100 },
+	{ name: 'cpu-waves-50', cards: 50, waveSize: 5 },
+];
 const CARD_COUNT = 10;
 
 const TARGET_FILTER = process.env.TARGETS
@@ -126,7 +131,7 @@ async function renderOnce(mod, scenario, collect = false) {
 	const chunks = [];
 	let html = '';
 	const t0 = performance.now();
-	await mod.renderStream(scenario, (chunk) => {
+	await renderScenario(mod, scenario, (chunk) => {
 		if (chunk.length === 0) return;
 		chunks.push({ t: performance.now() - t0, bytes: Buffer.byteLength(chunk) });
 		if (collect) html += chunk;
@@ -139,6 +144,13 @@ async function renderOnce(mod, scenario, collect = false) {
 		bytes: chunks.reduce((a, c) => a + c.bytes, 0),
 		html,
 	};
+}
+
+function renderScenario(mod, scenario, onChunk) {
+	const controlled = CPU_SCENARIOS.find((candidate) => candidate.name === scenario);
+	return controlled
+		? mod.renderControlledStream(controlled.cards, controlled.waveSize, onChunk)
+		: mod.renderStream(scenario, onChunk);
 }
 
 // Correctness gate shared with the ssr-http suite (same fixtures, same
@@ -156,8 +168,16 @@ for (const t of selected) {
 		continue;
 	}
 	const mod = await import(pathToFileURL(entry).href);
+	if (t.name === 'octane-tsrx' && typeof mod.renderControlledStream !== 'function') {
+		failures.push(`${t.name}: CPU entry missing from bundle (rebuild without --no-build)`);
+		continue;
+	}
 	const target = { name: t.name, scenarios: {} };
-	for (const scenario of SCENARIOS) {
+	const scenarios = [
+		...SCENARIOS,
+		...(typeof mod.renderControlledStream === 'function' ? CPU_SCENARIOS.map((s) => s.name) : []),
+	];
+	for (const scenario of scenarios) {
 		console.error(`running ${t.name}/${scenario} (${WARMUP} warmup + ${ITER} timed renders)…`);
 		try {
 			// Warm up FIRST (template compilation, JIT), then verify against a warm
@@ -169,7 +189,7 @@ for (const t of selected) {
 			let html = '';
 			const vt0 = performance.now();
 			let vChunks = 0;
-			await mod.renderStream(scenario, (chunk) => {
+			await renderScenario(mod, scenario, (chunk) => {
 				if (chunk.length === 0) return;
 				if (vChunks === 0) firstChunk = chunk;
 				vChunks++;
@@ -179,8 +199,11 @@ for (const t of selected) {
 				t.name,
 				scenario,
 				{ html, firstChunk, total: performance.now() - vt0 },
-				CARD_COUNT,
+				CPU_SCENARIOS.find((candidate) => candidate.name === scenario)?.cards ?? CARD_COUNT,
 			);
+			if (scenario.startsWith('cpu-') && firstChunk.includes('<article')) {
+				throw new Error(`${t.name}/${scenario}: controlled data appeared before shell acceptance`);
+			}
 			const shell = [];
 			const total = [];
 			const chunkCounts = [];
@@ -191,6 +214,9 @@ for (const t of selected) {
 				total.push(r.total);
 				chunkCounts.push(r.chunkCount);
 				bytes = r.bytes;
+			}
+			if (scenario.startsWith('cpu-') && chunkCounts.some((count) => count !== vChunks)) {
+				throw new Error(`${t.name}/${scenario}: producer pacing changed across timed samples`);
 			}
 			target.scenarios[scenario] = {
 				shell: summarize(shell),
@@ -214,7 +240,7 @@ const kb = (n) => (n / 1024).toFixed(1).padStart(7);
 console.log(
 	`\nstreaming-ssr — shell TTFB + stream-end totals (${ITER} renders/scenario, production builds)`,
 );
-for (const scenario of SCENARIOS) {
+for (const scenario of [...SCENARIOS, ...CPU_SCENARIOS.map((s) => s.name)]) {
 	console.log(`\n[${scenario}]`);
 	console.log(
 		'target       | shell score |  (min)   | total score |  (min)   | chunks | bytes KB | renders/s',
@@ -269,10 +295,25 @@ if (process.env.BENCH_JSON) {
 				ops.shell_allfast = timingStatForJson(af.shell);
 				ops.total_allfast = timingStatForJson(af.total);
 			}
+			const controlledCpu = {};
+			for (const scenario of CPU_SCENARIOS) {
+				const result = r.scenarios[scenario.name];
+				if (!result) continue;
+				const name = scenario.name.replaceAll('-', '_');
+				ops[`shell_${name}`] = timingStatForJson(result.shell);
+				ops[`total_${name}`] = timingStatForJson(result.total);
+				controlledCpu[scenario.name] = {
+					cards: scenario.cards,
+					waveSize: scenario.waveSize,
+					chunks: result.chunkCount,
+					bytes: result.bytes,
+				};
+			}
 			return {
 				name: r.name,
 				ops,
 				meta: {
+					...(Object.keys(controlledCpu).length > 0 ? { controlledCpu } : {}),
 					chunksStaggered: st ? st.chunkCount : null,
 					bytesStaggered: st ? st.bytes : null,
 					skeletonsStaggered: st ? st.skeletonsInStream : null,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -3239,27 +3239,9 @@ function captureComponentReplayState(scope: SSRScope, frame: Frame | null) {
 		streamNextId: stream?.nextId ?? 0,
 		streamActiveTryKeys: stream?.activeTryKeys.slice() ?? [],
 		streamActiveOwnerKeys: stream?.activeOwnerKeys.slice() ?? [],
-		streamPassBoundaryKeys:
-			stream?.activePassBoundaryKeys === null || stream?.activePassBoundaryKeys === undefined
-				? null
-				: new Set(stream.activePassBoundaryKeys),
+		streamPassBoundaryCount: stream?.activePassBoundaryKeys?.size ?? 0,
 		asyncScope: ASYNC_SCOPE,
-		streamBoundaries:
-			stream === null
-				? null
-				: Array.from(stream.boundaries, ([key, entry]) => ({
-						key,
-						entry,
-						id: entry.id,
-						order: entry.order,
-						state: entry.state,
-						html: entry.html,
-						seeds: entry.seeds.slice(),
-						pendingIdOffset: entry.pendingIdOffset,
-						ancestors: entry.ancestors.slice(),
-						owners: entry.owners.slice(),
-						namespace: entry.namespace,
-					})),
+		streamReplayCheckpoint: stream?.replay?.length ?? 0,
 		frameDeferred: frame?.deferred ?? false,
 		frameNextChild: frame?.nextChild ?? 0,
 		frameScopedChildren:
@@ -3319,30 +3301,21 @@ function rewindComponentReplayState(
 		VT_SSR_STACK.push(entry.candidate);
 	}
 	const stream = snapshot.stream;
-	if (stream !== null && snapshot.streamBoundaries !== null) {
+	if (stream !== null) {
 		stream.nextId = snapshot.streamNextId;
-		if (stream.activePassBoundaryKeys !== null && snapshot.streamPassBoundaryKeys !== null) {
-			stream.activePassBoundaryKeys.clear();
-			for (const key of snapshot.streamPassBoundaryKeys) stream.activePassBoundaryKeys.add(key);
+		if (stream.activePassBoundaryKeys !== null) {
+			// Discovery only appends during a pass. Trim the discarded suffix on
+			// the rare retry instead of copying the growing set for every component.
+			let index = 0;
+			for (const key of stream.activePassBoundaryKeys) {
+				if (index++ >= snapshot.streamPassBoundaryCount) stream.activePassBoundaryKeys.delete(key);
+			}
 		}
 		stream.activeTryKeys.length = 0;
 		stream.activeTryKeys.push(...snapshot.streamActiveTryKeys);
 		stream.activeOwnerKeys.length = 0;
 		stream.activeOwnerKeys.push(...snapshot.streamActiveOwnerKeys);
-		stream.boundaries.clear();
-		for (const saved of snapshot.streamBoundaries) {
-			const entry = saved.entry;
-			entry.id = saved.id;
-			entry.order = saved.order;
-			entry.state = saved.state;
-			entry.html = saved.html;
-			entry.seeds = saved.seeds.slice();
-			entry.pendingIdOffset = saved.pendingIdOffset;
-			entry.ancestors = saved.ancestors.slice();
-			entry.owners = saved.owners.slice();
-			entry.namespace = saved.namespace;
-			stream.boundaries.set(saved.key, entry);
-		}
+		rewindStreamBoundaryReplay(stream, snapshot.streamReplayCheckpoint);
 	}
 	scope.$$ctxValues = snapshot.context;
 	if (frame !== null) {
@@ -6817,6 +6790,58 @@ interface StreamState {
 	activeTryKeys: string[];
 	/** All arm owners (content/catch/fallback) while walking nested `ssrTry` calls. */
 	activeOwnerKeys: string[];
+	/** Undo log scoped to one synchronous full pass; null between passes. */
+	replay: StreamBoundaryReplayEntry[] | null;
+}
+
+interface StreamBoundaryReplayEntry {
+	key: string;
+	boundary: StreamBoundary | undefined;
+	value: StreamBoundary | undefined;
+}
+
+// Render-phase retries need the stream registry as it stood on entry to the
+// component. Copying every boundary at EVERY component multiplies a full wave's
+// work by the already-discovered boundary count. Checkpoint this pass-local log
+// instead, recording only actual registry mutations. Boundary arrays are replaced,
+// never mutated, so their previous references are sufficient for rollback.
+function recordStreamBoundaryMutation(stream: StreamState, key: string): void {
+	if (stream.replay === null) return;
+	const boundary = stream.boundaries.get(key);
+	stream.replay.push({
+		key,
+		boundary,
+		value: boundary === undefined ? undefined : { ...boundary },
+	});
+}
+
+function rewindStreamBoundaryReplay(stream: StreamState, checkpoint: number): void {
+	const replay = stream.replay;
+	if (replay === null) return;
+	let restoredDeletion = false;
+	while (replay.length > checkpoint) {
+		const saved = replay.pop()!;
+		if (saved.boundary === undefined) {
+			stream.boundaries.delete(saved.key);
+		} else {
+			const boundary = saved.boundary;
+			const value = saved.value!;
+			Object.assign(boundary, value);
+			// These optional fields can be introduced by the discarded pass.
+			boundary.error = value.error;
+			boundary.errorReported = value.errorReported;
+			boundary.errorFlushed = value.errorFlushed;
+			if (!stream.boundaries.has(saved.key)) restoredDeletion = true;
+			stream.boundaries.set(saved.key, boundary);
+		}
+	}
+	if (restoredDeletion) {
+		// Restoring a pruned boundary appends it to Map. Re-establish discovery
+		// order only on this rare path, including recoverable-error report order.
+		const ordered = [...stream.boundaries].sort((a, b) => a[1].order - b[1].order);
+		stream.boundaries.clear();
+		for (const [key, boundary] of ordered) stream.boundaries.set(key, boundary);
+	}
 }
 
 // Every boundary id includes a render-unique token. The counter proves
@@ -6874,6 +6899,7 @@ function pruneUnrepresentedStreamDescendants(
 			}
 			if (nearestOwner !== ownerKey) continue;
 			if (ownerHtml.includes(STREAM_BOUNDARY_ATTR + '="' + child.id + '"')) continue;
+			recordStreamBoundaryMutation(stream, childKey);
 			stream.boundaries.delete(childKey);
 			removed = true;
 		}
@@ -6950,7 +6976,10 @@ export function ssrTry(
 		ancestorKeys = stream.activeTryKeys.slice();
 		ownerKeys = stream.activeOwnerKeys.slice();
 		entry = stream.boundaries.get(key);
-		if (entry !== undefined) entry.namespace = namespace;
+		if (entry !== undefined) {
+			recordStreamBoundaryMutation(stream, key);
+			entry.namespace = namespace;
+		}
 		if (entry !== undefined && entry.state === 'pending') {
 			entry.ancestors = ancestorKeys;
 			entry.owners = ownerKeys;
@@ -7178,6 +7207,7 @@ export function ssrTry(
 							ancestors: ancestorKeys,
 							owners: ownerKeys,
 						};
+						recordStreamBoundaryMutation(stream, key);
 						stream.boundaries.set(key, entry);
 						enterBoundaryIds(pendingIdOffset);
 					} else {
@@ -7241,6 +7271,7 @@ export function ssrTry(
 						ancestors: ancestorKeys,
 						owners: ownerKeys,
 					};
+					recordStreamBoundaryMutation(stream, key);
 					stream.boundaries.set(key, entry);
 					enterBoundaryIds(pendingIdOffset);
 				} else if (entry.state === 'pending') {
@@ -7587,6 +7618,7 @@ async function runStream(
 		activePassBoundaryKeys: null,
 		activeTryKeys: [],
 		activeOwnerKeys: [],
+		replay: null,
 	};
 	const renderFullPass = (): {
 		pass: FullPassResult;
@@ -7594,7 +7626,9 @@ async function runStream(
 	} => {
 		const boundaryKeys = new Set<string>();
 		const previousBoundaryKeys = stream.activePassBoundaryKeys;
+		const previousReplay = stream.replay;
 		stream.activePassBoundaryKeys = boundaryKeys;
+		stream.replay = [];
 		try {
 			return {
 				pass: withStream(stream, () =>
@@ -7604,6 +7638,7 @@ async function runStream(
 			};
 		} finally {
 			stream.activePassBoundaryKeys = previousBoundaryKeys;
+			stream.replay = previousReplay;
 		}
 	};
 	// ── External injection (cold path: every hook below no-ops when absent) ──

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -20311,6 +20311,23 @@ function reconcileDeoptNode(
 // not reused are removed; survivors are reordered to match the descriptor. No markers
 // are introduced — the element fully owns its children, so this is raw-DOM reuse.
 function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): void {
+	// A scalar leaf keeps its sole owned Text node at the implicit first slot.
+	// Other shapes still need keyed matching: a lone text node may belong to a
+	// different array position, a nested wrapper, or independently inserted DOM.
+	const type = typeof children;
+	if ((type === 'string' && children !== '') || type === 'number' || type === 'bigint') {
+		const first = getFirstChild(el);
+		if (
+			first !== null &&
+			first.nodeType === 3 &&
+			getNextSibling(first) === null &&
+			(first as any).$$deoptKey === 0 &&
+			(first as any).$$portalEnd == null
+		) {
+			updateTextValue(first as Text, String(children));
+			return;
+		}
+	}
 	// The element that owns these children is authoritative. This matters when a
 	// component or dynamic tag made the lexical namespace unknowable, and when an
 	// SVG foreignObject resets its descendants to HTML.
@@ -20494,10 +20511,10 @@ function deoptItemBody(item: any, scope: Scope): void {
 	// construction (hydrated items always adopt the server's pair).
 	const existingChild = scope.slots[0] as ChildSlot | undefined;
 	const needsBlocks =
-		descNeedsBlocks(item) ||
 		(isHostDescriptor(item) &&
 			existingChild?.__kind === 'childSlot' &&
-			existingChild.currentComp === (hostElementBody as unknown as ComponentBody));
+			existingChild.currentComp === (hostElementBody as unknown as ComponentBody)) ||
+		descNeedsBlocks(item);
 	const sm = block.startMarker;
 	if (
 		sm !== null &&
@@ -21839,8 +21856,8 @@ export function childSlot(
 	const pureHost =
 		preparedList === null &&
 		isHostDescriptor(value) &&
-		!descNeedsBlocks(value) &&
-		state?.currentComp !== (hostElementBody as unknown as ComponentBody);
+		state?.currentComp !== (hostElementBody as unknown as ComponentBody) &&
+		!descNeedsBlocks(value);
 	let rootShapeChanged = false;
 	if (state !== undefined && ROOT_RENDER_TRANSACTION !== null) {
 		const component =

--- a/packages/octane/tests/_fixtures/generic-child-transitions.tsrx
+++ b/packages/octane/tests/_fixtures/generic-child-transitions.tsrx
@@ -1,4 +1,4 @@
-import { use, useSyncExternalStore, useTransition, type OctaneNode } from 'octane';
+import { createElement, use, useSyncExternalStore, useTransition, type OctaneNode } from 'octane';
 
 export interface GenericChildSnapshot {
 	value: OctaneNode;
@@ -21,6 +21,10 @@ function OnlyChild(props: { value: OctaneNode }) @{
 	<main id="only-child">{props.value}</main>
 }
 
+function DescriptorChild(props: { value: OctaneNode }) {
+	return createElement('p', { id: 'descriptor-child' }, props.value);
+}
+
 function AnchoredChild(props: { value: OctaneNode }) @{
 	<section id="anchored-child">
 		<span>{'before:'}</span>
@@ -38,6 +42,7 @@ function ReadyValue(props: { request: Promise<string> }) @{
 function Contents(props: { snapshot: GenericChildSnapshot }) @{
 	<div>
 		<OnlyChild value={props.snapshot.value} />
+		<DescriptorChild value={props.snapshot.value} />
 		<AnchoredChild value={props.snapshot.value} />
 		<ReadyValue request={props.snapshot.request} />
 	</div>

--- a/packages/octane/tests/_fixtures/ssr-suspense.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-suspense.tsrx
@@ -14,6 +14,41 @@ export function AsyncLeaf(props) @{
 	<div id="leaf">{value as string}</div>
 }
 
+type ReplayedStreamProps = {
+	promise: Promise<string>;
+	onClick?: (value: string) => void;
+};
+
+function ReplayedStreamContent(props: ReplayedStreamProps & { parentSettled: boolean }) @{
+	const [settled, setSettled] = useState(false);
+	if (!settled) setSettled(true);
+	@try {
+		const value = use(props.promise);
+		const contentId = useId();
+		<button
+			id={contentId}
+			data-replayed-stream=""
+			onClick={() => props.onClick?.(value)}
+		>{(props.parentSettled && settled ? 'Accepted: ' : 'Discarded: ') + value as string}</button>
+	} @pending {
+		<p>{'Waiting for replayed content'}</p>
+	}
+}
+
+export function ReplayedStreamBoundary(props: ReplayedStreamProps) @{
+	const [settled, setSettled] = useState(false);
+	const shellId = useId();
+	if (!settled) setSettled(true);
+	<main aria-describedby={shellId}>
+		<p id={shellId}>{'Replay shell'}</p>
+		<ReplayedStreamContent
+			parentSettled={settled}
+			promise={props.promise}
+			onClick={props.onClick}
+		/>
+	</main>
+}
+
 export function DeferredAsyncLeaf(props) @{
 	<Hydrate when={props.when} split={false}>
 		<AsyncLeaf promise={props.promise} />

--- a/packages/octane/tests/deopt-child-key-aliasing.test.ts
+++ b/packages/octane/tests/deopt-child-key-aliasing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createElement, Fragment, positionalChildren, useState } from 'octane';
+import { createElement, Fragment, positionalChildren, useState, type OctaneNode } from 'octane';
 import { mount } from './_helpers';
 import { RowsHole } from './_fixtures/deopt-child-keys.tsrx';
 
@@ -18,6 +18,90 @@ import { RowsHole } from './_fixtures/deopt-child-keys.tsrx';
 // spelling — the encoding may change as long as these hold.
 
 const text = (nodes: Element[]) => nodes.map((n) => n.textContent);
+
+function TextHost({ value }: { value: OctaneNode }) {
+	return createElement('p', { 'data-testid': 'text' }, value);
+}
+
+describe('scalar host children', () => {
+	it('updates strings and numbers without replacing the surviving text node', () => {
+		const root = mount(TextHost, { value: 'first' });
+		try {
+			const host = root.find('p');
+			const child = host.firstChild;
+			for (const value of ['first second', 0, -0, 42n, 'last']) {
+				root.update(TextHost, { value });
+				expect(root.find('p')).toBe(host);
+				expect(host.firstChild).toBe(child);
+				expect(host.textContent).toBe(String(value));
+			}
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('keeps scalar, empty, and nested positional children in their own slots', () => {
+		const root = mount(TextHost, { value: [null, 'second slot'] });
+		try {
+			const host = root.find('p');
+			const secondSlot = host.firstChild;
+			root.update(TextHost, { value: 'first slot' });
+			expect(host.textContent).toBe('first slot');
+			expect(host.firstChild).not.toBe(secondSlot);
+			const firstSlot = host.firstChild;
+
+			root.update(TextHost, { value: [['nested slot']] });
+			expect(host.textContent).toBe('nested slot');
+			expect(host.firstChild).not.toBe(firstSlot);
+			const nestedSlot = host.firstChild;
+			root.update(TextHost, { value: 'returned scalar' });
+			expect(host.textContent).toBe('returned scalar');
+			expect(host.firstChild).not.toBe(nestedSlot);
+
+			root.update(TextHost, { value: ['left', 'right'] });
+			const left = host.firstChild;
+			const right = host.lastChild!;
+			root.update(TextHost, { value: 'single' });
+			expect(host.textContent).toBe('single');
+			expect(host.firstChild).toBe(left);
+			expect(right.isConnected).toBe(false);
+
+			root.update(TextHost, { value: createElement('em', null, 'element child') });
+			const element = host.querySelector('em')!;
+			root.update(TextHost, { value: 'after element' });
+			expect(host.textContent).toBe('after element');
+			expect(element.isConnected).toBe(false);
+			for (const value of ['', false, null, 'restored', 0]) {
+				root.update(TextHost, { value });
+				expect(root.find('p')).toBe(host);
+				expect(host.textContent).toBe(value == null || value === false ? '' : String(value));
+			}
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not adopt or remove independently inserted text while its own text changes', () => {
+		const root = mount(TextHost, { value: null });
+		try {
+			const host = root.find('p');
+			const foreign = document.createTextNode('external:');
+			host.appendChild(foreign);
+			root.update(TextHost, { value: 'first' });
+			expect(host.textContent).toBe('external:first');
+			const own = foreign.nextSibling;
+			root.update(TextHost, { value: 'second' });
+			expect(host.textContent).toBe('external:second');
+			expect(host.firstChild).toBe(foreign);
+			expect(foreign.nextSibling).toBe(own);
+			root.update(TextHost, { value: null });
+			expect(host.textContent).toBe('external:');
+			expect(host.firstChild).toBe(foreign);
+		} finally {
+			root.unmount();
+		}
+	});
+});
 
 describe('de-opt child keys — an explicit key never aliases a positional index', () => {
 	it('keeps an unkeyed child and a child keyed "0" in separate slots', () => {

--- a/packages/octane/tests/deopt-pure-host-upgrade.test.ts
+++ b/packages/octane/tests/deopt-pure-host-upgrade.test.ts
@@ -26,7 +26,7 @@ function Comp() {
 		'form',
 		null,
 		createElement('p', { 'data-testid': 'p' }, String(on)),
-		createElement('button', { 'data-testid': 'btn', onClick: () => setOn(true) }, 'flip'),
+		createElement('button', { 'data-testid': 'btn', onClick: () => setOn(!on) }, 'flip'),
 		on && createElement(Inner, null),
 	);
 }
@@ -103,11 +103,33 @@ describe('de-opt pure-host → component upgrade', () => {
 		r.unmount();
 	});
 
-	it('tears the upgraded tree down cleanly (flip off again)', () => {
+	it('preserves the host and siblings when the last component disappears and returns', () => {
 		const r = mount(Comp);
-		r.click('[data-testid="btn"]');
-		expect(r.find('[data-testid="inner"]')).toBeTruthy();
-		r.unmount();
+		try {
+			const form = r.find('form');
+			const paragraph = r.find('[data-testid="p"]');
+			const button = r.find('[data-testid="btn"]');
+			r.click('[data-testid="btn"]');
+			const input = r.find('[data-testid="inner"]') as HTMLInputElement;
+			input.value = 'temporary detail';
+
+			r.click('[data-testid="btn"]');
+			expect(r.findAll('[data-testid="inner"]')).toEqual([]);
+			expect(input.isConnected).toBe(false);
+			expect(r.find('form')).toBe(form);
+			expect(r.find('[data-testid="p"]')).toBe(paragraph);
+			expect(paragraph.textContent).toBe('false');
+			expect(r.find('[data-testid="btn"]')).toBe(button);
+
+			r.click('[data-testid="btn"]');
+			expect(r.find('form')).toBe(form);
+			expect(r.find('[data-testid="p"]')).toBe(paragraph);
+			expect(paragraph.textContent).toBe('true');
+			expect(r.find('[data-testid="inner"]')).not.toBe(input);
+			expect((r.find('[data-testid="inner"]') as HTMLInputElement).value).toBe('');
+		} finally {
+			r.unmount();
+		}
 		expect(document.querySelector('[data-testid="inner"]')).toBeNull();
 	});
 });

--- a/packages/octane/tests/generic-child-transitions.test.ts
+++ b/packages/octane/tests/generic-child-transitions.test.ts
@@ -47,10 +47,12 @@ describe('renderable children in a held transition', () => {
 		try {
 			await act(() => {});
 			const onlyChild = root.find('#only-child');
+			const descriptorChild = root.find('#descriptor-child');
 			const anchoredChild = root.find('#anchored-child');
 			const input = root.find('#retained-input') as HTMLInputElement;
 			input.value = 'typed by the user';
 			expect(onlyChild.textContent).toBe('first');
+			expect(descriptorChild.textContent).toBe('first');
 			expect(anchoredChild.textContent).toBe('before:first:after');
 
 			// The store keeps its new snapshot while the later sibling suspends.
@@ -58,6 +60,7 @@ describe('renderable children in a held transition', () => {
 			// update for content that already reached the screen.
 			await act(() => startTransition(() => store.set({ value, request: second.promise })));
 			expect(onlyChild.textContent).toBe('first');
+			expect(descriptorChild.textContent).toBe('first');
 			expect(anchoredChild.textContent).toBe('before:first:after');
 			expect(root.find('#ready').textContent).toBe('ready:first');
 			expect(root.find('#pending').textContent).toBe('pending');
@@ -65,8 +68,10 @@ describe('renderable children in a held transition', () => {
 
 			await act(() => second.resolve('ready:second'));
 			expect(root.find('#only-child')).toBe(onlyChild);
+			expect(root.find('#descriptor-child')).toBe(descriptorChild);
 			expect(root.find('#anchored-child')).toBe(anchoredChild);
 			expect(onlyChild.textContent).toBe(expected);
+			expect(descriptorChild.textContent).toBe(expected);
 			expect(anchoredChild.textContent).toBe(`before:${expected}:after`);
 			expect(root.find('#ready').textContent).toBe('ready:second');
 			expect(root.find('#pending').textContent).toBe('idle');

--- a/packages/octane/tests/hydration/descriptor-list-hydrate.test.ts
+++ b/packages/octane/tests/hydration/descriptor-list-hydrate.test.ts
@@ -199,6 +199,22 @@ describe('descriptor-authored keyed lists hydrate self-delimiting server hosts',
 				);
 				expect([...container.querySelectorAll('li')]).toEqual([rows[1], rows[0]]);
 				expect(betaInput.value).toBe('typed before hydration');
+
+				const betaButton = rows[1].querySelector('button')!;
+				const betaText = betaButton.firstChild;
+				for (const label of ['Beta streamed', 'Beta streamed again']) {
+					flushSync(() =>
+						root.render(client.DescriptorRows, {
+							items: [{ ...items[1], label }, items[0]],
+							onPick,
+							refs,
+						}),
+					);
+					expect(rows[1].querySelector('button')).toBe(betaButton);
+					expect(betaButton.firstChild).toBe(betaText);
+					expect(betaButton.textContent).toBe(label);
+					expect(betaInput.value).toBe('typed before hydration');
+				}
 			} finally {
 				root.unmount();
 			}

--- a/packages/octane/tests/ssr-stream-state-regressions.test.ts
+++ b/packages/octane/tests/ssr-stream-state-regressions.test.ts
@@ -297,11 +297,163 @@ const mod = evalServer(
 				<strong class="late-catch">{error.message as string}</strong>
 			}
 		}
+
+		type ReplayedPendingProps = {
+			discarded: Promise<string>;
+			final: Promise<string>;
+			fallback: Promise<string>;
+		};
+		function ReplayedPendingParent(props: ReplayedPendingProps) @{
+			const [settled, setSettled] = useState(false);
+			if (!settled) setSettled(true);
+			@try {
+				@if (settled) {
+					const value = use(props.final);
+					<strong class="replayed-final">{'final:' + value as string}</strong>
+				} @else {
+					const value = use(props.discarded);
+					<strong class="replayed-discarded">{value as string}</strong>
+				}
+			} @pending {
+				<SharedBoundary label="fallback" promise={props.fallback} />
+			}
+		}
+
+		export function ReplayPrunedFallback(props: ReplayedPendingProps & {
+			trigger: Promise<string>;
+			trailing?: Promise<string>;
+		}) @{
+			<main>
+				<ReplayedPendingParent
+					discarded={props.discarded}
+					final={props.final}
+					fallback={props.fallback}
+				/>
+				<SharedBoundary label="trigger" promise={props.trigger} />
+				@if (props.trailing) {
+					<SharedBoundary label="trailing" promise={props.trailing} />
+				}
+			</main>
+		}
   `,
 	'ssr-stream-state-regressions.tsrx',
 );
 
 describe('SSR stream state regressions', () => {
+	it('keeps a fallback child reachable when a discarded render completed its parent', async () => {
+		const discarded = deferred<string>();
+		const final = deferred<string>();
+		const fallback = deferred<string>();
+		const trigger = deferred<string>();
+		const output = collector();
+		const onError = vi.fn();
+		const stream = ServerRuntime.renderToPipeableStream(
+			mod.ReplayPrunedFallback,
+			{
+				discarded: discarded.promise,
+				final: final.promise,
+				fallback: fallback.promise,
+				trigger: trigger.promise,
+			},
+			{ onError, timeoutMs: 1000 },
+		);
+		stream.pipe(output.destination);
+		try {
+			discarded.resolve('discarded');
+			trigger.resolve('ready');
+			await vi.waitFor(() => {
+				expect(output.chunks.some((chunk) => chunk.includes('trigger:ready'))).toBe(true);
+			});
+
+			fallback.resolve('revealed');
+			await vi.waitFor(() => {
+				expect(output.chunks.some((chunk) => chunk.includes('fallback:revealed'))).toBe(true);
+			});
+			const intermediate = activateChunks(output.chunks);
+			try {
+				expect(intermediate.querySelector('[data-label="fallback"]')?.textContent).toBe(
+					'fallback:revealed',
+				);
+				expect(intermediate.querySelector('[data-label="trigger"]')?.textContent).toBe(
+					'trigger:ready',
+				);
+				expect(intermediate.querySelector('.replayed-discarded')).toBeNull();
+			} finally {
+				intermediate.remove();
+				resetStreamRuntimeGlobals();
+			}
+
+			final.resolve('kept');
+			await output.ended;
+			const completed = activateChunks(output.chunks);
+			try {
+				expect(completed.querySelector('.replayed-final')?.textContent).toBe('final:kept');
+				expect(completed.querySelector('[data-label="fallback"]')).toBeNull();
+				expect(completed.querySelector('.replayed-discarded')).toBeNull();
+				expect(onError).not.toHaveBeenCalled();
+			} finally {
+				completed.remove();
+			}
+		} finally {
+			stream.abort();
+			await output.ended;
+			resetStreamRuntimeGlobals();
+		}
+	});
+
+	it('reports same-wave fallback and sibling failures in discovery order after a render retry', async () => {
+		const discarded = deferred<string>();
+		const final = deferred<string>();
+		const fallback = deferred<string>();
+		const trigger = deferred<string>();
+		const trailing = deferred<string>();
+		const output = collector();
+		const errors: unknown[] = [];
+		const props = {
+			discarded: discarded.promise,
+			final: final.promise,
+			fallback: fallback.promise,
+			trigger: trigger.promise,
+			trailing: trailing.promise,
+		};
+		const stream = ServerRuntime.renderToPipeableStream(mod.ReplayPrunedFallback, props, {
+			onError: (error) => errors.push(error),
+			timeoutMs: 1000,
+		});
+		stream.pipe(output.destination);
+		try {
+			discarded.resolve('discarded');
+			trigger.resolve('ready');
+			await vi.waitFor(() => {
+				expect(output.chunks.some((chunk) => chunk.includes('trigger:ready'))).toBe(true);
+			});
+			// Keep the parent pending on later passes, so both retained fallbacks
+			// remain visible when their data rejects together.
+			props.discarded = new Promise<string>(() => {});
+			const fallbackError = new Error('fallback failed');
+			const trailingError = new Error('trailing failed');
+			fallback.reject(fallbackError);
+			trailing.reject(trailingError);
+			await vi.waitFor(() => expect(errors).toHaveLength(2));
+			expect([...errors]).toEqual([fallbackError, trailingError]);
+			const visible = activateChunks(output.chunks);
+			try {
+				expect(visible.querySelector('[data-waiting="fallback"]')?.textContent).toBe(
+					'fallback:waiting',
+				);
+				expect(visible.querySelector('[data-waiting="trailing"]')?.textContent).toBe(
+					'trailing:waiting',
+				);
+			} finally {
+				visible.remove();
+			}
+		} finally {
+			stream.abort();
+			await output.ended;
+			resetStreamRuntimeGlobals();
+		}
+	});
+
 	it('does not retain a boundary registered by a discarded render-phase pass', async () => {
 		const data = deferred<string>();
 		const output = collector();

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -10,6 +10,7 @@ import * as HydrationRT from 'octane/hydration';
 import { prerender } from 'octane/static';
 import { initializeHydrationEventCapture, interaction } from 'octane/hydration';
 import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
+import { collectPipeableStream, collectReadableStream } from './_server-stream.js';
 // CLIENT-compiled fixture (registers click delegation at import).
 import {
 	Boundary,
@@ -22,6 +23,7 @@ import {
 	NestedDeferredStreamedHydrates,
 	NestedStreamSeedScopes,
 	ReasonBoundary,
+	ReplayedStreamBoundary,
 	Siblings,
 	StyledBoundary,
 } from './_fixtures/ssr-suspense.tsrx';
@@ -128,6 +130,46 @@ afterEach(() => {
 });
 
 describe('renderToPipeableStream — chunk protocol', () => {
+	it.each([
+		['pipeable', collectPipeableStream],
+		['readable', collectReadableStream],
+	] as const)(
+		'hydrates the accepted render-phase content of a %s stream',
+		async (_name, collect) => {
+			const value = deferred<string>();
+			const rendered = collect(server.ReplayedStreamBoundary, { promise: value.promise });
+			value.resolve('ready');
+			const result = await rendered;
+			expect(result.errors).toEqual([]);
+			container.innerHTML = result.html;
+			activate(container);
+			const button = container.querySelector<HTMLButtonElement>('[data-replayed-stream]')!;
+			const shell = container.querySelector('p')!;
+			expect(button.textContent).toBe('Accepted: ready');
+			expect(button.id).not.toBe(shell.id);
+			const contentId = button.id;
+			const onClick = vi.fn();
+			const onRecoverableError = vi.fn();
+			const root = hydrateRoot(
+				container,
+				ReplayedStreamBoundary as any,
+				{ promise: new Promise<string>(() => {}), onClick },
+				{ onRecoverableError },
+			);
+			try {
+				flushSync(() => {});
+				expect(container.querySelector('[data-replayed-stream]')).toBe(button);
+				expect(container.querySelector('p')).toBe(shell);
+				expect(button.id).toBe(contentId);
+				button.click();
+				expect(onClick).toHaveBeenCalledWith('ready');
+				expect(onRecoverableError).not.toHaveBeenCalled();
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
 	it('streams a deferred Hydrate child and later adopts its revealed DOM and seed', async () => {
 		const serverValue = deferred<string>();
 		const c = collector();


### PR DESCRIPTION
## Summary

- Reduce Octane streaming SSR replay overhead by replacing per-component boundary-registry copies with scalar checkpoints and a pass-local mutation journal.
- Speed up repeated descriptor text updates and avoid reclassifying host subtrees that already require component reconciliation.
- Add regression coverage and controlled Octane benchmarks without changing streaming scheduling, chunk delivery, or rendering semantics.

## Why

Streaming SSR copied the growing boundary registry and discovery set on entry to every component, even when no render-phase retry occurred. This multiplied work as boundary counts and resolution waves increased. Generic descriptor streams also paid keyed-child bookkeeping for a single owned Text node and repeated recursive classification for established component-bearing hosts.

## Changes

- Record actual boundary mutations and rewind to component checkpoints on retry. Restore pruned boundaries and discovery order; release journal state after each synchronous pass.
- Keep scalar updates on the existing Activity/transition-aware text writer, guarded by sole-node ownership, positional key, and portal checks.
- Preserve the established host Block path when component descendants disappear and return.
- Cover nested render retries, both streaming transports, hydration seeds/IDs, fallback reachability, error callback ordering, foreign DOM, topology changes, and held transitions. Deliberate faults were observed to fail the new protections before restoring the implementation.
- Extend the existing SSR benchmark with timer-free consumer-driven cases and add a descriptor-streaming sidecar to the chat-stream benchmark.
- Include an `octane` patch changeset.

## Performance evidence

Baseline: `c974d34bc4a65030848ec48720e2fad164f8f2df`. Same fixtures, production compiler options, dependency inputs, and machine; A–B–B–A ordering with no overlapping build/test work. Values below are full pooled elapsed-time means, not selected best samples.

| Workload | Baseline | Candidate | Reduction |
| --- | ---: | ---: | ---: |
| SSR, 10 boundaries in one wave | 0.185 ms | 0.156 ms | 16.0% |
| SSR, 50 boundaries in one wave | 0.854 ms | 0.610 ms | 28.5% |
| SSR, 100 boundaries in one wave | 1.991 ms | 1.116 ms | 43.9% |
| SSR, 50 boundaries across ten waves | 3.478 ms | 1.845 ms | 46.9% |
| Client host descriptors, fine chunks | 6.735 ms | 5.245 ms | 22.1% |
| Client host descriptors, coarse chunks | 1.055 ms | 0.812 ms | 23.1% |
| Client component-bearing descriptors | 7.583 ms | 5.692 ms | 24.9% |

SSR: 100 warmups per variant/case and 500 renders per block, giving 1,000 measured renders per variant/case. Every corresponding sample matched wire bytes, chunks, and producer-release groups; complete visible card HTML also matched. Stream-token widths were compared at matching render ordinals without rewriting output.

Client: three warmups and 30 streams per block, giving 60 measured streams per variant. The shared corpus contains 2,817 tokens and 28 blocks. Mount, first chunk, GC, semantic checks, and teardown are outside timing. Every-chunk correctness checks cover content, surviving DOM identity, and component state/events. The scalar-text negative control has the same 0.8 ms median; the compiled chat fixture produces a byte-identical bundle.

Environment: Apple M5 Max, macOS 26.6.2, Node 26.4.0, esbuild 0.28.1, Chromium 149.0.7827.55. The generic descriptor bundle grows by 186 bytes; the preserved unminified Node SSR bundle grows by 580 bytes.

These are controlled renderer measurements, not end-to-end application latency or a uniform percentage improvement across workloads. Component-bearing client measurements have greater between-session variance. The benchmark READMEs document the repeatable workloads and their semantic controls.

## Validation

- [x] `pnpm sync` (no generated changes).
- [x] Core development and production suites: **14,915 tests passed across 879 file executions** with `vitest run --project octane --project octane-prod --maxWorkers=4`.
- [x] Core source typecheck: `tsgo --noEmit -p packages/octane/tsconfig.json`.
- [x] Core public type tests: `tsgo --noEmit -p packages/octane/typetests/tsconfig.json`.
- [x] Scoped formatting checks for all changed/new files and `git diff --check`.
- [x] Descriptor-stream A–B–B–A comparison with all semantic controls passing.
- [x] Production SSR benchmark smoke: `TARGETS=octane node benchmarks/streaming-ssr/run.mjs 3`; all five scenarios passed.
- [x] Compiled chat production-work gate: one text write for a streamed update in a 200-message history; no list/message-body/text work on a composer update.
- [ ] Full repository `pnpm format:check`, `pnpm typecheck`, and `pnpm test` were not run locally; the scoped checks above were run, and full CI is required on the pushed head.

Scoped fixture/test checking with `tsrx-tsc` reports the same 117 pre-existing diagnostics on baseline and candidate, with zero added or removed after comparing full normalized diagnostic multisets. Neither runtime source reports a diagnostic. No declaration suppressions or weaker test assertions were introduced.

## Risk / follow-ups

The sensitive paths are render-phase rollback, boundary discovery/error order, and DOM ownership during interrupted updates. The journal is pass-local rather than a retained cache; scheduling, serialization, backpressure, and abort behavior remain unchanged. Cold generic mount, paint/layout, parser work, deployment throughput, and peak memory were not independently benchmarked.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790168208&installation_model_id=432790&pr_number=835&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F835&signature=05f69d9f70cecc6656d75261aea124db633e5b0327877edaa290921ba4b81a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches streaming SSR render-phase rollback (boundary registry, discovery/error order, hydration seeds) and client host-child reuse. Scheduling and wire protocol are unchanged, but bugs here would mis-stream or replace live DOM.
> 
> **Overview**
> **Streaming SSR** no longer snapshots the full Suspense boundary map on every component. Each full pass keeps a short mutation journal; retries rewind to a scalar checkpoint, restore pruned entries in discovery order, and drop the journal between passes.
> 
> **Client descriptors** update a sole owned text node in place instead of running keyed-child matching, and keep the Block path once a host has component descendants so dropping/re-adding those children does not recreate the host.
> 
> Adds regression coverage for replayed streams, fallback reachability, error-report order, foreign text, and interrupted updates. Extends streaming-ssr with timer-free CPU/wave cases and adds a chat-stream descriptor sidecar for Markdown-style `createElement` streams. Patch changeset for `octane`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfef5d8954d98108a0582fcebbb89dbdc1c6099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->