### PR TITLE
perf(rsbuild): skip ordinary RPC source masking

### DIFF
--- a/.changeset/quick-rsbuild-server-discovery.md
+++ b/.changeset/quick-rsbuild-server-discovery.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/rsbuild-plugin': patch
+---
+
+Skip allocation-heavy RPC owner masking for ordinary project modules.

--- a/packages/rsbuild-plugin-octane/src/project.js
+++ b/packages/rsbuild-plugin-octane/src/project.js
@@ -106,6 +106,7 @@ function maskNonCode(source) {
  * @param {string} id
  */
 function ownsServerModule(source, id) {
+	if (!source.includes('module') || !source.includes('server')) return false;
 	if (!SERVER_MODULE_CANDIDATE.test(maskNonCode(source))) return false;
 	const compiled = compile(source, id, { mode: 'server' });
 	return COMPILED_SERVER_NAMESPACE.test(maskNonCode(compiled.code));


### PR DESCRIPTION
## Summary

- skip allocation-heavy syntax masking for ordinary Rsbuild project modules that contain neither RPC declaration token
- preserve the existing syntax-aware mask and compiler validation for every possible `module server` candidate
- publish the build-time improvement as a patch changeset for `@octanejs/rsbuild-plugin`

## Why

Rsbuild's RPC owner discovery scans every project `.tsx` and `.tsrx` file. The common no-owner path split each entire source into a character array, rewrote it, and joined it again only to prove that `module server` was absent.

On a synthetic 32 MiB project of 256 ordinary components, the same seven-sample harness improved from a 332.6 ms median to 25.4 ms (92.4% lower, 13.1x faster). A control where every file contained both words still took 341.2 ms, confirming that candidate validation was not skipped or made artificially faster.

## Changes

- use allocation-free substring checks as a conservative candidate gate
- retain masking and compilation whenever both tokens occur, including comment-separated declarations
- add a patch changeset

## Validation

- [ ] `pnpm format:check` (targeted Prettier check passed for both changed files)
- [ ] `pnpm typecheck` (`tsgo --noEmit -p packages/rsbuild-plugin-octane/tsconfig.typecheck.json` passed)
- [ ] `pnpm test` (targeted Rsbuild validation used instead)
- [x] `pnpm sync`
- [x] Rsbuild non-browser suite: 6 files, 40 tests passed
- [x] final discovery/helper suite: 1 file, 10 tests passed
- [x] localhost integration rerun: 3 server/dev cases passed; 2 browser cases could not run locally because Playwright Chromium revision 1228 is not installed

## Risk / follow-ups

- Actual candidates pay two native substring scans before their existing mask and compiler pass. This is the rare path, and the both-token control showed no meaningful shortcut.
- CI remains responsible for the two Chromium-backed integration cases unavailable locally.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790346856&installation_model_id=432790&pr_number=861&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F861&signature=2d2a4e9c7029b7e2a262336d25679d2ad8a75469afdca3ab93107c5c90cd8e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only early return in discovery; candidate detection behavior stays the same when both tokens are present.
> 
> **Overview**
> **Rsbuild RPC owner discovery** now bails out of `ownsServerModule` with cheap `includes` checks for `module` and `server` before running `maskNonCode` and server compilation on every scanned `.tsx` / `.tsrx` file.
> 
> Files that lack both substrings skip the allocation-heavy character-array masking path entirely. When both appear—including comment-separated `module server` candidates—the existing mask, regex gate, and compiler validation still run unchanged.
> 
> A patch changeset records the build-time improvement for `@octanejs/rsbuild-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173bd209972b0b5c96e4b9915a3b9f166574d79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->