### PR TITLE
perf(lynx): drain reentrant commits linearly

### DIFF
--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1968,6 +1968,14 @@
     "note": "First real native tap after the identical 10,000-row mount. A 21-sample run measured Octane 7.62 ms vs ReactLynx 9.06 ms (0.84x); the guard prevents mount work from moving into the first interaction."
   },
   {
+    "suite": "lynx-render",
+    "op": "drain_ms",
+    "target": "octane-lynx-reentrant-20k",
+    "reference": "octane-lynx-reentrant-10k",
+    "maxRatio": 3.5,
+    "note": "Same-run scaling guard for commits queued synchronously during Element PAPI reentry. Matched 5-sample runs measured the cursor drain at 113.9 / 56.4 = 2.02x; the former front-shift drain measured 249.2 / 56.3 = 4.43x."
+  },
+  {
     "suite": "lynx-bundle-size",
     "op": "bundle_gzip",
     "target": "octane-ifr",

--- a/benchmarks/lynx-render/README.md
+++ b/benchmarks/lynx-render/README.md
@@ -25,6 +25,10 @@ Targets:
   a fully settled mount, including the resulting state and visible-tree update.
   This prevents mount optimizations from merely deferring their work to the
   first user interaction.
+- `drain_ms` on `octane-lynx-reentrant-{10k,20k}` — an Octane-only transport
+  scaling pair that queues a synchronous commit burst from inside one Element
+  PAPI update. Every version must be acknowledged and completed in order, and
+  the final native host must expose the last queued value.
 
 Each 1,000-row sample must create exactly 9,008 reachable host nodes and install
 2,000 native event tokens; 10,000-row samples must create 90,008 nodes and
@@ -34,6 +38,9 @@ order while ignoring allocation order and Octane's renderer-private ref
 selectors. Both targets must also deliver three real native taps through
 `lynxCoreInject.tt.publishEvent`, exercising separate row handlers and state
 updates, and produce matching visible trees after each interaction.
+The reentrant transport pair is intentionally not compared with ReactLynx: it
+exercises Octane's public wire protocol directly and guards 20,000 commits
+against the same-run 10,000-commit baseline to catch superlinear queue drains.
 After each timed Octane mount, the harness also verifies that every keyed row
 used the same compiled nine-host program in one batched run, that host and
 listener identities were derived from contiguous ranges, and that the entire

--- a/benchmarks/lynx-render/run.mjs
+++ b/benchmarks/lynx-render/run.mjs
@@ -177,6 +177,23 @@ try {
 		}
 	}
 
+	function validateReentrantCommits(count, result) {
+		const target = `octane-lynx-reentrant-${count / 1_000}k`;
+		if (result.diagnostics.length !== 0) {
+			failures.push(`${target}: ${result.diagnostics.join(' | ')}`);
+		}
+		if (result.acknowledgements !== count + 2 || result.completions !== count + 2) {
+			failures.push(
+				`${target}: received ${result.acknowledgements} acknowledgements and ${result.completions} completions, expected ${count + 2} of each.`,
+			);
+		}
+		if (result.finalVersion !== count + 2 || result.finalId !== `queued-${count - 1}`) {
+			failures.push(
+				`${target}: finished at version ${result.finalVersion ?? 'missing'} with id ${JSON.stringify(result.finalId)}, expected version ${count + 2} and id ${JSON.stringify(`queued-${count - 1}`)}.`,
+			);
+		}
+	}
+
 	function run(framework, scenario) {
 		if (scenario.rows === null) return framework.workload.runEmptyStartup();
 		return scenario.op.startsWith('update_')
@@ -209,6 +226,30 @@ try {
 					...(result.transport === undefined ? null : { transport: result.transport }),
 				};
 			}
+		}
+	}
+
+	const reentrantCommitCases = [10_000, 20_000];
+	for (const count of reentrantCommitCases) {
+		validateReentrantCommits(count, workload.runReentrantCommits(count));
+	}
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		const ordered =
+			iteration % 2 === 0 ? reentrantCommitCases : [...reentrantCommitCases].reverse();
+		for (const count of ordered) {
+			const result = workload.runReentrantCommits(count);
+			validateReentrantCommits(count, result);
+			const target = record(
+				`octane-lynx-reentrant-${count / 1_000}k`,
+				'drain_ms',
+				result.durationMs,
+			);
+			target.meta = {
+				acknowledgements: result.acknowledgements,
+				completions: result.completions,
+				finalId: result.finalId,
+				finalVersion: result.finalVersion,
+			};
 		}
 	}
 

--- a/benchmarks/lynx-render/workload.ts
+++ b/benchmarks/lynx-render/workload.ts
@@ -14,6 +14,12 @@ import type {
 	LynxContextProxy,
 	LynxContextProxyEvent,
 } from '../../packages/lynx/src/core/protocol.js';
+import {
+	LYNX_BACKGROUND_TO_MAIN_EVENT,
+	LYNX_MAIN_TO_BACKGROUND_EVENT,
+	LYNX_TRANSPORT_PROTOCOL_VERSION,
+	LYNX_TRANSPORT_RENDERER,
+} from '../../packages/lynx/src/core/protocol.js';
 import type { LynxElementEventListener } from '../../packages/lynx/src/core/papi.js';
 import { BenchApp, EmptyApp, type BenchRow } from './src/App.lynx.tsrx';
 
@@ -78,6 +84,7 @@ export class FakeElementPAPI {
 	readonly nodes = new Map<number, FakeNode>();
 	flushes = 0;
 	createdElements = 0;
+	onSetId: ((node: FakeNode, value: string | null) => void) | null = null;
 
 	private create(type: string, text = ''): FakeNode {
 		const sign = this.nextSign++;
@@ -159,6 +166,7 @@ export class FakeElementPAPI {
 			},
 			__SetID: (node: FakeNode, id: string | null) => {
 				node.id = id;
+				this.onSetId?.(node, id);
 			},
 			__FlushElementTree: () => {
 				this.flushes++;
@@ -232,6 +240,13 @@ export class FakeElementPAPI {
 			if (node.attributes?.has('octane-ref') === true) count++;
 		}
 		return count;
+	}
+
+	rootChildId(): string | null {
+		const page = [...this.nodes.values()].find(
+			(node) => node.type === 'page' && node.parent === null,
+		);
+		return page?.children[0]?.id ?? null;
 	}
 }
 
@@ -329,6 +344,76 @@ export interface LynxTransportMetrics {
 	readonly legacyCreates: number;
 	readonly acknowledgements: number;
 	readonly compactAcknowledgements: number;
+}
+
+export interface ReentrantCommitResult {
+	readonly durationMs: number;
+	readonly acknowledgements: number;
+	readonly completions: number;
+	readonly finalId: string | null;
+	readonly finalVersion: number | undefined;
+	readonly diagnostics: readonly string[];
+}
+
+/** Drain a synchronous burst queued reentrantly during one native host update. */
+export function runReentrantCommits(count: number): ReentrantCommitResult {
+	if (!Number.isSafeInteger(count) || count <= 0) {
+		throw new TypeError(
+			`Reentrant commit count must be a positive safe integer, received ${count}.`,
+		);
+	}
+	const contexts = createContextPair();
+	const papi = new FakeElementPAPI();
+	const diagnostics: Error[] = [];
+	let acknowledgements = 0;
+	let completions = 0;
+	const main = installLynxMainThread({
+		target: papi.globals(),
+		context: contexts.main,
+		onDiagnostic: (error) => diagnostics.push(error),
+	});
+	contexts.background.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+		const type = (event.data as { readonly type?: unknown }).type;
+		if (type === 'ack') acknowledgements++;
+		else if (type === 'complete') completions++;
+	});
+	const dispatchCommit = (version: number, commands: readonly Record<string, unknown>[]): void => {
+		contexts.background.dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				root: 1,
+				version,
+				type: 'commit',
+				batch: { renderer: LYNX_TRANSPORT_RENDERER, version, commands },
+			},
+		});
+	};
+	dispatchCommit(1, [
+		{ op: 'create', id: 1, type: 'view', props: { id: 'initial' } },
+		{ op: 'insert', parent: null, id: 1, before: null },
+	]);
+	papi.onSetId = () => {
+		papi.onSetId = null;
+		for (let index = 0; index < count; index++) {
+			dispatchCommit(index + 3, [{ op: 'update', id: 1, props: { id: `queued-${index}` } }]);
+		}
+	};
+	const started = performance.now();
+	dispatchCommit(2, [{ op: 'update', id: 1, props: { id: 'outer' } }]);
+	const durationMs = performance.now() - started;
+	const finalVersion = main.activeIdentity()?.version;
+	const finalId = papi.rootChildId();
+	main.close();
+	return {
+		durationMs,
+		acknowledgements,
+		completions,
+		finalId,
+		finalVersion,
+		diagnostics: diagnostics.map((error) => error.message),
+	};
 }
 
 function transportMetrics(harness: Harness): LynxTransportMetrics {

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -603,7 +603,9 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let deferredFirstTreeCapabilities: LynxMainThreadCapabilities | undefined;
 	let firstTreeSnapshotSent = false;
 	let uninstallFirstScreenHost: (() => void) | null = null;
-	const queuedCommits: LynxCommitMessage[] = [];
+	// Reentrant PAPI work can enqueue a large burst; consumed slots are tombstoned
+	// so the drain stays linear without retaining every processed message.
+	const queuedCommits: Array<LynxCommitMessage | undefined> = [];
 	const queuedNativeEvents: Array<readonly LynxQueuedNativeEventDelivery[]> = [];
 	const queuedLifecycleMessages: LynxLifecycleMessage[] = [];
 	const queuedReadyRequests = new Set<number>();
@@ -2330,6 +2332,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		commitInProgress = true;
 		try {
 			let next: LynxCommitMessage | undefined = message;
+			let queuedIndex = 0;
 			do {
 				handleCommitExclusive(next, {
 					protocol: next.protocol,
@@ -2341,8 +2344,14 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 					queuedCommits.length = 0;
 					break;
 				}
-				next = queuedCommits.shift();
+				if (queuedIndex === queuedCommits.length) {
+					next = undefined;
+				} else {
+					next = queuedCommits[queuedIndex];
+					queuedCommits[queuedIndex++] = undefined;
+				}
 			} while (next !== undefined);
+			queuedCommits.length = 0;
 		} catch (error) {
 			// A response delivery failure terminally tears down the background
 			// transport. Do not replay commits it dispatched reentrantly before


### PR DESCRIPTION
## Summary

- drain synchronous reentrant Lynx commits with a cursor instead of repeated front shifts
- add a real-path 10k/20k scaling benchmark and ratio guard

## Why

- front-shifting the queue copied its remaining tail on every commit, making large reentrant bursts quadratic
- matched five-sample runs reduced 20k from 249.2 ms to 113.9 ms (54.3%) and scaling from 4.43x to 2.02x

## Changes

- tombstone consumed queue slots so processed messages remain collectible without tail copies
- verify every acknowledgement/completion and the final native value in `lynx-render`
- guard 20k/10k reentrant-drain scaling at 3.5x

## Validation

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted formatting: changed files pass `pnpm format:files:check`
- [x] targeted tests: `pnpm --filter @octanejs/lynx test` (25 files, 362 tests)
- [x] targeted typecheck: `tsgo --noEmit` for Lynx source, testing, and typetests projects
- [x] benchmark: `node benchmarks/bench.mjs --quick --ratios lynx-render`
- [x] `pnpm sync`

## Risk / follow-ups

- The committed scaling guard allows normal timing variance while rejecting the former superlinear drain.
- The package-local `tsc` script still reports the pre-existing acknowledgement literal error at `src/main-thread.ts:2257`; root/CI uses `tsgo`, and all three relevant `tsgo` projects pass.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790343996&installation_model_id=432790&pr_number=860&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F860&signature=7717880e144d89f6a89c60fb536db9f9ec2b408cc3eebb2b478b7981c543f101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Lynx main-thread commit ordering and reentrant queue draining on the hot transport path; behavior is guarded by targeted tests and new benchmark correctness checks.
> 
> **Overview**
> Fixes **superlinear drain cost** when many Lynx commits are queued synchronously during Element PAPI work (e.g. reentrant `__SetID`). The main-thread commit loop no longer **`shift()`s** the pending queue; it walks with an index, **tombstones** consumed entries, then clears the array so large bursts stay **O(n)** instead of copying the tail on every dequeue.
> 
> Adds an **Octane-only `lynx-render` workload** (`runReentrantCommits`) that fires a 10k/20k commit burst from inside one host update, checks ordered **acks/completions** and the final native **id/version**, and records **`drain_ms`**. **`ratios.json`** caps 20k vs same-run 10k at **3.5x** to catch regressions back toward the old ~4.4x scaling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9154091b816fcd4799b0da308c06e1a2b75234af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->