### PR TITLE
perf(octane): skip unnecessary host prop sorts

### DIFF
--- a/.changeset/skip-ordinary-prop-sorts.md
+++ b/.changeset/skip-ordinary-prop-sorts.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip sorting normalized client and server host props when no later raw alias changes their insertion order.

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -2361,6 +2361,7 @@ export function ssrAttrs(
 		string,
 		readonly [name: string, value: unknown, firstOrder: number, lastOrder: number]
 	>();
+	let needsWinningOrderSort = false;
 	for (const writer of props.values()) {
 		const { rawName, value, firstOrder, lastOrder } = writer;
 		if (
@@ -2385,20 +2386,25 @@ export function ssrAttrs(
 		// SVG/MathML retain their case-sensitive qualified names.
 		const identity = namespace === 'html' ? name.toLowerCase() : name;
 		const previous = resolved.get(identity);
-		if (previous === undefined || previous[3] < lastOrder) {
-			resolved.set(identity, [
-				process.env.NODE_ENV !== 'production' && (rawName === 'tabIndex' || rawName === 'htmlFor')
-					? rawName
-					: name,
-				value,
-				firstOrder,
-				lastOrder,
-			]);
+		if (previous !== undefined) {
+			if (previous[3] >= lastOrder) continue;
+			// Map order already matches firstOrder unless a later raw alias replaces
+			// an earlier normalized identity without moving its Map entry.
+			needsWinningOrderSort = true;
 		}
+		resolved.set(identity, [
+			process.env.NODE_ENV !== 'production' && (rawName === 'tabIndex' || rawName === 'htmlFor')
+				? rawName
+				: name,
+			value,
+			firstOrder,
+			lastOrder,
+		]);
 	}
 
 	let out = '';
-	const ordered = [...resolved.values()].sort((a, b) => a[2] - b[2]);
+	const ordered = [...resolved.values()];
+	if (needsWinningOrderSort) ordered.sort((a, b) => a[2] - b[2]);
 	if (process.env.NODE_ENV !== 'production') {
 		devValidateSsrAriaProps(
 			ordered.map(([name]) => name),

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14665,24 +14665,30 @@ export function setHostPropSources(
 		string,
 		readonly [name: string, value: unknown, firstOrder: number, lastOrder: number]
 	>();
+	let needsWinningOrderSort = false;
 	for (const writer of props.values()) {
 		if (writer.rawName === 'key') continue;
 		const [identity, name] = normalizedHostProp(el, writer.rawName);
 		const previous = values.get(identity);
-		if (previous === undefined || previous[3] < writer.lastOrder) {
-			values.set(identity, [
-				process.env.NODE_ENV !== 'production' &&
-				(writer.rawName === 'tabIndex' || writer.rawName === 'htmlFor')
-					? writer.rawName
-					: name,
-				writer.value,
-				writer.firstOrder,
-				writer.lastOrder,
-			]);
+		if (previous !== undefined) {
+			if (previous[3] >= writer.lastOrder) continue;
+			// Map order already matches firstOrder unless a later raw alias replaces
+			// an earlier normalized identity without moving its Map entry.
+			needsWinningOrderSort = true;
 		}
+		values.set(identity, [
+			process.env.NODE_ENV !== 'production' &&
+			(writer.rawName === 'tabIndex' || writer.rawName === 'htmlFor')
+				? writer.rawName
+				: name,
+			writer.value,
+			writer.firstOrder,
+			writer.lastOrder,
+		]);
 	}
 	const resolved: Record<string, unknown> = Object.create(null);
-	const ordered = [...values.values()].sort((a, b) => a[2] - b[2]);
+	const ordered = [...values.values()];
+	if (needsWinningOrderSort) ordered.sort((a, b) => a[2] - b[2]);
 	for (const [name, value] of ordered) resolved[name] = value;
 	const formHost =
 		el.localName === 'input' || el.localName === 'textarea' || el.localName === 'select';

--- a/packages/octane/tests/conformance/server-input-spread-cascade.test.ts
+++ b/packages/octane/tests/conformance/server-input-spread-cascade.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from 'vitest';
 import { createElement } from 'octane';
 import { compile } from 'octane/compiler';
 import { renderToString } from 'octane/server';
-import { loadServerFixture } from '../_server-fixture.js';
+import { loadCompiledFixtureSource, loadServerFixture } from '../_server-fixture.js';
 import { collectPipeableStream } from '../_server-stream.js';
 import * as client from './_fixtures/server-input-spread-cascade.tsrx';
 import { createServerRenderMatrix } from './_helpers/server-render-matrix.js';
@@ -406,6 +406,31 @@ it('preserves arbitrary attribute evaluation order while resolving collisions', 
 // not move its insertion position in the JSX props snapshot.
 it('retains first insertion order when a later direct writer replaces the same prop', () => {
 	expect(renderToString(server.AttributeSpreadOrder).html).toBe('<div a="3" b="2"></div>');
+});
+
+// Distinct raw aliases share one host attribute, but the winning alias keeps
+// its own authored position for coercion and serialization.
+it('orders normalized alias winners by the winning raw prop position', () => {
+	const fixture = loadCompiledFixtureSource(
+		`export function AliasOrder(props) @{ <label htmlFor={props.firstFor} id={props.id} for={props.finalFor}>label</label> }`,
+		{ id: 'server-alias-application-order.tsrx', mode: 'server' },
+	);
+	const log: string[] = [];
+	const value = (label: string) => ({
+		toString() {
+			log.push(label);
+			return label;
+		},
+	});
+
+	expect(
+		renderToString(fixture.AliasOrder, {
+			firstFor: value('overwritten htmlFor'),
+			id: value('id'),
+			finalFor: value('final for'),
+		}).html,
+	).toBe('<label id="id" for="final for">label</label>');
+	expect(log).toEqual(['id', 'final for']);
 });
 
 // Per ReactJSXTransformIntegration-test.js:95. `children` participates in JSX


### PR DESCRIPTION
## Summary

- skip sorting resolved client and server host props when their `Map` insertion order is already the required authored order
- retain the sort when a later raw alias (for example `htmlFor` / `for`) replaces an earlier normalized identity
- add server regression coverage for alias winner serialization and coercion order
- add an `octane` patch changeset

## Why

Every spread-bearing host render copied normalized props into an array and sorted it, even though ordinary props have no normalized collisions and JavaScript `Map` insertion order already matches their first-authored order. Sorting is only required in the uncommon case where a later raw alias wins without moving the existing normalized `Map` entry.

This is separate from the recent form-diagnostic, stream-boundary, route-metadata, hydration-template, behavior-queue, deopt-list, and compiler-name performance work.

## Performance

Production SSR bundles were measured with the same warmed, adaptive microharness, 9 samples per process, in alternating baseline/candidate process order. The harness renders spread-bearing hosts 1,000 times per measurement and verifies identical serialized bytes and attribute counts.

| Resolved attributes | Baseline | Candidate | Change |
| ---: | ---: | ---: | ---: |
| 8 | 1.704 ms / 1k | 1.601 ms / 1k | -6.0% |
| 32 | 6.936 ms / 1k | 6.543 ms / 1k | -5.7% |
| 128 | 28.333 ms / 1k | 27.617 ms / 1k | -2.5% |
| 32 + forced alias collision | 8.123 ms / 1k | 8.093 ms / 1k | -0.4% |

The forced-alias case is the negative control: it still takes the sort branch and stays effectively flat. Bundle impact is +32 minified bytes in each production bundle (+17 gzip client, +16 gzip server).

## Validation

- `CI=true pnpm sync`
- `CI=true pnpm format:files:check packages/octane/src/runtime.ts packages/octane/src/runtime.server.ts packages/octane/tests/conformance/server-input-spread-cascade.test.ts .changeset/skip-ordinary-prop-sorts.md`
- `CI=true pnpm exec tsrx-tsc --noEmit -p packages/octane/tsconfig.json`
- `CI=true pnpm exec vitest run packages/octane/tests/conformance/client-host-source-aggregation.test.ts packages/octane/tests/conformance/server-input-spread-cascade.test.ts --reporter=dot` (4 files, 90 tests)
- regression test was observed failing in both `octane` and `octane-prod` when the alias-order sort was deliberately removed

## Risk

Low. The existing ordering array and downstream client/SSR behavior remain unchanged. A local boolean only skips `Array#sort` when no winning normalized collision occurred; any winning alias collision preserves the old sort path.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged when alias collisions occur (sort still runs); the change only avoids sort on the common no-collision path in spread-heavy host rendering.
> 
> **Overview**
> **Client and server host prop merging** no longer always sorts normalized props by `firstOrder` after building the resolved `Map`. A `needsWinningOrderSort` flag turns sorting on only when a later raw alias (e.g. `for` after `htmlFor`) wins over an existing normalized identity without moving that entry—otherwise iteration order is used as-is.
> 
> The merge loop now always writes the winning prop when `lastOrder` beats the previous winner, instead of skipping updates inside a single conditional branch.
> 
> A server conformance test asserts alias winner serialization and **coercion order** (`id` before the winning `for` value) for compiled JSX with `htmlFor` / `for` collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef9d563a0a116c37814d2ef041ca82985048158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790324731&installation_model_id=432790&pr_number=858&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F858&signature=0fb803f3f5d0c7f1b23c51a8c118aa3a1355b44b55c194b1649ad636ac41d284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->