### PR TITLE
perf(compiler): avoid quadratic generated name growth

### DIFF
--- a/.changeset/compact-compiler-locals.md
+++ b/.changeset/compact-compiler-locals.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep compiler-generated local names compact in production modules with many components, reducing compile work and intermediate output size.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -854,6 +854,14 @@
   {
     "suite": "codegen-size",
     "op": "raw",
+    "target": "component-module-200",
+    "reference": "component-module-100",
+    "maxRatio": 2.1,
+    "note": "Deterministic production output scaling for a module with twice as many memoizable component bodies. Compact collision-free compiler locals measured 2.03x after the fix; the 2.1x ceiling keeps raw intermediate code near linear instead of growing one identifier character per preceding component."
+  },
+  {
+    "suite": "codegen-size",
+    "op": "raw",
     "target": "text-types-inferred",
     "reference": "text-types-explicit",
     "maxRatio": 1.0,

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -857,7 +857,7 @@
     "target": "component-module-200",
     "reference": "component-module-100",
     "maxRatio": 2.1,
-    "note": "Deterministic production output scaling for a module with twice as many memoizable component bodies. Compact collision-free compiler locals measured 2.03x after the fix; the 2.1x ceiling keeps raw intermediate code near linear instead of growing one identifier character per preceding component."
+    "note": "Deterministic production output scaling for a module with twice as many memoizable component bodies. Compact collision-free compiler locals measured 2.04x after the fix; the 2.1x ceiling keeps raw intermediate code near linear instead of growing one identifier character per preceding component."
   },
   {
     "suite": "codegen-size",

--- a/benchmarks/codegen-size/run.mjs
+++ b/benchmarks/codegen-size/run.mjs
@@ -81,7 +81,7 @@ for (const rel of CORPUS) {
 
 const val = (bytes) => ({ median: bytes, min: bytes, samples: 1 });
 
-function compiledSize(source, filename, options = {}) {
+function compiledSize(source, filename, options = {}, validate = null) {
 	const { code } = compile(source, filename, {
 		mode: 'client',
 		hmr: false,
@@ -89,11 +89,33 @@ function compiledSize(source, filename, options = {}) {
 		...options,
 	});
 	const min = transformSync(code, { loader: 'js', minify: true }).code;
+	validate?.(code, min);
 	return {
 		raw: val(code.length),
 		minified: val(min.length),
 		gzip: val(gz(min)),
 	};
+}
+
+function componentModuleSource(count) {
+	return Array.from({ length: count }, (_, index) => {
+		const output = index === 0 ? '<span>leaf</span>' : `<Component${index - 1} />`;
+		return `export function Component${index}() @{ ${output} }`;
+	}).join('\n');
+}
+
+function componentModuleSize(count) {
+	return compiledSize(
+		componentModuleSource(count),
+		path.join(REPO, `benchmarks/codegen-size/component-module-${count}.tsrx`),
+		{},
+		(code) => {
+			const exports = code.match(/export const Component\d+\s*=/g)?.length ?? 0;
+			if (exports !== count) {
+				throw new Error(`component-module-${count} emitted ${exports}/${count} exports`);
+			}
+		},
+	);
 }
 
 // Keep the diagnostic sentinel OUT of the long-lived source/compiled aggregate:
@@ -114,6 +136,8 @@ for (const op of ['raw', 'minified', 'gzip']) {
 		);
 	}
 }
+const componentModule100 = componentModuleSize(100);
+const componentModule200 = componentModuleSize(200);
 
 // Keep the opt-in TypeScript sentinel separate from the fixed corpus. Its
 // reference spells out the same text guarantees with explicit `as string`
@@ -239,6 +263,16 @@ const payload = {
 		},
 		{ name: 'native-change-control', ops: diagnosticControl },
 		{ name: 'native-change-diagnostic', ops: diagnostic },
+		{
+			name: 'component-module-100',
+			ops: componentModule100,
+			meta: { components: 100 },
+		},
+		{
+			name: 'component-module-200',
+			ops: componentModule200,
+			meta: { components: 200 },
+		},
 		{ name: 'text-types-syntax', ops: textTypes.syntax },
 		{ name: 'text-types-explicit', ops: textTypes.explicit, meta: textTypes.meta },
 		{ name: 'text-types-inferred', ops: textTypes.inferred, meta: textTypes.meta },
@@ -254,6 +288,9 @@ console.log(
 );
 console.log(
 	`native-change production sentinel  raw ${diagnostic.raw.median}  min ${diagnostic.minified.median}  gz ${diagnostic.gzip.median}`,
+);
+console.log(
+	`component modules  100 raw ${componentModule100.raw.median}  200 raw ${componentModule200.raw.median}  scaling ${(componentModule200.raw.median / componentModule100.raw.median).toFixed(2)}x`,
 );
 console.log(
 	`TypeScript text sentinel  inferred ${textTypes.inferred.raw.median}/${textTypes.inferred.minified.median}/${textTypes.inferred.gzip.median}  explicit ${textTypes.explicit.raw.median}/${textTypes.explicit.minified.median}/${textTypes.explicit.gzip.median}  syntax ${textTypes.syntax.raw.median}/${textTypes.syntax.minified.median}/${textTypes.syntax.gzip.median}`,

--- a/benchmarks/codegen-size/run.mjs
+++ b/benchmarks/codegen-size/run.mjs
@@ -114,6 +114,14 @@ function componentModuleSize(count) {
 			if (exports !== count) {
 				throw new Error(`component-module-${count} emitted ${exports}/${count} exports`);
 			}
+			const expectedRegions = count - 1;
+			const caches = code.match(/let __memoCache[\w$]* =/g)?.length ?? 0;
+			const commits = code.match(/const __memoCommitted[\w$]* =/g)?.length ?? 0;
+			if (caches !== expectedRegions || commits !== expectedRegions) {
+				throw new Error(
+					`component-module-${count} emitted ${caches}/${commits}/${expectedRegions} cache/commit/expected memo regions`,
+				);
+			}
 		},
 	);
 }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3193,7 +3193,8 @@ const AST_WALK_SKIP_KEYS = new Set(['type', 'loc', 'start', 'end', 'range', 'met
 // user scopes, so both top-level duplicates and nested shadowing are unsafe.
 // Seed the allocator from lexical Identifier nodes (not raw source text, which
 // would spuriously treat comments/strings as bindings), then reserve each name
-// as it is emitted.
+// as it is emitted. Repeated bases keep a numeric suffix cursor: appending one
+// character per collision makes output size quadratic in component count.
 function collectIdentifierNames(root) {
 	const names = new Set();
 	const walk = (node) => {
@@ -3214,7 +3215,15 @@ function collectIdentifierNames(root) {
 
 function allocCompilerName(ctx, preferred) {
 	let name = preferred;
-	while (ctx.usedCompilerNames.has(name)) name += '$';
+	if (ctx.usedCompilerNames.has(name)) {
+		const suffixes = (ctx.compilerNameSuffixes ??= new Map());
+		let suffix = suffixes.get(preferred) ?? 1;
+		do {
+			name = suffix === 1 ? `${preferred}$` : `${preferred}$${suffix}`;
+			suffix++;
+		} while (ctx.usedCompilerNames.has(name));
+		suffixes.set(preferred, suffix);
+	}
 	ctx.usedCompilerNames.add(name);
 	return name;
 }
@@ -8277,6 +8286,7 @@ function compileInternal(
 	const ctx = {
 		filename,
 		usedCompilerNames: collectIdentifierNames(ast),
+		compilerNameSuffixes: null,
 		profileFilename: (options && options.profileFilename) || filename,
 		mode,
 		nativeChangeClassifications: nativeChangeAnalysis.classifications,
@@ -9522,6 +9532,7 @@ function compileServer(
 	const ctx = {
 		filename,
 		usedCompilerNames: collectIdentifierNames(ast),
+		compilerNameSuffixes: null,
 		mode: 'server',
 		hmr: false, // SSR never hot-swaps in place; client/server production slot shapes stay aligned
 		dev: !!(options && options.dev),

--- a/packages/octane/tests/_fixtures/auto-memo-name-collisions.tsrx
+++ b/packages/octane/tests/_fixtures/auto-memo-name-collisions.tsrx
@@ -1,0 +1,29 @@
+interface CompilerNameCollisionProps {
+	first: number;
+	second: number;
+	third: number;
+	fourth: number;
+	fifth: number;
+	sixth: number;
+	onSelect: () => void;
+}
+
+function CollisionTotal(props: { value: number }) @{
+	<span id="compiler-name-collision-total">{props.value as string}</span>
+}
+
+export function CompilerNameCollisionApp(props: CompilerNameCollisionProps) @{
+	const __memoCache = props.first;
+	const __memoCache$1 = props.second;
+	const __memoCache$2 = props.third;
+	const __memoCommitted = props.fourth;
+	const __memoCommitted$1 = props.fifth;
+	const __memoCommitted$2 = props.sixth;
+	const total =
+		__memoCache + __memoCache$1 + __memoCache$2 + __memoCommitted + __memoCommitted$1 +
+		__memoCommitted$2;
+
+	<button id="compiler-name-collision" onClick={props.onSelect}>
+		<CollisionTotal value={total} />
+	</button>
+}

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -5,6 +5,7 @@ import { createContext, createElement, flushSync, hydrateRoot } from '../src/ind
 import { act, flushEffects, mount } from './_helpers';
 import { loadCompiledFixtureSource } from './_server-fixture.js';
 import { AutoMemoApp } from './_fixtures/auto-memo.tsrx';
+import { CompilerNameCollisionApp } from './_fixtures/auto-memo-name-collisions.tsrx';
 import { ParentCaptureApp } from './_fixtures/auto-memo-parent-capture.tsrx';
 import {
 	TsxAutoMemoApp,
@@ -4722,6 +4723,37 @@ describe('compiler-owned component-region memoization', () => {
 			{ hmr: false, autoMemo: true },
 		).code;
 		expect(transitiveCapture.match(/const __memoDep[\w$]* = \(?live\)?;/g)).toHaveLength(2);
+	});
+
+	it('preserves authored locals that overlap compiler-generated names', () => {
+		const selections: string[] = [];
+		const root = mount(CompilerNameCollisionApp, {
+			first: 1,
+			second: 2,
+			third: 3,
+			fourth: 4,
+			fifth: 5,
+			sixth: 6,
+			onSelect: () => selections.push('selected'),
+		});
+
+		expect(root.find('#compiler-name-collision-total').textContent).toBe('21');
+		root.click('#compiler-name-collision');
+		expect(selections).toEqual(['selected']);
+
+		root.update(CompilerNameCollisionApp, {
+			first: 2,
+			second: 3,
+			third: 4,
+			fourth: 5,
+			fifth: 6,
+			sixth: 7,
+			onSelect: () => selections.push('updated'),
+		});
+		expect(root.find('#compiler-name-collision-total').textContent).toBe('27');
+		root.click('#compiler-name-collision');
+		expect(selections).toEqual(['selected', 'updated']);
+		root.unmount();
 	});
 
 	it('memoizes destructured-props callees while pattern-evaluating shapes fall back', () => {


### PR DESCRIPTION
## Summary

- keep compiler-generated local names compact by remembering the next suffix for each preferred name
- preserve the first-collision spelling (`name$`) while using `name$2`, `name$3`, and so on for later collisions, including authored-name collisions
- add behavioral regression coverage, a semantic benchmark control, a deterministic 100/200-component scaling guard, and an Octane patch changeset

## Why

The allocator previously restarted from the preferred name and appended another `$` for every collision. In a module containing many memoizable component bodies, generated identifiers and compiler string work therefore grew quadratically.

This branch is based directly on current `main` and contains only the compiler change and its tests, benchmark, and changeset. The unrelated binding work from #840 is not in this PR.

## Performance evidence

The synthetic benchmark isolates the pathological case and measures raw, unminified compiler output on current `main`:

| Component exports | Before | After |
| --- | ---: | ---: |
| 100 | 122,767 bytes | 61,818 bytes |
| 200 | 376,416 bytes | 125,817 bytes |
| 200/100 scaling | 3.07x | 2.04x |

This is not a shipped bundle-size claim. On the existing fixed corpus, raw compiled output changes from 156,614 to 156,227 bytes; minified output remains 76,409 bytes, and gzip changes from 27,060 to 27,062 bytes.

## Implementation

- keep a lazy, compilation-local suffix cursor per preferred generated name
- continue checking candidates against both authored identifiers and previously generated names
- exercise overlapping authored `__memoCache` and `__memoCommitted` locals through mount, update, event, and unmount behavior
- verify that the synthetic benchmark actually emits the expected memo-cache and memo-commit regions before measuring it
- guard component-module raw-output scaling at 2.1x when the component count doubles

## Validation

- [x] focused Vitest run: `packages/octane/tests/hmr.test.ts` and `packages/octane/tests/auto-memo.test.ts` — 4 files, 318 tests passed
- [x] changed-file Prettier check
- [x] `git diff --check`
- [x] old-allocator control: the new component-module guard fails at 3.07x
- [x] authored-collision control: removing candidate skipping produces a duplicate-identifier syntax error
- [ ] `node benchmarks/bench.mjs --quick --ratios codegen-size` — the new guard passes at 2.04x; the aggregate command still reports two pre-existing current-`main` ratio misses (`codegen-size` gzip and `css` client min)
- [ ] full tests and typecheck were intentionally not run locally; CI is the source of truth

## Risk

Generated local spelling after the first collision changes, but those names are compiler implementation details. The suffix map is allocated lazily for one compilation and adds no runtime state or shipped code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only compile-time identifier spelling for generated locals; runtime behavior is unchanged and tests cover authored-name collisions.
> 
> **Overview**
> **Fixes quadratic growth** in production compiler output when a module has many memoizable components that keep colliding on the same generated locals (e.g. `__memoCache` / `__memoCommitted`).
> 
> `allocCompilerName` no longer stacks another `$` on every collision. It keeps a per-compilation suffix cursor so the first clash stays `name$` and later ones become `name$2`, `name$3`, and so on, while still avoiding authored identifiers and names already emitted.
> 
> A new **codegen-size** benchmark compiles synthetic 100- and 200-component modules, validates export and memo-region counts, and a **2.1× raw scaling ceiling** in `ratios.json` blocks a return to ~3× growth when component count doubles. Regression coverage mounts a fixture where user code already uses `__memoCache` / `__memoCommitted` names and checks totals, clicks, updates, and unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d0527a126fe05277c5dd9c5fe119ccf4003526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->