### PR TITLE
perf(app-core): reuse normalized hydration template

### DIFF
--- a/.changeset/cache-production-hydration-template.md
+++ b/.changeset/cache-production-hydration-template.md
@@ -2,5 +2,6 @@
 '@octanejs/app-core': patch
 ---
 
-Reuse the normalized production HTML template across SSR requests that do not
-set a CSP nonce, avoiding a full template scan and rewrite on every render.
+Prepare and reuse normalized production HTML template fragments across SSR
+requests that do not set a CSP nonce, avoiding repeated hydration normalization
+and static-template validation on every render.

--- a/.changeset/cache-production-hydration-template.md
+++ b/.changeset/cache-production-hydration-template.md
@@ -1,0 +1,6 @@
+---
+'@octanejs/app-core': patch
+---
+
+Reuse the normalized production HTML template across SSR requests that do not
+set a CSP nonce, avoiding a full template scan and rewrite on every render.

--- a/packages/app-core/src/server/production.js
+++ b/packages/app-core/src/server/production.js
@@ -138,7 +138,7 @@ function buildRpcDescriptors(rpcModules, hashFn) {
  * the body-marker contract.
  *
  * @param {string} html
- * @returns {(headContent: string) => [string, string]}
+ * @returns {(headContent: string) => string[]}
  */
 function prepareSsrTemplate(html) {
 	const [prefix, suffix] = splitSsrTemplate(html);

--- a/packages/app-core/src/server/production.js
+++ b/packages/app-core/src/server/production.js
@@ -54,6 +54,10 @@ import { patch_global_fetch, build_rpc_lookup, is_rpc_request } from '@ripple-ts
 
 export { resolveOctaneConfig } from '../resolve-config.js';
 
+const HEAD_MARKER = '<!--ssr-head-->';
+const BODY_MARKER = '<!--ssr-body-->';
+const BODY_CLOSE_TAG = /<\/body\s*>/i;
+
 // A server integration can reload its compiled manifest repeatedly while the
 // process (and global fetch) stays alive. Ripple's fetch patch is deliberately
 // idempotent, so calling it again cannot replace its closed-over handler or
@@ -125,6 +129,37 @@ function buildRpcDescriptors(rpcModules, hashFn) {
 }
 
 /**
+ * Split the immutable, validated production template around both insertion
+ * markers once. Dynamic head content is then concatenated into the prepared
+ * fragments without rescanning the complete template on every request.
+ *
+ * `splitSsrTemplate` historically revalidated after head insertion. Preserve
+ * that behavior on the exceptional path where inserted content could change
+ * the body-marker contract.
+ *
+ * @param {string} html
+ * @returns {(headContent: string) => [string, string]}
+ */
+function prepareSsrTemplate(html) {
+	const [prefix, suffix] = splitSsrTemplate(html);
+	const prefixHeadAt = prefix.indexOf(HEAD_MARKER);
+	const headInPrefix = prefixHeadAt !== -1;
+	const headAt = headInPrefix ? prefixHeadAt : suffix.indexOf(HEAD_MARKER);
+	const headSide = headInPrefix ? prefix : suffix;
+	const beforeHead = headSide.slice(0, headAt);
+	const afterHead = headSide.slice(headAt + HEAD_MARKER.length);
+
+	return (headContent) => {
+		const nextPrefix = headInPrefix ? beforeHead + headContent + afterHead : prefix;
+		const nextSuffix = headInPrefix ? suffix : beforeHead + headContent + afterHead;
+		if (headContent.includes(BODY_MARKER) || BODY_CLOSE_TAG.test(headContent)) {
+			return splitSsrTemplate(nextPrefix + BODY_MARKER + nextSuffix);
+		}
+		return [nextPrefix, nextSuffix];
+	};
+}
+
+/**
  * @typedef {import('@octanejs/app-core').RenderRoute} RenderRoute
  * @typedef {import('@octanejs/app-core').Middleware} Middleware
  * @typedef {import('@octanejs/app-core').Context} Context
@@ -156,10 +191,10 @@ export function createHandler(manifest, deps) {
 	const runtime = manifest.runtime;
 	validateSsrTemplate(htmlTemplate);
 	// Also pin the built-template contract up front. The marker is emitted by
-	// the integration's HTML transform and survives source hashing. Keep the
-	// normalized no-nonce template: this is the common request path, and its
-	// output is identical for every request handled by this manifest.
-	const hydrationTemplate = applyHydrationNonce(htmlTemplate, null);
+	// the integration's HTML transform and survives source hashing. Prepare the
+	// normalized no-nonce template once: this is the common request path, and its
+	// static fragments are identical for every request handled by this manifest.
+	const splitHydrationTemplate = prepareSsrTemplate(applyHydrationNonce(htmlTemplate, null));
 
 	// RPC lookup for statically imported `module server` functions
 	// (compiler hash → server function).
@@ -330,8 +365,7 @@ export function createHandler(manifest, deps) {
 		}
 
 		const headContent = [...preloadTags, dataScript].join('\n');
-		const noncedTemplate =
-			nonce === null ? hydrationTemplate : applyHydrationNonce(htmlTemplate, nonce);
+		const noncedTemplate = nonce === null ? null : applyHydrationNonce(htmlTemplate, nonce);
 
 		const status = route.status ?? 200;
 		const headers = { 'Content-Type': 'text/html; charset=utf-8' };
@@ -349,8 +383,12 @@ export function createHandler(manifest, deps) {
 		// match, and this text now carries author-controlled metadata as well as
 		// the serialized route data.
 		/** @param {string} hoistedHead */
-		const splitAroundBody = (hoistedHead) =>
-			splitSsrTemplate(noncedTemplate.replace('<!--ssr-head-->', () => headContent + hoistedHead));
+		const splitAroundBody = (hoistedHead) => {
+			const completeHead = headContent + hoistedHead;
+			return noncedTemplate === null
+				? splitHydrationTemplate(completeHead)
+				: splitSsrTemplate(noncedTemplate.replace(HEAD_MARKER, () => completeHead));
+		};
 
 		if (manifest.render === 'buffered') {
 			// Await-everything fallback (`prerender` from octane/static): no

--- a/packages/app-core/src/server/production.js
+++ b/packages/app-core/src/server/production.js
@@ -156,8 +156,10 @@ export function createHandler(manifest, deps) {
 	const runtime = manifest.runtime;
 	validateSsrTemplate(htmlTemplate);
 	// Also pin the built-template contract up front. The marker is emitted by
-	// the integration's HTML transform and survives source hashing.
-	applyHydrationNonce(htmlTemplate, null);
+	// the integration's HTML transform and survives source hashing. Keep the
+	// normalized no-nonce template: this is the common request path, and its
+	// output is identical for every request handled by this manifest.
+	const hydrationTemplate = applyHydrationNonce(htmlTemplate, null);
 
 	// RPC lookup for statically imported `module server` functions
 	// (compiler hash → server function).
@@ -328,7 +330,8 @@ export function createHandler(manifest, deps) {
 		}
 
 		const headContent = [...preloadTags, dataScript].join('\n');
-		const noncedTemplate = applyHydrationNonce(htmlTemplate, nonce);
+		const noncedTemplate =
+			nonce === null ? hydrationTemplate : applyHydrationNonce(htmlTemplate, nonce);
 
 		const status = route.status ?? 200;
 		const headers = { 'Content-Type': 'text/html; charset=utf-8' };

--- a/packages/vite-plugin-octane/tests/handler.test.ts
+++ b/packages/vite-plugin-octane/tests/handler.test.ts
@@ -172,14 +172,16 @@ describe('createHandler', () => {
 	});
 
 	it('threads a middleware CSP nonce through renderer and inline hydration scripts', async () => {
-		let rendererNonce: string | undefined;
+		const rendererNonces: Array<string | undefined> = [];
 		let rendererSignal: AbortSignal | undefined;
 		const nonce = 'request-123"&';
 		const handler = createHandler(
 			makeManifest({
 				middlewares: [
-					(context: { state: Map<string, unknown> }, next: () => Promise<Response>) => {
-						context.state.set(OCTANE_NONCE_STATE_KEY, nonce);
+					(context: { state: Map<string, unknown>; url: URL }, next: () => Promise<Response>) => {
+						if (context.url.searchParams.has('nonce')) {
+							context.state.set(OCTANE_NONCE_STATE_KEY, nonce);
+						}
 						return next();
 					},
 				],
@@ -191,17 +193,22 @@ describe('createHandler', () => {
 					_props: unknown,
 					options: { nonce?: string; signal?: AbortSignal } | undefined,
 				) => {
-					rendererNonce = options?.nonce;
+					rendererNonces.push(options?.nonce);
 					rendererSignal = options?.signal;
 					return streamOf('<main>page</main>');
 				},
 			} as any,
 		);
-		const request = new Request('http://localhost/');
-		const html = await (await handler(request)).text();
-		expect(rendererNonce).toBe(nonce);
-		expect(rendererSignal).toBe(request.signal);
+		const plainRequest = new Request('http://localhost/');
+		const noncedRequest = new Request('http://localhost/?nonce');
+		const firstPlainHtml = await (await handler(plainRequest)).text();
+		const html = await (await handler(noncedRequest)).text();
+		const secondPlainHtml = await (await handler(plainRequest)).text();
+		expect(rendererNonces).toEqual([undefined, nonce, undefined]);
+		expect(rendererSignal).toBe(plainRequest.signal);
 		expect(html.match(/nonce="request-123&quot;&amp;"/g)).toHaveLength(2);
+		expect(firstPlainHtml).not.toContain(' nonce=');
+		expect(secondPlainHtml).toBe(firstPlainHtml);
 	});
 
 	it('passes request Context.state to server route props without serializing it', async () => {

--- a/packages/vite-plugin-octane/tests/handler.test.ts
+++ b/packages/vite-plugin-octane/tests/handler.test.ts
@@ -4,6 +4,7 @@
 // byte-compat path is covered end-to-end in production.test.ts.
 import { describe, it, expect } from 'vitest';
 import { createHandler } from '../src/server/production.js';
+import { HYDRATION_NONCE_PLACEHOLDER } from '../src/server/html-template.js';
 import { RenderRoute, ServerRoute } from '../src/routes.js';
 import { OCTANE_NONCE_STATE_KEY } from '../src/constants.js';
 
@@ -171,10 +172,14 @@ describe('createHandler', () => {
 		expect(missing.status).toBe(404);
 	});
 
-	it('threads a middleware CSP nonce through renderer and inline hydration scripts', async () => {
+	it('isolates middleware CSP nonces across requests and threads them through SSR', async () => {
 		const rendererNonces: Array<string | undefined> = [];
 		let rendererSignal: AbortSignal | undefined;
 		const nonce = 'request-123"&';
+		const builtTemplate = TEMPLATE.replace(
+			' data-octane-hydrate',
+			` data-octane-hydrate nonce="${HYDRATION_NONCE_PLACEHOLDER}"`,
+		);
 		const handler = createHandler(
 			makeManifest({
 				middlewares: [
@@ -188,6 +193,7 @@ describe('createHandler', () => {
 			}) as any,
 			{
 				...baseDeps,
+				htmlTemplate: builtTemplate,
 				renderToReadableStream: async (
 					_component: Function,
 					_props: unknown,
@@ -208,6 +214,7 @@ describe('createHandler', () => {
 		expect(rendererSignal).toBe(plainRequest.signal);
 		expect(html.match(/nonce="request-123&quot;&amp;"/g)).toHaveLength(2);
 		expect(firstPlainHtml).not.toContain(' nonce=');
+		expect(firstPlainHtml).not.toContain(HYDRATION_NONCE_PLACEHOLDER);
 		expect(secondPlainHtml).toBe(firstPlainHtml);
 	});
 


### PR DESCRIPTION
## Summary

- normalize and split the built hydration template once when the production handler is created
- assemble nonce-free responses from cached static fragments while preserving request-specific head content
- keep the existing per-request CSP nonce rewrite path and body-contract diagnostics
- cover alternating plain and nonced requests with the placeholder-bearing built-template shape

## Performance

Synthetic buffered-handler benchmark using the real production `createHandler` on Node 24.18.0. Each candidate received 200 warmups and nine rotated batches in each of five fresh processes; the table reports the median of the five process medians. All candidates produced byte-identical response hashes for every row.

| Template payload / path | `origin/main` | Prior PR (`f5f8c283a`) | Current head | vs main | vs prior PR |
| --- | ---: | ---: | ---: | ---: | ---: |
| 4 KiB, nonce-free | 0.02805 ms/request | 0.02468 ms/request | 0.02171 ms/request | 22.6% faster | 12.0% faster |
| 32 KiB, nonce-free | 0.08850 ms/request | 0.07814 ms/request | 0.06995 ms/request | 21.0% faster | 10.5% faster |
| 128 KiB, nonce-free | 0.51239 ms/request | 0.40956 ms/request | 0.30401 ms/request | 40.7% faster | 25.8% faster |
| 128 KiB, CSP nonce control | 0.51523 ms/request | 0.51285 ms/request | 0.51134 ms/request | 0.8% faster | 0.3% faster |

The CSP-nonce row is the negative control: that request path intentionally retains the existing scan/rewrite work, and the prior and current heads converge within 0.3%.

## Validation

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm sync`
- [x] targeted tests:
  - app-core suite: 9 files, 112 tests passed
  - `packages/vite-plugin-octane/tests/handler.test.ts`: 16 tests passed
  - 52-case buffered/streaming equivalence matrix across plain/nonced, normalized/placeholder/fallback, marker-order, and error paths
  - scoped Prettier check, `node --check`, changeset validation, and `git diff --check`
- [x] five-process real-handler benchmark with byte-identical semantic controls and a nonce-path negative control

## Risk / follow-ups

The optimization moves hydration normalization and static template splitting from every nonce-free request to handler creation and retains prepared immutable fragments for the handler lifetime. Requests with a CSP nonce keep the existing per-request scan and rewrite path. Dynamic head content that could alter the body-marker contract falls back to the existing validation path. Full-repository validation is left to CI.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production HTML assembly and CSP nonce branching; incorrect fragment reuse could break SSR/hydration, though the exceptional revalidation path and unchanged nonce path mitigate that.
> 
> **Overview**
> **Caches normalized, split HTML shell fragments at handler creation** for the common CSP nonce-free SSR path, so each request only splices route-specific head content instead of re-running hydration normalization and full-template splitting.
> 
> `createHandler` now builds `splitHydrationTemplate` from `applyHydrationNonce(htmlTemplate, null)` plus new `prepareSsrTemplate`, which pre-splits around `<!--ssr-head-->` and concatenates dynamic head into fixed prefix/suffix. If inserted head could break the body-marker contract (body marker or `</body>` in head), it **falls back** to the existing `splitSsrTemplate` revalidation. Requests **with** a middleware CSP nonce still use per-request `applyHydrationNonce` and the prior replace/split path.
> 
> Handler tests now alternate plain and nonced requests against a placeholder-bearing built template to assert nonce isolation, identical plain HTML across requests, and unchanged nonce threading into the renderer and inline scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d16e77c5d3a606beecb68e3cb57f7142ff34854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255557&installation_model_id=432790&pr_number=845&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F845&signature=ad26ceceee08b682d26bc05e5a0720ecc0c2803746c8638edc90533ed89c9be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->