### PR TITLE
perf(app-core): cache production route metadata

### DIFF
--- a/.changeset/cache-production-route-metadata.md
+++ b/.changeset/cache-production-route-metadata.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/app-core': patch
+---
+
+Reuse production render-route indices and lazily cached per-route asset tags instead of rebuilding them for every request.

--- a/packages/app-core/src/server/production.js
+++ b/packages/app-core/src/server/production.js
@@ -169,6 +169,71 @@ function prepareSsrTemplate(html) {
  */
 
 /**
+ * @typedef {Object} PreparedRenderRoute
+ * @property {number} index
+ * @property {string | undefined} assetHead
+ */
+
+/**
+ * Index the production manifest once, matching the router's handler-lifetime
+ * snapshot. Integrations create a new handler when replacing that manifest.
+ * Asset tags are populated lazily on the first request for each route, avoiding
+ * both repeated assembly on hot routes and eager work for routes an isolate may
+ * never serve.
+ *
+ * @param {import('@octanejs/app-core').Route[]} routes
+ * @returns {Map<RenderRoute, PreparedRenderRoute>}
+ */
+function prepareRenderRoutes(routes) {
+	/** @type {Map<RenderRoute, PreparedRenderRoute>} */
+	const prepared = new Map();
+	let index = 0;
+	for (const route of routes) {
+		if (route.type !== 'render') continue;
+		// Preserve Array#indexOf semantics if a caller reuses one route object.
+		if (!prepared.has(route)) prepared.set(route, { index, assetHead: undefined });
+		index++;
+	}
+	return prepared;
+}
+
+/**
+ * @param {ServerManifest} manifest
+ * @param {RenderRoute} route
+ * @param {string | undefined} entryPath
+ * @returns {string}
+ */
+function prepareRouteAssetHead(manifest, route, entryPath) {
+	/** @type {string[]} */
+	const tags = [];
+	const clientAssets = manifest.clientAssets;
+	if (clientAssets) {
+		/** @type {Set<string>} */
+		const stylesheets = new Set();
+		for (const modulePath of [
+			entryPath,
+			route.layout,
+			manifest.rootBoundary?.pending ? manifest.rootBoundaryEntries?.pending?.path : undefined,
+			manifest.rootBoundary?.catch ? manifest.rootBoundaryEntries?.catch?.path : undefined,
+		]) {
+			if (!modulePath) continue;
+			for (const cssFile of clientAssets[modulePath]?.css ?? []) {
+				if (stylesheets.has(cssFile)) continue;
+				stylesheets.add(cssFile);
+				tags.push(`<link rel="stylesheet" href="/${cssFile}">`);
+			}
+		}
+	}
+	// Only the page chunk was already eager; do not promote layout, fallback,
+	// or island JavaScript while making their server-rendered CSS available.
+	const entryAssets = entryPath ? clientAssets?.[entryPath] : undefined;
+	if (entryAssets?.js) {
+		tags.push(`<link rel="modulepreload" href="/${entryAssets.js}">`);
+	}
+	return tags.join('\n');
+}
+
+/**
  * Create the production request handler from a manifest.
  *
  * The returned function is a standard Web `fetch`-style handler:
@@ -185,6 +250,7 @@ function prepareSsrTemplate(html) {
 export function createHandler(manifest, deps) {
 	const { renderToReadableStream, prerender, htmlTemplate, executeServerFunction } = deps;
 	const router = createRouter(manifest.routes);
+	const preparedRenderRoutes = prepareRenderRoutes(manifest.routes);
 	const globalMiddlewares = manifest.middlewares ?? [];
 	const trustProxy = manifest.trustProxy ?? false;
 	const rpcPolicy = manifest.rpc;
@@ -281,6 +347,7 @@ export function createHandler(manifest, deps) {
 	 * @returns {Promise<Response>}
 	 */
 	async function renderRoute(route, context) {
+		const preparedRoute = preparedRenderRoutes.get(route);
 		const entryPath = get_route_entry_path(route.entry);
 		const exportName = get_route_entry_export_name(route.entry);
 		const PageComponent = entryPath
@@ -325,7 +392,7 @@ export function createHandler(manifest, deps) {
 			entry: entryPath,
 			exportName: exportName ?? null,
 			layout: route.layout ?? null,
-			routeIndex: getRenderRouteIndex(manifest.routes, route),
+			routeIndex: preparedRoute?.index,
 			params: context.params,
 			url: requestUrl,
 			preHydrate: manifest.preHydrate ?? null,
@@ -337,34 +404,12 @@ export function createHandler(manifest, deps) {
 		// server HTML before hydration. Their asset records also include CSS for
 		// deferred Hydrate descendants, whose JavaScript must remain lazy. Keep
 		// page CSS first, preserve each record's order, and link shared files once.
-		/** @type {string[]} */
-		const preloadTags = [];
-		const clientAssets = manifest.clientAssets;
-		const entryAssets = entryPath ? clientAssets?.[entryPath] : undefined;
-		if (clientAssets) {
-			/** @type {Set<string>} */
-			const stylesheets = new Set();
-			for (const modulePath of [
-				entryPath,
-				route.layout,
-				manifest.rootBoundary?.pending ? manifest.rootBoundaryEntries?.pending?.path : undefined,
-				manifest.rootBoundary?.catch ? manifest.rootBoundaryEntries?.catch?.path : undefined,
-			]) {
-				if (!modulePath) continue;
-				for (const cssFile of clientAssets[modulePath]?.css ?? []) {
-					if (stylesheets.has(cssFile)) continue;
-					stylesheets.add(cssFile);
-					preloadTags.push(`<link rel="stylesheet" href="/${cssFile}">`);
-				}
-			}
+		let assetHead = preparedRoute?.assetHead;
+		if (assetHead === undefined) {
+			assetHead = prepareRouteAssetHead(manifest, route, entryPath);
+			if (preparedRoute) preparedRoute.assetHead = assetHead;
 		}
-		// Only the page chunk was already eager; do not promote layout, fallback,
-		// or island JavaScript while making their server-rendered CSS available.
-		if (entryAssets?.js) {
-			preloadTags.push(`<link rel="modulepreload" href="/${entryAssets.js}">`);
-		}
-
-		const headContent = [...preloadTags, dataScript].join('\n');
+		const headContent = assetHead === '' ? dataScript : assetHead + '\n' + dataScript;
 		const noncedTemplate = nonce === null ? null : applyHydrationNonce(htmlTemplate, nonce);
 
 		const status = route.status ?? 200;
@@ -436,17 +481,6 @@ export function createHandler(manifest, deps) {
 	}
 
 	return handler;
-}
-
-/**
- * @param {import('@octanejs/app-core').Route[]} routes
- * @param {RenderRoute} route
- * @returns {number | undefined}
- */
-function getRenderRouteIndex(routes, route) {
-	const renderRoutes = routes.filter((r) => r.type === 'render');
-	const index = renderRoutes.indexOf(route);
-	return index === -1 ? undefined : index;
 }
 
 /**

--- a/packages/app-core/tests/production-assets.test.ts
+++ b/packages/app-core/tests/production-assets.test.ts
@@ -157,20 +157,34 @@ describe.each(['buffered', 'streaming'] as const)('%s production route assets', 
 		expect(html).toMatch(/<script(?=[^>]*data-octane-hydrate)(?=[^>]*nonce="asset-nonce")[^>]*>/);
 	});
 
-	it('only includes the matched page and its configured boundaries', async () => {
+	it('keeps matched page assets isolated across concurrent and subsequent requests', async () => {
 		const handler = createHandler(makeManifest(render), renderOptions);
-		const response = await handler(new Request('https://octane.test/other'));
-		const html = await response.text();
+		const selectedRequest = new Request('https://octane.test/selected/ready');
+		const [firstSelectedResponse, otherResponse] = await Promise.all([
+			handler(selectedRequest),
+			handler(new Request('https://octane.test/other')),
+		]);
+		const [firstSelected, other] = await Promise.all([
+			firstSelectedResponse.text(),
+			otherResponse.text(),
+		]);
+		const secondSelected = await (await handler(selectedRequest)).text();
 
-		expect(response.status).toBe(200);
-		expect(html).toContain('class="other"');
-		expect(assetHrefs(html, 'stylesheet')).toEqual([
+		expect(otherResponse.status).toBe(200);
+		expect(other).toContain('class="other"');
+		expect(assetHrefs(other, 'stylesheet')).toEqual([
 			'/assets/other.css',
 			'/assets/shared.css',
 			'/assets/pending.css',
 			'/assets/catch.css',
 		]);
-		expect(assetHrefs(html, 'modulepreload')).toEqual(['/assets/other.js']);
+		expect(assetHrefs(other, 'modulepreload')).toEqual(['/assets/other.js']);
+		expect(assetHrefs(secondSelected, 'stylesheet')).toEqual(
+			assetHrefs(firstSelected, 'stylesheet'),
+		);
+		expect(assetHrefs(secondSelected, 'modulepreload')).toEqual(
+			assetHrefs(firstSelected, 'modulepreload'),
+		);
 	});
 
 	it('keeps layout and boundary CSS when the page has no asset record', async () => {

--- a/packages/vite-plugin-octane/tests/handler.test.ts
+++ b/packages/vite-plugin-octane/tests/handler.test.ts
@@ -106,12 +106,16 @@ describe('createHandler', () => {
 		expect(head).toContain('<title>a $& b $` c</title>');
 	});
 
-	it('uses the RenderRoute status (catch-all 404) and route params', async () => {
-		const handler = createHandler(makeManifest() as any, baseDeps as any);
+	it('uses the RenderRoute status, params, and render-only route index', async () => {
+		const manifest = makeManifest();
+		const [rootRoute, catchAllRoute, serverRoute] = manifest.routes;
+		manifest.routes = [rootRoute, serverRoute, catchAllRoute];
+		const handler = createHandler(manifest as any, baseDeps as any);
 		const response = await handler(new Request('http://localhost/not/a/page'));
 		expect(response.status).toBe(404);
 		const html = await response.text();
 		expect(html).toContain('"params":{"splat":"not/a/page"}');
+		expect(html).toContain('"routeIndex":1');
 	});
 
 	it("render: 'buffered' awaits prerender and sends one document (css leads the body)", async () => {


### PR DESCRIPTION
## Summary

- index production render routes once per handler instead of filtering and searching the route list on every rendered request
- lazily cache each visited route's ordered, deduplicated stylesheet/modulepreload markup
- keep request-specific hydration data, CSP nonces, and hoisted metadata outside the cache
- cover render-only route indices plus concurrent and alternating route asset responses

## Why

The production render path still did two pieces of static manifest work per request: `filter()` + `indexOf()` to recover the hydration route index, and a new array/Set/string assembly pass for route assets. The generated manifest is stable for the handler lifetime, while integrations construct a new handler when replacing it.

The route index is prepared eagerly because it is small and removes route-count scaling. Asset markup is populated on the first request for a route so cold isolates do not prepare or retain strings for routes they never serve.

## Performance

Synthetic buffered-handler benchmark using the real production `createHandler` on Node 24.18.0 with a minimal renderer to isolate app-core request overhead. Each candidate ran in five fresh Node processes in rotated order. Each scenario used 500 explicit warmups, adaptive calibration, and seven approximately 150 ms batches; the table reports the median of the five process medians. Response SHA-256, byte length, render index, and stylesheet count were identical between candidates for every row.

| Workload | `main` | Current head | Delta |
| --- | ---: | ---: | ---: |
| 1 render route, no assets | 0.01195 ms/request | 0.01139 ms/request | 4.7% faster |
| 64 render routes, no assets | 0.01248 ms/request | 0.01154 ms/request | 7.6% faster |
| 512 render routes, no assets | 0.01539 ms/request | 0.01164 ms/request | 24.4% faster |
| 1 route, 8 CSS files per contributing module | 0.01831 ms/request | 0.01431 ms/request | 21.9% faster |
| 1 route, 32 CSS files per contributing module | 0.03196 ms/request | 0.02038 ms/request | 36.2% faster |
| 1 route, 128 CSS files per contributing module | 0.08875 ms/request | 0.04391 ms/request | 50.5% faster |
| 512-route ServerRoute control | 0.00682 ms/request | 0.00678 ms/request | 0.5% faster |
| Handler creation + first render, 256 routes / 32 CSS files per module | 0.16484 ms | 0.17281 ms | 4.8% slower (+0.008 ms) |

The ServerRoute row is the negative control and remains within 0.5%. The cold row repeatedly constructs a handler and serves a route's first request; its 8 microsecond cost is smaller than the steady-state saving on the next equivalent asset-bearing request. Lazy asset preparation avoids multiplying that cold work across unvisited routes.

## Changes

- add handler-scoped metadata keyed by RenderRoute identity, preserving the previous first-occurrence/render-only index semantics
- retain at most one prepared asset string per visited render route while preserving page/layout/boundary CSS order, deduplication, and page-only module preload behavior
- add a patch changeset for `@octanejs/app-core`

## Validation

- [ ] `pnpm format:check` (full-repository check left to CI)
- [ ] `pnpm typecheck` (left to CI)
- [ ] `pnpm test` (full suite left to CI)
- [x] `pnpm sync`
- [x] targeted Vitest: 10 files, 128 tests passed
- [x] scoped Prettier check
- [x] `node --check packages/app-core/src/server/production.js`
- [x] `git diff --check`
- [x] five-process benchmark with byte-identical semantic controls and cold/server negative controls

## Risk / follow-ups

The cache lifetime matches the router's existing handler-lifetime manifest snapshot. Route index metadata is bounded by the configured render-route count; asset strings are retained only for routes that have been requested. Buffered and streaming output, concurrent first requests, alternating routes, missing asset records, layout/root-boundary assets, CSP nonces, and server routes remain covered. Full-repository validation is delegated to CI.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790300137&installation_model_id=432790&pr_number=854&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F854&signature=876fe8efd1883cdc32d8d3c0aa2f9f19cc55c46394f4f31918f1a78d653c26ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Handler-lifetime caching on the production render path with unchanged hydration/asset rules; scoped tests cover concurrency and index semantics.
> 
> **Overview**
> Production `createHandler` now **builds render-route metadata once per handler** instead of redoing manifest work on every HTML response.
> 
> **Route index:** A handler-scoped map assigns each `RenderRoute` its hydration **`routeIndex`** up front (render-only routes, same first-occurrence semantics as the old `filter` + `indexOf`). Non-render routes in the manifest no longer affect the index.
> 
> **Asset head:** Stylesheet and page **modulepreload** markup is extracted into `prepareRouteAssetHead` and **cached lazily** on the first hit for each route; later requests reuse the string while **`__octane_data`**, CSP nonces, and hoisted SSR head stay per-request.
> 
> Tests cover **concurrent/alternating routes**, **render-only indexing** when a `ServerRoute` sits between render routes, and a patch changeset for `@octanejs/app-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8af046bf71a19ceca387a697d0e946f26b4f872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->