### PR TITLE
feat(compiler): add experimental Valdi writer target

### DIFF
--- a/.changeset/valdi-writer-compiler.md
+++ b/.changeset/valdi-writer-compiler.md
@@ -1,0 +1,8 @@
+---
+"octane": patch
+---
+
+Add an experimental client-only Valdi writer compiler target with an explicit
+application-provided adapter contract, public compiler option types, and
+self-contained regression tests. Existing DOM and universal targets remain
+unchanged; no native runtime or application build integration is bundled.

--- a/docs/universal-renderer-architecture.md
+++ b/docs/universal-renderer-architecture.md
@@ -9,6 +9,10 @@ existing DOM compiler and runtime remain the production renderer; the
 universal path is a separate compiler target and runtime module until non-DOM
 evidence justifies sharing more machinery.
 
+The separate [Valdi writer target](./valdi-compiler.md) emits calls to an
+application-provided writer adapter instead of universal host plans. It does
+not change the universal renderer's runtime or ownership model described here.
+
 The central decision is:
 
 > Renderer selection happens while lowering a template. DOM templates keep

--- a/docs/valdi-compiler.md
+++ b/docs/valdi-compiler.md
@@ -1,0 +1,174 @@
+# Valdi writer compiler
+
+The experimental `valdi` target compiles `.tsrx` and `.tsx` components to
+Valdi-style writer calls. It is opt-in and client-only. The DOM and universal
+targets keep their existing compiler and runtime paths.
+
+This package supplies the compiler, not a Valdi renderer or hook runtime. An
+application must provide an adapter implementing the contract below. Compiling
+successfully does not establish native rendering or lifecycle correctness.
+
+## Select the target
+
+```ts
+import { compile } from 'octane/compiler';
+
+const result = compile(source, 'src/Scene.tsrx', {
+	mode: 'client',
+	hmr: false,
+	renderer: {
+		id: 'valdi',
+		module: '@example/valdi-adapter',
+		target: 'valdi',
+		server: 'unsupported',
+		text: 'reject',
+	},
+});
+```
+
+`module` is an application-provided package or project-root module identifier.
+`@example/valdi-adapter` is a placeholder, not an adapter bundled with Octane.
+Generated imports are resolved by the consuming build; the compiler does not
+load the adapter while compiling. The declarative registry rejects relative
+`./` and `../` module identifiers.
+
+The same target is accepted by the declarative renderer registry:
+
+```ts
+import { octane } from 'octane/compiler/vite';
+
+octane({
+	hmr: false,
+	renderers: {
+		registry: {
+			valdi: {
+				module: '@example/valdi-adapter',
+				target: 'valdi',
+				server: 'unsupported',
+				text: 'reject',
+			},
+		},
+		rules: [{ include: 'src/**/*.valdi.tsrx', renderer: 'valdi' }],
+	},
+});
+```
+
+HMR must be disabled for this target. Registry selection is a compiler facility,
+not a native application build, packaging, or deployment integration.
+
+## Adapter contract
+
+`VALDI_COMPILER_ABI_VERSION`, exported by `octane/compiler`, identifies the
+generated contract. Its initial value is `1`. Each generated module calls
+`assertValdiCompilerAbi(version)` before creating prototypes or registering
+components. An adapter must reject incompatible versions before any of that
+work happens. Include the compiler version, ABI version, and renderer
+configuration in persistent compilation cache keys.
+
+The following exports are required when used by a compiled module:
+
+| Export | Contract |
+| --- | --- |
+| `assertValdiCompilerAbi(version)` | Reject unsupported compiler ABI versions. |
+| `jsx` | Stable writer facade with the methods below. |
+| `defineValdiComponent(render, { hasHooks })` | Register a writer function and return an opaque component descriptor. `hasHooks` is conservative; render-time calls may invoke custom hooks. |
+| `getValdiComponentConstructor(component)` | Resolve a descriptor to the constructor accepted by `jsx.beginComponent`. |
+| `valdiKey(prototype, ...keys)` | Produce a stable writer key for the opaque call-site prototype and ordered key parts. Distinguish types and key boundaries; the compiler neither encodes keys nor reads prototype fields. |
+| `setValdiAttributes(props)` | Apply the complete spread-attribute set to the current host, clearing previously supplied attributes that are now absent. |
+
+These bridge exports are a new Octane-facing adapter contract, not exports
+already supplied by Valdi. The `jsx` methods below follow the
+[public Valdi writer surface](https://github.com/Snapchat/Valdi/blob/1ca7a06f349c6967ac93aadb814c3e3bb221e1ac/src/valdi_modules/src/valdi/valdi_core/src/JSXBootstrap.ts):
+
+| Method | Purpose |
+| --- | --- |
+| `makeNodePrototype(tag, staticPairs?)` | Create an opaque host prototype. Pairs are a flat `[name, value, ...]` array. |
+| `makeComponentPrototype(staticPairs?)` | Create an opaque component-props prototype. |
+| `beginRender(prototype, key)` / `endRender()` | Open and close a host element. |
+| `setAttribute(name, value)` | Apply an attribute with the host's normal normalization and observation behavior. |
+| `setAttributeBool`, `setAttributeNumber`, `setAttributeString`, `setAttributeFunction`, `setAttributeStyle` | Apply a proven attribute kind without changing its host semantics. |
+| `beginComponent(constructor, prototype, key)` / `endComponent()` | Open and close a child component. |
+| `setViewModelProperty(name, value)` | Apply a dynamic component prop. |
+| `setViewModelFull(props)` | Replace a component's complete spread-props set. |
+
+Prototypes are created once per generated module. A missing key is passed as
+`undefined`; explicit non-nullish keys and keyed loop paths are delegated to
+`valdiKey`. Host parents establish a new child-key scope. Attribute expressions
+and spread getters retain authored evaluation order; `key` is not forwarded as
+a host attribute or component prop.
+
+The adapter also owns component instances, scheduling, error recovery, unmount,
+hook state, and effect cleanup. Writer calls are not a transaction or a native
+renderer implementation supplied by this compiler. If rendering throws, the
+adapter must restore its writer and hook scopes.
+
+### Hooks
+
+The supported hooks are `useState`, `useMemo`, `useCallback`, `useLayoutEffect`,
+and `useRef`. Their imports are routed to the selected adapter. They retain
+Octane's compiler-assigned opaque slot convention, including conditional hooks,
+dependency inference, and the third state getter.
+
+Adapters must implement the existing generated hook helpers when used:
+`hookSlots`, `withSlot`, `__useStateWithGetter`, and `__methodDep`. These are
+versioned compiler-to-adapter exports, not promises about a runtime's object
+layout. The compiler emits no owner-field access or host memoization protocol.
+See [Octane's hook semantics](./differences-from-react.md) for the observable
+state and dependency behavior.
+
+Custom hooks that import Octane hooks must pass through the same full compiler
+with the same Valdi renderer, for example in a `.tsrx` module or a direct
+`compile()` call. The bundler's lighter plain `.ts`/`.js` hook-slot pass does
+not reroute those imports to the adapter. Such helpers need explicit adapter
+imports or application-owned module resolution; selecting the target for a
+component alone does not adapt its entire dependency graph.
+
+## Attribute type facts
+
+The compiler uses conservative syntax and lexical proofs for specialized
+attribute writers. A caller with a type checker may additionally supply
+`valdiWriterFacts`:
+
+```ts
+import type { ValdiWriterFacts } from 'octane/compiler';
+
+const facts: ValdiWriterFacts = {
+	version: 1,
+	expressions: [
+		{ start: 42, end: 53, effectiveType: 'number', isNullable: false },
+	],
+};
+```
+
+Offsets are UTF-16 code units into the exact source passed to `compile`, with an
+exclusive `end`. Each range must describe one complete authored expression.
+The example offsets are illustrative, not facts for a particular component.
+Supported effective types are `boolean`, `number`, `string`, `function`, and
+`style`; nullability is recorded separately. Facts are trusted input and must
+not be reused after source edits. Missing proofs fall back to the generic
+writer. The compiler entry does not import a TypeScript checker or native SDK.
+
+## Supported scope and diagnostics
+
+The initial target supports stable module-level function and `const`
+components, imported components, fragments, dynamic attributes, ordered
+spreads, early returns, conditionals, and explicitly keyed template loops.
+Mutable `let`/`var` components and writes to component bindings are rejected.
+Both development and production compilation use the same external writer
+contract.
+
+Unsupported constructs fail with diagnostics rather than falling back to DOM
+code. These include server rendering/hydration, HMR, Octane profiling,
+cross-renderer boundaries, dynamic or namespace component tags, component
+children/render props, authored `ref`/`children` props, `@try`, `@switch`, and
+`style`/`slot`/`slotted` elements. Spread `ref`/`children` values are checked at
+execution time. Unkeyed or asynchronous template loops and slot-keyed hooks
+directly inside loops are rejected; put hooks in a keyed child component.
+
+Raw text is rejected by default. Use a host attribute such as a label's value,
+or explicitly choose `text: 'ignore'` to discard raw text. `text: 'host'` is not
+supported.
+
+Tests execute generated modules against a small synthetic writer recorder and
+check diagnostics, source maps, compiler selection, and neighboring targets.
+They do not validate a native Valdi application or establish a performance win.

--- a/packages/octane/README.md
+++ b/packages/octane/README.md
@@ -25,6 +25,11 @@ Vite builds can fold proven immutable CSS-module class strings into templates.
 See the [CSS-module constants guide](https://github.com/octanejs/octane/blob/main/docs/compiler-css-module-constants.md)
 for the provider contract and stylesheet-loading guarantees.
 
+Custom native integrations can opt into the experimental
+[Valdi writer compiler](https://github.com/octanejs/octane/blob/main/docs/valdi-compiler.md).
+It requires an application-provided adapter; Octane does not bundle a Valdi
+runtime or native build integration.
+
 Direct Node or Bun server scripts can preload `octane/compiler/register` to
 compile imported Octane components without going through Vite. See the
 [SSR guide](https://github.com/octanejs/octane/blob/main/docs/ssr.md#run-an-ssg-script-directly).

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -1082,7 +1082,7 @@ class OctaneBundlerCompiler {
 		if (!hostOwned) this._assertClientOnlySourceSupported(file, filename, renderer, collected);
 		if (
 			plainHelperSource &&
-			renderer.target === 'universal' &&
+			(renderer.target === 'universal' || renderer.target === 'valdi') &&
 			renderer.validation !== undefined &&
 			this._isProjectOwnedSource(file) &&
 			!this.exclude.some((path) => file.includes(path)) &&

--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -1622,6 +1622,12 @@ function importSourceRanges(sources) {
 export function validateRendererModuleSource(source, filename, renderer) {
 	if (renderer?.validation === undefined) return;
 	const ast = parseModule(source, filename);
+	validateRendererAst(ast, filename, renderer);
+}
+
+/** Reuse renderer restrictions without reparsing an already adopted AST. */
+export function validateRendererAst(ast, filename, renderer) {
+	if (renderer?.validation === undefined) return;
 	validateRendererSource(ast, { filename, renderer });
 }
 

--- a/packages/octane/src/compiler/compile-valdi.js
+++ b/packages/octane/src/compiler/compile-valdi.js
@@ -762,6 +762,14 @@ function emitIntrinsicContents(node, state, attrs) {
 	return statements;
 }
 
+function isEmptyChild(node) {
+	return (
+		node == null ||
+		(node.type === 'JSXText' && /^[\s;]*$/.test(node.value ?? '')) ||
+		(node.type === 'JSXExpressionContainer' && node.expression?.type === 'JSXEmptyExpression')
+	);
+}
+
 function emitElement(node, state, keys) {
 	const name = elementName(node);
 	const tag = intrinsicTag(node);
@@ -788,9 +796,7 @@ function emitElement(node, state, keys) {
 		return statements;
 	}
 	const component = componentExpression(name, state, node);
-	const children = (node.children ?? []).filter(
-		(child) => child.type !== 'JSXText' || !/^[\s;]*$/.test(child.value ?? ''),
-	);
+	const children = (node.children ?? []).filter((child) => !isEmptyChild(child));
 	if (children.length !== 0) {
 		throw valdiError(state, node, 'component children/render props are not supported yet.');
 	}
@@ -995,9 +1001,9 @@ function rewriteComponentStatement(node, state, keys, allowReturn) {
 function emitNodes(nodes, state, keys, allowReturn) {
 	const output = [];
 	for (const node of nodes) {
-		if (node == null) continue;
+		if (isEmptyChild(node)) continue;
 		if (node.type === 'JSXText') {
-			if (/^[\s;]*$/.test(node.value ?? '') || state.renderer.text === 'ignore') continue;
+			if (state.renderer.text === 'ignore') continue;
 			throw valdiError(
 				state,
 				node,
@@ -1005,7 +1011,6 @@ function emitNodes(nodes, state, keys, allowReturn) {
 			);
 		}
 		if (node.type === 'JSXExpressionContainer') {
-			if (node.expression?.type === 'JSXEmptyExpression') continue;
 			output.push(...emitRenderable(node.expression, state, keys));
 		} else if (isTemplate(node)) {
 			output.push(...emitRenderable(node, state, keys));

--- a/packages/octane/src/compiler/compile-valdi.js
+++ b/packages/octane/src/compiler/compile-valdi.js
@@ -1,0 +1,1148 @@
+/**
+ * Experimental Valdi writer backend.
+ *
+ * This pass owns only template lowering. It emits the same JSXBootstrap writer
+ * operations as Valdi's TSX compiler, then gives its JSX-free Program to the
+ * existing client finisher for hook slots, inferred dependencies, TypeScript
+ * erasure, and the single source-map print. It never enters the DOM planner or
+ * constructs a universal renderer tree.
+ */
+import { builders as b } from '@tsrx/core';
+import { parseModule } from '#octane/compiler-parser';
+import { createLexicalAnalysis, validateRendererAst } from './compile-universal.js';
+import { HOOK_NAMES } from './hook-names.js';
+import {
+	analyzeRendererBoundaries,
+	assertRendererBoundaryAnalysis,
+} from './renderer-boundaries.js';
+
+/** Bump when the generated Valdi runtime contract changes. */
+export const VALDI_COMPILER_ABI_VERSION = 1;
+
+/** @typedef {'boolean' | 'number' | 'string' | 'function' | 'style'} ValdiWriterEffectiveType */
+/**
+ * A type-checker fact for one complete authored expression. Offsets are UTF-16
+ * code units and `end` is exclusive. Nullish members are represented separately,
+ * as in Valdi's own effective-type classification.
+ * @typedef {{ start: number, end: number, effectiveType: ValdiWriterEffectiveType, isNullable: boolean }} ValdiWriterExpressionFact
+ */
+/** @typedef {{ version: 1, expressions: readonly ValdiWriterExpressionFact[] }} ValdiWriterFacts */
+
+const VALDI_WRITER_TYPES = new Set(['boolean', 'number', 'string', 'function', 'style']);
+const VALDI_HOOKS = new Set(['useState', 'useCallback', 'useLayoutEffect', 'useMemo', 'useRef']);
+
+export const VALDI_COMPILER_RUNTIME_IMPORTS = new Set([
+	...VALDI_HOOKS,
+	'__methodDep',
+	'__useStateWithGetter',
+	'hookSlots',
+	'withSlot',
+]);
+
+const AST_SKIP_KEYS = new Set([
+	'end',
+	'loc',
+	'metadata',
+	'parent',
+	'range',
+	'start',
+	'returnType',
+	'typeAnnotation',
+	'typeArguments',
+	'typeParameters',
+]);
+const FUNCTION_TYPES = new Set([
+	'FunctionDeclaration',
+	'FunctionExpression',
+	'ArrowFunctionExpression',
+]);
+const TRANSPARENT_EXPRESSIONS = new Set([
+	'ParenthesizedExpression',
+	'TSAsExpression',
+	'TSTypeAssertion',
+	'TSNonNullExpression',
+	'TSSatisfiesExpression',
+]);
+
+function valdiError(state, node, message) {
+	const start = node?.loc?.start;
+	const at = start ? ` at ${state.filename}:${start.line}:${start.column}` : '';
+	return new Error(`Octane Valdi compiler: ${message}${at}`);
+}
+
+function forEachChild(node, visit) {
+	for (const [key, child] of Object.entries(node)) {
+		if (!AST_SKIP_KEYS.has(key)) visit(child);
+	}
+}
+
+function walk(root, visit) {
+	const seen = new WeakSet();
+	const descend = (node) => {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (Array.isArray(node)) {
+			for (const child of node) descend(child);
+			return;
+		}
+		if (visit(node) !== false) forEachChild(node, descend);
+	};
+	descend(root);
+}
+
+// Authored subtrees are shared and can be frozen. Only unlocated generated
+// spines are rebuilt; every authored expression retains its precise location.
+function withOrigin(root, origin) {
+	const visit = (node) => {
+		if (node === null || typeof node !== 'object') return node;
+		if (Array.isArray(node)) {
+			let output = null;
+			for (let index = 0; index < node.length; index++) {
+				const child = visit(node[index]);
+				if (output === null && child !== node[index]) output = node.slice(0, index);
+				if (output !== null) output.push(child);
+			}
+			return output ?? node;
+		}
+		let output = null;
+		if (typeof node.type === 'string' && node.loc == null && origin?.loc != null) {
+			output = b.set_location({ ...node }, origin);
+		}
+		for (const [key, child] of Object.entries(node)) {
+			if (AST_SKIP_KEYS.has(key)) continue;
+			const next = visit(child);
+			if (next !== child) {
+				output ??= { ...node };
+				output[key] = next;
+			}
+		}
+		return output ?? node;
+	};
+	return visit(root);
+}
+
+function allocName(state, preferred) {
+	let name = preferred;
+	while (state.names.has(name)) name += '$';
+	state.names.add(name);
+	return name;
+}
+
+function helper(state, imported) {
+	let local = state.helpers.get(imported);
+	if (local === undefined) {
+		local = allocName(state, `__octaneValdi${imported[0].toUpperCase()}${imported.slice(1)}`);
+		state.helpers.set(imported, local);
+	}
+	return b.id(local);
+}
+
+function call(state, imported, args, origin) {
+	return withOrigin(b.call(helper(state, imported), ...args), origin);
+}
+
+function writerCall(state, method, args, origin) {
+	if (state.jsxFacade === null) {
+		// Valdi's stock TSX output acquires the stable facade once per module.
+		// Keep method lookup/receiver semantics and every other helper import live.
+		helper(state, 'jsx');
+		state.jsxFacade = allocName(state, '__octaneValdiJsxFacade');
+	}
+	return withOrigin(b.call(b.member(b.id(state.jsxFacade), method), ...args), origin);
+}
+
+function writerStatement(state, method, args, origin) {
+	return withOrigin(b.stmt(writerCall(state, method, args, origin)), origin);
+}
+
+function unwrap(node) {
+	while (TRANSPARENT_EXPRESSIONS.has(node?.type)) node = node.expression;
+	return node;
+}
+
+function isTemplate(node) {
+	return (
+		node?.type === 'Element' ||
+		node?.type === 'Fragment' ||
+		(typeof node?.type === 'string' && node.type.startsWith('JSX'))
+	);
+}
+
+function assertNoTemplate(node, state, context) {
+	walk(node, (child) => {
+		if (isTemplate(child) || child.type === 'Tsrx' || child.type === 'Tsx') {
+			throw valdiError(state, child, `${context} is not supported by the Valdi writer target.`);
+		}
+	});
+	return node;
+}
+
+// Only an actual Octane import (including aliases) or the compiler's unbound
+// builtin shorthand is a builtin. A locally bound useEffect/object.useEffect
+// is a custom hook by Octane's reserved use[A-Z] convention, not an import of
+// the unsupported effect phase.
+function importedHookName(node, state) {
+	const callee = unwrap(node?.callee);
+	if (callee?.type === 'Identifier') {
+		const binding = state.lexical.resolveBinding(
+			state.lexical.nodeScopes.get(callee) ?? state.lexical.rootScope,
+			callee.name,
+		);
+		if (binding?.scope === state.lexical.rootScope && state.runtimeImports.has(callee.name)) {
+			return state.runtimeImports.get(callee.name);
+		}
+		if (binding === null || binding === undefined) {
+			if (HOOK_NAMES.has(callee.name) || callee.name === 'use' || callee.name === 'useContext') {
+				return callee.name;
+			}
+		}
+		return null;
+	}
+	return null;
+}
+
+function slotHookName(node, state) {
+	const imported = importedHookName(node, state);
+	if (imported !== null) return imported;
+	const callee = unwrap(node?.callee);
+	if (
+		callee?.type === 'Identifier' &&
+		/^use[A-Z]/.test(callee.name) &&
+		callee.name !== 'useContext'
+	)
+		return callee.name;
+	if (
+		callee?.type === 'MemberExpression' &&
+		!callee.computed &&
+		callee.property?.type === 'Identifier' &&
+		/^use[A-Z]/.test(callee.property.name) &&
+		callee.property.name !== 'useContext'
+	) {
+		return callee.property.name;
+	}
+	return null;
+}
+
+function validateRuntimeImports(ast, state) {
+	for (const node of ast.body ?? []) {
+		if (node.importKind === 'type' || node.exportKind === 'type') continue;
+		if (
+			(node.specifiers?.length ?? 0) > 0 &&
+			node.specifiers.every(
+				(specifier) => specifier.importKind === 'type' || specifier.exportKind === 'type',
+			)
+		)
+			continue;
+		const request = node.source?.value;
+		if (request === 'server') {
+			throw valdiError(state, node, '`module server` RPC imports are not supported yet.');
+		}
+		if (typeof request !== 'string' || (request !== 'octane' && !request.startsWith('octane/')))
+			continue;
+		if (node.type !== 'ImportDeclaration' || request !== 'octane') {
+			throw valdiError(state, node, `runtime request ${JSON.stringify(request)} is unsupported.`);
+		}
+		for (const specifier of node.specifiers ?? []) {
+			if (specifier.importKind === 'type') continue;
+			if (specifier.type !== 'ImportSpecifier') {
+				throw valdiError(state, specifier, 'Valdi modules require named imports from octane.');
+			}
+			const name = specifier.imported?.name ?? specifier.imported?.value;
+			if (!VALDI_HOOKS.has(name)) {
+				throw valdiError(
+					state,
+					specifier,
+					`runtime import ${JSON.stringify(name)} has no Valdi writer implementation.`,
+				);
+			}
+			state.runtimeImports.set(specifier.local.name, name);
+		}
+	}
+	walk(ast, (node) => {
+		if (node.type === 'TSModuleDeclaration' && node.declare !== true && node.kind === 'module') {
+			throw valdiError(state, node, '`module server` is not supported yet.');
+		}
+		if (node.type !== 'CallExpression') return;
+		const name = importedHookName(node, state);
+		if (
+			(HOOK_NAMES.has(name) || name === 'use' || name === 'useContext') &&
+			!VALDI_HOOKS.has(name)
+		) {
+			throw valdiError(state, node, `hook ${JSON.stringify(name)} is not supported yet.`);
+		}
+	});
+}
+
+function hasOwnTemplate(fn) {
+	let found = false;
+	walk(fn.body, (node) => {
+		if (FUNCTION_TYPES.has(node.type)) return false;
+		if (isTemplate(node)) {
+			found = true;
+			return false;
+		}
+	});
+	return found;
+}
+
+function componentShape(node) {
+	const exportKind =
+		node.type === 'ExportNamedDeclaration'
+			? 'named'
+			: node.type === 'ExportDefaultDeclaration'
+				? 'default'
+				: null;
+	const declaration = exportKind === null ? node : node.declaration;
+	if (declaration?.type === 'FunctionDeclaration') {
+		return { node, fn: declaration, name: declaration.id?.name, exportKind };
+	}
+	if (
+		exportKind === 'default' &&
+		(declaration?.type === 'FunctionExpression' || declaration?.type === 'ArrowFunctionExpression')
+	) {
+		return { node, fn: declaration, name: declaration.id?.name, exportKind };
+	}
+	if (declaration?.type === 'VariableDeclaration' && declaration.declarations?.length === 1) {
+		const item = declaration.declarations[0];
+		const fn = unwrap(item.init);
+		if (
+			item.id?.type === 'Identifier' &&
+			(fn?.type === 'FunctionExpression' || fn?.type === 'ArrowFunctionExpression')
+		) {
+			return { node, fn, name: item.id.name, exportKind };
+		}
+	}
+	return null;
+}
+
+function collectComponents(ast, state) {
+	const referenced = new Set();
+	walk(ast, (node) => {
+		const name = node.openingElement?.name;
+		if (name?.type === 'JSXIdentifier' && !/^[a-z]/.test(name.name)) referenced.add(name.name);
+	});
+	for (const node of ast.body ?? []) {
+		const shape = componentShape(node);
+		if (shape === null) continue;
+		if (
+			!hasOwnTemplate(shape.fn) &&
+			!referenced.has(shape.name) &&
+			shape.exportKind !== 'default' &&
+			!(shape.exportKind === 'named' && /^[A-Z]/.test(shape.name ?? ''))
+		) {
+			continue;
+		}
+		const declaration = node.declaration ?? node;
+		if (declaration.type === 'VariableDeclaration' && declaration.kind !== 'const') {
+			throw valdiError(state, declaration, 'component function bindings must use const.');
+		}
+		shape.name ??= allocName(state, '__octaneValdiDefault');
+		state.components.set(shape.name, shape);
+		state.componentNodes.set(node, shape);
+	}
+}
+
+function forEachAssignmentBinding(pattern, visit) {
+	const node = unwrap(pattern);
+	if (node?.type === 'Identifier') visit(node);
+	else if (node?.type === 'RestElement') forEachAssignmentBinding(node.argument, visit);
+	else if (node?.type === 'AssignmentPattern') forEachAssignmentBinding(node.left, visit);
+	else if (node?.type === 'ArrayPattern') {
+		for (const element of node.elements) forEachAssignmentBinding(element, visit);
+	} else if (node?.type === 'ObjectPattern') {
+		for (const property of node.properties) {
+			forEachAssignmentBinding(
+				property.type === 'RestElement' ? property.argument : property.value,
+				visit,
+			);
+		}
+	}
+}
+
+function validateComponentBindings(ast, state) {
+	const lexical = state.lexical;
+	const assertStable = (identifier) => {
+		const shape = state.components.get(identifier.name);
+		if (shape === undefined) return;
+		const scope = lexical.resolveBinding(
+			lexical.nodeScopes.get(identifier) ?? lexical.rootScope,
+			identifier.name,
+		)?.scope;
+		let componentBinding = scope === lexical.rootScope;
+		// The lexical analysis also records a declaration's self-name in its
+		// parameter scope. It denotes the component unless a parameter shadows it.
+		if (
+			!componentBinding &&
+			shape.fn.type === 'FunctionDeclaration' &&
+			shape.fn.id?.name === identifier.name &&
+			scope === lexical.nodeScopes.get(shape.fn.id)
+		) {
+			componentBinding = true;
+			for (const parameter of shape.fn.params ?? []) {
+				forEachAssignmentBinding(parameter, (binding) => {
+					if (binding.name === identifier.name) componentBinding = false;
+				});
+			}
+		}
+		if (componentBinding) {
+			throw valdiError(state, identifier, 'component bindings must not be reassigned.');
+		}
+	};
+	walk(ast, (node) => {
+		if (node.type === 'AssignmentExpression') forEachAssignmentBinding(node.left, assertStable);
+		else if (node.type === 'UpdateExpression')
+			forEachAssignmentBinding(node.argument, assertStable);
+		else if (node.type === 'ForOfStatement' || node.type === 'ForInStatement') {
+			forEachAssignmentBinding(node.left, assertStable);
+		}
+	});
+}
+
+function hasRenderTimeCalls(fn) {
+	let found = false;
+	walk(fn, (node) => {
+		if (node !== fn && FUNCTION_TYPES.has(node.type)) return false;
+		if (node.type === 'CallExpression' || node.type === 'NewExpression') {
+			found = true;
+			return false;
+		}
+	});
+	return found;
+}
+
+function attributeValue(attribute, state) {
+	if (attribute.value == null) return withOrigin(b.literal(true), attribute);
+	const value =
+		attribute.value.type === 'JSXExpressionContainer'
+			? attribute.value.expression
+			: attribute.value;
+	if (!value || value.type === 'JSXEmptyExpression') {
+		throw valdiError(state, attribute, 'empty attribute expressions are unsupported.');
+	}
+	return assertNoTemplate(value, state, 'JSX-valued attributes');
+}
+
+function attributeEntries(node, state) {
+	return (node.openingElement?.attributes ?? node.attributes ?? []).map((attribute) => {
+		if (attribute.type === 'JSXSpreadAttribute' || attribute.type === 'SpreadAttribute') {
+			return {
+				name: null,
+				value: assertNoTemplate(attribute.argument, state, 'JSX-valued spread attributes'),
+				origin: attribute,
+			};
+		}
+		const name = attribute.name?.type === 'JSXIdentifier' ? attribute.name.name : null;
+		if (name === null) throw valdiError(state, attribute, 'namespaced attributes are unsupported.');
+		if (name === 'ref' || name === 'children') {
+			throw valdiError(state, attribute, `authored ${name} props are not supported yet.`);
+		}
+		return { name, value: attributeValue(attribute, state), origin: attribute };
+	});
+}
+
+function isStaticAttribute(value) {
+	const node = unwrap(value);
+	return (
+		(node?.type === 'Literal' &&
+			(node.value === null || ['string', 'number', 'boolean'].includes(typeof node.value))) ||
+		(node?.type === 'UnaryExpression' &&
+			(node.operator === '+' || node.operator === '-') &&
+			node.argument?.type === 'Literal' &&
+			typeof node.argument.value === 'number')
+	);
+}
+
+function normalizeWriterFacts(facts, sourceLength, filename) {
+	if (facts === undefined) return null;
+	const invalid = (message) => {
+		throw new TypeError(`Octane Valdi writer facts for ${filename}: ${message}`);
+	};
+	if (
+		facts === null ||
+		typeof facts !== 'object' ||
+		Array.isArray(facts) ||
+		facts.version !== 1 ||
+		!Array.isArray(facts.expressions)
+	) {
+		invalid('expected version 1 and an expressions array.');
+	}
+	const ranges = new Map();
+	for (let index = 0; index < facts.expressions.length; index++) {
+		const fact = facts.expressions[index];
+		if (
+			fact === null ||
+			typeof fact !== 'object' ||
+			Array.isArray(fact) ||
+			!Number.isInteger(fact.start) ||
+			!Number.isInteger(fact.end) ||
+			fact.start < 0 ||
+			fact.end <= fact.start ||
+			fact.end > sourceLength ||
+			!VALDI_WRITER_TYPES.has(fact.effectiveType) ||
+			typeof fact.isNullable !== 'boolean'
+		) {
+			invalid(`invalid expression record at index ${index}.`);
+		}
+		const key = `${fact.start}:${fact.end}`;
+		const previous = ranges.get(key);
+		if (
+			previous !== undefined &&
+			(previous.effectiveType !== fact.effectiveType || previous.isNullable !== fact.isNullable)
+		) {
+			invalid(`conflicting expression records at ${key}.`);
+		}
+		ranges.set(key, fact);
+	}
+	return ranges;
+}
+
+function suppliedAttributeKind(expression, state) {
+	if (state.writerFacts === null) return null;
+	// Never unwrap or follow bindings here: a fact about a subexpression or a
+	// different occurrence does not prove the complete authored attribute value.
+	// In particular, explicit keys may have replaced that value with a temporary.
+	// Valdi's typed writers also clear nullish values, so its effective type is
+	// sufficient even when the type-checker record has isNullable: true.
+	return state.writerFacts.get(`${expression.start}:${expression.end}`)?.effectiveType ?? null;
+}
+
+// Only immutable bindings with proven initializers are followed. A mutable
+// local, imported value, parameter, or shadowing loop item must not inherit an
+// outer binding's type. These records live for one compilation, not at runtime.
+function collectAttributeBindings(ast, lexical) {
+	const bindings = new WeakMap();
+	walk(ast, (node) => {
+		if (node.type !== 'VariableDeclaration' || node.kind !== 'const' || node.declare) return;
+		for (const declaration of node.declarations ?? []) {
+			if (declaration.id?.type !== 'Identifier' || declaration.init == null) continue;
+			const name = declaration.id.name;
+			const scope = lexical.resolveBinding(
+				lexical.nodeScopes.get(declaration.id) ?? lexical.rootScope,
+				name,
+			)?.scope;
+			if (scope === undefined) continue;
+			let locals = bindings.get(scope);
+			if (locals === undefined) bindings.set(scope, (locals = new Map()));
+			locals.set(name, { initializer: declaration.init, kind: undefined, resolving: false });
+		}
+	});
+	return bindings;
+}
+
+function attributeBindingKind(identifier, state) {
+	const lexical = state.lexical;
+	const scope = lexical.resolveBinding(
+		lexical.nodeScopes.get(identifier) ?? lexical.rootScope,
+		identifier.name,
+	)?.scope;
+	const binding =
+		scope === undefined
+			? undefined
+			: state.attributeFacts.bindings.get(scope)?.get(identifier.name);
+	if (binding === undefined || binding.resolving) return null;
+	if (binding.kind !== undefined) return binding.kind;
+	binding.resolving = true;
+	binding.kind = attributeExpressionKind(binding.initializer, state);
+	binding.resolving = false;
+	return binding.kind;
+}
+
+// Keep source-level proofs local to this target. Unknown expressions use the
+// generic setter; an integration can provide exact checked expression facts.
+function attributeExpressionKind(expression, state) {
+	const node = unwrap(expression);
+	if (node?.type === 'Literal') {
+		const kind = typeof node.value;
+		return kind === 'string' || kind === 'number' || kind === 'boolean' ? kind : null;
+	}
+	if (node?.type === 'TemplateLiteral') return 'string';
+	if (node?.type === 'Identifier') return attributeBindingKind(node, state);
+	if (node?.type === 'ArrowFunctionExpression' || node?.type === 'FunctionExpression')
+		return 'function';
+	if (node?.type === 'ConditionalExpression') {
+		const consequent = attributeExpressionKind(node.consequent, state);
+		return consequent === attributeExpressionKind(node.alternate, state) ? consequent : null;
+	}
+	if (node?.type === 'BinaryExpression' && node.operator === '+') {
+		return attributeExpressionKind(node.left, state) === 'string' ||
+			attributeExpressionKind(node.right, state) === 'string'
+			? 'string'
+			: null;
+	}
+	if (node?.type === 'CallExpression' && importedHookName(node, state) === 'useCallback') {
+		return attributeExpressionKind(node.arguments?.[0], state) === 'function' ? 'function' : null;
+	}
+	return null;
+}
+
+function encodedKeyExpression(state, prototype, keys, origin) {
+	// Key encoding belongs to the adapter. Prototypes and returned keys are
+	// opaque: generated code never reads their fields or assumes a string format.
+	return call(state, 'valdiKey', [prototype, ...keys], origin);
+}
+
+function keyExpression(state, prototype, keys, explicit, origin) {
+	const base =
+		keys.length === 0
+			? b.unary('void', b.literal(0))
+			: encodedKeyExpression(state, prototype, keys, origin);
+	if (explicit === null) return withOrigin(base, origin);
+	return withOrigin(
+		b.conditional(
+			b.binary('==', explicit, b.literal(null)),
+			base,
+			encodedKeyExpression(state, prototype, [...keys, explicit], origin),
+		),
+		origin,
+	);
+}
+
+function mergedAttributes(entries, state, origin) {
+	const keyName = allocName(state, '__octaneValdiKey');
+	const refName = allocName(state, '__octaneValdiRef');
+	const childrenName = allocName(state, '__octaneValdiChildren');
+	const propsName = allocName(state, '__octaneValdiProps');
+	const expression = b.object(
+		entries.map((entry) =>
+			entry.name === null
+				? b.spread(entry.value)
+				: b.prop('init', b.literal(entry.name), entry.value, entry.name === '__proto__'),
+		),
+	);
+	const pattern = b.object_pattern([
+		b.prop('init', b.id('key'), b.id(keyName)),
+		b.prop('init', b.id('ref'), b.id(refName)),
+		b.prop('init', b.id('children'), b.id(childrenName)),
+		b.rest(b.id(propsName)),
+	]);
+	const prelude = [
+		b.const(pattern, expression),
+		b.if(
+			b.logical(
+				'||',
+				b.binary('!==', b.id(refName), b.unary('void', b.literal(0))),
+				b.binary('!==', b.id(childrenName), b.unary('void', b.literal(0))),
+			),
+			b.block([
+				b.throw_error('Octane Valdi compiler: spread ref/children props are not supported yet.'),
+			]),
+			null,
+		),
+	];
+	return {
+		prelude: prelude.map((statement) => withOrigin(statement, origin)),
+		key: withOrigin(b.id(keyName), origin),
+		props: withOrigin(b.id(propsName), origin),
+	};
+}
+
+function prepareAttributes(entries, state, origin) {
+	if (entries.some((entry) => entry.name === null)) {
+		return { ...mergedAttributes(entries, state, origin), statics: [], dynamic: [], spread: true };
+	}
+	const counts = new Map();
+	for (const entry of entries) counts.set(entry.name, (counts.get(entry.name) ?? 0) + 1);
+	const hasKey = counts.has('key');
+	const prelude = [];
+	const statics = [];
+	const dynamic = [];
+	let key = null;
+	for (const entry of entries) {
+		if (entry.name !== 'key' && counts.get(entry.name) === 1 && isStaticAttribute(entry.value)) {
+			statics.push(withOrigin(b.literal(entry.name), entry.origin), entry.value);
+			continue;
+		}
+		let value = entry.value;
+		if (hasKey) {
+			const name = allocName(state, '__octaneValdiAttribute');
+			prelude.push(withOrigin(b.const(name, value), entry.origin));
+			value = withOrigin(b.id(name), entry.origin);
+		}
+		if (entry.name === 'key') key = value;
+		else dynamic.push({ ...entry, value, originalValue: entry.value });
+	}
+	return { prelude, statics, dynamic, key, spread: false };
+}
+
+function setterForAttribute(entry, state) {
+	if (entry.name === 'style') return 'setAttributeStyle';
+	const value = unwrap(entry.originalValue);
+	const literalKind = value?.type === 'Literal' ? typeof value.value : null;
+	const kind =
+		literalKind === 'boolean' || literalKind === 'number'
+			? literalKind
+			: (attributeExpressionKind(entry.originalValue, state) ??
+				suppliedAttributeKind(entry.originalValue, state));
+	// These names have extra work in Valdi's generic writer. Only select a
+	// typed writer whose contract includes that same normalization/observation.
+	if (
+		entry.name === 'ref' ||
+		entry.name === '$ref' ||
+		entry.name === '$onLayout' ||
+		((entry.name === 'class' || entry.name === '$class') && kind !== 'string') ||
+		((entry.name === 'onVisibilityChanged' || entry.name === 'onViewportChanged') &&
+			kind !== 'function')
+	)
+		return 'setAttribute';
+	if (kind === 'boolean') return 'setAttributeBool';
+	if (kind === 'number') return 'setAttributeNumber';
+	if (kind === 'string') return 'setAttributeString';
+	if (kind === 'function') return 'setAttributeFunction';
+	if (kind === 'style') return 'setAttributeStyle';
+	return 'setAttribute';
+}
+
+function componentExpression(name, state, origin) {
+	if (name?.type !== 'JSXIdentifier' && name?.type !== 'Identifier') {
+		throw valdiError(state, origin, 'dynamic component tags are not supported yet.');
+	}
+	const lexical = state.lexical;
+	const binding = lexical.resolveBinding(
+		lexical.nodeScopes.get(name) ?? lexical.rootScope,
+		name.name,
+	);
+	const current = state.currentComponent;
+	const selfScope = current?.fn.id
+		? lexical.resolveBinding(lexical.nodeScopes.get(current.fn.id) ?? lexical.rootScope, name.name)
+				?.scope
+		: null;
+	if (
+		binding === null ||
+		binding === undefined ||
+		(binding.scope !== lexical.rootScope &&
+			!(current?.name === name.name && binding.scope === selfScope)) ||
+		(binding.importSource === null && !state.components.has(name.name))
+	) {
+		throw valdiError(
+			state,
+			origin,
+			'component tags must name a stable imported or module component.',
+		);
+	}
+	return withOrigin(b.id(name.name), name);
+}
+
+function hoistPrototype(state, method, args, origin) {
+	const name = allocName(state, `__octaneValdiPrototype${state.prototypes.length}`);
+	state.prototypes.push(withOrigin(b.const(name, writerCall(state, method, args, origin)), origin));
+	return withOrigin(b.id(name), origin);
+}
+
+function elementName(node) {
+	return node.openingElement?.name ?? node.name;
+}
+
+function intrinsicTag(node) {
+	const name = elementName(node);
+	const tag = name?.type === 'JSXIdentifier' || name?.type === 'Identifier' ? name.name : null;
+	return typeof tag === 'string' && (/^[a-z]/.test(tag) || tag.includes('-')) ? tag : null;
+}
+
+function emitIntrinsicContents(node, state, attrs) {
+	const statements = [];
+	if (attrs.spread) {
+		statements.push(
+			withOrigin(b.stmt(call(state, 'setValdiAttributes', [attrs.props], node)), node),
+		);
+	} else {
+		for (const entry of attrs.dynamic) {
+			statements.push(
+				writerStatement(
+					state,
+					setterForAttribute(entry, state),
+					[b.literal(entry.name), entry.value],
+					entry.origin,
+				),
+			);
+		}
+	}
+	// Valdi matches children within this virtual parent. Its own key already
+	// consumed the pending loop path; only loops below it need new key parts.
+	statements.push(...emitNodes(node.children ?? [], state, [], false));
+	return statements;
+}
+
+function emitElement(node, state, keys) {
+	const name = elementName(node);
+	const tag = intrinsicTag(node);
+	const intrinsic = tag !== null;
+	const entries = attributeEntries(node, state);
+	const attrs = prepareAttributes(entries, state, node);
+	const prototypeArgs = intrinsic ? [b.literal(tag)] : [];
+	if (attrs.statics.length > 0) prototypeArgs.push(b.array(attrs.statics));
+	const prototype = hoistPrototype(
+		state,
+		intrinsic ? 'makeNodePrototype' : 'makeComponentPrototype',
+		prototypeArgs,
+		node,
+	);
+	const key = keyExpression(state, prototype, keys, attrs.key, node);
+	const statements = [...attrs.prelude];
+	if (intrinsic) {
+		if (tag === 'slot' || tag === 'slotted' || tag === 'style') {
+			throw valdiError(state, node, `<${tag}> is not supported by the Valdi writer target.`);
+		}
+		statements.push(writerStatement(state, 'beginRender', [prototype, key], node));
+		statements.push(...emitIntrinsicContents(node, state, attrs));
+		statements.push(writerStatement(state, 'endRender', [], node.closingElement ?? node));
+		return statements;
+	}
+	const component = componentExpression(name, state, node);
+	const children = (node.children ?? []).filter(
+		(child) => child.type !== 'JSXText' || !/^[\s;]*$/.test(child.value ?? ''),
+	);
+	if (children.length !== 0) {
+		throw valdiError(state, node, 'component children/render props are not supported yet.');
+	}
+	statements.push(
+		writerStatement(
+			state,
+			'beginComponent',
+			[call(state, 'getValdiComponentConstructor', [component], node), prototype, key],
+			node,
+		),
+	);
+	if (attrs.spread) {
+		statements.push(writerStatement(state, 'setViewModelFull', [attrs.props], node));
+	} else {
+		for (const entry of attrs.dynamic) {
+			statements.push(
+				writerStatement(
+					state,
+					'setViewModelProperty',
+					[b.literal(entry.name), entry.value],
+					entry.origin,
+				),
+			);
+		}
+	}
+	statements.push(writerStatement(state, 'endComponent', [], node.closingElement ?? node));
+	return statements;
+}
+
+function emitFor(node, state, keys) {
+	if (node.await || node.statementType === 'ForInStatement') {
+		throw valdiError(state, node, 'only synchronous @for-of is supported.');
+	}
+	if (!node.key) throw valdiError(state, node, '@for requires an explicit key.');
+	if (node.left?.type !== 'VariableDeclaration' || node.left.declarations?.length !== 1) {
+		throw valdiError(state, node, '@for requires one item binding.');
+	}
+	walk(node.body, (child) => {
+		if (FUNCTION_TYPES.has(child.type)) return false;
+		if (child.type === 'CallExpression' && slotHookName(child, state) !== null) {
+			throw valdiError(
+				state,
+				child,
+				'hooks directly inside @for are not supported yet; use a child component.',
+			);
+		}
+	});
+	const keyName = allocName(state, '__octaneValdiItemKey');
+	const indexName = node.index || node.empty ? allocName(state, '__octaneValdiIndex') : null;
+	const prefix = [];
+	if (node.index) {
+		prefix.push(b.const(node.index, b.update('++', b.id(indexName), false)));
+	} else if (indexName !== null) {
+		prefix.push(b.stmt(b.update('++', b.id(indexName), false)));
+	}
+	prefix.push(b.const(keyName, assertNoTemplate(node.key, state, '@for keys containing JSX')));
+	const body = b.block([
+		...prefix.map((statement) => withOrigin(statement, node)),
+		...emitNodes(
+			node.body?.body ?? [],
+			state,
+			[...keys, withOrigin(b.id(keyName), node.key)],
+			false,
+		),
+	]);
+	const output = [];
+	if (indexName !== null) output.push(withOrigin(b.let(indexName, b.literal(0)), node));
+	output.push(
+		withOrigin(
+			b.for_of(node.left, assertNoTemplate(node.right, state, '@for sources containing JSX'), body),
+			node,
+		),
+	);
+	if (node.empty) {
+		output.push(
+			withOrigin(
+				b.if(
+					b.binary('===', b.id(indexName), b.literal(0)),
+					b.block(emitNodes(node.empty.body ?? [], state, keys, false)),
+					null,
+				),
+				node.empty,
+			),
+		);
+	}
+	return output;
+}
+
+function emitIf(node, state, keys) {
+	const alternate = node.alternate;
+	return [
+		withOrigin(
+			b.if(
+				assertNoTemplate(node.test, state, '@if conditions containing JSX'),
+				b.block(emitNodes(node.consequent?.body ?? [node.consequent], state, keys, false)),
+				alternate == null
+					? null
+					: alternate.type === 'JSXIfExpression'
+						? emitIf(alternate, state, keys)[0]
+						: b.block(emitNodes(alternate.body ?? [alternate], state, keys, false)),
+			),
+			node,
+		),
+	];
+}
+
+function isNullishOutput(node, state) {
+	const value = unwrap(node);
+	return (
+		value == null ||
+		(value.type === 'Literal' && (value.value === null || typeof value.value === 'boolean')) ||
+		(value.type === 'Identifier' &&
+			value.name === 'undefined' &&
+			state.lexical.resolveBinding(
+				state.lexical.nodeScopes.get(value) ?? state.lexical.rootScope,
+				value.name,
+			) == null) ||
+		(value.type === 'UnaryExpression' && value.operator === 'void')
+	);
+}
+
+function emitRenderable(node, state, keys) {
+	const value = unwrap(node);
+	if (isNullishOutput(value, state)) {
+		return value?.type === 'UnaryExpression'
+			? [withOrigin(b.stmt(assertNoTemplate(value, state, 'JSX inside a void expression')), node)]
+			: [];
+	}
+	if (value?.type === 'ConditionalExpression') {
+		return [
+			withOrigin(
+				b.if(
+					assertNoTemplate(value.test, state, 'conditional JSX tests'),
+					b.block(emitRenderable(value.consequent, state, keys)),
+					b.block(emitRenderable(value.alternate, state, keys)),
+				),
+				node,
+			),
+		];
+	}
+	if (value?.type === 'LogicalExpression' && value.operator === '&&') {
+		return [
+			withOrigin(
+				b.if(
+					assertNoTemplate(value.left, state, 'conditional JSX tests'),
+					b.block(emitRenderable(value.right, state, keys)),
+					null,
+				),
+				node,
+			),
+		];
+	}
+	if (value?.type === 'JSXElement' || value?.type === 'Element')
+		return emitElement(value, state, keys);
+	if (value?.type === 'JSXFragment' || value?.type === 'Fragment')
+		return emitNodes(value.children ?? [], state, keys, false);
+	if (value?.type === 'JSXForExpression') return emitFor(value, state, keys);
+	if (value?.type === 'JSXIfExpression') return emitIf(value, state, keys);
+	throw valdiError(
+		state,
+		node,
+		`unsupported renderable ${value?.type ?? 'value'}; render text with a <label value={...} />.`,
+	);
+}
+
+function rewriteComponentStatement(node, state, keys, allowReturn) {
+	if (node?.type === 'ReturnStatement') {
+		if (!allowReturn) {
+			throw valdiError(state, node, 'early returns inside template regions are not supported yet.');
+		}
+		return withOrigin(
+			b.block([...emitRenderable(node.argument, state, keys), b.return(null)]),
+			node,
+		);
+	}
+	if (FUNCTION_TYPES.has(node?.type)) {
+		return assertNoTemplate(node, state, 'nested component declarations');
+	}
+	if (node?.type === 'BlockStatement') {
+		return { ...node, body: emitNodes(node.body ?? [], state, keys, allowReturn) };
+	}
+	if (node?.type === 'IfStatement') {
+		return {
+			...node,
+			test: assertNoTemplate(node.test, state, 'JavaScript conditions containing JSX'),
+			consequent: rewriteComponentStatement(node.consequent, state, keys, allowReturn),
+			alternate: node.alternate
+				? rewriteComponentStatement(node.alternate, state, keys, allowReturn)
+				: null,
+		};
+	}
+	if (!allowReturn && (node?.type === 'BreakStatement' || node?.type === 'ContinueStatement')) {
+		throw valdiError(
+			state,
+			node,
+			'JavaScript jumps inside template regions are not supported yet.',
+		);
+	}
+	return assertNoTemplate(node, state, 'JSX in JavaScript setup');
+}
+
+function emitNodes(nodes, state, keys, allowReturn) {
+	const output = [];
+	for (const node of nodes) {
+		if (node == null) continue;
+		if (node.type === 'JSXText') {
+			if (/^[\s;]*$/.test(node.value ?? '') || state.renderer.text === 'ignore') continue;
+			throw valdiError(
+				state,
+				node,
+				'authored text children are unsupported; use <label value={...} />.',
+			);
+		}
+		if (node.type === 'JSXExpressionContainer') {
+			if (node.expression?.type === 'JSXEmptyExpression') continue;
+			output.push(...emitRenderable(node.expression, state, keys));
+		} else if (isTemplate(node)) {
+			output.push(...emitRenderable(node, state, keys));
+		} else {
+			output.push(rewriteComponentStatement(node, state, keys, allowReturn));
+		}
+	}
+	return output;
+}
+
+function emitComponent(shape, state) {
+	const { fn, name, exportKind } = shape;
+	if (fn.async || fn.generator) {
+		throw valdiError(state, fn, 'async/generator components are not supported yet.');
+	}
+	for (const parameter of fn.params ?? [])
+		assertNoTemplate(parameter, state, 'component parameters');
+	state.currentComponent = shape;
+	let statements;
+	if (fn.body?.type === 'JSXCodeBlock') {
+		statements = [
+			...emitNodes(fn.body.body ?? [], state, [], true),
+			...emitRenderable(fn.body.render, state, []),
+		];
+	} else if (fn.body?.type === 'BlockStatement') {
+		statements = emitNodes(fn.body.body ?? [], state, [], true);
+	} else {
+		statements = emitRenderable(fn.body, state, []);
+	}
+	state.currentComponent = null;
+	// A named expression called `name` would shadow the outer branded component
+	// inside its own body, breaking recursive <Name /> calls. The raw writer body
+	// gets a distinct binding; authored self-references keep the public descriptor.
+	const renderName = allocName(state, `__octaneValdiRender${name}`);
+	const render = withOrigin(
+		b.function(b.id(renderName), fn.params ?? [], b.block(statements), false, fn.typeParameters),
+		fn,
+	);
+	const options = b.object([b.prop('init', b.id('hasHooks'), b.literal(hasRenderTimeCalls(fn)))]);
+	const declaration = withOrigin(
+		b.const(name, call(state, 'defineValdiComponent', [render, options], fn)),
+		fn,
+	);
+	if (exportKind === 'named') return [withOrigin(b.export(declaration), shape.node)];
+	if (exportKind === 'default')
+		return [declaration, withOrigin(b.export_default(b.id(name)), shape.node)];
+	return [declaration];
+}
+
+/** Lower an authored module and finish it through the shared client pipeline. */
+export function compileValdi(
+	source,
+	filename,
+	renderer,
+	compileClient,
+	options = {},
+	parsedAst = null,
+) {
+	if (
+		!renderer ||
+		typeof renderer.id !== 'string' ||
+		typeof renderer.module !== 'string' ||
+		renderer.target !== 'valdi'
+	) {
+		throw new TypeError('Octane Valdi compiler requires a resolved Valdi renderer.');
+	}
+	const ast = parsedAst ?? parseModule(source, filename);
+	const state = {
+		filename,
+		renderer,
+		names: new Set(),
+		helpers: new Map(),
+		jsxFacade: null,
+		prototypes: [],
+		components: new Map(),
+		componentNodes: new Map(),
+		currentComponent: null,
+		runtimeImports: new Map(),
+		lexical: createLexicalAnalysis(ast),
+		attributeFacts: null,
+		writerFacts: normalizeWriterFacts(options.valdiWriterFacts, source.length, filename),
+	};
+	if (options.hmr !== undefined && options.hmr !== false) {
+		throw valdiError(state, ast, 'HMR is not supported yet; compile with hmr: false.');
+	}
+	if (options.profile === true) {
+		throw valdiError(
+			state,
+			ast,
+			'Octane profiling is not supported by the Valdi writer target yet.',
+		);
+	}
+	if (renderer.text === 'host') {
+		throw valdiError(state, ast, 'host text is unsupported; use text: "reject" or "ignore".');
+	}
+	const boundaries = assertRendererBoundaryAnalysis(
+		analyzeRendererBoundaries(source, {
+			ast,
+			filename,
+			rendererBoundaries: options.rendererBoundaries,
+		}),
+	);
+	if (boundaries.boundaries.length > 0) {
+		throw valdiError(state, ast, 'cross-renderer boundaries are not supported yet.');
+	}
+	walk(ast, (node) => {
+		if (
+			(node.type === 'Identifier' || node.type === 'JSXIdentifier') &&
+			typeof node.name === 'string'
+		)
+			state.names.add(node.name);
+	});
+	validateRuntimeImports(ast, state);
+	validateRendererAst(ast, filename, renderer);
+	state.attributeFacts = {
+		bindings: collectAttributeBindings(ast, state.lexical),
+	};
+	collectComponents(ast, state);
+	validateComponentBindings(ast, state);
+	const body = [];
+	for (const node of ast.body ?? []) {
+		const shape = state.componentNodes.get(node);
+		if (shape !== undefined) body.push(...emitComponent(shape, state));
+		else body.push(assertNoTemplate(node, state, 'JSX outside a component'));
+	}
+	const origin = ast.body?.[0] ?? ast;
+	const guard = withOrigin(
+		b.stmt(call(state, 'assertValdiCompilerAbi', [b.literal(VALDI_COMPILER_ABI_VERSION)], origin)),
+		origin,
+	);
+	const writerPrelude =
+		state.jsxFacade === null
+			? []
+			: [withOrigin(b.const(state.jsxFacade, helper(state, 'jsx')), origin)];
+	const imports = [withOrigin(b.imports([...state.helpers], renderer.module), origin)];
+	return compileClient(
+		{ ...ast, body: [...imports, ...writerPrelude, ...state.prototypes, ...body] },
+		guard,
+	);
+}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -62,6 +62,9 @@ import {
 	UNIVERSAL_COMPILER_RUNTIME_IMPORTS,
 	UNIVERSAL_THREAD_RUNTIME_IMPORTS,
 } from './compile-universal.js';
+import { compileValdi, VALDI_COMPILER_RUNTIME_IMPORTS } from './compile-valdi.js';
+import { HOOK_NAMES } from './hook-names.js';
+export { HOOK_NAMES } from './hook-names.js';
 import {
 	expandDomRendererRegionsAst,
 	prepareRendererBoundaryRegions,
@@ -1913,28 +1916,6 @@ function classifyViewTransitionOwnership(astBody, production, ownComponents) {
 	}
 	return { global, owners };
 }
-
-export const HOOK_NAMES = new Set([
-	'useState',
-	'useLinkedState',
-	'useReducer',
-	'useEffect',
-	'useLayoutEffect',
-	'useInsertionEffect',
-	'useMemo',
-	'useCallback',
-	'useRef',
-	'useId',
-	'useEffectEvent',
-	'useImperativeHandle',
-	'useDeferredValue',
-	'useTransition',
-	'useSyncExternalStore',
-	// React 19 Actions bundle.
-	'useActionState',
-	'useFormStatus',
-	'useOptimistic',
-]);
 
 function hookRuntimeModulesForCompile(options, universalUnits = []) {
 	const modules = new Set(options?.__hookRuntimeModules || []);
@@ -7828,7 +7809,7 @@ function instrumentProfileComponents(ast, ctx) {
  * Compile a .tsrx source string into JS targeting `octane`.
  * @param {string} source
  * @param {string} filename
- * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, strong?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], textTypeFacts?: { version: 1, filename: string, sourceVersion: string, projectVersion: string, stringChildRanges: readonly (readonly [number, number])[] }, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
+ * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, strong?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], valdiWriterFacts?: import('./compile-valdi.js').ValdiWriterFacts, textTypeFacts?: { version: 1, filename: string, sourceVersion: string, projectVersion: string, stringChildRanges: readonly (readonly [number, number])[] }, renderer?: { id: string, module: string, target: 'dom' | 'universal' | 'valdi', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal' | 'valdi', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
  *   `dev: true` emits client hydration source-location metadata (per-component
  *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
  *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
@@ -7839,13 +7820,17 @@ function instrumentProfileComponents(ast, ctx) {
  *   `import.meta.webpackHot` wiring with dispose-data wrapper handoff. Dev
  *   tooling should select its dialect in serve mode and leave HMR off for
  *   production builds.
- *   `mode` selects the codegen target: `'client'` (default) emits the
- *   template-clone DOM runtime; `'server'` emits HTML-string SSR output (static
+ *   `mode` selects client or server execution. The default client renderer
+ *   emits the template-clone DOM runtime; `renderer.target: 'valdi'` opts into
+ *   the experimental external writer adapter. `'server'` emits HTML-string SSR output (static
  *   chunks interleaved with `ssr*` helpers) carrying the hydration markers the
  *   client `hydrateRoot` adopts.
  *   `rendererBoundaries` and `rendererRegistry` are the normalized static
  *   boundary table and renderer registry. Pass them together when a client
  *   module may contain an explicitly renderer-owned component prop.
+ *   `valdiWriterFacts` supplies exact authored attribute-expression type proofs
+ *   for the Valdi target. That target uses ordinary keyed hook calls and does
+ *   not use the DOM-specific `autoMemo` or `inlineHookMemo` optimizations.
  * @returns {{ code: string, map: any, diagnostics: readonly unknown[] }}
  */
 function cleanCompileFilename(filename) {
@@ -7924,6 +7909,50 @@ function compileInternal(
 	const universalRuntime = normalizeUniversalRuntime(options?.universalRuntime);
 	if (!options?.__rendererBoundariesLowered) {
 		assertUniversalRuntimeTarget(universalRuntime, mode, options?.renderer);
+	}
+	if (options?.renderer?.target === 'valdi') {
+		const renderer = options.renderer;
+		if (mode !== 'client') {
+			throw new Error(
+				`Renderer ${JSON.stringify(renderer.id)} does not provide the serialization/hydration capability required by server compilation.`,
+			);
+		}
+		return compileValdi(
+			source,
+			filename,
+			renderer,
+			(loweredAst, abiGuard) =>
+				compileInternal(
+					source,
+					filename,
+					{
+						...options,
+						renderer: undefined,
+						universalRuntime: undefined,
+						rendererBoundaries: undefined,
+						rendererRegistry: undefined,
+						// The external writer ABI exposes ordinary keyed hook calls,
+						// not DOM-owned memo cells or component scopes.
+						inlineHookMemo: false,
+						autoMemo: false,
+						__hydratePrepared: true,
+						__rendererBoundariesLowered: true,
+						__valdiAbiGuard: abiGuard,
+						__hookRuntimeModules: [...(options.__hookRuntimeModules ?? []), renderer.module],
+						__runtimeImportRoutes: [
+							...(options.__runtimeImportRoutes ?? []),
+							{ module: renderer.module, imported: VALDI_COMPILER_RUNTIME_IMPORTS },
+						],
+						__nativeChangeDiagnostics: [],
+					},
+					loweredAst,
+					mode,
+					null,
+					hasStringChildProofs,
+				),
+			options,
+			analyzedAst,
+		);
 	}
 	if (!options?.__hydratePrepared) {
 		const cleanFilename = cleanCompileFilename(filename);
@@ -9335,6 +9364,17 @@ function compileInternal(
 		...hmrNodes,
 		...profileNodes,
 	];
+	if (options?.__valdiAbiGuard !== undefined) {
+		// Fail before even compiler-hoisted hook-slot allocation can call an
+		// incompatible external adapter. Keep imports first for downstream
+		// CommonJS transforms that lower imports at their statement positions.
+		const imports = [];
+		const statements = [];
+		for (const node of moduleBody) {
+			(node.type === 'ImportDeclaration' ? imports : statements).push(node);
+		}
+		moduleBody = [...imports, options.__valdiAbiGuard, ...statements];
+	}
 	if (ctx.inlineHookMemo && ctx.hasSlotMemoCandidates) {
 		moduleBody = lowerSlotMemoFunctions(moduleBody, {
 			allocateName: (preferred) => allocCompilerName(ctx, preferred),

--- a/packages/octane/src/compiler/hook-names.js
+++ b/packages/octane/src/compiler/hook-names.js
@@ -1,0 +1,22 @@
+/** Slot-keyed builtins shared by the compiler backends. */
+export const HOOK_NAMES = new Set([
+	'useState',
+	'useLinkedState',
+	'useReducer',
+	'useEffect',
+	'useLayoutEffect',
+	'useInsertionEffect',
+	'useMemo',
+	'useCallback',
+	'useRef',
+	'useId',
+	'useEffectEvent',
+	'useImperativeHandle',
+	'useDeferredValue',
+	'useTransition',
+	'useSyncExternalStore',
+	// React 19 Actions bundle.
+	'useActionState',
+	'useFormStatus',
+	'useOptimistic',
+]);

--- a/packages/octane/src/compiler/index.d.ts
+++ b/packages/octane/src/compiler/index.d.ts
@@ -6,7 +6,7 @@ export type { TextTypeFacts } from './typescript.js';
 export interface CompileRenderer {
 	id: string;
 	module: string;
-	target: 'dom' | 'universal';
+	target: 'dom' | 'universal' | 'valdi';
 	server?: string;
 	/** Additional normalized renderer capabilities. */
 	[option: string]: unknown;
@@ -30,6 +30,27 @@ export interface OctaneCssModuleConstants {
 	default?: Readonly<Record<string, string>>;
 }
 
+/** The version checked by compiler-emitted external Valdi adapter calls. */
+export const VALDI_COMPILER_ABI_VERSION: 1;
+
+export type ValdiWriterEffectiveType = 'boolean' | 'number' | 'string' | 'function' | 'style';
+
+/** An exact authored-expression fact supplied by an integration's type checker. */
+export interface ValdiWriterExpressionFact {
+	/** UTF-16 source offset, inclusive. */
+	start: number;
+	/** UTF-16 source offset, exclusive. */
+	end: number;
+	effectiveType: ValdiWriterEffectiveType;
+	/** Typed adapter setters must also accept and clear nullish values. */
+	isNullable: boolean;
+}
+
+export interface ValdiWriterFacts {
+	version: 1;
+	expressions: readonly ValdiWriterExpressionFact[];
+}
+
 export interface CompileOptions {
 	mode?: 'client' | 'server';
 	hmr?: boolean | 'vite' | 'webpack';
@@ -45,6 +66,8 @@ export interface CompileOptions {
 	dataCallbackHooks?: readonly string[];
 	/** Exact authored-source facts from octane/compiler/typescript. */
 	textTypeFacts?: TextTypeFacts;
+	/** Optional exact attribute-expression proofs; used only by the Valdi target. */
+	valdiWriterFacts?: ValdiWriterFacts;
 	/**
 	 * Trusted bundler/provider proof of an already initialized, immutable CSS
 	 * class string. `property` is null for a named string import, or the static
@@ -65,7 +88,7 @@ export interface CompileOptions {
 	renderer?: CompileRenderer;
 	rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, CompileRendererBoundary>>>>;
 	rendererRegistry?: Readonly<
-		Record<string, { module: string; target: 'dom' | 'universal'; server?: string }>
+		Record<string, { module: string; target: 'dom' | 'universal' | 'valdi'; server?: string }>
 	>;
 	universalRuntime?: { runtime: string; thread: 'background' | 'main-thread' };
 	clientOnlyImports?: readonly unknown[];

--- a/packages/octane/src/compiler/index.js
+++ b/packages/octane/src/compiler/index.js
@@ -3,5 +3,6 @@
 // `@octanejs/vite-plugin`), which is where its `node:fs`/`node:path` graph
 // belongs.
 export { compile } from './compile.js';
+export { VALDI_COMPILER_ABI_VERSION } from './compile-valdi.js';
 export { analyzeNativeChangeDiagnostics as __analyzeNativeChangeDiagnostics } from './native-change-diagnostics.js';
 export { compileToVolarMappings } from './volar.js';

--- a/packages/octane/src/compiler/renderers.js
+++ b/packages/octane/src/compiler/renderers.js
@@ -205,8 +205,8 @@ function normalizeRegistryEntry(id, value, path) {
 		assertKnownKeys(value, REGISTRY_ENTRY_KEYS, path);
 		moduleId = validateModuleId(value.module, `${path}.module`);
 		target = value.target ?? 'universal';
-		if (target !== 'dom' && target !== 'universal') {
-			throw configError(`${path}.target must be "dom" or "universal".`);
+		if (target !== 'dom' && target !== 'universal' && target !== 'valdi') {
+			throw configError(`${path}.target must be "dom", "universal", or "valdi".`);
 		}
 
 		server = value.server ?? (target === 'dom' ? 'render' : 'unsupported');
@@ -221,6 +221,11 @@ function normalizeRegistryEntry(id, value, path) {
 		if (target === 'universal' && server === 'render') {
 			throw configError(
 				`${path}.server cannot be "render" until the universal renderer provides a validated server serializer.`,
+			);
+		}
+		if (target === 'valdi' && server === 'render') {
+			throw configError(
+				`${path}.server cannot be "render" for the client-only Valdi writer target.`,
 			);
 		}
 

--- a/packages/octane/src/compiler/vite.d.ts
+++ b/packages/octane/src/compiler/vite.d.ts
@@ -30,7 +30,7 @@ export type OctaneRendererRegistryEntry =
 	| string
 	| {
 			module: string;
-			target?: 'dom' | 'universal';
+			target?: 'dom' | 'universal' | 'valdi';
 			server?: 'render' | 'client-only' | 'unsupported';
 			intrinsics?: string;
 			text?: 'reject' | 'ignore' | 'host';

--- a/packages/octane/tests/_fixtures/valdi-writer.tsrx
+++ b/packages/octane/tests/_fixtures/valdi-writer.tsrx
@@ -1,0 +1,31 @@
+// Synthetic compiler input for the recording adapter in _valdi-writer.ts.
+interface ItemData {
+	id: string;
+	value: string;
+}
+
+interface SceneProps {
+	active: boolean;
+	extra: Record<string, unknown>;
+	tone: string;
+	onTap: (value: string) => void;
+	items: ItemData[];
+}
+
+function Item(props: { item: ItemData; tone: string }) @{
+	<label value={props.item.value} tone={props.tone} />
+}
+
+export function Scene(props: SceneProps) @{
+	<view enabled={true} {...props.extra} tone="final" onTap={props.onTap}>
+		@if (props.active) {
+			@for (const item of props.items; key item.id) {
+				<Item item={item} tone={props.tone} />
+			} @empty {
+				<label value="empty" />
+			}
+		} @else {
+			<label value="inactive" />
+		}
+	</view>
+}

--- a/packages/octane/tests/_server-fixture.ts
+++ b/packages/octane/tests/_server-fixture.ts
@@ -32,6 +32,8 @@ export interface CompiledFixtureSourceOptions {
 	mode: 'client' | 'server';
 	/** Additional public compiler options; `mode` is always enforced. */
 	compileOptions?: Record<string, unknown>;
+	/** Self-contained external modules used by custom-renderer fixtures. */
+	runtimeModules?: Readonly<Record<string, CompiledFixtureModule>>;
 }
 
 export interface PlainHookFixtureSourceOptions {
@@ -49,7 +51,7 @@ export function loadCompiledFixtureSource<T extends CompiledFixtureModule = Comp
 		...options.compileOptions,
 		mode,
 	});
-	return evaluateCompiledFixtureCode<T>(code, id, mode);
+	return evaluateCompiledFixtureCode<T>(code, id, mode, options.runtimeModules);
 }
 
 /** Execute the public plain-module transform through the shared module loader. */
@@ -76,13 +78,14 @@ export function loadPlainHookFixtureSource<T extends CompiledFixtureModule = Com
 			verbatimModuleSyntax: true,
 		},
 	});
-	return evaluateCompiledFixtureCode<T>(outputText, options.id, 'client');
+	return evaluateCompiledFixtureCode<T>(outputText, options.id, 'client', undefined);
 }
 
 function evaluateCompiledFixtureCode<T extends CompiledFixtureModule>(
 	code: string,
 	id: string,
 	mode: 'client' | 'server',
+	runtimeModules: Readonly<Record<string, CompiledFixtureModule>> | undefined,
 ): T {
 	const runtime = mode === 'server' ? ServerRuntime : ClientRuntime;
 	const internalRuntime = mode === 'server' ? InternalServerRuntime : InternalClientRuntime;
@@ -107,6 +110,18 @@ function evaluateCompiledFixtureCode<T extends CompiledFixtureModule>(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/hydration['"];?/g,
 		(_match: string, names: string) =>
 			`const {${names.replace(/\s+as\s+/g, ': ')}} = __hydrationRuntime;`,
+	);
+	code = code.replace(
+		/import\s+(\*\s+as\s+[\w$]+|\{[^}]*\}|[\w$]+)\s+from\s*['"]([^'"]+)['"];?/g,
+		(match: string, binding: string, request: string) => {
+			if (runtimeModules === undefined || !Object.hasOwn(runtimeModules, request)) return match;
+			const module = `__runtimeModules[${JSON.stringify(request)}]`;
+			if (binding.startsWith('*'))
+				return `const ${binding.replace(/^\*\s+as\s+/, '')} = ${module};`;
+			if (binding.startsWith('{'))
+				return `const ${binding.replace(/\s+as\s+/g, ': ')} = ${module};`;
+			return `const ${binding} = ${module}.default;`;
+		},
 	);
 
 	// `export function X` must stay a real function *declaration*: compiled
@@ -144,10 +159,11 @@ function evaluateCompiledFixtureCode<T extends CompiledFixtureModule>(
 		'__runtime',
 		'__internalRuntime',
 		'__hydrationRuntime',
+		'__runtimeModules',
 		'__exports',
 		`'use strict';\n${code}\n//# sourceURL=${id}?${mode}-fixture\nreturn __exports;`,
 	);
-	return evaluate(runtime, internalRuntime, HydrationRuntime, {}) as T;
+	return evaluate(runtime, internalRuntime, HydrationRuntime, runtimeModules, {}) as T;
 }
 
 export function loadServerFixture<T extends CompiledFixtureModule = CompiledFixtureModule>(

--- a/packages/octane/tests/_valdi-writer.ts
+++ b/packages/octane/tests/_valdi-writer.ts
@@ -1,0 +1,232 @@
+/**
+ * A synthetic adapter for the published compiler/writer contract. It records
+ * writes; it does not implement a native renderer, reconciliation, or a host
+ * runtime. Keys and hook slots are opaque tokens owned by this test adapter.
+ */
+export interface WrittenNode {
+	tag: string;
+	key: string | undefined;
+	props: Record<string, any>;
+	children: WrittenNode[];
+}
+
+interface Prototype {
+	tag: string;
+	props: Record<string, any>;
+}
+
+type Component = (props: any) => void;
+
+interface TokenTree {
+	children: Map<unknown, TokenTree>;
+	value?: any;
+}
+
+function tokenTree(): TokenTree {
+	return { children: new Map() };
+}
+
+function entry(tree: TokenTree, path: unknown[]): TokenTree {
+	for (const token of path) {
+		let child = tree.children.get(token);
+		if (child === undefined) tree.children.set(token, (child = tokenTree()));
+		tree = child;
+	}
+	return tree;
+}
+
+function propsFromPairs(pairs: any[] | undefined): Record<string, any> {
+	const props: Record<string, any> = {};
+	for (let i = 0; i < (pairs?.length ?? 0); i += 2) props[pairs![i]] = pairs![i + 1];
+	return props;
+}
+
+export function createWriterRecorder() {
+	let roots: WrittenNode[] = [];
+	const elements: WrittenNode[] = [];
+	const components: Array<{ component: Component; props: Record<string, any> }> = [];
+	const path: unknown[] = [];
+	const hooksAllowed: boolean[] = [];
+	const registered = new Set<Component>();
+	const keys = tokenTree();
+	const hooks = tokenTree();
+	let nextKey = 0;
+	let nextSlot = 0;
+	const effects: Array<{ create: () => unknown; deps: readonly unknown[] | null }> = [];
+
+	const current = () => {
+		const node = elements.at(-1);
+		if (node === undefined) throw new Error('No open writer element');
+		return node;
+	};
+	const setAttribute = (name: string, value: unknown) => {
+		current().props[name] = value;
+	};
+	const typedAttribute = (kind: string) => (name: string, value: unknown) => {
+		if (value !== null && value !== undefined && typeof value !== kind)
+			throw new TypeError(`Expected a ${kind} writer value for ${name}`);
+		if (name === '$onLayout') throw new TypeError('$onLayout requires the generic writer');
+		setAttribute(name, value);
+	};
+	const currentComponent = () => {
+		const component = components.at(-1);
+		if (component === undefined) throw new Error('No open writer component');
+		return component;
+	};
+	const hook = (slot: unknown) => {
+		if (!hooksAllowed.at(-1)) throw new Error('Hook requires a component registered with hooks');
+		if (slot === undefined) throw new Error('Hook requires a compiler-assigned slot');
+		return entry(hooks, [...path, slot]);
+	};
+	const state = (initial: any, slot: unknown) => {
+		const cell = hook(slot);
+		cell.value ??= { current: typeof initial === 'function' ? initial() : initial };
+		return [
+			cell.value.current,
+			(next: any) => {
+				cell.value.current = typeof next === 'function' ? next(cell.value.current) : next;
+			},
+			() => cell.value.current,
+		];
+	};
+	const memo = (
+		calculate: (...args: any[]) => any,
+		deps: readonly unknown[] | null,
+		slot: unknown,
+	) => {
+		const cell = hook(slot);
+		const previous = cell.value;
+		if (
+			previous === undefined ||
+			deps === null ||
+			previous.deps === null ||
+			deps.length !== previous.deps.length ||
+			deps.some((value, index) => !Object.is(value, previous.deps[index]))
+		)
+			cell.value = { current: calculate(...(deps ?? [])), deps };
+		return cell.value.current;
+	};
+
+	const adapter = {
+		assertValdiCompilerAbi(version: number) {
+			if (version !== 1) throw new Error(`Unsupported writer ABI ${version}`);
+		},
+		jsx: {
+			makeNodePrototype(tag: string, pairs: any[] | undefined): Prototype {
+				return { tag, props: propsFromPairs(pairs) };
+			},
+			makeComponentPrototype(pairs: any[] | undefined): Prototype {
+				return { tag: 'component', props: propsFromPairs(pairs) };
+			},
+			beginRender(prototype: Prototype, key: string | undefined) {
+				const node = { tag: prototype.tag, key, props: { ...prototype.props }, children: [] };
+				if (elements.length === 0) roots.push(node);
+				else current().children.push(node);
+				elements.push(node);
+				path.push(key ?? prototype);
+			},
+			endRender() {
+				if (elements.pop() === undefined) throw new Error('Unbalanced writer element');
+				path.pop();
+			},
+			setAttribute,
+			setAttributeBool: typedAttribute('boolean'),
+			setAttributeNumber: typedAttribute('number'),
+			setAttributeString: typedAttribute('string'),
+			setAttributeFunction: typedAttribute('function'),
+			setAttributeStyle: setAttribute,
+			beginComponent(component: Component, prototype: Prototype, key: string | undefined) {
+				components.push({ component, props: { ...prototype.props } });
+				path.push(key ?? prototype);
+			},
+			setViewModelProperty(name: string, value: unknown) {
+				currentComponent().props[name] = value;
+			},
+			setViewModelFull(props: Record<string, any>) {
+				currentComponent().props = props;
+			},
+			endComponent() {
+				const frame = components.pop();
+				if (frame === undefined) throw new Error('Unbalanced writer component');
+				try {
+					frame.component(frame.props);
+				} finally {
+					path.pop();
+				}
+			},
+		},
+		defineValdiComponent(body: Component, options: { hasHooks: boolean }): Component {
+			const component = (props: any) => {
+				path.push(component);
+				hooksAllowed.push(options.hasHooks);
+				try {
+					body(props);
+				} finally {
+					hooksAllowed.pop();
+					path.pop();
+				}
+			};
+			registered.add(component);
+			return component;
+		},
+		getValdiComponentConstructor(component: Component): Component {
+			if (!registered.has(component)) throw new Error('Unregistered writer component');
+			return component;
+		},
+		valdiKey(prototype: Prototype, ...parts: unknown[]): string {
+			const key = entry(keys, [prototype, ...parts]);
+			return (key.value ??= `test-key-${nextKey++}`);
+		},
+		setValdiAttributes(props: Record<string, any>) {
+			Object.assign(current().props, props);
+		},
+		hookSlots(count: number) {
+			const first = nextSlot;
+			nextSlot += count;
+			return first;
+		},
+		withSlot(slot: unknown, callback: (...args: any[]) => any, ...args: any[]) {
+			path.push(slot);
+			try {
+				return callback(...args);
+			} finally {
+				path.pop();
+			}
+		},
+		useState: state,
+		__useStateWithGetter: state,
+		useMemo: memo,
+		useCallback(callback: (...args: any[]) => any, deps: readonly unknown[] | null, slot: unknown) {
+			return memo(() => callback, deps, slot);
+		},
+		useRef(initial: unknown, slot: unknown) {
+			return (hook(slot).value ??= { current: initial });
+		},
+		useLayoutEffect(create: () => unknown, deps: readonly unknown[] | null, slot: unknown) {
+			hook(slot);
+			effects.push({ create, deps });
+		},
+		__methodDep(object: Record<string, unknown>, name: string) {
+			return object[name];
+		},
+	};
+
+	return {
+		adapter,
+		effects,
+		render(component: Component, props: Record<string, any> | undefined): WrittenNode[] {
+			roots = [];
+			effects.length = 0;
+			try {
+				component(props);
+				if (elements.length !== 0 || components.length !== 0 || path.length !== 0)
+					throw new Error('Writer did not close its output');
+				return roots;
+			} finally {
+				elements.length = 0;
+				components.length = 0;
+				path.length = 0;
+			}
+		},
+	};
+}

--- a/packages/octane/tests/compiler/browser-compiler-bundle.test.ts
+++ b/packages/octane/tests/compiler/browser-compiler-bundle.test.ts
@@ -13,7 +13,9 @@ describe('octane/compiler browser bundle', () => {
 			stdin: {
 				contents:
 					"import { compile } from 'octane/compiler';\n" +
-					"compile(`export function App() @{ <p>{'browser compiler'}</p> }`, 'App.tsrx');\n",
+					"compile(`export function App() @{ <p>{'browser compiler'}</p> }`, 'App.tsrx');\n" +
+					'compile(`export function Scene() @{ <label value="writer" /> }`, \'Scene.tsrx\', {' +
+					"hmr: false, renderer: { id: 'native', module: '@test/valdi-writer', target: 'valdi' } });\n",
 				resolveDir: OCTANE_PACKAGE_ROOT,
 				sourcefile: 'browser-compiler-entry.js',
 			},

--- a/packages/octane/tests/compiler/valdi-compiler.test.ts
+++ b/packages/octane/tests/compiler/valdi-compiler.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment node
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+import { normalizeRendererConfig, resolveRendererForFile } from 'octane/compiler/renderers';
+import { decodeMappings } from '../_source-map.js';
+
+const { parseModule } = createRequire(new URL('../../package.json', import.meta.url))('@tsrx/core');
+
+const renderer = {
+	id: 'native',
+	module: '@test/valdi-writer',
+	target: 'valdi',
+	server: 'unsupported',
+	text: 'reject',
+} as const;
+
+const source = `export function Scene(props: { label: string }) @{
+	<view padding={4}><label value={props.label} /></view>
+}`;
+const filename = '/src/Scene.tsrx';
+
+function imports(code: string): string[] {
+	return parseModule(code, 'Scene.js')
+		.body.filter((node: any) => node.type === 'ImportDeclaration')
+		.map((node: any) => node.source.value);
+}
+
+describe('Valdi compiler option', () => {
+	it('selects a configurable external writer adapter', () => {
+		const { code, diagnostics } = compile(source, filename, { renderer, hmr: false });
+		expect(new Set(imports(code))).toEqual(new Set([renderer.module]));
+		expect(diagnostics).toEqual([]);
+	});
+
+	it('resolves the opt-in target independently from universal renderer configuration', () => {
+		const { id, ...entry } = renderer;
+		const config = normalizeRendererConfig({
+			registry: { [id]: entry },
+			rules: [{ include: '**/*.native.tsrx', renderer: id }],
+		});
+		expect(resolveRendererForFile(config, '/src/Scene.native.tsrx')).toMatchObject(renderer);
+		expect(resolveRendererForFile(config, '/src/App.tsrx').target).toBe('dom');
+		expect(config.signature).not.toBe(
+			normalizeRendererConfig({
+				registry: { [id]: { ...entry, target: 'universal' } },
+				rules: config.rules,
+			}).signature,
+		);
+	});
+
+	it.each([false, true])('retains authored expression locations in dev=%s', (dev) => {
+		const result = compile(source, filename, { renderer, hmr: false, dev });
+		const expression = 'props.label';
+		const position = (text: string) => {
+			const offset = text.indexOf(expression);
+			expect(offset).toBeGreaterThanOrEqual(0);
+			const before = text.slice(0, offset);
+			return [before.split('\n').length - 1, offset - before.lastIndexOf('\n') - 1];
+		};
+		const [line, column] = position(result.code);
+		const [authoredLine, authoredColumn] = position(source);
+		expect(result.map.sourcesContent).toEqual([source]);
+		expect(decodeMappings(result.map.mappings)[line]).toContainEqual([
+			column,
+			0,
+			authoredLine,
+			authoredColumn,
+		]);
+	});
+
+	it.each([
+		['raw text', 'export function Scene() @{ <label>hello</label> }', /text children/],
+		[
+			'text expressions',
+			'export function Scene(props) @{ <label>{props.label as string}</label> }',
+			/render text with a <label value=/,
+		],
+		['refs', 'export function Scene(props) @{ <view ref={props.ref} /> }', /ref props/],
+		[
+			'dynamic component tags',
+			'export function Scene(props) @{ <props.Child /> }',
+			/dynamic component tags/,
+		],
+		[
+			'unstable components',
+			'export function Scene({ Child }) @{ <Child /> }',
+			/stable imported or module component/,
+		],
+		[
+			'unkeyed loops',
+			'export function Scene(props) @{ @for (const item of props.items) { <label value={item} /> } }',
+			/@for requires an explicit key/,
+		],
+		[
+			'hooks inside a keyed loop',
+			`import { useState } from 'octane';
+			 export function Scene(props) @{
+				@for (const item of props.items; key item.id) {
+					const [value] = useState(item.value);
+					<label value={value} />
+				}
+			 }`,
+			/hooks directly inside @for/,
+		],
+		[
+			'unsupported hooks',
+			"import { useEffect } from 'octane'; export function Scene() @{ useEffect(() => {}); <view /> }",
+			/runtime import "useEffect"/,
+		],
+		[
+			'context hooks',
+			"import { useContext } from 'octane'; export function Scene(props) @{ const value = useContext(props.context); <label value={value} /> }",
+			/runtime import "useContext"/,
+		],
+		[
+			'template exception regions',
+			'export function Scene() @{ @try { <view /> } @catch (error) { <label /> } }',
+			/unsupported renderable JSXTryExpression/,
+		],
+		[
+			'template switches',
+			'export function Scene(props) @{ @switch (props.value) { @case 1: { <view /> } @default: { <label /> } } }',
+			/unsupported renderable JSXSwitchExpression/,
+		],
+		[
+			'server blocks',
+			'module server { export function value() { return 1; } } export function Scene() @{ <view /> }',
+			/`module server` is not supported/,
+		],
+		[
+			'let component bindings',
+			'export let Scene = () => @{ <view /> };',
+			/component function bindings must use const/,
+		],
+		[
+			'var component bindings',
+			'export var Scene = () => @{ <view /> };',
+			/component function bindings must use const/,
+		],
+		[
+			'reassigned component declarations',
+			'export function Scene() @{ <view /> } Scene = () => null;',
+			/component bindings must not be reassigned/,
+		],
+	])('reports an explicit diagnostic for %s', (_label, input, diagnostic) => {
+		expect(() => compile(input, filename, { renderer, hmr: false })).toThrow(diagnostic);
+	});
+
+	it('accepts const arrow components and unrelated shadowed local assignments', () => {
+		const result = compile(
+			`export const Scene = () => @{ <view /> };
+			 function replace(Scene) { Scene = null; return Scene; }`,
+			filename,
+			{ renderer, hmr: false },
+		);
+		expect(result.diagnostics).toEqual([]);
+		expect(new Set(imports(result.code))).toEqual(new Set([renderer.module]));
+	});
+
+	it.each([
+		[{ mode: 'server' as const }, /does not provide.*server compilation/],
+		[{ hmr: true }, /HMR is not supported/],
+		[{ profile: true }, /profiling is not supported/],
+	])('rejects an unsupported execution mode: %j', (options, diagnostic) => {
+		expect(() => compile(source, filename, { renderer, hmr: false, ...options })).toThrow(
+			diagnostic,
+		);
+	});
+
+	it('rejects a renderer configuration that promises server rendering', () => {
+		const { id, ...entry } = renderer;
+		expect(() =>
+			normalizeRendererConfig({
+				registry: { [id]: { ...entry, server: 'render' } },
+			}),
+		).toThrow(/client-only Valdi writer target/);
+	});
+
+	it('applies the configured renderer restrictions without DOM-specific diagnostics', () => {
+		expect(() =>
+			compile('export function Scene() @{ <label value={document.title} /> }', filename, {
+				renderer: { ...renderer, validation: { forbiddenGlobals: ['document'] } },
+				hmr: false,
+			}),
+		).toThrow(/forbids unbound global "document"/);
+		const { diagnostics } = compile(
+			'export function Scene(props) @{ <input onChange={props.onChange} /> }',
+			filename,
+			{ renderer, hmr: false, dev: true },
+		);
+		expect(diagnostics).toEqual([]);
+	});
+
+	it('does not change the DOM default or the existing universal target', () => {
+		const dom = compile(source, filename, { hmr: false });
+		const universalOptions = {
+			hmr: false,
+			renderer: { ...renderer, target: 'universal' as const },
+		};
+		const universal = compile(source, filename, universalOptions);
+		compile(source, filename, { renderer, hmr: false });
+		expect(compile(source, filename, { hmr: false })).toEqual(dom);
+		expect(compile(source, filename, universalOptions)).toEqual(universal);
+		expect(imports(dom.code)).toContain('octane');
+		expect(imports(universal.code)).toContain(renderer.module);
+	});
+});

--- a/packages/octane/tests/fixture-loader.test.ts
+++ b/packages/octane/tests/fixture-loader.test.ts
@@ -30,6 +30,32 @@ export function List() {
 `;
 
 describe('loadCompiledFixtureSource', () => {
+	it.each([
+		["import { answer as value } from '@test/fixture-values';", 'value'],
+		["import * as values from '@test/fixture-values';", 'values.answer'],
+		["import value from '@test/fixture-values';", 'value'],
+	])('evaluates a supplied external module: %s', (declaration, expression) => {
+		const mod = loadCompiledFixtureSource(
+			`${declaration}\nexport function readValue() { return ${expression}; }`,
+			{
+				id: '/src/external-fixture.ts',
+				mode: 'client',
+				compileOptions: { hmr: false },
+				runtimeModules: { '@test/fixture-values': { answer: 42, default: 42 } },
+			},
+		);
+		expect(mod.readValue()).toBe(42);
+	});
+
+	it('rejects an external import that was not explicitly supplied', () => {
+		expect(() =>
+			loadCompiledFixtureSource(
+				"import { answer } from '@test/missing'; export function readValue() { return answer; }",
+				{ id: '/src/missing-fixture.ts', mode: 'client', compileOptions: { hmr: false } },
+			),
+		).toThrow(/contains an import\/export shape the shared loader cannot evaluate/);
+	});
+
 	it('evaluates client modules whose tail and siblings reference exported components by name', () => {
 		const mod = loadCompiledFixtureSource(source, {
 			id: '/packages/octane/tests/_fixtures/fixture-loader-exports.tsx',

--- a/packages/octane/tests/valdi-writer.test.ts
+++ b/packages/octane/tests/valdi-writer.test.ts
@@ -33,6 +33,44 @@ function writerFixture(source: string, dev: boolean, options?: CompileOptions) {
 }
 
 describe.each([false, true])('compiled Valdi writer behavior in dev=%s', (dev) => {
+	it.each([
+		[
+			'Comments.tsrx',
+			`function Leaf() @{ <label value="child" /> }
+			 export function Scene() @{ <Leaf>{/* explanation */}{} { /* another comment */ }</Leaf> }`,
+		],
+		[
+			'Comments.tsx',
+			`function Leaf() { return <label value="child" />; }
+			 export function Scene() { return <Leaf>{/* explanation */}{} { /* another comment */ }</Leaf>; }`,
+		],
+	])('treats comments and empty expressions as absent component children in %s', (id, source) => {
+		const recorder = createWriterRecorder();
+		const module = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { renderer, hmr: false, dev },
+			runtimeModules: { [renderer.module]: recorder.adapter },
+		});
+		const output = recorder.render(module.Scene, {});
+		expect(
+			output.map((node) => ({ tag: node.tag, props: node.props, children: node.children })),
+		).toEqual([{ tag: 'label', props: { value: 'child' }, children: [] }]);
+	});
+
+	it.each(['text', '<label value="nested" />', '{() => null}'])(
+		'continues to reject nonempty component children: %s',
+		(children) => {
+			expect(() =>
+				writerFixture(
+					`function Leaf() @{ <label value="child" /> }
+					 export function Scene() @{ <Leaf>{/* explanation */}${children}</Leaf> }`,
+					dev,
+				),
+			).toThrow(/component children\/render props are not supported/);
+		},
+	);
+
 	it('writes host and component props through conditionals and keyed loops', () => {
 		const fixture = writerFixture(writerSource, dev);
 		const onTap = vi.fn();

--- a/packages/octane/tests/valdi-writer.test.ts
+++ b/packages/octane/tests/valdi-writer.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { CompileOptions, ValdiWriterEffectiveType } from 'octane/compiler';
+import { loadCompiledFixtureSource } from './_server-fixture.js';
+import { createWriterRecorder } from './_valdi-writer.js';
+
+const renderer = {
+	id: 'native',
+	module: '@test/valdi-writer',
+	target: 'valdi',
+	server: 'unsupported',
+	text: 'reject',
+} as const;
+
+const writerSource = readFileSync(
+	join(import.meta.dirname, '_fixtures', 'valdi-writer.tsrx'),
+	'utf8',
+);
+
+// These synthetic source fixtures use an explicitly supplied writer adapter,
+// rather than the DOM compiler selected by the normal Vitest fixture plugin.
+function writerFixture(source: string, dev: boolean, options?: CompileOptions) {
+	const recorder = createWriterRecorder();
+	const module = loadCompiledFixtureSource(source, {
+		id: '/src/WriterFixture.tsrx',
+		mode: 'client',
+		compileOptions: { ...options, renderer, hmr: false, dev },
+		runtimeModules: { [renderer.module]: recorder.adapter },
+	});
+	return { ...recorder, module };
+}
+
+describe.each([false, true])('compiled Valdi writer behavior in dev=%s', (dev) => {
+	it('writes host and component props through conditionals and keyed loops', () => {
+		const fixture = writerFixture(writerSource, dev);
+		const onTap = vi.fn();
+		const props = {
+			active: true,
+			extra: { tone: 'spread', amount: 3 },
+			tone: 'calm',
+			onTap,
+			items: [
+				{ id: 'a', value: 'Alpha' },
+				{ id: 'b', value: 'Beta' },
+			],
+		};
+		const [root] = fixture.render(fixture.module.Scene, props);
+		expect(root.tag).toBe('view');
+		expect(root.props).toEqual({ enabled: true, amount: 3, tone: 'final', onTap });
+		expect(root.children.map((node) => [node.tag, node.props])).toEqual([
+			['label', { value: 'Alpha', tone: 'calm' }],
+			['label', { value: 'Beta', tone: 'calm' }],
+		]);
+		root.props.onTap('selected');
+		expect(onTap).toHaveBeenCalledWith('selected');
+
+		const empty = fixture.render(fixture.module.Scene, { ...props, items: [] });
+		expect(empty[0].children.map((node) => node.props.value)).toEqual(['empty']);
+		const inactive = fixture.render(fixture.module.Scene, { ...props, active: false });
+		expect(inactive[0].children.map((node) => node.props.value)).toEqual(['inactive']);
+		const withoutExtra = fixture.render(fixture.module.Scene, { ...props, extra: {} });
+		expect(withoutExtra[0].props).toEqual({ enabled: true, tone: 'final', onTap });
+	});
+
+	it('preserves typed and nullish attribute values without applying proofs to enclosing expressions', () => {
+		const source = `export function Scene(props) @{
+			<view flag={props.flag} amount={props.amount} label={props.label}
+				onTap={props.onTap} style={props.style} mixed={props.primary ?? props.fallback} />
+		}`;
+		const proofs: Array<[string, ValdiWriterEffectiveType]> = [
+			['props.flag', 'boolean'],
+			['props.amount', 'number'],
+			['props.label', 'string'],
+			['props.onTap', 'function'],
+			['props.style', 'style'],
+			['props.primary', 'string'],
+		];
+		const fixture = writerFixture(source, dev, {
+			valdiWriterFacts: {
+				version: 1,
+				expressions: proofs.map(([expression, effectiveType]) => {
+					const start = source.indexOf(expression);
+					return { start, end: start + expression.length, effectiveType, isNullable: true };
+				}),
+			},
+		});
+		const onTap = vi.fn();
+		const style = { opacity: 0.5 };
+		const fallback = { arbitrary: 'object' };
+		const [first] = fixture.render(fixture.module.Scene, {
+			flag: true,
+			amount: 3,
+			label: 'label',
+			onTap,
+			style,
+			primary: undefined,
+			fallback,
+		});
+		expect(first.props).toEqual({
+			flag: true,
+			amount: 3,
+			label: 'label',
+			onTap,
+			style,
+			mixed: fallback,
+		});
+		for (const empty of [null, undefined]) {
+			const [cleared] = fixture.render(fixture.module.Scene, {
+				flag: empty,
+				amount: empty,
+				label: empty,
+				onTap: empty,
+				style: empty,
+				primary: undefined,
+				fallback,
+			});
+			expect(cleared.props).toEqual({
+				flag: empty,
+				amount: empty,
+				label: empty,
+				onTap: empty,
+				style: empty,
+				mixed: fallback,
+			});
+		}
+	});
+
+	it('uses the generic writer contract for the special layout callback', () => {
+		const fixture = writerFixture(
+			`export function Scene(props) @{ <view $onLayout={() => props.record('layout')} /> }`,
+			dev,
+		);
+		const record = vi.fn();
+		const [node] = fixture.render(fixture.module.Scene, { record });
+		node.props.$onLayout();
+		expect(record).toHaveBeenCalledWith('layout');
+	});
+
+	it('evaluates spreads and explicit keys once in authored order', () => {
+		const fixture = writerFixture(
+			`export function Scene(props) @{
+				<view left={props.read('left')} {...props.spread()}
+					key={props.read('key')} right={props.read('right')} />
+			 }`,
+			dev,
+		);
+		const order: string[] = [];
+		const [node] = fixture.render(fixture.module.Scene, {
+			read(name: string) {
+				order.push(name);
+				return name;
+			},
+			spread() {
+				order.push('spread');
+				return { left: 'overridden', middle: 5, key: 'spread-key' };
+			},
+		});
+		expect(order).toEqual(['left', 'spread', 'key', 'right']);
+		expect(node.props).toEqual({ left: 'overridden', middle: 5, right: 'right' });
+		expect(node.key).toBeDefined();
+	});
+
+	it('passes spread component props without turning their key into a view-model property', () => {
+		const fixture = writerFixture(
+			`function Child(props) @{ <label value={props.value} leakedKey={props.key} /> }
+			 export function Scene(props) @{ <Child value="before" {...props.extra} key={props.id} /> }`,
+			dev,
+		);
+		const [node] = fixture.render(fixture.module.Scene, {
+			extra: { value: 'after', key: 'spread-key' },
+			id: 'explicit-key',
+		});
+		expect(node.props).toEqual({ value: 'after', leakedKey: undefined });
+	});
+
+	it('keeps nested and typed keys distinct and stable when rows are reordered', () => {
+		const fixture = writerFixture(
+			`export function Scene(props) @{
+				<>
+					@for (const group of props.groups; key group.id) {
+						<>
+							@for (const item of group.items; key item.id) {
+								<label key={item.version} value={item.value} />
+							}
+						</>
+					}
+				</>
+			 }`,
+			dev,
+		);
+		const groups = [
+			{
+				id: 'left',
+				items: [
+					{ id: 1, value: 'number', version: 'v1' },
+					{ id: '1', value: 'string', version: 'v1' },
+				],
+			},
+			{ id: 'right', items: [{ id: 1, value: 'other group', version: 'v1' }] },
+		];
+		const before = fixture.render(fixture.module.Scene, { groups });
+		const identities = new Map(before.map((node) => [node.props.value, node.key]));
+		expect(new Set(identities.values()).size).toBe(3);
+		expect([...identities.values()].every((key) => key !== undefined)).toBe(true);
+		const reordered = fixture.render(fixture.module.Scene, {
+			groups: [...groups]
+				.reverse()
+				.map((group) => ({ ...group, items: [...group.items].reverse() })),
+		});
+		expect(reordered.map((node) => node.props.value)).toEqual(['other group', 'string', 'number']);
+		for (const node of reordered) expect(node.key).toBe(identities.get(node.props.value));
+		const changed = fixture.render(fixture.module.Scene, {
+			groups: [{ ...groups[0], items: [{ ...groups[0].items[0], version: 'v2' }] }],
+		});
+		expect(changed[0].key).not.toBe(identities.get('number'));
+	});
+
+	it('preserves independent custom and conditional state plus the live state getter', () => {
+		const fixture = writerFixture(
+			`import { useState as state } from 'octane';
+			 function useCounter(start) { return state(start); }
+			 export function Scene(props) @{
+				const [first, setFirst, getFirst] = useCounter(1);
+				let hidden;
+				if (props.include) {
+					const [value, setValue] = state(10);
+					hidden = value;
+					props.capture(setValue);
+				}
+				const [second, setSecond] = useCounter(100);
+				<view first={first} second={second} hidden={hidden} getFirst={getFirst}
+					setFirst={setFirst} setSecond={setSecond} />
+			 }`,
+			dev,
+		);
+		let setHidden: (value: number) => void = () => {
+			throw new Error('The conditional state setter was not published');
+		};
+		const capture = (setter: (value: number) => void) => {
+			setHidden = setter;
+		};
+		const [first] = fixture.render(fixture.module.Scene, { include: true, capture });
+		expect(first.props).toMatchObject({ first: 1, second: 100, hidden: 10 });
+		first.props.setFirst((value: number) => value + 2);
+		first.props.setSecond(200);
+		setHidden(20);
+		expect(first.props.getFirst()).toBe(3);
+		const [without] = fixture.render(fixture.module.Scene, { include: false, capture });
+		expect(without.props).toMatchObject({ first: 3, second: 200, hidden: undefined });
+		const [restored] = fixture.render(fixture.module.Scene, { include: true, capture });
+		expect(restored.props).toMatchObject({ first: 3, second: 200, hidden: 20 });
+	});
+
+	it('allows a custom hook in a component parameter initializer', () => {
+		const fixture = writerFixture(
+			`import { useState } from 'octane';
+			 function useDefaults() { const [value, setValue] = useState(7); return { value, setValue }; }
+			 export function Scene(props = useDefaults()) @{
+				<label value={props.value} increment={() => props.setValue((value) => value + 1)} />
+			 }`,
+			dev,
+		);
+		const [first] = fixture.render(fixture.module.Scene, undefined);
+		expect(first.props.value).toBe(7);
+		first.props.increment();
+		expect(fixture.render(fixture.module.Scene, undefined)[0].props.value).toBe(8);
+	});
+
+	it('does not mistake a shadowed undefined binding for a key or a spread ref', () => {
+		const fixture = writerFixture(
+			`export function Scene({ values, undefined }) @{ <view {...values} /> }`,
+			dev,
+		);
+		const [node] = fixture.render(fixture.module.Scene, {
+			values: { value: 'value', ref: undefined, children: undefined },
+			undefined: 'shadowed',
+		});
+		expect(node.key).toBeUndefined();
+		expect(node.props).toEqual({ value: 'value' });
+	});
+
+	it('forwards memo, callback, ref, and layout-effect semantics to the adapter', () => {
+		const fixture = writerFixture(
+			`import { useMemo, useCallback, useRef, useLayoutEffect } from 'octane';
+			 export function Scene(props) @{
+				const total = useMemo(() => props.amount * 2);
+				const format = useCallback(() => props.prefix + total);
+				const marker = useRef(props.marker);
+				useLayoutEffect(() => {
+					props.events.push('effect:' + total);
+					return () => props.events.push('cleanup:' + total);
+				}, [total]);
+				<view total={total} format={format} marker={marker.current} />
+			 }`,
+			dev,
+		);
+		const events: string[] = [];
+		const [first] = fixture.render(fixture.module.Scene, {
+			amount: 3,
+			prefix: 'a:',
+			marker: 'first',
+			events,
+		});
+		expect(first.props.total).toBe(6);
+		expect(first.props.format()).toBe('a:6');
+		expect(first.props.marker).toBe('first');
+		expect(fixture.effects.map((effect) => effect.deps)).toEqual([[6]]);
+		const cleanup = fixture.effects[0].create() as () => void;
+		const [next] = fixture.render(fixture.module.Scene, {
+			amount: 5,
+			prefix: 'b:',
+			marker: 'second',
+			events,
+		});
+		expect(next.props.total).toBe(10);
+		expect(next.props.format()).toBe('b:10');
+		expect(next.props.marker).toBe('first');
+		expect(fixture.effects.map((effect) => effect.deps)).toEqual([[10]]);
+		cleanup();
+		fixture.effects[0].create();
+		expect(events).toEqual(['effect:6', 'cleanup:6', 'effect:10']);
+	});
+
+	it('resolves recursive calls through the registered component export', () => {
+		const fixture = writerFixture(
+			`export function Scene(props) @{
+				<view value={props.depth}>
+					@if (props.depth > 0) { <Scene depth={props.depth - 1} /> }
+				</view>
+			 }`,
+			dev,
+		);
+		const [root] = fixture.render(fixture.module.Scene, { depth: 2 });
+		expect(root.props.value).toBe(2);
+		expect(root.children[0].props.value).toBe(1);
+		expect(root.children[0].children[0].props.value).toBe(0);
+		expect(root.children[0].children[0].children).toEqual([]);
+	});
+
+	it('keeps default-exported components callable', () => {
+		const fixture = writerFixture(
+			'export default function Scene(props) @{ <label value={props.value} /> }',
+			dev,
+		);
+		expect(fixture.render(fixture.module.default, { value: 'default' })[0].props.value).toBe(
+			'default',
+		);
+	});
+});
+
+it('rejects an incompatible writer ABI before initializing adapter-owned values', () => {
+	const recorder = createWriterRecorder();
+	const makePrototype = vi.spyOn(recorder.adapter.jsx, 'makeNodePrototype');
+	const defineComponent = vi.spyOn(recorder.adapter, 'defineValdiComponent');
+	const allocateSlots = vi.spyOn(recorder.adapter, 'hookSlots');
+	vi.spyOn(recorder.adapter, 'assertValdiCompilerAbi').mockImplementation(() => {
+		throw new Error('Adapter does not support this compiler ABI');
+	});
+	expect(() =>
+		loadCompiledFixtureSource(
+			`import { useState } from 'octane';
+			 function useValue() { return useState(1); }
+			 export function Scene() @{ const [value] = useValue(); <label value={value} /> }`,
+			{
+				id: '/src/UnsupportedWriter.tsrx',
+				mode: 'client',
+				compileOptions: { renderer, hmr: false },
+				runtimeModules: { [renderer.module]: recorder.adapter },
+			},
+		),
+	).toThrow(/Adapter does not support this compiler ABI/);
+	expect(makePrototype).not.toHaveBeenCalled();
+	expect(defineComponent).not.toHaveBeenCalled();
+	expect(allocateSlots).not.toHaveBeenCalled();
+});

--- a/packages/octane/typetests/compiler-valdi.test-d.ts
+++ b/packages/octane/typetests/compiler-valdi.test-d.ts
@@ -1,0 +1,57 @@
+import {
+	compile,
+	VALDI_COMPILER_ABI_VERSION,
+	type CompileOptions,
+	type CompileRenderer,
+	type CompileResult,
+	type ValdiWriterFacts,
+} from 'octane/compiler';
+import { octane, type OctaneVitePluginOptions } from 'octane/compiler/vite';
+
+export const abi: number = VALDI_COMPILER_ABI_VERSION;
+export const renderer = {
+	id: 'valdi',
+	module: '@example/valdi-adapter',
+	target: 'valdi',
+	server: 'unsupported',
+	text: 'reject',
+} satisfies CompileRenderer;
+export const facts = {
+	version: 1,
+	expressions: [{ start: 0, end: 1, effectiveType: 'number', isNullable: false }],
+} satisfies ValdiWriterFacts;
+export const compileOptions = {
+	hmr: false,
+	renderer,
+	rendererRegistry: { valdi: renderer },
+	valdiWriterFacts: facts,
+} satisfies CompileOptions;
+export const compiled: CompileResult = compile('', 'src/Scene.tsrx', compileOptions);
+
+export const viteOptions = {
+	hmr: false,
+	renderers: {
+		registry: {
+			valdi: {
+				module: '@example/valdi-adapter',
+				target: 'valdi',
+				server: 'unsupported',
+				text: 'reject',
+			},
+		},
+		rules: [{ include: 'src/**/*.valdi.tsrx', renderer: 'valdi' }],
+	},
+} satisfies OctaneVitePluginOptions;
+octane(viteOptions);
+
+// @ts-expect-error — renderer targets are a closed public union.
+compile('', 'src/Scene.tsrx', { renderer: { ...renderer, target: 'native' } });
+// @ts-expect-error — facts describe expressions, not a type-checker instance.
+compile('', 'src/Scene.tsrx', { valdiWriterFacts: 'number' });
+// @ts-expect-error — the fact schema is versioned.
+const invalidFacts: ValdiWriterFacts = { version: 2, expressions: [] };
+const invalidKind: ValdiWriterFacts = {
+	version: 1,
+	// @ts-expect-error — only supported writer kinds can be asserted.
+	expressions: [{ start: 0, end: 1, effectiveType: 'object', isNullable: false }],
+};


### PR DESCRIPTION
## Summary

- Add the opt-in, experimental `renderer.target: 'valdi'` compiler path, emitting JSXBootstrap-shaped writer calls through an application-provided adapter.
- Define an explicit ABI 1 guard, public compiler/Vite option types, optional attribute-expression facts, and adapter documentation.
- Add synthetic writer, hook, key, spread, diagnostic, source-map, browser-bundle, and public-type coverage.

## Why

Native writer integrations need a separate lowering path without inheriting DOM code generation or the universal renderer's runtime ownership model. The existing DOM and universal paths remain separate.

## Scope

This is a compiler-only contribution: 21 files covering compiler code, public types, synthetic tests, documentation, and a patch changeset. The diff has been independently audited for provenance and portability. No native runtime implementation, application code, platform build configuration, local machine setup, benchmark data, or runtime-specific key/owner/memo implementation is included. The writer methods are grounded in the public Valdi API; the additional adapter exports are documented as new integration obligations.

## Validation

Local validation used Node 26.4.0 and the existing frozen pnpm lockfile, without dependency or test-configuration changes.

- [x] Core development and production suites: `vitest run --project octane --project octane-prod --maxWorkers 4` — **882 suite instances, 15,019 tests passed**.
- [x] Focused target/adapter/browser/loader coverage — **109 tests passed** across both applicable projects. The initial option-selection regression was observed failing on the base revision before implementation.
- [x] Core package and public typetests: `tsgo --noEmit` for `packages/octane/tsconfig.json` and `packages/octane/typetests/tsconfig.json`; scoped changed-test typechecks.
- [x] `node packages/octane/scripts/build.mjs` — publishable output and imports verified; error-code precheck passed.
- [x] `node benchmarks/codegen-size/run.mjs` — baseline and candidate outputs match exactly, including the 16-file corpus and semantic sentinels. Compiled totals remain 156,614 raw / 76,409 minified / 26,959 gzipped bytes.
- [x] 58 local baseline-versus-candidate DOM client/dev/server and universal dev/prod comparisons — byte-identical code, maps, and diagnostics.
- [x] Changed-file Prettier, changeset, test-marker, source-publication, `git diff --check`, and final `pnpm sync` checks.
- [ ] Full monorepo `pnpm test` / `pnpm typecheck` were not run locally.
- [x] [Upstream CI run 32739551484](https://github.com/octanejs/octane/actions/runs/32739551484) on `4ec844b4` — **all 26 jobs passed**, including lint, full typecheck, test shards, browser/parity/example integrations, publishable packages, and CI provenance. Current-head Bugbot passed; its earlier empty-child finding is fixed and the review thread is resolved.

## Risk / follow-ups

- This is client-only and requires an external adapter. Native rendering, lifecycle correctness, and performance are not validated by the synthetic recorder; no speedup is claimed.
- Unsupported constructs and execution modes fail explicitly. HMR, SSR/hydration, cross-renderer boundaries, and several component/hook forms remain outside the initial scope.
- Plain `.ts`/`.js` bundler helper imports are not automatically retargeted; custom hooks need the documented full-compiler or explicit-adapter path.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public compiler/renderer API and a large new lowering path, but the target is opt-in, client-only, and existing DOM/universal outputs are intended to stay unchanged.
> 
> **Overview**
> Adds an experimental `renderer.target: 'valdi'` compiler path that lowers `.tsrx`/`.tsx` templates to Valdi-style writer calls against an **application-provided adapter**, not a bundled native runtime.
> 
> Generated modules import the adapter, assert `VALDI_COMPILER_ABI_VERSION` (1) before prototypes or hook slots, and finish through the existing client pipeline with hooks routed to the adapter. Optional `valdiWriterFacts` can specialize attribute setters. Unsupported constructs (SSR, HMR, profiling, cross-renderer boundaries, unkeyed loops, most extra hooks, component children/refs) fail with diagnostics instead of falling back to DOM.
> 
> The renderer registry and public types now accept `'valdi'` as a client-only target. DOM and universal compilation stay on their existing paths. Coverage is synthetic (recorder adapter, diagnostics, source maps, types); no native Valdi integration is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec844b4ab7e29132f3fa08b3cb1141e4d83ba4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790172895&installation_model_id=432790&pr_number=837&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F837&signature=98956dfec677abe3b9f0775a7047327bb70cb4177fe08e64469f6e2b7293d584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->