### PR TITLE
fix(octane): compile setup-bearing child blocks

### DIFF
--- a/.agents/memories/tsrx-authoring.md
+++ b/.agents/memories/tsrx-authoring.md
@@ -18,6 +18,24 @@ export function X() @{ <div /> }
 function getX() { return <div />; }
 ```
 
+Inside JSX, a nested `@{ … }` block owns a child render scope at its authored
+sibling position. Its setup may use hooks and capture parent locals; the scope
+and hook state survive parent updates. Its final JSX output is optional, so a
+code-only block is valid and renders no element. An empty child block disappears,
+while a render-only child block is transparent grouping.
+
+```tsx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		observe();
+	}
+</section>
+```
+
 ## Text holes
 
 Dynamic text uses a cast: `{expr as string}`.

--- a/.changeset/calm-child-scopes.md
+++ b/.changeset/calm-child-scopes.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Allow nested TSRX `@{ ... }` child blocks to contain setup statements, hooks,
+and no rendered JSX. Setup-bearing blocks now compile as scoped child render
+bodies in client, server, and hydration output, while render-only blocks remain
+transparent grouping.

--- a/.claude/rules/tsrx-authoring.md
+++ b/.claude/rules/tsrx-authoring.md
@@ -22,6 +22,24 @@ export function X() @{ <div /> }
 function getX() { return <div />; }
 ```
 
+Inside JSX, a nested `@{ … }` block owns a child render scope at its authored
+sibling position. Its setup may use hooks and capture parent locals; the scope
+and hook state survive parent updates. Its final JSX output is optional, so a
+code-only block is valid and renders no element. An empty child block disappears,
+while a render-only child block is transparent grouping.
+
+```tsx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		observe();
+	}
+</section>
+```
+
 ## Text holes
 
 Dynamic text uses a cast: `{expr as string}`.

--- a/.cursor/rules/tsrx-authoring.mdc
+++ b/.cursor/rules/tsrx-authoring.mdc
@@ -23,6 +23,24 @@ export function X() @{ <div /> }
 function getX() { return <div />; }
 ```
 
+Inside JSX, a nested `@{ … }` block owns a child render scope at its authored
+sibling position. Its setup may use hooks and capture parent locals; the scope
+and hook state survive parent updates. Its final JSX output is optional, so a
+code-only block is valid and renders no element. An empty child block disappears,
+while a render-only child block is transparent grouping.
+
+```tsx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		observe();
+	}
+</section>
+```
+
 ## Text holes
 
 Dynamic text uses a cast: `{expr as string}`.

--- a/.gemini/memories/tsrx-authoring.md
+++ b/.gemini/memories/tsrx-authoring.md
@@ -18,6 +18,24 @@ export function X() @{ <div /> }
 function getX() { return <div />; }
 ```
 
+Inside JSX, a nested `@{ … }` block owns a child render scope at its authored
+sibling position. Its setup may use hooks and capture parent locals; the scope
+and hook state survive parent updates. Its final JSX output is optional, so a
+code-only block is valid and renders no element. An empty child block disappears,
+while a render-only child block is transparent grouping.
+
+```tsx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		observe();
+	}
+</section>
+```
+
 ## Text holes
 
 Dynamic text uses a cast: `{expr as string}`.

--- a/.github/instructions/tsrx-authoring.instructions.md
+++ b/.github/instructions/tsrx-authoring.instructions.md
@@ -24,6 +24,24 @@ export function X() @{ <div /> }
 function getX() { return <div />; }
 ```
 
+Inside JSX, a nested `@{ … }` block owns a child render scope at its authored
+sibling position. Its setup may use hooks and capture parent locals; the scope
+and hook state survive parent updates. Its final JSX output is optional, so a
+code-only block is valid and renders no element. An empty child block disappears,
+while a render-only child block is transparent grouping.
+
+```tsx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		observe();
+	}
+</section>
+```
+
 ## Text holes
 
 Dynamic text uses a cast: `{expr as string}`.

--- a/.rulesync/rules/tsrx-authoring.md
+++ b/.rulesync/rules/tsrx-authoring.md
@@ -25,6 +25,24 @@ export function X() @{ <div /> }
 function getX() { return <div />; }
 ```
 
+Inside JSX, a nested `@{ … }` block owns a child render scope at its authored
+sibling position. Its setup may use hooks and capture parent locals; the scope
+and hook state survive parent updates. Its final JSX output is optional, so a
+code-only block is valid and renders no element. An empty child block disappears,
+while a render-only child block is transparent grouping.
+
+```tsx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		observe();
+	}
+</section>
+```
+
 ## Text holes
 
 Dynamic text uses a cast: `{expr as string}`.

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -50,6 +50,36 @@ function Label(props) {
 }
 ```
 
+### Nested child scopes
+
+Inside JSX, a nested `@{ … }` block owns a child render scope at that exact
+sibling position. Its setup runs when the child renders, may use hooks and
+capture parent locals, and keeps its hook state across parent updates. The final
+JSX node is optional: a code-only block runs its setup and renders no element.
+
+```jsx
+export function AccountRow(props: {
+	name: string;
+	observe: (name: string) => void;
+}) @{
+	<li>
+		<span>{props.name as string}</span>
+		@{
+			const [expanded, setExpanded] = useState(false);
+			<button onClick={() => setExpanded(!expanded)}>
+				{expanded ? 'Hide details' : 'Show details'}
+			</button>
+		}
+		@{
+			props.observe(props.name);
+		}
+	</li>
+}
+```
+
+An empty child block disappears. A child block containing only a JSX node is
+transparent grouping and does not create an extra render scope.
+
 Dynamic text needs a cast, `{expr as string}`, unless the expression is provably
 a string. A bare `{expr}` is a renderable hole, not text.
 

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -12375,9 +12375,30 @@ function ssrEmitTsrxExpression(node, ctx, name, inlinedSubs, parentNs, cssHash, 
 		return ssrEmitIf(asIf, ctx, name, inlinedSubs, parentNs, cssHash, componentNs);
 	}
 	ctx.runtimeNeeded.add('ssrChild');
-	// rewriteHookCalls first (key any `use(thenable)` in the hole — it bypasses the
-	// setup rewrite), then rewriteJsxValues (lower nested JSX to createElement).
-	const lowered = rewriteJsxValues(rewriteHookCalls(expr, ctx, name), ctx);
+	let lowered;
+	if (expr?.type === 'ArrowFunctionExpression' && expr.body?.type === 'JSXCodeBlock') {
+		// A child-position `@{ … }` is represented internally as a zero-argument
+		// sub-template arrow. Compile its setup + optional render node as a local
+		// server component so ssrChild emits the same independently stateful range
+		// that the client childSlot owns. The declaration remains inside the parent
+		// body, preserving lexical captures without evaluating setup eagerly.
+		const helperName = `__tsrx$${ctx.nextHelperId++}`;
+		const synth = inheritOriginLoc(
+			{
+				params: expr.params || [],
+				body: expr.body,
+			},
+			expr,
+		);
+		inlinedSubs.push(
+			ssrCompileBody(synth, ctx, helperName, cssHash, [], parentNs, false, componentNs),
+		);
+		lowered = inheritOriginLoc(b.id(helperName), expr);
+	} else {
+		// rewriteHookCalls first (key any `use(thenable)` in the hole — it bypasses
+		// the setup rewrite), then rewriteJsxValues (lower nested JSX to createElement).
+		lowered = rewriteJsxValues(rewriteHookCalls(expr, ctx, name), ctx);
+	}
 	const childExpr = ssrCall('ssrChild', [resolveStyleExpr(lowered, cssHash), b.id('__s')], node);
 	if (componentNs === null) return childExpr;
 	ctx.runtimeNeeded.add('ssrInNamespace');
@@ -17247,6 +17268,32 @@ function objectProp(hn, valNode) {
 	return b.prop('init', b.id(hn), valNode);
 }
 
+// Dynamic values extracted from a returned host/fragment are evaluated in the
+// owning component and threaded into its hoisted renderer as props. Sub-template
+// arrows need one additional lowering step there: their compiled helper must live
+// in the OWNER's body so it can close over setup locals, while the renderer only
+// receives the helper function as its ordinary `props.hN` hole value.
+function rewriteExtractedFragmentHole(expression, ctx, parentNs) {
+	const lowered = rewriteChildHoleValue(expression, ctx);
+	if (lowered?.type !== 'ArrowFunctionExpression' || lowered.body?.type !== 'JSXCodeBlock') {
+		return lowered;
+	}
+	const fold = ctx._foldCtx;
+	if (fold?.compInlinedSubs === undefined) return lowered;
+	return rewriteTsrxBlocks(lowered, ctx, 'fragment', fold.compInlinedSubs, parentNs, fold.cssHash);
+}
+
+// A bare sub-template arrow at a renderable child hole is owned by the rich
+// child dispatcher: rewriteTsrxBlocks compiles it immediately afterward. Keep
+// its JSXCodeBlock intact until then. Other value positions still need the full
+// rewriteJsxValues walk, whose server folding semantics are intentionally
+// different (nested component declarations and portal body values rely on it).
+function rewriteChildHoleValue(expression, ctx) {
+	return expression?.type === 'ArrowFunctionExpression' && expression.body?.type === 'JSXCodeBlock'
+		? expression
+		: rewriteJsxValues(expression, ctx);
+}
+
 // A bare, immutable same-module component needs no descriptor when its JSX is
 // consumed immediately by a returned host. Keep every value/props boundary on
 // the ordinary path: only this attribute-free call can remain in the template
@@ -17422,14 +17469,14 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 			const hn = `h${holeProps.length}`;
 			if (expr && expr.type === 'TSAsExpression') {
 				// Preserve the `as T` cast in the renderer (it marks a dynamic TEXT hole).
-				holeProps.push(objectProp(hn, rewriteJsxValues(expr.expression, ctx)));
+				holeProps.push(objectProp(hn, rewriteExtractedFragmentHole(expr.expression, ctx, childNs)));
 				newChildren.push(
 					b.jsx_expression_container(
 						b.ts_as(memberProps(hn, expr.expression), expr.typeAnnotation),
 					),
 				);
 			} else {
-				holeProps.push(objectProp(hn, rewriteJsxValues(expr, ctx)));
+				holeProps.push(objectProp(hn, rewriteExtractedFragmentHole(expr, ctx, childNs)));
 				// A hole the compiler proved is a string (concat / template / tracked
 				// local) is a TEXT hole — but the renderer only sees `props.hN`, which it
 				// can't prove. Re-assert it with an `as string` cast so the renderer keeps
@@ -17489,14 +17536,34 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 			// renderer. Extract its dynamic values/directives too; leaving it raw would
 			// make authored outer locals resolve against the renderer's hole-props object.
 			newChildren.push(extractFragment(child, ctx, holeProps, childNs));
-		} else if (t === 'JSXCodeBlock' && (child.body || []).length === 0 && child.render) {
-			// A render-only child block is transparent template grouping. Extract its
-			// render root too so expressions still evaluate in the outer component and
-			// arrive as ordered hole props in the hoisted renderer.
-			newChildren.push({
-				...child,
-				render: extractFragmentRoot(child.render, ctx, holeProps, childNs),
-			});
+		} else if (t === 'JSXCodeBlock') {
+			const body = child.body || [];
+			if (body.length === 0) {
+				if (child.render) {
+					// A render-only child block is transparent template grouping. Extract its
+					// render root too so expressions still evaluate in the outer component and
+					// arrive as ordered hole props in the hoisted renderer.
+					newChildren.push({
+						...child,
+						render: extractFragmentRoot(child.render, ctx, holeProps, childNs),
+					});
+				}
+			} else {
+				// Setup-bearing (including code-only) child blocks are independent render
+				// scopes. Pass their compiled body helper into the returned fragment rather
+				// than moving setup into the module-hoisted renderer, where outer captures
+				// would be out of scope.
+				const expression = childCodeBlockArrow(child);
+				const hn = `h${holeProps.length}`;
+				holeProps.push(objectProp(hn, rewriteExtractedFragmentHole(expression, ctx, childNs)));
+				newChildren.push(b.jsx_expression_container(memberProps(hn, child)));
+			}
+		} else if (t === 'TSRXExpression') {
+			// prepareSetupValueDirective may normalize a setup-bearing child block
+			// before fragment extraction. It is still an owner-side renderable hole.
+			const hn = `h${holeProps.length}`;
+			holeProps.push(objectProp(hn, rewriteExtractedFragmentHole(child.expression, ctx, childNs)));
+			newChildren.push(b.jsx_expression_container(memberProps(hn, child)));
 		} else if ((t === 'IfStatement' || t === 'JSXIfExpression') && ctx._foldCtx) {
 			// FOLD a directive: lower its branch bodies on the COMPONENT side (so the
 			// `__then$N`/`__else$N` helpers keep their closure over setup locals/props),
@@ -17894,7 +17961,14 @@ function lowerHostFragment(
  * locals via closure. It cannot capture params of nested arrows — see
  * compiler README.
  */
-function rewriteTsrxBlocks(node, ctx, componentName, inlinedSubs) {
+function rewriteTsrxBlocks(
+	node,
+	ctx,
+	componentName,
+	inlinedSubs,
+	parentNs = 'html',
+	cssHash = null,
+) {
 	return mapAst(node, (n) => {
 		if (n.type === 'Tsrx' || n.type === 'Tsx') {
 			const helperName = `__tsrx$${ctx.nextHelperId++}`;
@@ -17904,7 +17978,7 @@ function rewriteTsrxBlocks(node, ctx, componentName, inlinedSubs) {
 				params: [],
 				body: n.children || [],
 			};
-			inlinedSubs.push(compileFunctionBody(fakeBody, ctx, helperName));
+			inlinedSubs.push(compileFunctionBody(fakeBody, ctx, helperName, parentNs, cssHash));
 			// The hoisted-helper reference maps to the authored sub-template.
 			return inheritOriginLoc(b.id(helperName), n);
 		}
@@ -17922,7 +17996,7 @@ function rewriteTsrxBlocks(node, ctx, componentName, inlinedSubs) {
 			);
 			fakeBody.generator = n.generator;
 			if (n.returnType !== undefined) fakeBody.returnType = n.returnType;
-			inlinedSubs.push(compileFunctionBody(fakeBody, ctx, helperName));
+			inlinedSubs.push(compileFunctionBody(fakeBody, ctx, helperName, parentNs, cssHash));
 			return inheritOriginLoc(b.id(helperName), n);
 		}
 		return null;
@@ -17970,10 +18044,10 @@ function prepareSetupValueDirective(directive, ctx, componentName) {
 		// as <title>, exactly like returned descriptor-backed fragments do.
 		const opaque = rewriteOpaqueTitles(prepared, ctx, 'opaque');
 		if (opaque.type !== 'JSXCodeBlock') return opaque;
-		// Render-only child blocks are transparent grouping; normalize them now so
-		// the server does not mistake the code-block node for another setup value
-		// and recurse indefinitely. normalizeChildren also owns the durable error
-		// for setup-bearing child blocks, keeping client/server diagnostics aligned.
+		// Normalize child blocks now so the server does not mistake the code-block
+		// node for another setup value and recurse indefinitely. Render-only blocks
+		// become transparent children; setup-bearing and code-only blocks become
+		// scoped sub-template expressions.
 		return inheritOriginLoc(b.jsx_fragment(normalizeChildren([opaque], false, ctx)), opaque);
 	} finally {
 		ctx._puInlineLowering = prevPuInlineLowering;
@@ -19934,18 +20008,11 @@ function normalizeChildren(nodes, inSvg = false, ctx = null, inNoscript = false)
 			// synthetic SwitchStatement for makeSwitchCall to consume.
 			out.push(inheritOriginLoc(b.switch(n.discriminant, n.cases || []), n));
 		} else if (n.type === 'JSXCodeBlock') {
-			// `@{ … }` at child position — tsrx 0.1.29 lets `@{}` appear here as
-			// well as on function bodies. The node has `.body` (setup statements)
-			// and `.render` (the single optional render output).
-			//   - Empty: drop (degenerate but legal).
-			//   - Render-only: recurse — the wrapped JSX is a sibling.
-			//   - Code-only or setup+render: ambiguous at child position (when do
-			//     the setup statements run? Per-render? Once per parent mount?
-			//     The runtime would need a fresh Scope and a way to thread state
-			//     back to siblings — there is no sensible answer in our model).
-			//     Throw with a workaround hint pointing at the render-prop arrow
-			//     form `{() => @{ … }}`, which IS supported via the existing
-			//     ArrowFunctionExpression → JSXCodeBlock path (compile.js:1081).
+			// `@{ … }` at child position has `.body` setup statements and one optional
+			// `.render` output. Render-only grouping stays transparent. A setup-bearing
+			// or code-only block lowers to the existing sub-template/childSlot path: its
+			// setup runs in an independent child scope at this exact sibling position,
+			// can close over the parent render, and keeps hook state across parent updates.
 			const body = n.body || [];
 			const render = n.render || null;
 			if (body.length === 0 && render === null) continue;
@@ -19953,10 +20020,14 @@ function normalizeChildren(nodes, inSvg = false, ctx = null, inNoscript = false)
 				// Recurse — render is a single JSX node, treat as a sibling child.
 				out.push(...normalizeChildren([render], inSvg, ctx, inNoscript));
 			} else {
-				throw new Error(
-					'`@{ … }` with setup statements is not supported at JSX child position. ' +
-						'Wrap it in a render-prop arrow form instead — `{() => @{ … }}` — ' +
-						'or extract the setup into its own component.',
+				out.push(
+					inheritOriginLoc(
+						{
+							type: 'TSRXExpression',
+							expression: childCodeBlockArrow(n),
+						},
+						n,
+					),
 				);
 			}
 		} else {
@@ -19964,6 +20035,10 @@ function normalizeChildren(nodes, inSvg = false, ctx = null, inNoscript = false)
 		}
 	}
 	return out;
+}
+
+function childCodeBlockArrow(block) {
+	return inheritOriginLoc(b.arrow([], block), block);
 }
 
 /**
@@ -22490,9 +22565,9 @@ function makeBag() {
 
 // Apply server-mode hook keying and `<tsrx>`/`() => @{…}` hoisting at
 // expression position, returning the rewritten AST for direct embedding.
-function tsrxExprNode(node, ctx, componentName, inlinedSubs) {
+function tsrxExprNode(node, ctx, componentName, inlinedSubs, parentNs = 'html', cssHash = null) {
 	const keyed = ctx.mode === 'server' ? rewriteHookCalls(node, ctx, componentName) : node;
-	return rewriteTsrxBlocks(keyed, ctx, componentName, inlinedSubs);
+	return rewriteTsrxBlocks(keyed, ctx, componentName, inlinedSubs, parentNs, cssHash);
 }
 
 // Placeholder nodes for positional runtime-call arguments. Fresh per call —
@@ -23584,7 +23659,7 @@ function emitNodeHtml(
 		// Bare `{expr}` (no string cast) → RENDERABLE hole at a top-level / multi-
 		// root position. Host is the parent (the dropped last path segment), anchor
 		// is this node's `<!>` slot.
-		const ch = makeChildCall(node.expression, ctx, componentName, inlinedSubs, cssHash);
+		const ch = makeChildCall(node.expression, ctx, componentName, inlinedSubs, cssHash, parentNs);
 		ch.hostPath = path.slice(0, -1);
 		ch.anchorPath = path;
 		compCalls.push(ch);
@@ -23622,7 +23697,7 @@ function emitNodeHtml(
 			(ctx._portalCalls ??= []).push(pc);
 			return templatePart('<!>', 'anchor');
 		}
-		const ch = makeChildCall(node.expression, ctx, componentName, inlinedSubs, cssHash);
+		const ch = makeChildCall(node.expression, ctx, componentName, inlinedSubs, cssHash, parentNs);
 		ch.hostPath = path.slice(0, -1);
 		ch.anchorPath = path;
 		compCalls.push(ch);
@@ -24764,7 +24839,14 @@ function emitElementHtml(
 			// runtime `childTextHole` owns that branch; the server emits `ssrChildText`
 			// (markerless text for a primitive, a `<!--[-->…<!--]-->` block otherwise),
 			// so hydration adopts either shape.
-			const ch = makeChildCall(txtChild.expression, ctx, componentName, inlinedSubs, cssHash);
+			const ch = makeChildCall(
+				txtChild.expression,
+				ctx,
+				componentName,
+				inlinedSubs,
+				cssHash,
+				childNs,
+			);
 			ch.hostPath = path;
 			ch.onlyChildText = true;
 			ch.potentialDangerouslySetInnerHTML = potentialDangerouslySetInnerHTML;
@@ -24931,7 +25013,14 @@ function emitElementHtml(
 					// Bare `{expr}` (no string cast) → RENDERABLE hole (component /
 					// element / children-fn render; primitive → text; nullish/boolean →
 					// nothing). Same `<!>` anchor + host as a component child.
-					const ch = makeChildCall(child.expression, ctx, componentName, inlinedSubs, cssHash);
+					const ch = makeChildCall(
+						child.expression,
+						ctx,
+						componentName,
+						inlinedSubs,
+						cssHash,
+						childNs,
+					);
 					ch.hostPath = path;
 					ch.anchorPath = [...path, childIdx];
 					compCalls.push(ch);
@@ -25122,7 +25211,7 @@ function emitElementHtml(
 					// `{<li/>}`, and array-of-elements children compile (the runtime
 					// de-opt childSlot renders the result) — and rides the TSRX-aware
 					// printer + childSlot path like the simpler Text branch.
-					const ch = makeChildCall(expr, ctx, componentName, inlinedSubs, cssHash);
+					const ch = makeChildCall(expr, ctx, componentName, inlinedSubs, cssHash, childNs);
 					ch.hostPath = path;
 					ch.anchorPath = [...path, childIdx];
 					ch.potentialDangerouslySetInnerHTML = potentialDangerouslySetInnerHTML;
@@ -25673,17 +25762,19 @@ function soleRenderPropChild(children) {
 // emitted `childSlot(...)` call as unparseable source. The transformed
 // expression remains AST throughout so a nested `() => @{…}` sub-template
 // hoists (and server-mode `use(thenable)` calls get their stable keys).
-function makeChildCall(expr, ctx, componentName, inlinedSubs, cssHash) {
+function makeChildCall(expr, ctx, componentName, inlinedSubs, cssHash, parentNs = 'html') {
 	const child = {
 		id: ctx.nextHelperId++,
 		loc: devLoc(ctx, expr),
 		origin: expr,
 		isChild: true,
 		valueExpr: tsrxExprNode(
-			resolveStyleExpr(rewriteJsxValues(expr, ctx), cssHash),
+			resolveStyleExpr(rewriteChildHoleValue(expr, ctx), cssHash),
 			ctx,
 			componentName,
 			inlinedSubs,
+			parentNs,
+			cssHash,
 		),
 	};
 	if (

--- a/packages/octane/tests/_fixtures/code-block-child.tsrx
+++ b/packages/octane/tests/_fixtures/code-block-child.tsrx
@@ -1,7 +1,8 @@
-// `@{ … }` at JSX child position — supported when the block is
-// render-only (no setup statements). Empty `@{}` is silently dropped.
-// Setup-bearing blocks throw at compile time with a workaround hint
-// pointing at the render-prop arrow form.
+import { useState } from 'octane';
+
+// `@{ … }` at JSX child position. Empty blocks disappear, render-only
+// blocks merge into their parent template, and setup-bearing blocks own a
+// render scope at their authored child position.
 
 export function RenderOnlyChild() @{
 	<div class="outer">
@@ -37,4 +38,81 @@ export function EmptyBlockDropped() @{
 		@{}
 		<span class="after">{'after'}</span>
 	</div>
+}
+
+export function SetupBearingChild(props: { label: string }) @{
+	<section class="setup-children">
+		<span id="setup-before">{'before'}</span>
+		@{
+			let name = props.label;
+			const [count, setCount] = useState(0);
+
+			<button id="setup-action" onClick={() => setCount(count + 1)}>{name + ':' + count}</button>
+		}
+		<span id="setup-after">{'after'}</span>
+	</section>
+}
+
+export function ExplicitSetupBearingChild(props: { label: string }) @{
+	<section class="setup-children">
+		<span id="setup-before">{'before'}</span>
+		{() => @{
+			const [count, setCount] = useState(0);
+
+			<button id="setup-action" onClick={() => setCount(count + 1)}>
+				{props.label + ':' + count}
+			</button>
+		}}
+		<span id="setup-after">{'after'}</span>
+	</section>
+}
+
+export function ReturnedSetupBearingChild(props: { label: string }) {
+	return <section class="setup-children">
+		<span id="setup-before">{'before'}</span>
+		@{
+			const [count, setCount] = useState(0);
+
+			<button id="setup-action" onClick={() => setCount(count + 1)}>
+				{props.label + ':' + count}
+			</button>
+		}
+		<span id="setup-after">{'after'}</span>
+	</section>;
+}
+
+export function StoredSetupBearingChild(props: { label: string }) @{
+	const content = <section class="setup-children">
+		<span id="setup-before">{'before'}</span>
+		@{
+			const [count, setCount] = useState(0);
+
+			<button id="setup-action" onClick={() => setCount(count + 1)}>
+				{props.label + ':' + count}
+			</button>
+		}
+		<span id="setup-after">{'after'}</span>
+	</section>;
+
+	<main>{content}</main>
+}
+
+export function CodeOnlyChild(props: {
+	label: string;
+	observe: (value: string) => void;
+}) @{
+	<section id="code-only-children">
+		<span id="code-only-before">{'before'}</span>
+		@{
+			props.observe(props.label);
+		}
+		<span id="code-only-after">{'after'}</span>
+	</section>
+}
+
+export function SvgSetupBearingChild(props: { radius: number }) @{
+	<svg id="setup-svg">@{
+		const diameter = props.radius * 2;
+		<circle id="setup-circle" r={props.radius} data-diameter={diameter} />
+	}</svg>
 }

--- a/packages/octane/tests/_fixtures/code-block-child.tsrx
+++ b/packages/octane/tests/_fixtures/code-block-child.tsrx
@@ -1,4 +1,4 @@
-import { useState } from 'octane';
+import { useEffect, useState } from 'octane';
 
 // `@{ … }` at JSX child position. Empty blocks disappear, render-only
 // blocks merge into their parent template, and setup-bearing blocks own a
@@ -51,6 +51,48 @@ export function SetupBearingChild(props: { label: string }) @{
 		}
 		<span id="setup-after">{'after'}</span>
 	</section>
+}
+
+export function ConditionalHooksInSetupBearingChild(props: {
+	enabled: boolean;
+	log: string[];
+}) @{
+	<section id="conditional-hook-child">@{
+		let label = 'disabled';
+		let increment = () => {};
+
+		if (props.enabled) {
+			const [count, setCount] = useState(0);
+			useEffect(() => {
+				props.log.push('create:' + count);
+				return () => {
+					props.log.push('cleanup:' + count);
+				};
+			}, [count, props.log]);
+			label = 'count:' + count;
+			increment = () => setCount(count + 1);
+		}
+
+		<button id="conditional-hook-action" onClick={increment}>{label}</button>
+	}</section>
+}
+
+export function TemplateIfHooksInSetupBearingChild() @{
+	<section id="template-if-hook-child">@{
+		const [show, setShow] = useState(true);
+
+		<div>
+			<button id="template-if-toggle" onClick={() => setShow(!show)}>
+				{show ? 'hide' : 'show'}
+			</button>
+			@if (show) {
+				const [count, setCount] = useState(0);
+				<button id="template-if-action" onClick={() => setCount(count + 1)}>
+					{'count:' + count}
+				</button>
+			}
+		</div>
+	}</section>
 }
 
 export function ExplicitSetupBearingChild(props: { label: string }) @{

--- a/packages/octane/tests/code-block-child.test.ts
+++ b/packages/octane/tests/code-block-child.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import { compile } from 'octane/compiler';
-import { mount } from './_helpers';
+import { mount, nextPaint } from './_helpers';
 import { flushSync, hydrateRoot } from '../src/index.js';
 import { loadServerFixture } from './_server-fixture.js';
 import {
@@ -9,6 +9,8 @@ import {
 	MultipleBlocks,
 	EmptyBlockDropped,
 	SetupBearingChild,
+	ConditionalHooksInSetupBearingChild,
+	TemplateIfHooksInSetupBearingChild,
 	ExplicitSetupBearingChild,
 	ReturnedSetupBearingChild,
 	StoredSetupBearingChild,
@@ -71,6 +73,55 @@ describe('@{ } at JSX child position', () => {
 		r.update(SetupBearingChild, { label: 'second' });
 		expect(r.find('#setup-action')).toBe(action);
 		expect(action.textContent).toBe('second:1');
+		r.unmount();
+	});
+
+	it('preserves conditional hook state and lifecycle in a scoped child', async () => {
+		const log: string[] = [];
+		const r = mount(ConditionalHooksInSetupBearingChild, { enabled: true, log });
+		const action = r.find('#conditional-hook-action') as HTMLButtonElement;
+
+		await nextPaint();
+		expect(action.textContent).toBe('count:0');
+		expect(log).toEqual(['create:0']);
+
+		r.click('#conditional-hook-action');
+		await nextPaint();
+		expect(action.textContent).toBe('count:1');
+		expect(log).toEqual(['create:0', 'cleanup:0', 'create:1']);
+
+		r.update(ConditionalHooksInSetupBearingChild, { enabled: false, log });
+		await nextPaint();
+		expect(r.find('#conditional-hook-action')).toBe(action);
+		expect(action.textContent).toBe('disabled');
+		expect(log).toEqual(['create:0', 'cleanup:0', 'create:1', 'cleanup:1']);
+
+		r.update(ConditionalHooksInSetupBearingChild, { enabled: true, log });
+		await nextPaint();
+		expect(r.find('#conditional-hook-action')).toBe(action);
+		expect(action.textContent).toBe('count:1');
+		expect(log).toEqual(['create:0', 'cleanup:0', 'create:1', 'cleanup:1', 'create:1']);
+
+		r.unmount();
+		await nextPaint();
+		expect(log.at(-1)).toBe('cleanup:1');
+	});
+
+	it('keeps @if hook state scoped to its branch inside a scoped child', () => {
+		const r = mount(TemplateIfHooksInSetupBearingChild);
+		const action = r.find('#template-if-action');
+
+		r.click('#template-if-action');
+		expect(action.textContent).toBe('count:1');
+
+		r.click('#template-if-toggle');
+		expect(r.findAll('#template-if-action')).toHaveLength(0);
+
+		r.click('#template-if-toggle');
+		const remountedAction = r.find('#template-if-action');
+		expect(remountedAction).not.toBe(action);
+		expect(remountedAction.textContent).toBe('count:0');
+
 		r.unmount();
 	});
 

--- a/packages/octane/tests/code-block-child.test.ts
+++ b/packages/octane/tests/code-block-child.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { mount } from './_helpers';
+import * as ServerRuntime from 'octane/server';
 import { compile } from 'octane/compiler';
+import { mount } from './_helpers';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { loadServerFixture } from './_server-fixture.js';
 import {
 	RenderOnlyChild,
 	MultipleBlocks,
 	EmptyBlockDropped,
+	SetupBearingChild,
+	ExplicitSetupBearingChild,
+	ReturnedSetupBearingChild,
+	StoredSetupBearingChild,
+	CodeOnlyChild,
+	SvgSetupBearingChild,
 } from './_fixtures/code-block-child.tsrx';
+
+const FIXTURE = 'packages/octane/tests/_fixtures/code-block-child.tsrx';
 
 describe('@{ } at JSX child position', () => {
 	it('render-only @{} renders its JSX root as a sibling', () => {
@@ -31,10 +42,155 @@ describe('@{ } at JSX child position', () => {
 		r.unmount();
 	});
 
-	it('compiler rejects setup-bearing @{} at child position with workaround hint', () => {
-		const src = 'export function A() @{ <div>@{ const x = 1; <span>{x as string}</span> }</div> }';
-		expect(() => compile(src, 'setup-block.tsrx')).toThrow(
-			/`@\{ … \}` with setup statements is not supported at JSX child position[\s\S]*\{\(\) =>/,
-		);
+	it('lowers setup-bearing syntax to the explicit scoped-child form', () => {
+		const direct = 'export function App() @{ <div>@{ let name = 1; <b>name: {name}</b> }</div> }';
+		const explicit =
+			'export function App() @{ <div>{() => @{ let name = 1; <b>name: {name}</b> }}</div> }';
+
+		for (const mode of ['client', 'server'] as const) {
+			expect(compile(direct, 'App.tsrx', { mode }).code).toBe(
+				compile(explicit, 'App.tsrx', { mode }).code,
+			);
+		}
+	});
+
+	it('runs setup in a scoped child and preserves it across parent updates', () => {
+		const r = mount(SetupBearingChild, { label: 'first' });
+		const action = r.find('#setup-action') as HTMLButtonElement;
+
+		expect(Array.from(r.find('.setup-children').children, (child) => child.id)).toEqual([
+			'setup-before',
+			'setup-action',
+			'setup-after',
+		]);
+		expect(action.textContent).toBe('first:0');
+
+		r.click('#setup-action');
+		expect(action.textContent).toBe('first:1');
+
+		r.update(SetupBearingChild, { label: 'second' });
+		expect(r.find('#setup-action')).toBe(action);
+		expect(action.textContent).toBe('second:1');
+		r.unmount();
+	});
+
+	it.each([
+		['template body', 'SetupBearingChild', SetupBearingChild],
+		['explicit scoped child', 'ExplicitSetupBearingChild', ExplicitSetupBearingChild],
+		['returned JSX', 'ReturnedSetupBearingChild', ReturnedSetupBearingChild],
+		['stored JSX value', 'StoredSetupBearingChild', StoredSetupBearingChild],
+	])('server-renders and hydrates a setup-bearing child in %s', (_case, exportName, Component) => {
+		const server = loadServerFixture(FIXTURE);
+		const { html } = ServerRuntime.renderToString(server[exportName], {
+			label: 'server',
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const action = container.querySelector('#setup-action') as HTMLButtonElement;
+
+		const root = hydrateRoot(container, Component, { label: 'server' });
+		flushSync(() => {});
+		expect(container.querySelector('#setup-action')).toBe(action);
+		expect(action.textContent).toBe('server:0');
+
+		flushSync(() => action.click());
+		expect(action.textContent).toBe('server:1');
+
+		root.render(Component, { label: 'client' });
+		flushSync(() => {});
+		expect(container.querySelector('#setup-action')).toBe(action);
+		expect(action.textContent).toBe('client:1');
+		root.unmount();
+		container.remove();
+	});
+
+	it('runs a code-only child scope without rendering an element', () => {
+		const seen: string[] = [];
+		const r = mount(CodeOnlyChild, {
+			label: 'first',
+			observe: (value: string) => seen.push(value),
+		});
+		const before = r.find('#code-only-before');
+		const after = r.find('#code-only-after');
+
+		expect(seen).toEqual(['first']);
+		expect(Array.from(r.find('#code-only-children').children, (child) => child.id)).toEqual([
+			'code-only-before',
+			'code-only-after',
+		]);
+
+		r.update(CodeOnlyChild, {
+			label: 'second',
+			observe: (value: string) => seen.push(value),
+		});
+		expect(seen).toEqual(['first', 'second']);
+		expect(r.find('#code-only-before')).toBe(before);
+		expect(r.find('#code-only-after')).toBe(after);
+		r.unmount();
+	});
+
+	it('server-renders and hydrates a code-only child scope', () => {
+		const server = loadServerFixture(FIXTURE);
+		const serverSeen: string[] = [];
+		const { html } = ServerRuntime.renderToString(server.CodeOnlyChild, {
+			label: 'server',
+			observe: (value: string) => serverSeen.push(value),
+		});
+		expect(serverSeen).toEqual(['server']);
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const before = container.querySelector('#code-only-before');
+		const after = container.querySelector('#code-only-after');
+		const clientSeen: string[] = [];
+		const root = hydrateRoot(container, CodeOnlyChild, {
+			label: 'hydrate',
+			observe: (value: string) => clientSeen.push(value),
+		});
+		flushSync(() => {});
+
+		expect(clientSeen).toEqual(['hydrate']);
+		expect(container.querySelector('#code-only-before')).toBe(before);
+		expect(container.querySelector('#code-only-after')).toBe(after);
+		expect(container.querySelector('#code-only-children')?.children).toHaveLength(2);
+
+		root.render(CodeOnlyChild, {
+			label: 'client',
+			observe: (value: string) => clientSeen.push(value),
+		});
+		flushSync(() => {});
+		expect(clientSeen).toEqual(['hydrate', 'client']);
+		expect(container.querySelector('#code-only-before')).toBe(before);
+		expect(container.querySelector('#code-only-after')).toBe(after);
+		root.unmount();
+		container.remove();
+	});
+
+	it('preserves the parent SVG namespace in a scoped child', () => {
+		const server = loadServerFixture(FIXTURE);
+		const { html } = ServerRuntime.renderToString(server.SvgSetupBearingChild, {
+			radius: 4,
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const circle = container.querySelector('#setup-circle');
+
+		const root = hydrateRoot(container, SvgSetupBearingChild, { radius: 4 });
+		flushSync(() => {});
+		expect(container.querySelector('#setup-circle')).toBe(circle);
+		expect(circle?.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(circle?.getAttribute('r')).toBe('4');
+		expect(circle?.getAttribute('data-diameter')).toBe('8');
+
+		root.render(SvgSetupBearingChild, { radius: 6 });
+		flushSync(() => {});
+		expect(container.querySelector('#setup-circle')).toBe(circle);
+		expect(circle?.getAttribute('r')).toBe('6');
+		expect(circle?.getAttribute('data-diameter')).toBe('12');
+		root.unmount();
+		container.remove();
 	});
 });

--- a/packages/octane/tests/control-fold.test.ts
+++ b/packages/octane/tests/control-fold.test.ts
@@ -893,7 +893,7 @@ describe('template directives in a returned fragment', () => {
 		container.remove();
 	});
 
-	it('preserves returned-fragment template diagnostics', () => {
+	it('preserves returned-fragment head diagnostics', () => {
 		for (const mode of ['client', 'server'] as const) {
 			expect(() =>
 				compile(
@@ -902,30 +902,35 @@ describe('template directives in a returned fragment', () => {
 					{ mode },
 				),
 			).toThrow(/<head>.*not supported/);
+		}
+	});
+
+	it('compiles a setup-bearing child block in a returned fragment', () => {
+		for (const mode of ['client', 'server'] as const) {
 			expect(() =>
 				compile(
-					`export function BadBlock() { return <>@{ const value = 'bad'; <span>{value}</span> }</>; }`,
+					`export function ChildBlock() { return <>@{ const value = 'ok'; <span>{value}</span> }</>; }`,
 					`returned-child-block-${mode}.tsrx`,
 					{ mode },
 				),
-			).toThrow(/setup statements.*not supported at JSX child position/);
+			).not.toThrow();
 		}
 	});
 });
 
 describe('template directives in JSX setup values', () => {
-	it('preserves child-code-block diagnostics in client and server compilation', () => {
+	it('compiles a setup-bearing child block in a stored JSX value', () => {
 		for (const mode of ['client', 'server'] as const) {
 			expect(() =>
 				compile(
-					`export function BadSlot() @{
-						const slot = <div>@{ const value = 'bad'; <span>{value}</span> }</div>;
+					`export function Slot() @{
+						const slot = <div>@{ const value = 'ok'; <span>{value}</span> }</div>;
 						<main>{slot}</main>
 					}`,
 					`setup-value-child-block-${mode}.tsrx`,
 					{ mode },
 				),
-			).toThrow(/setup statements.*not supported at JSX child position/);
+			).not.toThrow();
 		}
 	});
 

--- a/website/src/content/docs/tsrx-vs-tsx.mdx
+++ b/website/src/content/docs/tsrx-vs-tsx.mdx
@@ -67,6 +67,24 @@ These compile to the same kind of component. `@{ ... }` is optional in a `.tsrx`
 file, so use a normal function body when an early return or a non-JSX value reads
 better.
 
+Within JSX, a nested `@{ ... }` creates a child render scope at that sibling
+position. It can capture parent locals and use hooks whose state survives parent
+updates. Its final JSX node is optional, so a code-only block can run setup while
+rendering no element; an empty block disappears, and a render-only block is
+transparent grouping.
+
+```tsrx
+<section>
+	@{
+		const [count, setCount] = useState(0);
+		<button onClick={() => setCount(count + 1)}>{'Count: ' + count}</button>
+	}
+	@{
+		props.observe();
+	}
+</section>
+```
+
 <h2 id="rendered-control-flow">Branches and lists that read top to bottom</h2>
 
 TSX puts rendered control flow inside JavaScript expressions: ternaries, `&&`, and


### PR DESCRIPTION
fixes #848 

## Summary

- Compile setup-bearing and code-only nested `@{ ... }` JSX children through Octane's existing scoped child-template path instead of rejecting them.
- Keep render-only blocks as transparent grouping and empty blocks as no-ops.
- Apply the same lowering across client rendering, SSR, hydration, returned/stored JSX values, parent namespaces, and captured CSS scope.
- Document the behavior and add a patch changeset.

## Validation

- [ ] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests:
  - `pnpm exec vitest run packages/octane/tests/code-block-child.test.ts packages/octane/tests/control-fold.test.ts packages/octane/tests/tsrx-block.test.ts packages/octane/tests/text-conversions.test.ts` — 6 files / 122 tests passed
  - `pnpm typecheck:files packages/octane/tests/_fixtures/code-block-child.tsrx`
  - `pnpm format:files:check`
  - `pnpm sync`
  - `git diff --check`

The full `pnpm test` run was deliberately not completed because the local all-project matrix is slow; validation is scoped to the compiler normalization, client, server, and hydration paths changed here.

## Performance

- No runtime hot-path source changed; this is compiler-only lowering.
- The direct shorthand and explicit `{() => @{ ... }}` form produce byte-identical output in both modes (1,173 client bytes; 302 server bytes for the regression sample).
- A corpus comparison found all 406 existing client/server outputs across 203 unaffected fixtures byte-identical to `main`.
- Five alternating, GC-controlled compiler passes showed no measurable throughput regression (candidate/base paired median 0.963; range 0.693–1.020).

## Risk / follow-ups

- Only blocks with setup statements gain an independent child scope. Render-only grouping retains its existing output shape.
- Custom universal/Valdi targets retain their existing lack of JSXCodeBlock subtemplate support, including the already-explicit arrow form; this change covers Octane DOM client/server/hydration.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790268984&installation_model_id=432790&pr_number=849&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F849&signature=7aa8c3286f5b4a4f4ebe50192b6d0a0b1abd3e31378353c85058e8a9bbd05190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core compiler lowering for JSX children and SSR/hydration parity changed, though runtime hot paths are unchanged and unaffected fixtures stayed byte-identical per PR validation.
> 
> **Overview**
> Nested **`@{ … }`** blocks at JSX child positions with setup (hooks, locals, side effects) are **compiled** instead of rejected. They lower to the same scoped child-template path as **`{() => @{ … }}`**, with **byte-identical** client/server output for the shorthand vs explicit form.
> 
> **Render-only** and **empty** child blocks keep prior behavior (transparent grouping and no-op). **Code-only** blocks run setup without emitting a DOM node. The compiler threads this through **client `childSlot`**, **SSR `ssrChild`**, **returned/stored JSX**, **hoisted fragment extraction**, and **parent namespace / CSS scope** so hook state and captures survive parent updates.
> 
> Docs, agent rules, and a patch changeset describe nested child scopes. Tests cover hooks, `@if` branches, hydration, code-only observers, and SVG namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ef6034d4672ee247396d0e26c093e3d5579b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->