### PR TITLE
perf(compiler): propagate memo witnesses incrementally

### DIFF
--- a/.changeset/expose-tsrx-component-graph-benchmark.md
+++ b/.changeset/expose-tsrx-component-graph-benchmark.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/mcp-server': patch
+---
+
+Expose the TSrX component-graph compilation benchmark through the MCP benchmark tool.

--- a/.changeset/fast-tsrx-component-graphs.md
+++ b/.changeset/fast-tsrx-component-graphs.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Speed up production TSrX compilation for deep same-module component graphs by propagating automatic-memoization witnesses incrementally.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -238,6 +238,7 @@ internally, get their own baseline and guard namespace.
 | `codegen-size` | codegen-size | none (Node-only) | compiled-output bytes: fixed corpus through octane/compiler, raw/min/gzip, `compiled` vs `source` |
 | `hook-memo` | hook-memo | none (Node-only) | production hook-memo compiler on/off, clean semantic controls, deterministic function/array creation events, and compiled/bundled bytes |
 | `compiler-throughput` | compiler-throughput | none (Node-only) | six real production compiler pipelines, cold/warm/incremental transformations, 10/100/1,000 components, and heap diagnostics |
+| `tsrx-component-graph` | tsrx-component-graph | none (Node-only) | 2,400-component live-import propagation with dependent-first vs dependency-first declarations |
 | `bundle-size` | bundle-size | none (builds) | shipped JS bytes: production builds of js-framework, TodoMVC, chat-stream, and weather-app, normalized minify, raw/gzip/brotli |
 | `bundle-reachability` | bundle-size | none (builds and executes in jsdom) | isolated public feature imports, exact production-bundle behavior, forbidden-module reachability, and committed raw/gzip/brotli budgets |
 | `three-renderer` | three | Octane Three, R3F, plain Three | 1,000-object lifecycle, reconstruction/disposal, frame subscribers, and raycast events |

--- a/benchmarks/baselines/local/tsrx-component-graph.json
+++ b/benchmarks/baselines/local/tsrx-component-graph.json
@@ -1,0 +1,59 @@
+{
+  "suite": "tsrx-component-graph",
+  "iterations": 8,
+  "targets": [
+    {
+      "name": "dependent-first",
+      "ops": {
+        "compile": {
+          "score": 547.9454081999996,
+          "median": 573.0002910000003,
+          "min": 497.684874999999,
+          "mean": 554.2704999999996,
+          "p95": 593.553042,
+          "sd": 34.6998367642841,
+          "rme": 5.234700256566655,
+          "scoreRme": 8.070372100966491,
+          "warmupRatio": 1.02152884799008,
+          "samples": 8,
+          "p99": 593.553042
+        }
+      },
+      "meta": {
+        "components": 2400,
+        "callEdges": 2399,
+        "liveBindingWitnesses": 2399,
+        "sourceBytes": 139419,
+        "outputBytes": 2101978,
+        "correctness": "pass"
+      }
+    },
+    {
+      "name": "dependency-first",
+      "ops": {
+        "compile": {
+          "score": 568.8790668000004,
+          "median": 557.7939589999996,
+          "min": 538.6395000000002,
+          "mean": 569.1891512500002,
+          "p95": 633.2404169999991,
+          "sd": 34.540953307324955,
+          "rme": 5.074156494518103,
+          "scoreRme": 8.094480463119899,
+          "warmupRatio": 0.9881976968536257,
+          "samples": 8,
+          "p99": 633.2404169999991
+        }
+      },
+      "meta": {
+        "components": 2400,
+        "callEdges": 2399,
+        "liveBindingWitnesses": 2399,
+        "sourceBytes": 139419,
+        "outputBytes": 2064782,
+        "correctness": "pass"
+      }
+    }
+  ],
+  "harnessExit": 0
+}

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -3070,5 +3070,13 @@
     "reference": "activity-bundle-model",
     "maxRatio": 0,
     "note": "The executed ordinary production bundle must tree-shake the optional Activity implementation. The shared reachability oracle verifies actual behavior before the diagnostic is accepted; existing bundle byte budgets are not loosened."
+  },
+  {
+    "suite": "tsrx-component-graph",
+    "op": "compile",
+    "target": "dependent-first",
+    "reference": "dependency-first",
+    "maxRatio": 1.25,
+    "note": "A 2,400-component live-import chain declared root-first must stay within 25% of the same graph declared leaf-first. Both orders verify every transitive witness and alternate measurement order; whole-module fixed-point rescans were about 2x slower."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -732,6 +732,13 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		name: 'tsrx-component-graph',
+		cwd: 'tsrx-component-graph',
+		servers: [],
+		iter: { normal: 8, quick: 4 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Shipped-bytes comparison (Node-only): production `vite build` of each
 		// js-framework app with ONE normalized minify setting, reporting raw/gzip/
 		// brotli JS bytes per framework. Deterministic; the iteration knob is unused.

--- a/benchmarks/tsrx-component-graph/README.md
+++ b/benchmarks/tsrx-component-graph/README.md
@@ -1,0 +1,23 @@
+# TSrX component graph compilation
+
+This Node-only suite compiles the same 2,400-component production TSrX graph in
+two declaration orders. Every component wraps the next component, and the leaf
+reads one live import. The compiler must carry that import witness through all
+2,399 same-module call edges so automatic memoization cannot hide a later live
+binding update.
+
+`dependent-first` declares the exported root before its dependencies. A graph
+analysis should not care about that ordinary function-hoisting choice.
+`dependency-first` declares the leaf first and is the same-machine reference.
+Both variants require zero diagnostics and exactly 2,399 emitted live-binding
+witnesses before their samples count.
+
+```bash
+node benchmarks/bench.mjs --quick --ratios tsrx-component-graph
+node benchmarks/bench.mjs tsrx-component-graph
+```
+
+The ratio guard allows timing noise but rejects a return to whole-module fixed
+point rescans, whose work grows with both component count and dependency depth.
+`OCTANE_GRAPH_ROOT=/path/to/checkout` selects a different compiler checkout for
+an A/B run while retaining this exact harness and fixture generator.

--- a/benchmarks/tsrx-component-graph/run.mjs
+++ b/benchmarks/tsrx-component-graph/run.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_ROOT = process.env.OCTANE_GRAPH_ROOT
+	? path.resolve(process.env.OCTANE_GRAPH_ROOT)
+	: path.resolve(HERE, '../..');
+const { compile } = await import(
+	pathToFileURL(path.join(SOURCE_ROOT, 'packages/octane/src/compiler/index.js')).href
+);
+const COMPONENTS = 2_400;
+const iterations = Number.parseInt(process.argv[2] ?? '8', 10);
+const options = { mode: 'client', hmr: false, dev: false, autoMemo: true };
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('TSrX component graph iterations must be a positive integer');
+}
+
+function sourceFor(reverse) {
+	const declarations = Array.from({ length: COMPONENTS }, (_, index) => {
+		const body = index === COMPONENTS - 1 ? '{live as string}' : `<Component${index + 1} />`;
+		return `${index === 0 ? 'export ' : ''}function Component${index}() @{ <div>${body}</div> }`;
+	});
+	if (reverse) declarations.reverse();
+	return `import { live } from './live';\n${declarations.join('\n')}`;
+}
+
+const variants = [
+	{ name: 'dependent-first', source: sourceFor(false), samples: [] },
+	{ name: 'dependency-first', source: sourceFor(true), samples: [] },
+];
+
+function compileVariant(variant) {
+	const started = performance.now();
+	const result = compile(variant.source, `${variant.name}.tsrx`, options);
+	const elapsed = performance.now() - started;
+	const witnesses = result.code.match(/const __memoDep[\w$]* = live;/g)?.length ?? 0;
+	assert.equal(result.diagnostics.length, 0, `${variant.name} emitted compiler diagnostics`);
+	assert.equal(
+		witnesses,
+		COMPONENTS - 1,
+		`${variant.name} did not preserve every transitive live-binding witness`,
+	);
+	variant.meta = {
+		components: COMPONENTS,
+		callEdges: COMPONENTS - 1,
+		liveBindingWitnesses: witnesses,
+		sourceBytes: Buffer.byteLength(variant.source),
+		outputBytes: Buffer.byteLength(result.code),
+		correctness: 'pass',
+	};
+	return elapsed;
+}
+
+let failure;
+const rows = [];
+
+try {
+	for (let warmup = 0; warmup < 2; warmup++) {
+		for (const variant of warmup % 2 === 0 ? variants : variants.toReversed()) {
+			compileVariant(variant);
+		}
+	}
+
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		for (const variant of iteration % 2 === 0 ? variants : variants.toReversed()) {
+			variant.samples.push(compileVariant(variant));
+		}
+	}
+
+	for (const variant of variants) {
+		const compileStat = timingStatForJson(summarizeSamples(variant.samples), { p99: true });
+		rows.push({ name: variant.name, ops: { compile: compileStat }, meta: variant.meta });
+		console.log(
+			`PASS tsrx-component-graph/${variant.name}: ${compileStat.score.toFixed(3)}ms ` +
+				`for ${COMPONENTS} components`,
+		);
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL tsrx-component-graph/${failure}`);
+}
+
+const payload = {
+	suite: 'tsrx-component-graph',
+	iterations,
+	targets: rows,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+
+if (failure) process.exitCode = 1;

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -164,8 +164,8 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `scheduler-responsiveness`, `suspense-recovery`, `event-delegation`,
 `application-composition`, `scaling-curves`, `dev-form-diagnostics`,
 `behavior-root-events`, `activity`, `streaming-ssr`, `streaming-backpressure`,
-`compiler-throughput`, `codegen-size`, `hook-memo`, `bundle-size`,
-`bundle-reachability`, `three-renderer`, `three-bundle-size`, …)
+`compiler-throughput`, `tsrx-component-graph`, `codegen-size`, `hook-memo`,
+`bundle-size`, `bundle-reachability`, `three-renderer`, `three-bundle-size`, …)
 or every suite with `all`; `quick` selects the reduced-iteration smoke pass. The
 suite list mirrors the runner manifest and `node benchmarks/bench.mjs --list`.
 

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -96,6 +96,7 @@ export const BENCHMARK_SUITES = [
 	'codegen-size',
 	'hook-memo',
 	'compiler-throughput',
+	'tsrx-component-graph',
 	'bundle-size',
 	'bundle-reachability',
 	'three-renderer',

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8891,37 +8891,84 @@ function compileInternal(
 			}
 		}
 	}
-	// Pull live imported captures through the safe same-module call graph. This
-	// is a second fixed point because A -> B -> C chains and pure recursion may
-	// be declared in any order.
-	let autoMemoCapturesChanged = true;
-	while (autoMemoCapturesChanged) {
-		autoMemoCapturesChanged = false;
-		for (const [, info] of ctx.componentInfo) {
-			if (!info.autoMemoSafe) continue;
-			const captures = new Set(info.autoMemoCaptures);
-			const importedComponents = new Set(info.autoMemoImportedComponents);
-			let mayReadContext = info.autoMemoMayReadContext;
-			for (const name of info.autoMemoComponentDeps) {
-				const child = ctx.componentInfo.get(name);
-				if (!child?.autoMemoSafe) continue;
-				for (const capture of child.autoMemoCaptures) captures.add(capture);
-				for (const component of child.autoMemoImportedComponents) {
-					importedComponents.add(component);
-				}
-				if (child.autoMemoMayReadContext) mayReadContext = true;
-			}
-			if (
-				captures.size !== info.autoMemoCaptures.length ||
-				importedComponents.size !== info.autoMemoImportedComponents.length ||
-				mayReadContext !== info.autoMemoMayReadContext
-			) {
-				info.autoMemoCaptures = [...captures].sort();
-				info.autoMemoImportedComponents = [...importedComponents].sort();
-				info.autoMemoMayReadContext = mayReadContext;
-				autoMemoCapturesChanged = true;
-			}
+	// Pull live imported captures through the safe same-module call graph. Work
+	// flows from a dependency to its dependents, so declaration order cannot turn
+	// an A -> B -> C chain into one whole-module scan per edge. Pending deltas also
+	// let recursive components converge without repeatedly copying settled sets.
+	const autoMemoDependents = new Map();
+	const autoMemoPropagation = new Map();
+	const autoMemoQueue = [];
+	const enqueueAutoMemo = (name, state) => {
+		if (state.queued) return;
+		state.queued = true;
+		autoMemoQueue.push(name);
+	};
+	for (const [name, info] of ctx.componentInfo) {
+		if (!info.autoMemoSafe) continue;
+		const state = {
+			captures: new Set(info.autoMemoCaptures),
+			importedComponents: new Set(info.autoMemoImportedComponents),
+			mayReadContext: info.autoMemoMayReadContext,
+			pendingCaptures: [...info.autoMemoCaptures],
+			pendingImportedComponents: [...info.autoMemoImportedComponents],
+			pendingContext: info.autoMemoMayReadContext,
+			queued: false,
+		};
+		autoMemoPropagation.set(name, state);
+		if (
+			state.pendingCaptures.length > 0 ||
+			state.pendingImportedComponents.length > 0 ||
+			state.pendingContext
+		) {
+			enqueueAutoMemo(name, state);
 		}
+		for (const dependency of info.autoMemoComponentDeps) {
+			if (ctx.componentInfo.get(dependency)?.autoMemoSafe !== true) continue;
+			let dependents = autoMemoDependents.get(dependency);
+			if (dependents === undefined) {
+				autoMemoDependents.set(dependency, (dependents = []));
+			}
+			dependents.push(name);
+		}
+	}
+	for (let index = 0; index < autoMemoQueue.length; index++) {
+		const name = autoMemoQueue[index];
+		const state = autoMemoPropagation.get(name);
+		state.queued = false;
+		const pendingCaptures = state.pendingCaptures;
+		const pendingImportedComponents = state.pendingImportedComponents;
+		const pendingContext = state.pendingContext;
+		state.pendingCaptures = [];
+		state.pendingImportedComponents = [];
+		state.pendingContext = false;
+		for (const dependent of autoMemoDependents.get(name) ?? []) {
+			const dependentState = autoMemoPropagation.get(dependent);
+			let changed = false;
+			for (const capture of pendingCaptures) {
+				if (dependentState.captures.has(capture)) continue;
+				dependentState.captures.add(capture);
+				dependentState.pendingCaptures.push(capture);
+				changed = true;
+			}
+			for (const component of pendingImportedComponents) {
+				if (dependentState.importedComponents.has(component)) continue;
+				dependentState.importedComponents.add(component);
+				dependentState.pendingImportedComponents.push(component);
+				changed = true;
+			}
+			if (pendingContext && !dependentState.mayReadContext) {
+				dependentState.mayReadContext = true;
+				dependentState.pendingContext = true;
+				changed = true;
+			}
+			if (changed) enqueueAutoMemo(dependent, dependentState);
+		}
+	}
+	for (const [name, state] of autoMemoPropagation) {
+		const info = ctx.componentInfo.get(name);
+		info.autoMemoCaptures = [...state.captures].sort();
+		info.autoMemoImportedComponents = [...state.importedComponents].sort();
+		info.autoMemoMayReadContext = state.mayReadContext;
 	}
 	if (ctx.autoMemo) {
 		classifyStableHookfulChildCalls(ast.body, ctx);

--- a/packages/octane/tests/_fixtures/auto-memo-child.tsrx
+++ b/packages/octane/tests/_fixtures/auto-memo-child.tsrx
@@ -2,10 +2,10 @@ import { createContext, memo, useContext, useState } from 'octane';
 
 export const AutoMemoContext = createContext('t0');
 
-let opaqueVersion = 0;
+export let autoMemoOpaqueVersion = 0;
 
 export function bumpAutoMemoOpaqueVersions(): void {
-	opaqueVersion++;
+	autoMemoOpaqueVersion++;
 }
 
 function ChildImpl(props) @{
@@ -21,18 +21,18 @@ function ChildImpl(props) @{
 export const AutoMemoChild = memo(ChildImpl);
 
 export function AutoMemoOpaqueChild() @{
-	<span class="opaque">{'opaque ' + opaqueVersion}</span>
+	<span class="opaque">{'opaque ' + autoMemoOpaqueVersion}</span>
 }
 
 export function AutoMemoOpaqueReturned() {
 	return <>
-		<span class="returned-opaque-a">{'returned opaque a ' + opaqueVersion}</span>
-		<span class="returned-opaque-b">{'returned opaque b ' + opaqueVersion}</span>
+		<span class="returned-opaque-a">{'returned opaque a ' + autoMemoOpaqueVersion}</span>
+		<span class="returned-opaque-b">{'returned opaque b ' + autoMemoOpaqueVersion}</span>
 	</>;
 }
 
 function CustomChildImpl() @{
-	<span class="custom">{'custom ' + opaqueVersion}</span>
+	<span class="custom">{'custom ' + autoMemoOpaqueVersion}</span>
 }
 
 export const AutoMemoCustomChild = memo(CustomChildImpl, () => false);

--- a/packages/octane/tests/_fixtures/auto-memo.tsrx
+++ b/packages/octane/tests/_fixtures/auto-memo.tsrx
@@ -5,8 +5,27 @@ import {
 	AutoMemoCustomChild,
 	AutoMemoOpaqueChild,
 	AutoMemoOpaqueReturned,
+	autoMemoOpaqueVersion,
 	bumpAutoMemoOpaqueVersions,
 } from './auto-memo-child.tsrx';
+
+// Parent-first declarations force the compiler's same-module graph proof to
+// carry the leaf's live import through more than one dependency hop.
+function TransitiveLiveOuter() @{
+	<div>
+		<TransitiveLiveMiddle />
+	</div>
+}
+
+function TransitiveLiveMiddle() @{
+	<div>
+		<TransitiveLiveLeaf />
+	</div>
+}
+
+function TransitiveLiveLeaf() @{
+	<span id="auto-transitive-live">{'transitive ' + autoMemoOpaqueVersion}</span>
+}
 
 // A pure, same-module component region. Production compilation caches callers
 // the whole list by the `items` capture and reuse its full Block on equal deps.
@@ -102,5 +121,6 @@ export function AutoMemoApp() @{
 		<CustomRows />
 		<OpaqueRows />
 		<ReturnedOpaque />
+		<TransitiveLiveOuter />
 	</div>
 }

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -1459,6 +1459,9 @@ describe('compiler-owned component-region memoization', () => {
 	it('preserves dependency, context, child-state, and custom-comparator behavior', () => {
 		const root = mount(AutoMemoApp);
 		const initialOpaqueVersion = trailingVersion(root.find('.opaque').textContent);
+		const initialTransitiveVersion = trailingVersion(
+			root.find('#auto-transitive-live').textContent,
+		);
 		expect(root.find('.own-1').textContent).toBe('t0:a:0');
 		// The destructured-param twin renders through the same cached-region
 		// machinery and must be behaviorally indistinguishable from the
@@ -1474,6 +1477,9 @@ describe('compiler-owned component-region memoization', () => {
 		expect(trailingVersion(root.find('.custom').textContent)).toBe(initialOpaqueVersion + 1);
 		expect(trailingVersion(root.find('.returned-opaque-a').textContent)).toBe(
 			initialOpaqueVersion + 1,
+		);
+		expect(trailingVersion(root.find('#auto-transitive-live').textContent)).toBe(
+			initialTransitiveVersion + 1,
 		);
 
 		root.click('.own-1');


### PR DESCRIPTION
## Summary

- Replace production TSrX auto-memo witness fixed-point rescans with reverse-edge incremental propagation.
- Preserve live imported bindings, imported-component witnesses, and context-read facts through declaration-order-independent and recursive same-module component graphs.
- Add behavior coverage plus a 2,400-component benchmark, committed baseline, and declaration-order ratio guard.
- Expose the new benchmark through the MCP benchmark tool.

## Why

The compiler repeatedly scanned every component and recopied settled witness sets until a same-module call graph converged. A root-first chain therefore needed one whole-module pass per graph hop, making an ordinary declaration order quadratic for stupid reasons.

The replacement builds dependency-to-dependent edges once and forwards only newly discovered facts through a worklist. Its work follows graph edges and facts instead of rescanning unrelated components.

This is distinct from recent performance PRs for nesting diagnostics (#857), host-prop sorting (#858), stream boundaries (#856), form diagnostics (#851), generated names (#850), hydration templates (#845), behavior events (#843), and deopt upgrades (#842).

## Performance

The same harness compiled a 2,400-component chain from exact `origin/main` (`7e6236112`) and this branch in paired A/B/B/A process order. Every sample required zero diagnostics and all 2,399 transitive live-binding witnesses.

| Declaration order | Main paired mean | Candidate paired mean | Change |
| --- | ---: | ---: | ---: |
| dependent-first (root first) | 1,211.396 ms | 596.917 ms | -50.7% |
| dependency-first control | 634.665 ms | 613.622 ms | -3.3% |

The final idle candidate baseline recorded 547.945 ms dependent-first and 568.879 ms dependency-first. The committed guard requires the root-first case to stay within 1.25x of its leaf-first control; the old implementation was about 1.9x.

Generated code and diagnostics were byte-identical before and after for empty, direct, cyclic, diamond-capture, context, imported-component, unsafe-child, and empty-recursive-cycle cases.

## Validation

- [x] `CI=true pnpm sync` (clean)
- [x] `CI=true pnpm run typecheck`
- [x] scoped formatting for every changed file
- [x] `packages/octane/tests/compiler`: 42 files, 1,351 tests passed
- [x] `packages/octane/tests/auto-memo.test.ts`: 2 files, 248 tests passed
- [x] `packages/octane-mcp-server/src/index.test.js`: 1 file, 15 tests passed
- [x] `node benchmarks/bench.mjs --quick --ratios tsrx-component-graph`
- [x] regression test observed failing in production when transitive capture forwarding was deliberately disabled, then passing after restoration
- [ ] `CI=true pnpm run test`: attempted locally; the broad run accumulated unrelated unavailable-localStorage/browser-host failures and load-sensitive integration timeouts. It did expose one relevant MCP benchmark-manifest omission, which was fixed and its complete suite rerun green. Current-head CI remains authoritative for the full matrix.

## Risk

The change is confined to compiler metadata propagation before lowering. It does not mutate the parser AST or change runtime code. Final witness arrays retain their existing sorted order, and adversarial output comparisons are byte-identical. Cycles converge because only unseen deltas enter the queue.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790326647&installation_model_id=432790&pr_number=859&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F859&signature=6a4760eb7629a40f5796898566527fd1c082d622636b3b5d9334acc2bf376fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler-only auto-memo metadata before lowering; output is intended to stay byte-identical, but incorrect propagation could change memoization safety or emitted witnesses.
> 
> **Overview**
> Replaces the production TSrX **auto-memo** pass that repeatedly rescanned every same-module component until live-binding witnesses converged with **dependency→dependent worklist propagation**, so deep chains (especially root-first declaration order) no longer pay roughly one full-module scan per hop.
> 
> Adds regression coverage: a **2,400-component** `tsrx-component-graph` benchmark (dependent-first vs dependency-first), committed baseline, a **1.25×** declaration-order ratio guard, MCP `octane_benchmark` wiring, and auto-memo tests for **transitive live imports** across multiple same-module hops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a79f2fa4d42c250df7b10e6b9b4475e4c09f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->