### PR TITLE
perf(octane): skip unrelated stream boundary scans

### DIFF
--- a/.changeset/fast-stream-boundary-pruning.md
+++ b/.changeset/fast-stream-boundary-pruning.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip unrelated sibling boundaries when pruning completed streaming SSR segments.

--- a/benchmarks/streaming-ssr/README.md
+++ b/benchmarks/streaming-ssr/README.md
@@ -138,8 +138,10 @@ TARGETS=octane,react node benchmarks/streaming-ssr/run.mjs 10 --no-build
 `shell_allfast`, `total_allfast` (the latter carries `opsPerSec`); chunk
 counts, bytes, skeleton counts and all-fast renders/sec land in `meta`.
 Octane additionally reports `shell_cpu_10`, `total_cpu_10`, `shell_cpu_100`,
-`total_cpu_100`, `shell_cpu_waves_50`, and `total_cpu_waves_50`, with the actual
-card/group sizes, chunks, and bytes in `meta.controlledCpu`. Every CPU case
-passes the same complete-card-output gate and checks that the shell precedes
-the controlled data. Increase the iteration count for sub-millisecond cases;
-quick smoke runs establish correctness, not a performance claim.
+`total_cpu_100`, `shell_cpu_800`, `total_cpu_800`, `shell_cpu_waves_50`, and
+`total_cpu_waves_50`, with the actual card/group sizes, chunks, and bytes in
+`meta.controlledCpu`. The 800-card wave makes superlinear boundary bookkeeping
+visible. Every CPU case passes the same complete-card-output gate and checks
+that the shell precedes the controlled data. Increase the iteration count for
+sub-millisecond cases; quick smoke runs establish correctness, not a performance
+claim.

--- a/benchmarks/streaming-ssr/run.mjs
+++ b/benchmarks/streaming-ssr/run.mjs
@@ -68,6 +68,7 @@ const SCENARIOS = ['staggered', 'all-fast'];
 const CPU_SCENARIOS = [
 	{ name: 'cpu-10', cards: 10, waveSize: 10 },
 	{ name: 'cpu-100', cards: 100, waveSize: 100 },
+	{ name: 'cpu-800', cards: 800, waveSize: 800 },
 	{ name: 'cpu-waves-50', cards: 50, waveSize: 5 },
 ];
 const CARD_COUNT = 10;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -6782,6 +6782,8 @@ interface StreamBoundary {
 
 interface StreamState {
 	boundaries: Map<string, StreamBoundary>;
+	/** Conservative index of registered boundary owners; stale entries only cost a scan. */
+	boundaryOwnerKeys: Set<string>;
 	nextId: number;
 	token: string;
 	/** Boundary positions reached by the active full-tree pass, when tracked. */
@@ -6844,6 +6846,10 @@ function rewindStreamBoundaryReplay(stream: StreamState, checkpoint: number): vo
 	}
 }
 
+function recordStreamBoundaryOwners(stream: StreamState, owners: string[]): void {
+	for (const owner of owners) stream.boundaryOwnerKeys.add(owner);
+}
+
 // Every boundary id includes a render-unique token. The counter proves
 // uniqueness for every stream produced by this module instance; the realm salt
 // prevents a second bundled copy/server isolate from restarting at the same
@@ -6884,6 +6890,9 @@ function pruneUnrepresentedStreamDescendants(
 	ownerKey: string,
 	ownerHtml: string,
 ): void {
+	// Independent siblings are the common case. Without this guard every
+	// completed sibling scans every other registered sibling in the wave.
+	if (!stream.boundaryOwnerKeys.has(ownerKey)) return;
 	let removed = true;
 	while (removed) {
 		removed = false;
@@ -6978,6 +6987,7 @@ export function ssrTry(
 		entry = stream.boundaries.get(key);
 		if (entry !== undefined) {
 			recordStreamBoundaryMutation(stream, key);
+			if (ownerKeys.length !== 0) recordStreamBoundaryOwners(stream, ownerKeys);
 			entry.namespace = namespace;
 		}
 		if (entry !== undefined && entry.state === 'pending') {
@@ -7209,6 +7219,7 @@ export function ssrTry(
 						};
 						recordStreamBoundaryMutation(stream, key);
 						stream.boundaries.set(key, entry);
+						if (ownerKeys.length !== 0) recordStreamBoundaryOwners(stream, ownerKeys);
 						enterBoundaryIds(pendingIdOffset);
 					} else {
 						ID_COUNTER = entry.pendingIdOffset;
@@ -7273,6 +7284,7 @@ export function ssrTry(
 					};
 					recordStreamBoundaryMutation(stream, key);
 					stream.boundaries.set(key, entry);
+					if (ownerKeys.length !== 0) recordStreamBoundaryOwners(stream, ownerKeys);
 					enterBoundaryIds(pendingIdOffset);
 				} else if (entry.state === 'pending') {
 					entry.state = 'errored';
@@ -7613,6 +7625,7 @@ async function runStream(
 	const resolved: ResolvedMap = newResolvedMap();
 	const stream: StreamState = {
 		boundaries: new Map(),
+		boundaryOwnerKeys: new Set(),
 		nextId: 0,
 		token: createStreamToken(),
 		activePassBoundaryKeys: null,

--- a/packages/octane/tests/ssr-stream-state-regressions.test.ts
+++ b/packages/octane/tests/ssr-stream-state-regressions.test.ts
@@ -152,6 +152,12 @@ const mod = evalServer(
 				<i data-waiting={props.label}>{props.label + ':waiting' as string}</i>
 			}
 		}
+		export function PendingFallbackWithSibling(props) @{
+			<main>
+				<PendingInsideFallback outer={props.outer} inner={props.inner} />
+				<SharedBoundary label="sibling" promise={props.sibling} />
+			</main>
+		}
 		export function SharedAcrossOuterArms(props) @{
 			@try {
 				const outer = use(props.outer);
@@ -538,6 +544,34 @@ describe('SSR stream state regressions', () => {
 		await output.ended;
 		const container = activateChunks(output.chunks);
 		expect(container.querySelector('.outer-ready')!.textContent).toBe('READY');
+		expect(container.querySelector('.fallback-inner-pending')).toBeNull();
+		expect(onError).not.toHaveBeenCalled();
+		container.remove();
+		resetStreamRuntimeGlobals();
+	});
+
+	it('retires a removed fallback boundary without losing an independent sibling', async () => {
+		const outer = deferred<string>();
+		const inner = deferred<string>();
+		const sibling = deferred<string>();
+		const output = collector();
+		const onError = vi.fn();
+		ServerRuntime.renderToPipeableStream(
+			mod.PendingFallbackWithSibling,
+			{ outer: outer.promise, inner: inner.promise, sibling: sibling.promise },
+			{ timeoutMs: 80, onError },
+		).pipe(output.destination);
+
+		sibling.resolve('READY');
+		await vi.waitFor(() => {
+			expect(output.chunks.some((chunk) => chunk.includes('sibling:READY'))).toBe(true);
+		});
+		outer.resolve('OUTER');
+		await output.ended;
+
+		const container = activateChunks(output.chunks);
+		expect(container.querySelector('.outer-ready')!.textContent).toBe('OUTER');
+		expect(container.querySelector('[data-label="sibling"]')!.textContent).toBe('sibling:READY');
 		expect(container.querySelector('.fallback-inner-pending')).toBeNull();
 		expect(onError).not.toHaveBeenCalled();
 		container.remove();


### PR DESCRIPTION
## Summary

- skip descendant-pruning scans for streaming boundaries that cannot own another registered boundary
- retain a conservative per-stream owner index so nested fallback/content cleanup keeps its existing behavior
- add an 800-boundary CPU scenario to keep the superlinear bookkeeping visible

## Why

Completing each independent Suspense sibling called descendant pruning, which scanned the entire boundary registry even though none of those siblings had descendants. A same-wave group of siblings therefore paid quadratic bookkeeping for a relationship that did not exist.

This is separate from the recently merged form diagnostics, generated-name, hydration-template, behavior-event queue, and deopt-list performance changes.

## Changes

- record only owner keys observed on registered nested boundaries
- return from descendant pruning after one `Set.has` for the common independent-sibling case
- preserve the exact scan/prune path whenever a boundary may own descendants
- cover an independent revealed sibling beside a removed nested fallback boundary
- report an 800-card controlled wave in `streaming-ssr`

## Performance

Production bundles from current `origin/main` and this commit were measured A/B/B/A with 5 warmups and 30 timed renders per harness run. For the 800-boundary same-wave case:

- main: 22.58 ms / 20.90 ms total score
- candidate: 12.72 ms / 14.27 ms total score
- paired average: 21.74 ms → 13.50 ms (38% lower)
- semantic control: both emitted 2 chunks, 1,433,265 bytes, and 800 verified card payloads

The 10- and 100-boundary cases remain within observed wall-clock variance; the improvement is intentionally claimed only for the scaling workload that exposes the removed scans.

## Validation

- [ ] `pnpm format:check` (not run; scoped check used)
- [ ] `pnpm typecheck` (not run; scoped check used)
- [ ] `pnpm test` (not run; targeted matrix used)
- [x] `CI=true pnpm format:files:check packages/octane/src/runtime.server.ts packages/octane/tests/ssr-stream-state-regressions.test.ts benchmarks/streaming-ssr/run.mjs benchmarks/streaming-ssr/README.md .changeset/fast-stream-boundary-pruning.md`
- [x] `CI=true pnpm typecheck:files packages/octane/src/runtime.server.ts packages/octane/tests/ssr-stream-state-regressions.test.ts`
- [x] 264 streaming SSR tests in `octane` and `octane-prod`
- [x] new behavior test observed failing in both modes with descendant pruning deliberately disabled
- [x] `TARGETS=octane node benchmarks/streaming-ssr/run.mjs 30 --no-build` against A/B/B/A production bundles
- [x] `CI=true pnpm sync`

## Risk / follow-ups

- the new set is conservative and stream-scoped; replay or pruning may leave stale positives, which can only retain the old scan, not skip required cleanup
- no client runtime path changes; hydration behavior is covered through the streaming matrix

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-only streaming bookkeeping optimization with a conservative owner index; stale set entries only retain old scans, not skip required pruning, and hydration paths are unchanged.
> 
> **Overview**
> Streaming SSR **descendant pruning** no longer walks the full boundary registry when a completed boundary cannot own nested boundaries—the common case for independent Suspense siblings in the same wave.
> 
> `StreamState` now keeps a stream-scoped **`boundaryOwnerKeys`** set, populated when nested boundaries register with non-empty owner chains. **`pruneUnrepresentedStreamDescendants`** returns immediately if the finishing boundary’s key is absent from that set; nested fallback/content cleanup still runs the existing scan when owners were recorded.
> 
> Benchmarks add an **800-card same-wave CPU scenario** (`cpu-800`) so superlinear bookkeeping stays measurable. A regression test covers a **removed nested fallback** beside an independent sibling that resolves first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781d6e1284a611c5534bf925fe2854c7d67a270d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309140&installation_model_id=432790&pr_number=856&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F856&signature=cc7b1d854c91b08924f5020bc28ad77024e68636aab6060761000ebc98f3957f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->