### PR TITLE
fix: memoize snapshot method calls in Strong mode

### DIFF
--- a/.changeset/strong-render-snapshot-calls.md
+++ b/.changeset/strong-render-snapshot-calls.md
@@ -1,0 +1,10 @@
+---
+'octane': patch
+---
+
+Allow statically named render methods to participate in production memoization
+when a module opts into Strong mode's immutable snapshot contract. Preserve
+compatibility-mode live receivers, hooks, refs, and changing event captures, and
+add Strong diagnostics for detectable state-snapshot mutations and impure clock
+or random reads during render. Clarify keyed row identity, logging, and callback
+invalidation rules.

--- a/.changeset/strong-render-snapshot-calls.md
+++ b/.changeset/strong-render-snapshot-calls.md
@@ -1,5 +1,6 @@
 ---
 'octane': patch
+'@octanejs/mcp-server': patch
 ---
 
 Allow statically named render methods to participate in production memoization
@@ -8,3 +9,6 @@ compatibility-mode live receivers, hooks, refs, and changing event captures, and
 add Strong diagnostics for detectable state-snapshot mutations and impure clock
 or random reads during render. Clarify keyed row identity, logging, and callback
 invalidation rules.
+
+Expose the template-call memoization benchmark through the Octane MCP benchmark
+tool.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ they are written down in
 - **Behavior-only roots for externally owned DOM.** Attach abortable behavior
   and delegated native events to server-rendered or independently streamed
   markup without rendering it or taking reconciliation ownership.
+- **Optional immutable render snapshots.** Add `"use strong"` to one module, or
+  enable Strong mode for an application, to catch detectable render-purity
+  violations and unlock conservative production memoization for snapshot
+  receiver methods.
 - **`class` / `className` composes clsx-style** everywhere: strings, arrays,
   objects, and nesting, at every apply site.
 - **A current-state getter.** `useState` and `useReducer` return

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -237,6 +237,7 @@ internally, get their own baseline and guard namespace.
 | `lynx-bundle-size` | lynx-bundle-size | none (builds) | semantic-checksummed production Rspeedy artifact bytes for background preview and dual-thread IFR modes; source/build evidence only |
 | `codegen-size` | codegen-size | none (Node-only) | compiled-output bytes: fixed corpus through octane/compiler, raw/min/gzip, `compiled` vs `source` |
 | `hook-memo` | hook-memo | none (Node-only) | production hook-memo compiler on/off, clean semantic controls, deterministic function/array creation events, and compiled/bundled bytes |
+| `template-call-memo` | template-call-memo | none (Node-only) | production Strong/compatibility receiver-call counts, immutable keyed rows, real dependency changes, current event captures, and survivor identity |
 | `compiler-throughput` | compiler-throughput | none (Node-only) | six real production compiler pipelines, cold/warm/incremental transformations, 10/100/1,000 components, and heap diagnostics |
 | `tsrx-component-graph` | tsrx-component-graph | none (Node-only) | 2,400-component live-import propagation with dependent-first vs dependency-first declarations |
 | `tsrx-nesting-diagnostics` | tsrx-nesting-diagnostics | none (Node-only) | development TSRX compilation at 500 and 2,000 invalid HTML sites, with parsed diagnostic count/order controls and a per-diagnostic scaling guard |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -3094,5 +3094,69 @@
     "reference": "dependency-first",
     "maxRatio": 1.25,
     "note": "A 2,400-component live-import chain declared root-first must stay within 25% of the same graph declared leaf-first. Both orders verify every transitive witness and alternate measurement order; whole-module fixed-point rescans were about 2x slower."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "stable_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 0,
+    "note": "Two 16-row immutable lists receive 32 unrelated visible parent updates. Strong mode must reuse unchanged receiver-method rows, including the fixture with production console logging. Every label and survivor identity is checked."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "insert_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 1,
+    "note": "Appending and prepending one row to each of two Strong lists may read only the four inserted rows. Stable keyed survivors have no changed snapshot, method argument, or event capture."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "snapshot_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 1,
+    "note": "Replacing one immutable row snapshot in each list may read only those two rows. Both changed labels must update while retaining their keyed DOM nodes."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "argument_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 1,
+    "note": "A changed real method argument reaches all 36 current rows. Full output checks prevent an apparent saving obtained by retaining stale results."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "reorder_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 0,
+    "note": "Reversing lists that do not read the item index must preserve order and survivor identity without repeating snapshot receiver calls."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "stable_logs",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 0,
+    "note": "A production diagnostic console.log in a Strong keyed row must not defeat reuse across unrelated parent updates. The externally observed clean fixture still checks every row value and node identity."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "captured_append_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 1,
+    "note": "The control's remove handlers capture the whole rows array, so appending legitimately invalidates survivors. At most 17 reads are needed, and clicking the original remove handler must retain the appended row."
+  },
+  {
+    "suite": "template-call-memo",
+    "op": "captured_remove_reads",
+    "target": "strong",
+    "reference": "work-model",
+    "maxRatio": 1,
+    "note": "Removing the original row after append must preserve all 16 current survivors and their DOM identity, with no duplicate receiver reads."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -725,6 +725,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: () => [] }],
 	},
 	{
+		// Strong-mode keyed row reuse, with receiver calls observed outside the
+		// compiled source and DOM/event controls for every dependency change.
+		name: 'template-call-memo',
+		cwd: 'template-call-memo',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'run.mjs', args: () => [] }],
+	},
+	{
 		name: 'compiler-throughput',
 		cwd: 'compiler-throughput',
 		servers: [],

--- a/benchmarks/template-call-memo/README.md
+++ b/benchmarks/template-call-memo/README.md
@@ -1,0 +1,45 @@
+# Template call memoization
+
+This Node/happy-dom suite compiles the same keyed-list fixtures in production
+compatibility mode and Strong mode (`strong: true`, equivalent to a file's
+`"use strong"` directive). It measures receiver-method invocations, not elapsed
+time or heap allocation.
+
+```bash
+node benchmarks/bench.mjs --ratios template-call-memo
+BENCH_JSON=/tmp/template-call-memo.json node benchmarks/template-call-memo/run.mjs
+```
+
+Each list starts with 16 immutable row snapshots whose `read(suffix)` method
+returns a label. The parent updates an unrelated visible counter 32 times, then
+appends a row, prepends a row, replaces one row snapshot, changes the real method
+argument, and reverses the list. A second fixture includes a `console.log` in
+the row body to check that production diagnostic logging does not prevent
+Strong mode from reusing unchanged host rows.
+
+A control list's remove handler captures the complete current rows array. After
+appending a row, clicking the original row's remove button must keep the new
+row. This is a deliberate invalidation workload: every survivor has a changed
+event capture, even though its own row snapshot is unchanged.
+
+Every render checks all visible labels, ordering, and the identity of every
+surviving keyed DOM node. Changed snapshots retain the same key and DOM node.
+The remove handler runs through a native click; unmount must empty the root.
+Both modes run with and without observation and must produce the same semantic
+trace. The receiver methods and counters are supplied by the runner, outside
+the component source analyzed by the compiler. Probes therefore cannot make an
+otherwise eligible component appear impure. The logging observer also lives
+outside the compiled source.
+
+The `work-model` reference supplies fixed count ceilings. Positive references
+allow exact zero guards for stable rows and reorders. Insertions and changed
+snapshots should call only newly needed rows; changed real arguments and
+captured event data must still update the correct output. Per-fixture counters
+remain in result metadata. Minified compiler bytes and bundle gzip bytes expose
+code-size cost separately; neither includes the runner or its counters.
+
+`OCTANE_TEMPLATE_CALL_ROOT` can select a baseline checkout with its dependencies
+installed, while `OCTANE_TEMPLATE_CALL_DEPS` can select the dependency tree used
+by the bundler. Keep Node, dependencies, fixtures, and commands identical for a
+before/after comparison. These counters make no browser latency claim and do
+not measure SSR, hydration, or concurrent abort/replay.

--- a/benchmarks/template-call-memo/cases.tsrx
+++ b/benchmarks/template-call-memo/cases.tsrx
@@ -1,0 +1,46 @@
+type Row = { readonly id: number; readonly label: string; read(suffix: string): string };
+type Props = { rows: readonly Row[]; suffix: string; tick: number };
+
+export function Rows({ rows, suffix, tick }: Props) @{
+	<section>
+		<output>{String(tick)}</output>
+		<ul>
+			@for (const row of rows; key row.id) {
+				<li data-row={row.id}><span>{row.read(suffix) as string}</span></li>
+			}
+		</ul>
+	</section>
+}
+
+export function LoggedRows({ rows, suffix, tick }: Props) @{
+	<section>
+		<output>{String(tick)}</output>
+		<ul>
+			@for (const row of rows; key row.id) {
+				console.log('row', row.id);
+				<li data-row={row.id}><span>{row.read(suffix) as string}</span></li>
+			}
+		</ul>
+	</section>
+}
+
+export function CapturedRows({
+	rows,
+	suffix,
+	tick,
+	onRows,
+}: Props & { onRows: (rows: readonly Row[]) => void }) @{
+	<section>
+		<output>{String(tick)}</output>
+		<ul>
+			@for (const row of rows; key row.id) {
+				<li data-row={row.id}>
+					<span>{row.read(suffix) as string}</span>
+					<button onClick={() => onRows(rows.filter((current) => current.id !== row.id))}>
+						Remove
+					</button>
+				</li>
+			}
+		</ul>
+	</section>
+}

--- a/benchmarks/template-call-memo/cases.tsrx
+++ b/benchmarks/template-call-memo/cases.tsrx
@@ -6,7 +6,9 @@ export function Rows({ rows, suffix, tick }: Props) @{
 		<output>{String(tick)}</output>
 		<ul>
 			@for (const row of rows; key row.id) {
-				<li data-row={row.id}><span>{row.read(suffix) as string}</span></li>
+				<li data-row={row.id}>
+					<span>{row.read(suffix) as string}</span>
+				</li>
 			}
 		</ul>
 	</section>
@@ -18,18 +20,17 @@ export function LoggedRows({ rows, suffix, tick }: Props) @{
 		<ul>
 			@for (const row of rows; key row.id) {
 				console.log('row', row.id);
-				<li data-row={row.id}><span>{row.read(suffix) as string}</span></li>
+				<li data-row={row.id}>
+					<span>{row.read(suffix) as string}</span>
+				</li>
 			}
 		</ul>
 	</section>
 }
 
-export function CapturedRows({
-	rows,
-	suffix,
-	tick,
-	onRows,
-}: Props & { onRows: (rows: readonly Row[]) => void }) @{
+export function CapturedRows({ rows, suffix, tick, onRows }: Props & {
+	onRows: (rows: readonly Row[]) => void;
+}) @{
 	<section>
 		<output>{String(tick)}</output>
 		<ul>

--- a/benchmarks/template-call-memo/entry.mjs
+++ b/benchmarks/template-call-memo/entry.mjs
@@ -1,0 +1,2 @@
+export { createRoot, flushSync } from 'octane';
+export * from './cases.tsrx';

--- a/benchmarks/template-call-memo/run.mjs
+++ b/benchmarks/template-call-memo/run.mjs
@@ -1,0 +1,341 @@
+// Same-source production comparison. The receiver methods live in this runner,
+// outside the component AST, so observing calls cannot change purity analysis.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+const HERE = import.meta.dirname;
+const REPO = path.resolve(process.env.OCTANE_TEMPLATE_CALL_ROOT || path.join(HERE, '../..'));
+const DEPENDENCIES = path.resolve(process.env.OCTANE_TEMPLATE_CALL_DEPS || REPO);
+const OCTANE = path.join(REPO, 'packages/octane');
+const requireDependencies = createRequire(path.join(DEPENDENCIES, 'packages/octane/package.json'));
+const { build, transformSync, version: esbuildVersion } = requireDependencies('esbuild');
+const { Window } = await import(pathToFileURL(requireDependencies.resolve('happy-dom')).href);
+const { compile } = await import(pathToFileURL(path.join(OCTANE, 'src/compiler/index.js')).href);
+const exportsMap = JSON.parse(fs.readFileSync(path.join(OCTANE, 'package.json'), 'utf8')).exports;
+const fixtureFile = path.join(HERE, 'cases.tsrx');
+const fixture = fs.readFileSync(fixtureFile, 'utf8');
+const ROWS = 16;
+const REPEATS = 32;
+const stat = (score) => ({ score, median: score, min: score, samples: 1 });
+const hash = (source) => createHash('sha256').update(source).digest('hex');
+
+function dependencyVersion(name) {
+	let directory = path.dirname(requireDependencies.resolve(name));
+	while (directory !== path.dirname(directory)) {
+		const manifest = path.join(directory, 'package.json');
+		if (fs.existsSync(manifest)) {
+			const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+			if (pkg.name === name) return pkg.version;
+		}
+		directory = path.dirname(directory);
+	}
+	throw new Error(`Missing dependency metadata for ${name}`);
+}
+
+async function buildFixture(strong, outfile) {
+	const compiled = compile(fixture, fixtureFile, {
+		mode: 'client',
+		hmr: false,
+		dev: false,
+		strong,
+	});
+	assert.deepEqual(compiled.diagnostics, [], 'fixture compiler diagnostics');
+	const result = await build({
+		entryPoints: [path.join(HERE, 'entry.mjs')],
+		outfile,
+		bundle: true,
+		write: false,
+		format: 'esm',
+		platform: 'browser',
+		target: 'es2022',
+		logLevel: 'silent',
+		define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+		nodePaths: [
+			path.join(DEPENDENCIES, 'packages/octane/node_modules'),
+			path.join(DEPENDENCIES, 'node_modules'),
+		],
+		plugins: [
+			{
+				name: 'template-call-fixture',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => {
+						const entry = exportsMap[request === 'octane' ? '.' : './' + request.slice(7)];
+						const target = typeof entry === 'string' ? entry : entry?.import || entry?.default;
+						assert.equal(typeof target, 'string', `public runtime export ${request}`);
+						return { path: path.resolve(OCTANE, target) };
+					});
+					plugin.onLoad({ filter: /\.tsrx$/ }, ({ path: filename }) => {
+						assert.equal(filename, fixtureFile, 'unexpected fixture module');
+						return { contents: compiled.code, loader: 'js', resolveDir: HERE };
+					});
+				},
+			},
+		],
+	});
+	const bundle = result.outputFiles[0].text;
+	fs.writeFileSync(outfile, bundle);
+	return {
+		code_minified: Buffer.byteLength(transformSync(compiled.code, { minify: true }).code),
+		bundle_gzip: gzipSync(transformSync(bundle, { minify: true }).code).length,
+	};
+}
+
+function setupDom() {
+	const window = new Window({ url: 'http://localhost/' });
+	for (const key of [
+		'window',
+		'document',
+		'navigator',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'SVGElement',
+		'Text',
+		'Comment',
+		'DocumentFragment',
+		'Event',
+		'EventTarget',
+		'MutationObserver',
+		'HTMLInputElement',
+		'HTMLSelectElement',
+		'HTMLTextAreaElement',
+		'getComputedStyle',
+		'requestAnimationFrame',
+		'cancelAnimationFrame',
+	]) {
+		const value = key === 'window' ? window : window[key];
+		if (value !== undefined)
+			Object.defineProperty(globalThis, key, { value, writable: true, configurable: true });
+	}
+	return window;
+}
+
+function exercise(bundle, observed) {
+	const measurements = {};
+	const semantics = [];
+	let reads = 0;
+	let logs = 0;
+	const originalLog = console.log;
+	console.log = () => {
+		if (observed) logs++;
+	};
+	try {
+		for (const name of ['Rows', 'LoggedRows', 'CapturedRows']) {
+			function row(id, label = `row-${id}`) {
+				return Object.freeze({
+					id,
+					label,
+					read(suffix) {
+						if (observed) reads++;
+						return `${this.label}:${suffix}`;
+					},
+				});
+			}
+			let rows = Object.freeze(Array.from({ length: ROWS }, (_, index) => row(index)));
+			let suffix = 'first';
+			let tick = 0;
+			let previousNodes = new Map();
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			const root = bundle.createRoot(container);
+			const onRows = (next) => {
+				rows = Object.freeze(next);
+				render();
+			};
+
+			function check() {
+				assert.equal(
+					container.querySelector('output').textContent,
+					String(tick),
+					`${name}: parent update`,
+				);
+				const nodes = [...container.querySelectorAll('li')];
+				assert.equal(nodes.length, rows.length, `${name}: row count`);
+				for (let index = 0; index < rows.length; index++) {
+					const item = rows[index];
+					const node = nodes[index];
+					assert.equal(node.getAttribute('data-row'), String(item.id), `${name}: order`);
+					assert.equal(
+						node.querySelector('span').textContent,
+						`${item.label}:${suffix}`,
+						`${name}: value`,
+					);
+					if (previousNodes.has(item.id))
+						assert.equal(node, previousNodes.get(item.id), `${name}: survivor identity`);
+				}
+				previousNodes = new Map(rows.map((item, index) => [item.id, nodes[index]]));
+			}
+
+			function render() {
+				tick++;
+				bundle.flushSync(() => root.render(bundle[name], { rows, suffix, tick, onRows }));
+				check();
+			}
+
+			function phase(phaseName, operation) {
+				reads = logs = 0;
+				operation();
+				measurements[`${name}_${phaseName}`] = { reads, logs };
+				semantics.push({
+					name,
+					phase: phaseName,
+					tick,
+					rows: [...container.querySelectorAll('li')].map((node) => [
+						node.getAttribute('data-row'),
+						node.textContent,
+					]),
+				});
+			}
+
+			try {
+				phase('mount', render);
+				phase('stable', () => {
+					for (let index = 0; index < REPEATS; index++) render();
+				});
+				phase('append', () => {
+					rows = Object.freeze([...rows, row(ROWS)]);
+					render();
+				});
+				if (name === 'CapturedRows') {
+					phase('remove', () => {
+						bundle.flushSync(() => container.querySelector('[data-row="0"] button').click());
+						check();
+						assert.equal(rows.length, ROWS, 'remove uses the appended array');
+						assert.equal(rows.at(-1).id, ROWS, 'remove retains the appended row');
+						assert.ok(rows.every((item) => item.id !== 0), 'original row removed');
+					});
+				} else {
+					phase('prepend', () => {
+						rows = Object.freeze([row(ROWS + 1), ...rows]);
+						render();
+					});
+					phase('snapshot', () => {
+						rows = Object.freeze(
+							rows.map((item) => (item.id === 0 ? row(0, 'changed') : item)),
+						);
+						render();
+					});
+					phase('argument', () => {
+						suffix = 'second';
+						render();
+					});
+					phase('reorder', () => {
+						rows = Object.freeze([...rows].reverse());
+						render();
+					});
+				}
+			} finally {
+				root.unmount();
+				assert.equal(container.innerHTML, '', `${name}: teardown`);
+				container.remove();
+			}
+		}
+	} finally {
+		console.log = originalLog;
+	}
+	return { measurements, semantics };
+}
+
+function counts(measurements) {
+	const total = (phase) =>
+		['Rows', 'LoggedRows'].reduce((sum, name) => sum + measurements[`${name}_${phase}`].reads, 0);
+	return {
+		stable_reads: total('stable'),
+		insert_reads: total('append') + total('prepend'),
+		snapshot_reads: total('snapshot'),
+		argument_reads: total('argument'),
+		reorder_reads: total('reorder'),
+		stable_logs: measurements.LoggedRows_stable.logs,
+		captured_append_reads: measurements.CapturedRows_append.reads,
+		captured_remove_reads: measurements.CapturedRows_remove.reads,
+	};
+}
+
+const runMetadata = {
+	node: process.version,
+	esbuild: esbuildVersion,
+	tsrxCore: dependencyVersion('@tsrx/core'),
+	rows: ROWS,
+	repeats: REPEATS,
+	fixtureSha256: hash(fixture),
+	entrySha256: hash(fs.readFileSync(path.join(HERE, 'entry.mjs'))),
+	runnerSha256: hash(fs.readFileSync(path.join(HERE, 'run.mjs'))),
+	compilerSha256: hash(fs.readFileSync(path.join(OCTANE, 'src/compiler/compile.js'))),
+	measurement: 'method invocations outside the compiled AST; no timing or heap claim',
+};
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-template-call-memo-'));
+const window = setupDom();
+const targets = [];
+let failure;
+let expectedSemantics;
+try {
+	for (const [name, strong] of [
+		['compatibility', false],
+		['strong', true],
+	]) {
+		const outfile = path.join(directory, `${name}.mjs`);
+		const sizes = await buildFixture(strong, outfile);
+		const bundle = await import(pathToFileURL(outfile).href);
+		const clean = exercise(bundle, false);
+		const observed = exercise(bundle, true);
+		assert.deepEqual(observed.semantics, clean.semantics, 'call observation changed output');
+		if (expectedSemantics === undefined) expectedSemantics = clean.semantics;
+		else assert.deepEqual(clean.semantics, expectedSemantics, 'Strong mode changed output');
+		const work = counts(observed.measurements);
+		targets.push({
+			name,
+			ops: Object.fromEntries(
+				Object.entries({ ...work, ...sizes }).map(([key, value]) => [key, stat(value)]),
+			),
+			meta: { run: runMetadata, ...observed },
+		});
+		console.log(
+			`${name}: ${JSON.stringify(work)}; ${sizes.code_minified} compiled bytes, ${sizes.bundle_gzip} bundle gzip bytes`,
+		);
+	}
+	console.log(
+		'Template-call output, keyed survivor identity, current event captures, and teardown controls passed.',
+	);
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(failure);
+} finally {
+	await window.happyDOM.close();
+	fs.rmSync(directory, { recursive: true, force: true });
+}
+
+const payload = {
+	suite: 'template-call-memo',
+	iterations: 1,
+	targets: [
+		...targets,
+		{
+			name: 'work-model',
+			ops: Object.fromEntries(
+				Object.entries({
+					stable_reads: 1,
+					insert_reads: 4,
+					snapshot_reads: 2,
+					argument_reads: (ROWS + 2) * 2,
+					reorder_reads: 1,
+					stable_logs: 1,
+					captured_append_reads: ROWS + 1,
+					captured_remove_reads: ROWS,
+				}).map(([key, value]) => [key, stat(value)]),
+			),
+		},
+	],
+	meta: runMetadata,
+	...(failure ? { failed: failure } : {}),
+};
+if (process.env.BENCH_JSON)
+	fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');
+if (failure) process.exitCode = 1;

--- a/benchmarks/template-call-memo/run.mjs
+++ b/benchmarks/template-call-memo/run.mjs
@@ -210,7 +210,10 @@ function exercise(bundle, observed) {
 						check();
 						assert.equal(rows.length, ROWS, 'remove uses the appended array');
 						assert.equal(rows.at(-1).id, ROWS, 'remove retains the appended row');
-						assert.ok(rows.every((item) => item.id !== 0), 'original row removed');
+						assert.ok(
+							rows.every((item) => item.id !== 0),
+							'original row removed',
+						);
 					});
 				} else {
 					phase('prepend', () => {
@@ -218,9 +221,7 @@ function exercise(bundle, observed) {
 						render();
 					});
 					phase('snapshot', () => {
-						rows = Object.freeze(
-							rows.map((item) => (item.id === 0 ? row(0, 'changed') : item)),
-						);
+						rows = Object.freeze(rows.map((item) => (item.id === 0 ? row(0, 'changed') : item)));
 						render();
 					});
 					phase('argument', () => {

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -179,8 +179,9 @@ hook calls inside a custom hook; it only declines to modify calls to wrappers.
 
 ## Automatic memoization and calls in templates
 
-Production builds automatically memoize component regions under the same
-pure-render, immutable-snapshot contract assumed by React Compiler:
+Production builds automatically memoize component regions. The default
+compatibility mode is conservative about calls whose receivers can hide mutable
+state:
 
 ```tsx
 {formatPrice(cents)} // May memoize: formatPrice is imported.
@@ -196,7 +197,7 @@ A call keeps its surrounding region memoizable only when the callee is an
 imported binding or an unreassigned same-module function whose body is itself a
 value projection. Arguments must satisfy the same rule.
 
-Member calls fail closed because the receiver may be a live object:
+In compatibility mode, member calls fail closed because the receiver may be a live object:
 `header.getIsSorted()` can return a new answer while `header` retains the same
 identity. A module helper that merely wraps that method has the same hazard and
 does not qualify. Component-local callees, hooks (including `unstable_use*`),
@@ -209,6 +210,57 @@ rendering belongs in state or context. Octane cannot read across a module
 boundary, so an imported helper is taken at its word — that is the one place
 this analysis trusts rather than proves, and it matches React Compiler's own
 assumption.
+
+This preserves ordinary React rendering for live receivers; it is not a promise
+to reproduce every React Compiler optimization. React Compiler also identifies
+APIs with interior mutability, including TanStack Table v8, as
+[incompatible with memoization](https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library).
+Stable function or object identity alone does not prove a result is unchanged.
+
+### Strong mode and render calls
+
+A module that opts into [`"use strong"`](#optional-strong-mode) asserts a stricter
+contract: props, state, context, and method receivers represent immutable render
+snapshots. An ordinary render method must be a value projection of those inputs;
+it must not secretly read changing state behind an unchanged receiver. This lets
+production client builds memoize statically named member calls such as
+`item.format(prefix)` and the same-module helpers that wrap them. No new runtime
+cache or global behavior change is involved.
+
+Hooks and ref-backed receivers such as `ref.current.read()` remain live. Dynamic
+method names, callback-bearing or call-produced arguments, and known clocks and
+randomness remain conservative. Strong mode is not a whole-program purity
+proof: imported code and opaque methods still have to honor the snapshot
+contract. Keep a component using live accessors in compatibility mode, or pass an
+actual snapshot into a separate Strong component. Enabling Strong on a caller
+does not make an imported library's live object immutable.
+
+### Keyed rows and logging
+
+A key preserves a surviving row's DOM identity; it does not promise that its
+JavaScript body runs only once. In Strong production builds, diagnostic calls
+such as `console.log('row', item.id)` no longer disqualify an otherwise eligible
+row from reuse. Logging frequency is not a render or commit contract, and can
+differ in development, HMR, and profiling builds.
+
+A changed captured value still invalidates a row, including captures inside its
+event handlers:
+
+```tsx
+onClick={() => setItems(items.filter((entry) => entry.id !== item.id))}
+```
+
+Appending changes `items`, so surviving rows must receive a handler for the new
+snapshot. Skipping that update could make removing an original row also discard
+the appended item. If removal should use the latest state, a functional update
+does not capture the parent array:
+
+```tsx
+onClick={() => setItems((current) => current.filter((entry) => entry.id !== item.id))}
+```
+
+The first form remains correct and supported. Strong mode does not change its
+closure semantics or promise to skip its reevaluation.
 
 ## Derived values are cached at their declaration
 
@@ -223,7 +275,7 @@ An eligible `const` keeps the same identity until its tracked component-local
 inputs change. This lets a region key on the identity of a derived value instead
 of seeing a new array or object on every render.
 
-The same callee rule governs declaration caching. The virtualizer call must stay
+The same callee rule governs declaration caching. In compatibility mode, the virtualizer call must stay
 live because its window can move while the virtualizer object keeps the same
 identity. Most member calls, including arbitrary `items.filter(...)` calls,
 therefore remain uncached.
@@ -318,8 +370,9 @@ The tuple also supports the same optional latest-value getter as `useState`.
 
 ## Optional Strong mode
 
-Strong mode adds compile-time checks for patterns that make rendering harder to
-reason about. Opt into one module with a directive before its imports:
+Strong mode opts into the immutable render-snapshot contract above and adds
+compile-time checks for detectable violations. Opt into one module with a
+directive before its imports:
 
 ```tsx
 "use strong";
@@ -338,6 +391,13 @@ and functions returned by analyzable `useMemo` factories. Calling a statically
 known Effect Event during render or including it in an explicit hook dependency
 list is also a compile error. The hooks themselves remain supported, and other
 explicit dependency lists retain their existing meaning.
+
+The compiler also rejects render-time writes through a provable state snapshot
+(`OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION`) and direct calls to known
+non-idempotent globals such as `Date.now()` and `Math.random()`
+(`OCTANE_STRONG_RENDER_IMPURE_CALL`). These checks follow supported aliases and
+synchronous helpers; they do not prove arbitrary method bodies or imported code
+pure. Lazy state initialization may obtain an initial timestamp or random value.
 
 Event handlers, genuinely deferred callbacks, effect cleanup, effects that
 synchronize an external system, and normal DOM or timer refs remain supported.

--- a/docs/strict-state-plan.md
+++ b/docs/strict-state-plan.md
@@ -168,7 +168,7 @@ Three layers, with distinct jobs:
 
 | Layer | Current status | Intended role |
 | ----- | -------------- | ------------- |
-| Compiler | **Shipped**, opt-in Strong mode | Reject statically provable render/effect-setup updates and render-time ref writes with actionable diagnostics. |
+| Compiler | **Shipped**, opt-in Strong mode | Enforce the bounded immutable-snapshot and pure-render contract with actionable diagnostics, and admit eligible snapshot method calls to production client memoization. |
 | Runtime phase guard | **Not implemented**; historical proposal | Enforce a future runtime policy for user-callable setters/dispatchers in development and production. |
 | Dependency compatibility | **Shipped** through package containment | Keep dependencies and separate workspace packages in their existing mode unless their own module opts into Strong mode. |
 | Per-cell `stateWrites` policy | **Not implemented**; historical proposal | Attach a hypothetical strict/compat policy to hook cells if runtime enforcement is ever introduced. |

--- a/docs/strict-state-plan.md
+++ b/docs/strict-state-plan.md
@@ -32,7 +32,7 @@ composite sources need an explicit `sourceEqual` comparator. The optional
 `valueEqual` comparator and compiler-selected third getter are supported across
 client, server, hydration, and universal rendering.
 
-Strong mode is an optional **compiler check**, not a runtime state policy:
+Strong mode is an optional compiler contract, not a runtime state policy:
 
 ```ts
 // octane.config.ts
@@ -62,6 +62,12 @@ linked-state equality callbacks are render contexts too. Genuinely deferred
 callbacks and effect cleanup remain valid. There is no runtime phase guard,
 hook-cell policy, runtime-only enforcement, cleanup ban, or `stateWrites`
 configuration in the shipped model.
+
+Strong mode also opts into immutable render snapshots for production member-call
+memoization, with bounded state-snapshot mutation and nondeterministic-call
+diagnostics. Compatibility-mode consumers retain live-method behavior. See the
+current [call contract](./differences-from-react.md#automatic-memoization-and-calls-in-templates)
+for the optimization boundary and the limits of static enforcement.
 
 For current authoring guidance, see [State that follows another
 value](./tsrx-basics.md#state-that-follows-another-value),

--- a/docs/strict-state-policy-options.md
+++ b/docs/strict-state-policy-options.md
@@ -27,15 +27,21 @@ application-owned source: dependencies and separately manifested workspace
 packages retain their existing React-compatible behavior unless their own module
 opts in. Vite, Rspack, and Rsbuild also expose a `strong: true` plugin option.
 
-The shipped enforcement is **compile-time only**: it rejects statically provable
-state updates during render or synchronous effect setup and render-time
-`ref.current` writes. State initializers, `useLinkedState` reconcilers, and its
+The shipped contract is **compiler-owned**: Strong modules assert immutable
+render snapshots and pure render projections. The compiler rejects statically
+provable state updates during render or synchronous effect setup, render-time
+`ref.current` writes and state-snapshot mutations, and direct reads from known
+clock or randomness APIs. Production client builds may also memoize eligible
+statically named receiver methods while their snapshot inputs remain unchanged.
+State initializers, `useLinkedState` reconcilers, and its
 `sourceEqual`/`valueEqual` callbacks execute synchronously during render;
 genuinely deferred callbacks remain valid. `useLinkedState` replaces the
 originally proposed keyed-reset hook and compares sources with `Object.is` by
 default, including arrays; composite comparisons require `sourceEqual`.
 
-There is no runtime execution-phase guard, strict/compat hook-cell policy,
+These diagnostics are bounded rather than a whole-program purity proof, and
+imported live accessors do not become immutable merely because their caller is
+Strong. There is no runtime execution-phase guard, strict/compat hook-cell policy,
 package-manifest state-policy field, compatibility allowlist, package approval
 flow, or policy inventory. Published Octane packages ship authored source, not
 precompiled policy-bearing artifacts. See the current [Strong-mode

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -394,7 +394,8 @@ JavaScript. Only inject source you trust.
 
 ## Strong mode
 
-Strong mode is an optional compiler check for state, refs, and Effect Events.
+Strong mode is an optional immutable render-snapshot contract with compiler
+checks for state, refs, Effect Events, and detectable impure render calls.
 Start with one module by putting `"use strong"` before its imports:
 
 ```tsx
@@ -435,6 +436,12 @@ These patterns become compile errors:
   (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
 - Including a statically known Effect Event in an explicit hook dependency list
   (`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`).
+- Mutating a provable state snapshot during render, including supported aliases
+  and array mutations on state initialized with an array literal
+  (`OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION`).
+- Calling unshadowed `Date.now()`, `Math.random()`, `performance.now()`, `Date()`,
+  or `new Date()` without arguments during render
+  (`OCTANE_STRONG_RENDER_IMPURE_CALL`).
 
 The checks follow provable synchronous calls through local helpers,
 `useCallback` and `useEffectEvent` results, and functions returned by analyzable
@@ -451,8 +458,20 @@ or externally produced array is unchanged.
 Update state in event handlers instead. When state should reset or adjust after
 an input changes, use `useLinkedState`. Effects that connect to external systems,
 genuinely deferred callbacks, effect cleanup, and refs used for DOM elements,
-timers, or event callbacks remain valid. Strong mode does not restrict
-`Date.now()`, `Math.random()`, or similar values.
+timers, or event callbacks remain valid. Obtain changing timestamps or random
+values in events or effects and put them in state. A lazy state initializer such
+as `useState(() => new Date())` may also capture the initial value.
+
+Production client builds can memoize statically named member calls under this
+contract: an unchanged receiver and unchanged inputs must produce the same render
+value. Hooks, ref-backed reads, and opaque callback arguments retain their
+existing conservative treatment. Compiler diagnostics are bounded; an imported
+library with live accessors does not become snapshot-safe just because its
+caller opts in. Keep such consumers in compatibility mode, or pass snapshots to
+a Strong component. See
+[Automatic memoization and calls in templates](./differences-from-react.md#automatic-memoization-and-calls-in-templates)
+for the exact boundary and why changing event captures still invalidates keyed
+rows.
 
 `"use strong"` only affects its own module. Put it at the top of the file, before
 imports or other code; comments and other directives may come first. In files

--- a/packages/apollo-client/tests/conformance/client.test.ts
+++ b/packages/apollo-client/tests/conformance/client.test.ts
@@ -77,13 +77,17 @@ function createControlledClient() {
 }
 
 describe('@octanejs/apollo-client client hooks', () => {
-	it('useQuery source is accepted when its package opts into Strong mode', () => {
+	it('keeps useQuery in compatibility mode because it mutates render snapshots', () => {
 		const packageRoot = resolve(process.cwd(), 'packages/apollo-client');
 		const filename = resolve(packageRoot, 'src/react/hooks/useQuery.js');
-		const compiler = createOctaneCompiler({ root: packageRoot, strong: true });
+		const source = readFileSync(filename, 'utf8');
+		const compiler = createOctaneCompiler({ root: packageRoot });
 
-		expect(compiler.transform(readFileSync(filename, 'utf8'), filename)?.code).toEqual(
-			expect.any(String),
+		expect(compiler.transform(source, filename)?.code).toEqual(expect.any(String));
+
+		const strongCompiler = createOctaneCompiler({ root: packageRoot, strong: true });
+		expect(() => strongCompiler.transform(source, filename)).toThrow(
+			/OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION/,
 		);
 	});
 

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -165,7 +165,8 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `application-composition`, `scaling-curves`, `dev-form-diagnostics`,
 `behavior-root-events`, `activity`, `streaming-ssr`, `streaming-backpressure`,
 `compiler-throughput`, `tsrx-component-graph`, `codegen-size`, `hook-memo`,
-`bundle-size`, `bundle-reachability`, `three-renderer`, `three-bundle-size`, …)
+`template-call-memo`, `bundle-size`, `bundle-reachability`, `three-renderer`,
+`three-bundle-size`, …)
 or every suite with `all`; `quick` selects the reduced-iteration smoke pass. The
 suite list mirrors the runner manifest and `node benchmarks/bench.mjs --list`.
 

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -95,6 +95,7 @@ export const BENCHMARK_SUITES = [
 	'lynx-bundle-size',
 	'codegen-size',
 	'hook-memo',
+	'template-call-memo',
 	'compiler-throughput',
 	'tsrx-component-graph',
 	'tsrx-nesting-diagnostics',

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2480,9 +2480,10 @@ function rewriteAutoCallback(stmt, stable, componentLocals, ctx, invariant) {
 // what it keys on.
 //
 // A calculation is admitted on exactly the callee rule that governs regions
-// (plainCalleeIsMemoizable): the receiver of a member call can return a new
+// (plainCalleeIsMemoizable): in compatibility mode the receiver can return a new
 // answer while its own identity holds, and that hazard does not become safe
-// because the author named the result. `virtualizer.getVirtualItems()` in
+// because the author named the result. Strong modules explicitly opt into
+// snapshot receiver semantics. `virtualizer.getVirtualItems()` in
 // examples/pulseboard is the same shape as `header.column.getIsSorted()` — its
 // window moves with scroll while the virtualizer instance stays put — so
 // caching it froze a virtualized list mid-scroll. One rule, both paths.
@@ -2860,8 +2861,8 @@ function rewriteAutoCalculation(
 	// An arrow/function init is auto-callback's job, not ours.
 	if (FN_TYPES.has(init?.type)) return stmt;
 	if (!isPropCreationExpr(init, ctx)) return stmt;
-	// Every call reached during render must be a proven value projection — the
-	// same admission the region cache uses. A member call fails closed.
+	// Every call reached during render must satisfy the same projection contract
+	// the region cache uses. Compatibility-mode member calls fail closed.
 	const immutableProjection = immutableArrayProjection(init, immutableStates);
 	if (immutableProjection === null && containsRenderCall([init], ctx)) return stmt;
 	const deps = [];
@@ -4212,7 +4213,7 @@ function containsAutoMemoContextRead(root, ctx) {
  * item/deps a skipped survivor would have, so they can't go stale at render
  * time — the walk does not descend into function bodies or parameters.
  *
- * Passing `memoCtx` admits calls that are provable value projections — see
+ * Passing `memoCtx` admits projections under the selected render contract — see
  * `plainCalleeIsMemoizable` for the contract and why callee shapes are
  * classified differently. Callers that need "no call executes here" for a reason
  * other than memo staleness (SSR item identity) omit it and keep every call.
@@ -4245,8 +4246,10 @@ function containsRenderCall(stmts, memoCtx = null) {
 			t === 'TaggedTemplateExpression'
 		) {
 			if (memoCtx !== null && plainCalleeIsMemoizable(n, memoCtx)) {
-				// The callee is a proven projection; its ARGUMENTS still carry the
-				// render-value contract, so `fmt(row.get())` stays disqualified.
+				// Admitting a call never admits the expressions that resolve its
+				// callee or arguments. In compatibility mode `fmt(row.get())` still
+				// fails closed; Strong mode applies its snapshot contract to each call.
+				walk(n.callee);
 				walk(n.arguments);
 				return;
 			}
@@ -4278,6 +4281,234 @@ function isHookCalleeName(name) {
 	return HOOK_NAME_CONVENTION_RE.test(name);
 }
 
+const STRONG_MEMO_OPAQUE_GLOBAL_NAMES = new Set([
+	'Date',
+	'Math',
+	'performance',
+	'crypto',
+	'globalThis',
+	'window',
+	'self',
+	'global',
+]);
+
+// Strong mode may trust an opaque receiver's snapshot contract, but visible
+// callbacks must not hide hook cells behind a newly admitted method call.
+// Names are deliberately conservative across scopes: a shadowed callback name
+// only declines an optimization. Factory results passed as arguments also stay
+// opaque; they may return a callback that the method invokes synchronously.
+function containsStrongMemoCallbackValue(root, names) {
+	const seen = new WeakSet();
+	function walk(node) {
+		if (node === null || typeof node !== 'object') return false;
+		if (Array.isArray(node)) return node.some(walk);
+		if (seen.has(node)) return false;
+		seen.add(node);
+		if (isDeferredRefRead(node)) return true;
+		if (FN_TYPES.has(node.type) || node.type === 'ClassExpression') return true;
+		if (node.type === 'Identifier') return isHookCalleeName(node.name) || names.has(node.name);
+		if (node.type === 'CallExpression' || node.type === 'OptionalCallExpression') {
+			return true;
+		}
+		if (node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') {
+			return (
+				walk(node.object) ||
+				(node.computed
+					? walk(node.property)
+					: isHookCalleeName(node.property?.name) || names.has(node.property?.name))
+			);
+		}
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			if (
+				key === 'key' &&
+				(node.type === 'Property' || node.type === 'ObjectProperty') &&
+				!node.computed
+			)
+				continue;
+			if (walk(node[key])) return true;
+		}
+		return false;
+	}
+	return walk(root);
+}
+
+// Build the small dependency graph once, then propagate known hook aliases.
+// Ordinary method objects stay clean; only a reference to a hook or an already
+// tainted callable poisons its containing function/value. State-hook results
+// are snapshots, not aliases of the hook that produced them.
+function collectStrongMemoHookAliases(root) {
+	const aliases = new Set();
+	const dependents = new Map();
+	const visited = new WeakMap();
+	let opaqueStateTuple = false;
+	function references(name, owners) {
+		if (isHookCalleeName(name) || STRONG_MEMO_OPAQUE_GLOBAL_NAMES.has(name)) aliases.add(name);
+		if (owners.length === 0) return;
+		let targets = dependents.get(name);
+		if (targets === undefined) dependents.set(name, (targets = new Set()));
+		for (const owner of owners) targets.add(owner);
+	}
+	function targetNames(pattern) {
+		const names = new Set();
+		collectBindings(pattern, names);
+		if (pattern?.type === 'MemberExpression' && !pattern.computed && pattern.property?.name) {
+			names.add(pattern.property.name);
+		}
+		return [...names];
+	}
+	function walk(node, owners = []) {
+		if (opaqueStateTuple || node === null || typeof node !== 'object') return;
+		// Rewrites share subtrees. Visit each node only once per owner so sharing
+		// cannot multiply work, while a new enclosing value still gets its edges.
+		let previous = visited.get(node);
+		if (previous === undefined) visited.set(node, (previous = new Set()));
+		if (owners.length === 0) {
+			if (previous.has(null)) return;
+			previous.add(null);
+		} else {
+			owners = owners.filter((name) => {
+				if (previous.has(name)) return false;
+				previous.add(name);
+				return true;
+			});
+			if (owners.length === 0) return;
+		}
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child, owners);
+			return;
+		}
+		if (isDeferredRefRead(node)) {
+			for (const owner of owners) aliases.add(owner);
+			if (node.type === 'ObjectPattern') collectBindings(node, aliases);
+		}
+		if (node.type === 'Identifier') {
+			references(node.name, owners);
+			return;
+		}
+		if (node.type === 'ImportSpecifier') {
+			if (isHookCalleeName(node.imported?.name ?? node.imported?.value) && node.local?.name) {
+				aliases.add(node.local.name);
+			}
+			return;
+		}
+		if (
+			(node.type === 'FunctionDeclaration' ||
+				node.type === 'ClassDeclaration' ||
+				node.type === 'ClassExpression') &&
+			node.id?.name
+		) {
+			owners = [...owners, node.id.name];
+		} else if (
+			node.type === 'VariableDeclarator' ||
+			node.type === 'AssignmentExpression' ||
+			node.type === 'AssignmentPattern'
+		) {
+			const pattern = node.id ?? node.left;
+			const value = node.init ?? node.right;
+			const call = unwrapTsExpr(value);
+			const hook = stableHookCallName(call);
+			walk(pattern, owners);
+			if (hook === 'useState' || hook === 'useReducer' || hook === 'useLinkedState') {
+				// A retained tuple can launder its live getter through arbitrary
+				// indices and object wrappers. Keep this rare module on the existing
+				// compatibility memo path instead of guessing which element escapes.
+				if (pattern?.type !== 'ArrayPattern') {
+					opaqueStateTuple = true;
+					return;
+				}
+				collectBindings(pattern.elements[1], aliases);
+				collectBindings(pattern.elements[2], aliases);
+			}
+			// Follow a hook's supplied values, not the hook invocation itself:
+			// useState([]) is clean, but a supplied callback bag may hide hooks.
+			const callee = call?.type === 'CallExpression' ? unwrapTsExpr(call.callee) : null;
+			const calleeName =
+				hook ?? (callee?.type === 'Identifier' ? callee.name : callee?.property?.name);
+			if (calleeName !== undefined && isHookCalleeName(calleeName)) {
+				walk(call.callee, owners);
+				walk(call.arguments, [...owners, ...targetNames(pattern)]);
+			} else {
+				walk(value, [...owners, ...targetNames(pattern)]);
+			}
+			return;
+		} else if (
+			(node.type === 'Property' ||
+				node.type === 'ObjectProperty' ||
+				node.type === 'MethodDefinition' ||
+				node.type === 'PropertyDefinition' ||
+				node.type === 'ClassProperty') &&
+			(!node.computed || node.key?.type === 'Literal')
+		) {
+			const name = node.key?.name ?? node.key?.value;
+			if (typeof name === 'string') {
+				if (isHookCalleeName(name)) collectBindings(node.value, aliases);
+				walk(node.value, [...owners, name]);
+				return;
+			}
+		} else if (isJsxReturningMapCall(node)) {
+			// Returned JSX is folded to a keyed list after this pass. Carry the
+			// iterable's known hook-bearing values into the eventual item binding.
+			walk(node.callee.object, [...owners, ...targetNames(node.arguments[0].params[0])]);
+		} else if (node.type === 'JSXForExpression' || node.type === 'ForOfStatement') {
+			const pattern =
+				node.left?.type === 'VariableDeclaration' ? node.left.declarations?.[0]?.id : node.left;
+			walk(node.right, [...owners, ...targetNames(pattern)]);
+			for (const key in node) {
+				if (key === 'right' || AST_WALK_SKIP_KEYS.has(key)) continue;
+				walk(node[key], owners);
+			}
+			return;
+		}
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(node[key], owners);
+		}
+	}
+	walk(root);
+	if (opaqueStateTuple) return null;
+	const queue = [...aliases];
+	for (let index = 0; index < queue.length; index++) {
+		for (const name of dependents.get(queue[index]) ?? []) {
+			if (aliases.has(name)) continue;
+			aliases.add(name);
+			queue.push(name);
+		}
+	}
+	return aliases;
+}
+
+function strongMemberCalleeIsMemoizable(callee, ctx) {
+	if (
+		ctx?.strongMemo !== true ||
+		ctx._universalRuntimeUnit != null ||
+		callee?.type !== 'MemberExpression'
+	)
+		return false;
+	let receiver = callee;
+	while (receiver?.type === 'MemberExpression') {
+		if (
+			receiver.computed ||
+			receiver.property?.type !== 'Identifier' ||
+			receiver.property.name === 'current' ||
+			receiver.property.name === 'call' ||
+			receiver.property.name === 'apply' ||
+			receiver.property.name === 'bind' ||
+			isHookCalleeName(receiver.property.name) ||
+			ctx.strongMemoHookAliases.has(receiver.property.name)
+		)
+			return false;
+		receiver = unwrapTsExpr(receiver.object);
+	}
+	if (receiver?.type !== 'Identifier') return false;
+	if (isHookCalleeName(receiver.name) || ctx.strongMemoHookAliases.has(receiver.name)) return false;
+	// Strong does not turn clocks, randomness, or arbitrary global-object APIs
+	// into snapshot projections. Decline even a same-named local here; exact
+	// global provenance matters for diagnostics, not for this optional fast path.
+	if (STRONG_MEMO_OPAQUE_GLOBAL_NAMES.has(receiver.name)) return false;
+	return true;
+}
+
 /**
  * Is this call a memoizable value projection — `segText(seg, done)`,
  * `formatPrice(cents)`, `t('key')`?
@@ -4288,8 +4519,10 @@ function isHookCalleeName(name) {
  * in library bindings: reading mutable state through an object reachable from
  * the item or props, where neither the item ref nor any dep witnesses the change
  * (`header.column.getIsSorted()` flips while `header` stays the memoized
- * object). That hazard is carried by the RECEIVER, so a member callee always
- * fails closed.
+ * object). Compatibility mode therefore rejects every member callee. Strong
+ * modules explicitly assert immutable snapshots and pure render calls, so their
+ * production client regions can admit static non-hook receiver paths. Known
+ * callbacks, refs, dynamic methods, clocks, and randomness remain opaque.
  *
  * A bare identifier callee is admitted ONLY when the binding it resolves to is
  * a module-scope immutable identity:
@@ -4301,7 +4534,7 @@ function isHookCalleeName(name) {
  *     own body is a pure projection (see moduleHelperIsPureProjection). Because
  *     we CAN read that body, we check it: `function sortIcon(h) { return
  *     h.getIsSorted(); }` is the receiver hazard moved one call frame away and
- *     must fail closed exactly like the direct member call.
+ *     follows the same compatibility/Strong decision as the direct method.
  *
  * Everything else fails closed — in particular a COMPONENT-LOCAL callee. A local
  * `const read = () => item.read()` (or a local function declaration) wraps the
@@ -4322,9 +4555,19 @@ function isHookCalleeName(name) {
  * and React Compiler key on, and it is what the blanket call veto was
  * incidentally covering here.
  */
-function plainCalleeIsMemoizable(node, ctx) {
+function plainCalleeIsMemoizable(node, ctx, seen) {
 	if (node.type !== 'CallExpression' && node.type !== 'OptionalCallExpression') return false;
 	const callee = node.callee;
+	if (ctx?.strongMemo === true) {
+		const hook = node._octaneImportedHook ?? node._octaneHookRuntimeImportedHook;
+		if (
+			(hook !== undefined && isHookCalleeName(hook)) ||
+			(callee?.type === 'Identifier' && ctx.strongMemoHookAliases.has(callee.name)) ||
+			containsStrongMemoCallbackValue(node.arguments, ctx.strongMemoHookAliases)
+		)
+			return false;
+		if (strongMemberCalleeIsMemoizable(callee, ctx)) return true;
+	}
 	if (callee?.type !== 'Identifier') return false;
 	const name = callee.name;
 	if (isHookCalleeName(name)) return false;
@@ -4332,20 +4575,21 @@ function plainCalleeIsMemoizable(node, ctx) {
 	// bare is not callable as a projection.
 	if (ctx?.importNamespaceNames?.has(name)) return false;
 	if (ctx?.importedNames?.has(name)) return true;
-	return moduleHelperIsPureProjection(name, ctx);
+	return moduleHelperIsPureProjection(name, ctx, seen);
 }
 
 /**
  * Can a same-module `function` helper stand in for the value projection its call
- * site claims to be? True when its body performs no member-callee call, no
- * construction, and no tagged template in render-value position, and every plain
- * call it makes is itself an admitted projection.
+ * site claims to be? Every call in its body must satisfy the same admission
+ * rule as the call site, including Strong's explicitly opted-in member calls.
+ * Construction and tagged templates remain opaque in both modes.
  *
  * Cycles resolve to false: a recursive helper cannot be proven, and failing
  * closed is the safe direction. Nested function VALUES inside the helper are not
  * descended into for the same reason `containsRenderCall` skips them — they run
  * when invoked, not while the helper projects a value — but a helper that
- * *invokes* one through `.map(...)` trips the member-callee rule anyway.
+ * *invokes* one through `.map(...)` fails closed in compatibility mode and keeps
+ * Strong's callback-argument guard.
  */
 function moduleHelperIsPureProjection(name, ctx, seen) {
 	const decl = ctx?.moduleFunctionDeclarations?.get(name);
@@ -4379,18 +4623,11 @@ function moduleHelperIsPureProjection(name, ctx, seen) {
 			return;
 		}
 		if (t === 'CallExpression' || t === 'OptionalCallExpression') {
-			const callee = n.callee;
-			if (callee?.type !== 'Identifier' || isHookCalleeName(callee.name)) {
+			if (!plainCalleeIsMemoizable(n, ctx, active)) {
 				pure = false;
 				return;
 			}
-			if (
-				!ctx.importedNames?.has(callee.name) &&
-				!moduleHelperIsPureProjection(callee.name, ctx, active)
-			) {
-				pure = false;
-				return;
-			}
+			walk(n.callee);
 			walk(n.arguments);
 			return;
 		}
@@ -7874,7 +8111,8 @@ function compileAuthored(source, filename, options, bundlerMetadata) {
 	const analyzedAst = parseModule(source, cleanFilename);
 	analyzeTsrx(analyzedAst, cleanFilename);
 	adoptParserAst(analyzedAst);
-	assertStrongMode(analyzedAst, source, cleanFilename, options);
+	const strongModeEnabled =
+		assertStrongMode(analyzedAst, source, cleanFilename, options)?.enabled === true;
 	if (bundlerMetadata !== null) bundlerMetadata.hydrateAst = analyzedAst;
 	const textTypedAst = applyStringChildProofs(
 		analyzedAst,
@@ -7902,6 +8140,7 @@ function compileAuthored(source, filename, options, bundlerMetadata) {
 		mode,
 		bundlerMetadata,
 		textTypedAst !== analyzedAst,
+		strongModeEnabled,
 	);
 }
 
@@ -7913,6 +8152,7 @@ function compileInternal(
 	mode,
 	bundlerMetadata,
 	hasStringChildProofs,
+	strongModeEnabled,
 ) {
 	const authoredSource = source;
 	const universalRuntime = normalizeUniversalRuntime(options?.universalRuntime);
@@ -7958,6 +8198,7 @@ function compileInternal(
 					mode,
 					null,
 					hasStringChildProofs,
+					strongModeEnabled,
 				),
 			options,
 			analyzedAst,
@@ -8004,6 +8245,7 @@ function compileInternal(
 				mode,
 				null,
 				hasStringChildProofs,
+				strongModeEnabled,
 			);
 			return compiled;
 		}
@@ -8137,6 +8379,7 @@ function compileInternal(
 					mode,
 					null,
 					hasStringChildProofs,
+					strongModeEnabled,
 				);
 				return compiled;
 			},
@@ -8259,6 +8502,8 @@ function compileInternal(
 	// a stale-UI report can be bisected memoizer-vs-elsewhere in one line.
 	const autoMemoEnabled =
 		options?.autoMemo !== false && !hmrEnabled && !devEnabled && !profileEnabled;
+	const strongMemoEnabled =
+		strongModeEnabled && autoMemoEnabled && mode === 'client' && options?.__universal == null;
 	// Like `autoMemo: false`, `inlineHookMemo: false` is a diagnostic escape
 	// hatch only: it re-routes useMemo/useCallback and parallel-use creations
 	// back through the runtime-callback form so a miscompare can be bisected
@@ -8283,6 +8528,7 @@ function compileInternal(
 	});
 	const universalUnits =
 		options?.__universalUnits ?? rendererBoundaryPreparation?.universalUnits ?? [];
+	const strongMemoHookAliases = strongMemoEnabled ? collectStrongMemoHookAliases(ast) : null;
 	const ctx = {
 		filename,
 		usedCompilerNames: collectIdentifierNames(ast),
@@ -8293,6 +8539,8 @@ function compileInternal(
 		dev: devEnabled,
 		profile: profileEnabled,
 		autoMemo: autoMemoEnabled,
+		strongMemo: strongMemoHookAliases !== null,
+		strongMemoHookAliases,
 		// A split Hydrate query module is invoked as the existing server-rendered
 		// boundary body. Its sole component child must therefore keep the server's
 		// own component marker pair instead of borrowing the Hydrate block range.
@@ -26826,13 +27074,12 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			}
 		}
 		const hasNestedComp = containsComponentCallOrControlFlow(subStmts);
-		// A render-time call through a METHOD disqualifies the survivor
-		// short-circuit entirely: it can read state neither the item ref nor the
-		// deps tuple witnesses (`header.column.getIsSorted()` flips while `header`
-		// stays the memoized object), so a skipped body would render stale output —
-		// React re-runs bodies unconditionally. Property reads and plain-callee
-		// projections stay eligible (see plainCalleeIsMemoizable; the measured
-		// js-framework-benchmark/dbmon wins are read-only bodies).
+		// Compatibility mode keeps method calls live: an unchanged receiver can
+		// hide mutable state (`header.column.getIsSorted()` flips while `header`
+		// stays the same object). Strong production modules explicitly assert
+		// snapshot behavior and can admit static methods. Both modes still witness
+		// every capture, including callbacks that need the latest parent state;
+		// neither promise permits skipping hooks or ref reads.
 		const hasRenderCall = containsRenderCall(subStmts, ctx);
 		itemMemo =
 			ctx.autoMemo === true &&

--- a/packages/octane/src/compiler/index.d.ts
+++ b/packages/octane/src/compiler/index.d.ts
@@ -55,6 +55,7 @@ export interface CompileOptions {
 	mode?: 'client' | 'server';
 	hmr?: boolean | 'vite' | 'webpack';
 	dev?: boolean;
+	/** Opt into immutable render snapshots, bounded purity checks, and production call memoization. */
 	strong?: boolean;
 	profile?: boolean;
 	profileFilename?: string;

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -2,6 +2,17 @@ import { collectReassignedBindings } from './hook-deps.js';
 
 const STATE_HOOKS = new Set(['useState', 'useReducer', 'useLinkedState']);
 const EFFECT_HOOKS = new Set(['useEffect', 'useLayoutEffect', 'useInsertionEffect']);
+const ARRAY_MUTATORS = new Set([
+	'copyWithin',
+	'fill',
+	'pop',
+	'push',
+	'reverse',
+	'shift',
+	'sort',
+	'splice',
+	'unshift',
+]);
 const FUNCTION_TYPES = new Set([
 	'FunctionDeclaration',
 	'FunctionExpression',
@@ -25,6 +36,10 @@ const UNKNOWN_VALUE = NULLISH_VALUE | FALSY_VALUE | TRUTHY_VALUE;
 const UNKNOWN_PRIMITIVE = Symbol('unknown primitive');
 const NO_RETURN_VALUE = Symbol('no return value');
 const OTHER_BINDING = { kind: 'other' };
+const SNAPSHOT_BINDING = { kind: 'snapshot' };
+const ARRAY_SNAPSHOT_BINDING = { kind: 'snapshot', array: true };
+const STATE_TUPLE_BINDING = { kind: 'state-tuple', snapshot: SNAPSHOT_BINDING };
+const ARRAY_STATE_TUPLE_BINDING = { kind: 'state-tuple', snapshot: ARRAY_SNAPSHOT_BINDING };
 const UNDEFINED_BINDING = { kind: 'constant', value: UNDEFINED_VALUE, primitive: undefined };
 const SKIP_KEYS = new Set([
 	'type',
@@ -44,6 +59,8 @@ const SKIP_KEYS = new Set([
 export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+export const STRONG_RENDER_SNAPSHOT_MUTATION = 'OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION';
+export const STRONG_RENDER_IMPURE_CALL = 'OCTANE_STRONG_RENDER_IMPURE_CALL';
 export const STRONG_RENDER_EFFECT_EVENT_CALL = 'OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL';
 export const STRONG_EFFECT_EVENT_DEPENDENCY = 'OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY';
 export const STRONG_DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
@@ -104,6 +121,23 @@ function addPatternNames(pattern, bindings, value, overwrite = true) {
 				addPatternNames(property.argument ?? property.value, bindings, value, overwrite);
 			}
 	}
+}
+
+function bindSnapshotPattern(pattern, value, bind) {
+	if (pattern?.type === 'Identifier') {
+		bind(pattern, value);
+	} else if (pattern?.type === 'ObjectPattern') {
+		for (const property of pattern.properties ?? []) {
+			if (property.type === 'Property') {
+				bindSnapshotPattern(property.value, SNAPSHOT_BINDING, bind);
+			}
+		}
+	} else if (pattern?.type === 'ArrayPattern') {
+		for (const element of pattern.elements ?? []) {
+			bindSnapshotPattern(element, SNAPSHOT_BINDING, bind);
+		}
+	}
+	// Rest copies and default expressions can produce new mutable values.
 }
 
 function declarationOf(statement) {
@@ -339,8 +373,64 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	const reportedDiagnostics = new WeakMap();
 	const hoistedVarNames = new WeakMap();
 	const mayHaveHoistedVars = source.includes('var');
+	const renderRoots = new WeakSet();
+	const renderOutputs = new WeakMap();
+	function hasRenderOutput(fn) {
+		if (!FUNCTION_TYPES.has(fn?.type)) return false;
+		const known = renderOutputs.get(fn);
+		if (known !== undefined) return known;
+		function containsJsx(value) {
+			if (value == null || typeof value !== 'object') return false;
+			if (Array.isArray(value)) return value.some(containsJsx);
+			if (
+				FUNCTION_TYPES.has(value.type) ||
+				value.type === 'ClassDeclaration' ||
+				value.type === 'ClassExpression'
+			) {
+				return false;
+			}
+			if (
+				value.type === 'JSXCodeBlock' ||
+				value.type === 'JSXElement' ||
+				value.type === 'JSXFragment'
+			) {
+				return true;
+			}
+			for (const key in value) {
+				if (!SKIP_KEYS.has(key) && !key.startsWith('_octane') && containsJsx(value[key])) return true;
+			}
+			return false;
+		}
+		const result = containsJsx(fn.body);
+		renderOutputs.set(fn, result);
+		return result;
+	}
+	function addNamedRenderRoot(fn, name) {
+		if (
+			FUNCTION_TYPES.has(fn?.type) &&
+			(/^(?:unstable_)?use[A-Z0-9]/.test(name) || (/^[A-Z]/.test(name) && hasRenderOutput(fn)))
+		) {
+			renderRoots.add(fn);
+		}
+	}
+	for (const statement of ast.body ?? []) {
+		const declaration = declarationOf(statement);
+		if (declaration?.type === 'VariableDeclaration') {
+			for (const binding of declaration.declarations ?? []) {
+				if (binding.id?.type === 'Identifier') {
+					addNamedRenderRoot(unwrap(binding.init), binding.id.name);
+				}
+			}
+		} else {
+			addNamedRenderRoot(declaration, declaration?.id?.name ?? '');
+			if (statement.type === 'ExportDefaultDeclaration' && hasRenderOutput(declaration)) {
+				renderRoots.add(declaration);
+			}
+		}
+	}
 	let returnCycles = 0;
 	let currentFunctionIsAsync = false;
+	let currentFunctionChecksImpureCalls = false;
 
 	function predeclareHoistedVars(node, scope) {
 		if (!mayHaveHoistedVars || node == null) return;
@@ -403,6 +493,51 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			node,
 			'Strong mode does not allow writing to useRef.current during render. Move the write to an event or effect, or express the value as state.',
 		);
+	}
+
+	function reportSnapshotMutation(node) {
+		report(
+			STRONG_RENDER_SNAPSHOT_MUTATION,
+			node,
+			'Strong mode does not allow mutating a state snapshot during render. Derive a local copy, or pass a new value to the state updater from an event.',
+		);
+	}
+
+	function reportSnapshotWrite(target, scope) {
+		const member = unwrap(target);
+		if (member?.type === 'MemberExpression' && snapshotBinding(member.object, scope) !== null) {
+			reportSnapshotMutation(member);
+		}
+	}
+
+	function reportImpureCall(node) {
+		report(
+			STRONG_RENDER_IMPURE_CALL,
+			node,
+			'Strong mode does not allow nondeterministic calls during render. Read time or randomness outside render and pass the result as a prop or state snapshot.',
+		);
+	}
+
+	function unshadowedGlobal(node, scope, name) {
+		const value = unwrap(node);
+		return value?.type === 'Identifier' && value.name === name && resolve(scope, name) === null;
+	}
+
+	function impureStandardCall(callee, scope) {
+		if (unshadowedGlobal(callee, scope, 'Date')) return true;
+		if (callee?.type !== 'MemberExpression') return false;
+		const object = unwrap(callee.object);
+		if (
+			object?.type !== 'Identifier' ||
+			(object.name !== 'Date' && object.name !== 'Math' && object.name !== 'performance') ||
+			resolve(scope, object.name) !== null
+		) {
+			return false;
+		}
+		const property = callee.computed
+			? staticPrimitiveValue(callee.property, scope)
+			: callee.property?.name;
+		return object.name === 'Math' ? property === 'random' : property === 'now';
 	}
 
 	function reportEffectEventCall(node) {
@@ -805,7 +940,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 	function visitFunction(node, parentScope, phase, args = null) {
 		const enclosingFunctionIsAsync = currentFunctionIsAsync;
+		const enclosingFunctionChecksImpureCalls = currentFunctionChecksImpureCalls;
 		currentFunctionIsAsync = node.async === true;
+		if (phase === 'render' && !activeCallbacks.has(node)) {
+			// Ordinary module helpers may be used only by events. Check their
+			// standard calls when a known render root invokes them synchronously.
+			currentFunctionChecksImpureCalls =
+				renderRoots.has(node) || node.body?.type === 'JSXCodeBlock';
+		}
 		try {
 			const body = node.body;
 			let functionScope;
@@ -834,6 +976,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			}
 		} finally {
 			currentFunctionIsAsync = enclosingFunctionIsAsync;
+			currentFunctionChecksImpureCalls = enclosingFunctionChecksImpureCalls;
 		}
 	}
 
@@ -862,6 +1005,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			}
 		} else if (pattern?.type === 'RestElement') {
 			executionPhase = visitPatternExpressions(pattern.argument, scope, executionPhase);
+		} else if (pattern?.type === 'MemberExpression') {
+			visit(pattern, scope, executionPhase);
+			executionPhase = phaseAfter(pattern, executionPhase, true);
+			if (executionPhase === 'render') reportSnapshotWrite(pattern, scope);
 		}
 		return executionPhase;
 	}
@@ -876,11 +1023,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				declarationKind === 'const' || !isReassigned(identifier) ? value : OTHER_BINDING,
 			);
 		}
-		const stateTuple =
-			(initial?.type === 'CallExpression' &&
-				STATE_HOOKS.has(importedHook(initial.callee, scope))) ||
-			(initial?.type === 'Identifier' && resolve(scope, initial.name)?.kind === 'state-tuple');
+		const stateTuple = stateTupleBinding(initial, scope);
+		const snapshot =
+			stateTuple === null && declarationKind === 'const' ? snapshotBinding(initial, scope) : null;
 		if (declaration.id?.type === 'ArrayPattern' && stateTuple) {
+			bindSnapshotPattern(declaration.id.elements?.[0], stateTuple.snapshot, bind);
 			const element = declaration.id.elements?.[1];
 			const setter = element?.type === 'AssignmentPattern' ? element.left : element;
 			bind(setter, { kind: 'setter' });
@@ -896,11 +1043,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				const setter = value?.type === 'AssignmentPattern' ? value.left : value;
 				if ((key === 1 || key === '1') && setter?.type === 'Identifier') {
 					bind(setter, { kind: 'setter' });
+				} else if (key === 0 || key === '0') {
+					bindSnapshotPattern(value, stateTuple.snapshot, bind);
 				}
 			}
 		} else if (declaration.id?.type === 'Identifier') {
 			if (stateTuple) {
-				bind(declaration.id, { kind: 'state-tuple' });
+				bind(declaration.id, stateTuple);
 			} else if (
 				initial?.type === 'CallExpression' &&
 				importedHook(initial.callee, scope) === 'useRef'
@@ -908,6 +1057,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				bind(declaration.id, { kind: 'ref' });
 			} else if (declarationKind === 'const' && stateTupleUpdater(initial, scope)) {
 				target.bindings.set(declaration.id.name, { kind: 'setter' });
+			} else if (snapshot !== null) {
+				target.bindings.set(declaration.id.name, snapshot);
 			} else if (declarationKind === 'const' && initial?.type === 'Identifier') {
 				const value = resolve(scope, initial.name);
 				if (
@@ -966,7 +1117,40 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					});
 				}
 			}
+		} else if (snapshot !== null) {
+			bindSnapshotPattern(declaration.id, snapshot, bind);
 		}
+	}
+
+	function stateTupleBinding(expression, scope) {
+		const node = unwrap(expression);
+		if (node?.type === 'Identifier') {
+			const binding = resolve(scope, node.name);
+			return binding?.kind === 'state-tuple' ? binding : null;
+		}
+		if (node?.type !== 'CallExpression') return null;
+		const hook = importedHook(node.callee, scope);
+		if (!STATE_HOOKS.has(hook)) return null;
+		// A known array initializer is a narrow mutator check, not a judgment
+		// about arbitrary methods on object snapshots or opaque hook outputs.
+		return hook === 'useState' && unwrap(node.arguments?.[0])?.type === 'ArrayExpression'
+			? ARRAY_STATE_TUPLE_BINDING
+			: STATE_TUPLE_BINDING;
+	}
+
+	function snapshotBinding(expression, scope) {
+		const node = unwrap(expression);
+		if (node?.type === 'Identifier') {
+			const binding = resolve(scope, node.name);
+			return binding?.kind === 'snapshot' ? binding : null;
+		}
+		if (node?.type !== 'MemberExpression') return null;
+		const tuple = stateTupleBinding(node.object, scope);
+		if (tuple !== null && node.computed === true) {
+			const key = staticPrimitiveValue(node.property, scope);
+			if (key === 0 || key === '0') return tuple.snapshot;
+		}
+		return snapshotBinding(node.object, scope) !== null ? SNAPSHOT_BINDING : null;
 	}
 
 	function bindDeclaration(declaration, declarationKind, scope, phase) {
@@ -1437,6 +1621,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			if (
 				isCallableValue(binding) ||
 				binding?.kind === 'ref' ||
+				binding?.kind === 'snapshot' ||
 				binding?.kind === 'state-tuple' ||
 				binding?.kind === 'constant' ||
 				binding?.kind === 'linked-key'
@@ -1444,6 +1629,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				return binding;
 			}
 		}
+		const snapshot = snapshotBinding(node, scope);
+		if (snapshot !== null) return snapshot;
+		const tuple = stateTupleBinding(node, scope);
+		if (tuple !== null) return tuple;
 		const result = returnedExpression(node, scope);
 		if (result.callback !== null) return result.callback;
 		return result.value === UNKNOWN_VALUE && result.primitive === UNKNOWN_PRIMITIVE
@@ -1613,8 +1802,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
-	function visitSynchronousHookCallback(value, scope, phase) {
-		visitCallable(callableValue(value, scope), unwrap(value), phase);
+	function visitSynchronousHookCallback(value, scope, phase, stateInitializer = false) {
+		const checkImpureCalls = currentFunctionChecksImpureCalls;
+		// Lazy state initialization may read a clock or randomness. Keep its
+		// existing state/ref/Effect Event checks at the synchronous render phase.
+		if (stateInitializer) currentFunctionChecksImpureCalls = false;
+		try {
+			visitCallable(callableValue(value, scope), unwrap(value), phase);
+		} finally {
+			currentFunctionChecksImpureCalls = checkImpureCalls;
+		}
 	}
 
 	function containsEffectEvent(value) {
@@ -1927,6 +2124,12 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'CallExpression': {
 				const hook = importedHook(node.callee, scope);
 				const callee = unwrap(node.callee);
+				const wrapped =
+					hook === 'memo' || hook === 'lazy' ? callableValue(node.arguments?.[0], scope) : null;
+				const component =
+					wrapped?.kind === 'callback' && (hook === 'memo' || hasRenderOutput(wrapped.node))
+						? wrapped
+						: null;
 				if (!FUNCTION_TYPES.has(callee?.type)) {
 					visit(node.callee, scope, phase);
 				}
@@ -1941,7 +2144,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 								: -1;
 				for (let index = 0; index < (node.arguments?.length ?? 0); index++) {
 					const argument = node.arguments[index];
-					if (index !== synchronousCallbackIndex || !FUNCTION_TYPES.has(unwrap(argument)?.type)) {
+					if (
+						(index !== synchronousCallbackIndex && !(index === 0 && component !== null)) ||
+						!FUNCTION_TYPES.has(unwrap(argument)?.type)
+					) {
 						visit(argument, scope, executionPhase);
 					}
 					executionPhase = phaseAfter(argument, executionPhase);
@@ -1965,17 +2171,48 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					return;
 				}
 				if (hook === 'useState' || hook === 'useMemo') {
-					visitSynchronousHookCallback(node.arguments?.[0], scope, executionPhase);
+					visitSynchronousHookCallback(
+						node.arguments?.[0],
+						scope,
+						executionPhase,
+						hook === 'useState',
+					);
 					return;
 				}
 				if (hook === 'useReducer') {
-					visitSynchronousHookCallback(node.arguments?.[2], scope, executionPhase);
+					visitSynchronousHookCallback(node.arguments?.[2], scope, executionPhase, true);
 					return;
 				}
 				if (hook === 'useLinkedState') {
 					visitSynchronousHookCallback(node.arguments?.[1], scope, executionPhase);
 					visitLinkedStateComparators(node.arguments?.[2], scope, executionPhase);
 					return;
+				}
+				if (component !== null) {
+					// memo owns a component callback. lazy also accepts a module
+					// loader, so require JSX evidence before treating it as a render.
+					const checkImpureCalls = currentFunctionChecksImpureCalls;
+					currentFunctionChecksImpureCalls = true;
+					try {
+						visitCallback(component.node, component.scope, 'render');
+					} finally {
+						currentFunctionChecksImpureCalls = checkImpureCalls;
+					}
+					return;
+				}
+				if (executionPhase === 'render') {
+					if (currentFunctionChecksImpureCalls && impureStandardCall(callee, scope)) {
+						reportImpureCall(callee);
+					}
+					if (
+						callee?.type === 'MemberExpression' &&
+						snapshotBinding(callee.object, scope)?.array === true &&
+						ARRAY_MUTATORS.has(
+							callee.computed ? staticPrimitiveValue(callee.property, scope) : callee.property?.name,
+						)
+					) {
+						reportSnapshotMutation(callee);
+					}
 				}
 				if (
 					executionPhase === 'render' ||
@@ -2007,6 +2244,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					scope,
 					phaseAfter(node.callee, phase),
 				);
+				if (
+					executionPhase === 'render' &&
+					currentFunctionChecksImpureCalls &&
+					node.arguments?.length === 0 &&
+					unshadowedGlobal(callee, scope, 'Date')
+				) {
+					reportImpureCall(callee);
+				}
 				if (inlineConstructor) {
 					visitCallback(callee, scope, executionPhase, argumentValues(node.arguments, scope));
 				} else if (
@@ -2062,12 +2307,24 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				const rightPhase = phaseAfter(node.left, phase, true);
 				visit(node.right, scope, rightPhase);
 				const executionPhase = phaseAfter(node.right, rightPhase);
-				if (executionPhase === 'render' && currentRef(node.left, scope)) reportRef(node.left);
+				if (executionPhase === 'render') {
+					if (currentRef(node.left, scope)) reportRef(node.left);
+					reportSnapshotWrite(node.left, scope);
+				}
 				return;
 			}
 			case 'UpdateExpression':
 				if (phase === 'render' && currentRef(node.argument, scope)) reportRef(node.argument);
 				visit(node.argument, scope, phase);
+				if (phaseAfter(node.argument, phase, true) === 'render') {
+					reportSnapshotWrite(node.argument, scope);
+				}
+				return;
+			case 'UnaryExpression':
+				visit(node.argument, scope, phase);
+				if (node.operator === 'delete' && phaseAfter(node.argument, phase, true) === 'render') {
+					reportSnapshotWrite(node.argument, scope);
+				}
 				return;
 			case 'CatchClause': {
 				const catchScope = createScope(scope, 'block', [], node.param ? [node.param] : []);

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -397,7 +397,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				return true;
 			}
 			for (const key in value) {
-				if (!SKIP_KEYS.has(key) && !key.startsWith('_octane') && containsJsx(value[key])) return true;
+				if (!SKIP_KEYS.has(key) && !key.startsWith('_octane') && containsJsx(value[key]))
+					return true;
 			}
 			return false;
 		}
@@ -2208,7 +2209,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						callee?.type === 'MemberExpression' &&
 						snapshotBinding(callee.object, scope)?.array === true &&
 						ARRAY_MUTATORS.has(
-							callee.computed ? staticPrimitiveValue(callee.property, scope) : callee.property?.name,
+							callee.computed
+								? staticPrimitiveValue(callee.property, scope)
+								: callee.property?.name,
 						)
 					) {
 						reportSnapshotMutation(callee);

--- a/packages/octane/tests/_fixtures/for-strong-getter.tsrx
+++ b/packages/octane/tests/_fixtures/for-strong-getter.tsrx
@@ -1,0 +1,18 @@
+"use strong";
+
+import { useMemo, useState } from 'octane';
+
+export function TupleGetterMethodRows() @{
+	const tuple = useState(0);
+	const getCount = tuple[2];
+	const [getterRows] = useState([{ id: 1 }]);
+	const getterReader = useMemo(() => ({ readCount: getCount }), [getCount]);
+	<div>
+		<button id="tuple-method-bump" onClick={() => tuple[1]((count) => count + 1)}>bump</button>
+		<ul>
+			@for (const getterRow of getterRows; key getterRow.id) {
+				<li>{`${getterReader.readCount()}`}</li>
+			}
+		</ul>
+	</div>
+}

--- a/packages/octane/tests/_fixtures/for-strong-getter.tsrx
+++ b/packages/octane/tests/_fixtures/for-strong-getter.tsrx
@@ -1,4 +1,4 @@
-"use strong";
+'use strong';
 
 import { useMemo, useState } from 'octane';
 

--- a/packages/octane/tests/_fixtures/for-strong-hooks.tsrx
+++ b/packages/octane/tests/_fixtures/for-strong-hooks.tsrx
@@ -1,0 +1,79 @@
+"use strong";
+
+import { createContext, useContext, useRef, useState } from 'octane';
+
+const MethodContext = createContext('initial');
+const contextMethod = 'readContextValue';
+
+export function ComputedHookMethodRows({ value }: { value: string }) @{
+	const [contextRows] = useState(() => [
+		{
+			id: 1,
+			[contextMethod]() {
+				return useContext(MethodContext);
+			},
+		},
+	]);
+	<MethodContext.Provider value={value}>
+		<ul>
+			@for (const contextRow of contextRows; key contextRow.id) {
+				<li>{contextRow.readContextValue() as string}</li>
+			}
+		</ul>
+	</MethodContext.Provider>
+}
+
+const refFormatter = { formatRef(value: string) { return value; } };
+
+export function RefArgumentMethodRows() @{
+	const valueRef = useRef('first');
+	const [argumentRows] = useState([{ id: 1 }]);
+	const [, rerender] = useState(0);
+	<div>
+		<button id="mutate-ref" onClick={() => {
+			valueRef.current = 'second';
+			rerender((count) => count + 1);
+		}}>change</button>
+		<ul>
+			@for (const argumentRow of argumentRows; key argumentRow.id) {
+				<li>{refFormatter.formatRef(valueRef.current) as string}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function AliasedRefMethodRows() @{
+	const aliasRef = useRef({ label: 'first', readRefLabel() { return this.label; } });
+	const aliasedReader = aliasRef.current;
+	const [aliasRows] = useState([{ id: 1 }]);
+	const [, rerender] = useState(0);
+	<div>
+		<button id="mutate-ref" onClick={() => {
+			aliasRef.current.label = 'second';
+			rerender((count) => count + 1);
+		}}>change</button>
+		<ul>
+			@for (const aliasRow of aliasRows; key aliasRow.id) {
+				<li>{aliasedReader.readRefLabel() as string}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function DestructuredRefMethodRows() @{
+	const destructuredRef = useRef({ label: 'first', readDestructuredLabel() { return this.label; } });
+	const { current: destructuredReader } = destructuredRef;
+	const [destructuredRows] = useState([{ id: 1 }]);
+	const [, rerender] = useState(0);
+	<div>
+		<button id="mutate-ref" onClick={() => {
+			destructuredRef.current.label = 'second';
+			rerender((count) => count + 1);
+		}}>change</button>
+		<ul>
+			@for (const destructuredRow of destructuredRows; key destructuredRow.id) {
+				<li>{destructuredReader.readDestructuredLabel() as string}</li>
+			}
+		</ul>
+	</div>
+}

--- a/packages/octane/tests/_fixtures/for-strong-hooks.tsrx
+++ b/packages/octane/tests/_fixtures/for-strong-hooks.tsrx
@@ -1,4 +1,4 @@
-"use strong";
+'use strong';
 
 import { createContext, useContext, useRef, useState } from 'octane';
 
@@ -6,14 +6,16 @@ const MethodContext = createContext('initial');
 const contextMethod = 'readContextValue';
 
 export function ComputedHookMethodRows({ value }: { value: string }) @{
-	const [contextRows] = useState(() => [
-		{
-			id: 1,
-			[contextMethod]() {
-				return useContext(MethodContext);
+	const [contextRows] = useState(
+		() => [
+			{
+				id: 1,
+				[contextMethod]() {
+					return useContext(MethodContext);
+				},
 			},
-		},
-	]);
+		],
+	);
 	<MethodContext.Provider value={value}>
 		<ul>
 			@for (const contextRow of contextRows; key contextRow.id) {
@@ -23,17 +25,24 @@ export function ComputedHookMethodRows({ value }: { value: string }) @{
 	</MethodContext.Provider>
 }
 
-const refFormatter = { formatRef(value: string) { return value; } };
+const refFormatter = {
+	formatRef(value: string) {
+		return value;
+	},
+};
 
 export function RefArgumentMethodRows() @{
 	const valueRef = useRef('first');
 	const [argumentRows] = useState([{ id: 1 }]);
 	const [, rerender] = useState(0);
 	<div>
-		<button id="mutate-ref" onClick={() => {
-			valueRef.current = 'second';
-			rerender((count) => count + 1);
-		}}>change</button>
+		<button
+			id="mutate-ref"
+			onClick={() => {
+				valueRef.current = 'second';
+				rerender((count) => count + 1);
+			}}
+		>change</button>
 		<ul>
 			@for (const argumentRow of argumentRows; key argumentRow.id) {
 				<li>{refFormatter.formatRef(valueRef.current) as string}</li>
@@ -43,15 +52,23 @@ export function RefArgumentMethodRows() @{
 }
 
 export function AliasedRefMethodRows() @{
-	const aliasRef = useRef({ label: 'first', readRefLabel() { return this.label; } });
+	const aliasRef = useRef({
+		label: 'first',
+		readRefLabel() {
+			return this.label;
+		},
+	});
 	const aliasedReader = aliasRef.current;
 	const [aliasRows] = useState([{ id: 1 }]);
 	const [, rerender] = useState(0);
 	<div>
-		<button id="mutate-ref" onClick={() => {
-			aliasRef.current.label = 'second';
-			rerender((count) => count + 1);
-		}}>change</button>
+		<button
+			id="mutate-ref"
+			onClick={() => {
+				aliasRef.current.label = 'second';
+				rerender((count) => count + 1);
+			}}
+		>change</button>
 		<ul>
 			@for (const aliasRow of aliasRows; key aliasRow.id) {
 				<li>{aliasedReader.readRefLabel() as string}</li>
@@ -61,15 +78,23 @@ export function AliasedRefMethodRows() @{
 }
 
 export function DestructuredRefMethodRows() @{
-	const destructuredRef = useRef({ label: 'first', readDestructuredLabel() { return this.label; } });
+	const destructuredRef = useRef({
+		label: 'first',
+		readDestructuredLabel() {
+			return this.label;
+		},
+	});
 	const { current: destructuredReader } = destructuredRef;
 	const [destructuredRows] = useState([{ id: 1 }]);
 	const [, rerender] = useState(0);
 	<div>
-		<button id="mutate-ref" onClick={() => {
-			destructuredRef.current.label = 'second';
-			rerender((count) => count + 1);
-		}}>change</button>
+		<button
+			id="mutate-ref"
+			onClick={() => {
+				destructuredRef.current.label = 'second';
+				rerender((count) => count + 1);
+			}}
+		>change</button>
 		<ul>
 			@for (const destructuredRow of destructuredRows; key destructuredRow.id) {
 				<li>{destructuredReader.readDestructuredLabel() as string}</li>

--- a/packages/octane/tests/_fixtures/for-strong.tsrx
+++ b/packages/octane/tests/_fixtures/for-strong.tsrx
@@ -1,4 +1,4 @@
-"use strong";
+'use strong';
 
 import { createContext, useContext, useState } from 'octane';
 
@@ -72,7 +72,9 @@ export function CapturedSnapshotList() @{
 				<li class="captured-row" data-id={item.id}>
 					<span>{item.label as string}</span>
 					{console.log('eval:', item.id)}
-					<button onClick={() => setItems(items.filter((entry) => entry.id !== item.id))}>remove</button>
+					<button onClick={() => setItems(items.filter((entry) => entry.id !== item.id))}>
+						remove
+					</button>
 				</li>
 			} @empty {
 				<li class="captured-empty">Empty</li>
@@ -93,7 +95,9 @@ export function ContextArgumentMethodList({ items, prefix }: Omit<SnapshotListPr
 	</PrefixContext.Provider>
 }
 
-export function RefMethodList({ items }: {
+export function RefMethodList({
+	items,
+}: {
 	items: Array<{ id: number; current: { read(): string } }>;
 }) @{
 	<ul>

--- a/packages/octane/tests/_fixtures/for-strong.tsrx
+++ b/packages/octane/tests/_fixtures/for-strong.tsrx
@@ -1,0 +1,104 @@
+"use strong";
+
+import { createContext, useContext, useState } from 'octane';
+
+export interface SnapshotRow {
+	id: number;
+	label: string;
+	read(prefix: string): string;
+}
+
+export interface SnapshotListProps {
+	items: SnapshotRow[];
+	prefix: string;
+	onSelect: (item: SnapshotRow) => void;
+}
+
+interface SnapshotCalculationProps {
+	item: SnapshotRow;
+	prefix: string;
+	formatter: { read(item: SnapshotRow, prefix: string): string };
+}
+
+function readSnapshot({ formatter, item, prefix }: SnapshotCalculationProps) {
+	return formatter.read(item, prefix);
+}
+
+export function SnapshotCalculation({ formatter, item, prefix }: SnapshotCalculationProps) @{
+	const label = formatter.read(item, prefix);
+	<p>{label as string}</p>
+}
+
+export function WrappedSnapshotCalculation(props: SnapshotCalculationProps) @{
+	const label = readSnapshot(props);
+	<p>{label as string}</p>
+}
+
+export function SnapshotMethodList({ items, prefix, onSelect }: SnapshotListProps) @{
+	<ul>
+		@for (const item of items; key item.id) {
+			<li data-id={item.id}>
+				<span class="snapshot-label">{item.read(prefix) as string}</span>
+				<input defaultValue={item.label} />
+				<button onClick={() => onSelect(item)}>select</button>
+			</li>
+		} @empty {
+			<li class="snapshot-empty">{prefix + 'empty'}</li>
+		}
+	</ul>
+}
+
+// Keep the reported callback shape: it deliberately closes over this render's
+// items snapshot, so an append must refresh handlers on surviving rows.
+export function CapturedSnapshotList() @{
+	const [items, setItems] = useState([
+		{ id: 1, label: 'apple' },
+		{ id: 2, label: 'banana' },
+		{ id: 3, label: 'cherry' },
+	]);
+	const [nextId, setNextId] = useState(4);
+	const add = (position: 'start' | 'end') => {
+		const item = { id: nextId, label: 'item ' + nextId };
+		setNextId(nextId + 1);
+		setItems(position === 'start' ? [item, ...items] : [...items, item]);
+	};
+	<div>
+		<button id="captured-prepend" onClick={() => add('start')}>prepend</button>
+		<button id="captured-append" onClick={() => add('end')}>append</button>
+		<button id="captured-reverse" onClick={() => setItems([...items].reverse())}>reverse</button>
+		<button id="captured-clear" onClick={() => setItems([])}>clear</button>
+		<ul>
+			@for (const item of items; key item.id) {
+				<li class="captured-row" data-id={item.id}>
+					<span>{item.label as string}</span>
+					{console.log('eval:', item.id)}
+					<button onClick={() => setItems(items.filter((entry) => entry.id !== item.id))}>remove</button>
+				</li>
+			} @empty {
+				<li class="captured-empty">Empty</li>
+			}
+		</ul>
+	</div>
+}
+
+const PrefixContext = createContext('initial:');
+
+export function ContextArgumentMethodList({ items, prefix }: Omit<SnapshotListProps, 'onSelect'>) @{
+	<PrefixContext.Provider value={prefix}>
+		<ul>
+			@for (const item of items; key item.id) {
+				<li>{item.read(useContext(PrefixContext)) as string}</li>
+			}
+		</ul>
+	</PrefixContext.Provider>
+}
+
+export function RefMethodList({ items }: {
+	items: Array<{ id: number; current: { read(): string } }>;
+}) @{
+	<ul>
+		@for (const item of items; key item.id) {
+			<li>{item.current.read() as string}</li>
+		}
+	</ul>
+}

--- a/packages/octane/tests/_fixtures/for-strong.tsx
+++ b/packages/octane/tests/_fixtures/for-strong.tsx
@@ -1,0 +1,42 @@
+/** @jsxImportSource octane */
+"use strong";
+
+import { createContext, useContext, useState } from 'octane';
+import type { SnapshotListProps } from './for-strong.tsrx';
+
+export function SnapshotMappedList({ items, prefix, onSelect }: SnapshotListProps) {
+	return (
+		<ul>
+			{items.map((item) => (
+				<li key={item.id} data-id={item.id}>
+					<span className="snapshot-label">{item.read(prefix)}</span>
+					<input defaultValue={item.label} />
+					<button onClick={() => onSelect(item)}>select</button>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+const MapMethodContext = createContext('initial');
+const mapMethod = 'readMapContext';
+
+export function ComputedHookMappedRows({ value }: { value: string }) {
+	const [contextMapRows] = useState(() => [
+		{
+			id: 1,
+			[mapMethod]() {
+				return useContext(MapMethodContext);
+			},
+		},
+	]);
+	return (
+		<MapMethodContext.Provider value={value}>
+			<ul>
+				{contextMapRows.map((contextMapRow) => (
+					<li key={contextMapRow.id}>{contextMapRow.readMapContext()}</li>
+				))}
+			</ul>
+		</MapMethodContext.Provider>
+	);
+}

--- a/packages/octane/tests/_fixtures/for-strong.tsx
+++ b/packages/octane/tests/_fixtures/for-strong.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource octane */
-"use strong";
+'use strong';
 
 import { createContext, useContext, useState } from 'octane';
 import type { SnapshotListProps } from './for-strong.tsrx';

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -111,8 +111,8 @@ export function setExternal(v: string) {
 // A render-time call through a MEMBER callee defeats the survivor short-circuit
 // entirely: `item.read()` reads mutable state through a STABLE item ref (the
 // TanStack Table header pattern — `header.column.getIsSorted()` flips while the
-// header object stays memoized), so the body must re-run on every parent render,
-// React-parity. Contrast DepPureList below: a bare module-var READ stays
+// header object stays memoized), so compatibility mode re-runs the body on parent
+// renders, like ordinary React without its compiler. Contrast DepPureList: a bare module-var READ stays
 // eligible (documented at-your-own-risk), and so does a call through a plain
 // identifier callee (PlainCalleeList) — the receiver is what carries the hazard.
 const callItems = [

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -6,9 +6,294 @@ import { compileToVolarMappings } from '../../src/compiler/volar.js';
 const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+const RENDER_SNAPSHOT_MUTATION = 'OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION';
+const RENDER_IMPURE_CALL = 'OCTANE_STRONG_RENDER_IMPURE_CALL';
 const RENDER_EFFECT_EVENT_CALL = 'OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL';
 const EFFECT_EVENT_DEPENDENCY = 'OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY';
 const DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
+
+describe('Strong mode immutable render inputs', () => {
+	const component = (setup: string) => `import { useState, useReducer, useLinkedState } from 'octane';
+export function App(props) @{
+  ${setup}
+  <div />
+}`;
+
+	it.each([
+		['property assignments', 'const [state] = useState({ count: 0 }); state.count = 1;'],
+		['compound assignments', 'const [state] = useState({ count: 0 }); state.count += 1;'],
+		['updates', 'const [state] = useState({ count: 0 }); state.count++;'],
+		['deletions', 'const [state] = useState({ count: 0 }); delete state.count;'],
+		[
+			'destructuring assignment targets',
+			'const [state] = useState({ count: 0 }); [state.count] = [1];',
+		],
+		[
+			'nested property aliases',
+			'const [state] = useState({ nested: { count: 0 } }); const nested = state.nested; const alias = nested; alias.count++;',
+		],
+		[
+			'destructured property aliases',
+			'const [state] = useState({ nested: { count: 0 } }); const { nested } = state; nested.count++;',
+		],
+		[
+			'destructured snapshot properties',
+			'const [{ nested }] = useState({ nested: { count: 0 } }); nested.count++;',
+		],
+		[
+			'aliased tuple index access',
+			'const tuple = useState({ count: 0 }); const pair = tuple; const index = 0 as const; pair[index].count++;',
+		],
+		[
+			'object-pattern tuple access',
+			'const tuple = useState({ count: 0 }); const { 0: state } = tuple; state.count++;',
+		],
+		[
+			'reducer snapshots',
+			'const [state] = useReducer((value) => value, { count: 0 }); state.count++;',
+		],
+		[
+			'linked-state snapshots',
+			'const [state] = useLinkedState(props.value, (value) => ({ count: value })); state.count++;',
+		],
+		[
+			'synchronous helper parameters',
+			'const [state] = useState({ count: 0 }); function mutate(value) { value.count++; } mutate({ count: 0 }); mutate(state);',
+		],
+		[
+			'synchronous tuple parameters',
+			'const tuple = useState({ count: 0 }); function mutate(pair) { pair[0].count++; } mutate(tuple);',
+		],
+		[
+			'immediate callback parameters',
+			'const [state] = useState({ count: 0 }); ((value) => { delete value.count; })(state);',
+		],
+	])('rejects render snapshot mutation through %s', (_label, setup) => {
+		const source = component(setup);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_SNAPSHOT_MUTATION,
+		);
+	});
+
+	it.each([
+		'copyWithin(0, 1)',
+		'fill(3)',
+		'pop()',
+		'push(3)',
+		'reverse()',
+		'shift()',
+		'sort()',
+		'splice(0, 1)',
+		'unshift(3)',
+	])('rejects %s on an array state snapshot during render', (call) => {
+		const source = component(`const [items] = useState([2, 1]); items.${call};`);
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_SNAPSHOT_MUTATION,
+		);
+	});
+
+	it('preserves array snapshot evidence through aliases and synchronous parameters', () => {
+		const source = component(`const tuple = useState([2, 1]);
+  const items = tuple[0];
+  const alias = items;
+  function reorder(values) { values['reverse'](); }
+  reorder(alias);`);
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_SNAPSHOT_MUTATION,
+		);
+	});
+
+	it('allows local copies, shadowed hooks, and snapshot methods without an array proof', () => {
+		const source = component(`const [state] = useState({ count: 0, sort() { return 1; }, set() { return 2; } });
+  const [items] = useState([2, 1]);
+  const copy = { ...state };
+  copy.count++;
+  delete copy.count;
+  const sorted = [...items];
+  sorted.sort();
+  state.sort();
+  state.set();
+  function mutate(value) { value.count++; }
+  mutate({ count: 0 });
+  function replace(value) { value = { count: 0 }; value.count++; }
+  replace(state);
+  {
+    const useState = () => [{ count: 0 }];
+    const [local] = useState();
+    local.count++;
+  }`);
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps immutable event updates and local effect work legal', () => {
+		const source = `"use strong";
+import { useState, useEffect } from 'octane';
+export function App() @{
+  const [state, setState] = useState({ count: 0 });
+  useEffect(() => { const local = { count: state.count }; local.count++; }, [state]);
+  <button onClick={() => setState({ count: state.count + 1 })}>{state.count as string}</button>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])('enforces snapshot mutation in $mode compilation with dev=$dev', (options) => {
+		const source = component('const [state] = useState({ count: 0 }); state.count++;');
+		expect(() => compile(source, '/src/App.tsrx', { ...options, strong: true } as any)).toThrow(
+			RENDER_SNAPSHOT_MUTATION,
+		);
+	});
+
+	it('locates snapshot writes in plain modules and editor diagnostics', () => {
+		const setup = 'const [state] = useState({ count: 0 }); delete state.count;';
+		const source = `"use strong";\n${component(setup)}`;
+		const plain = `"use strong"; import { useState } from 'octane'; export function useCounter() { ${setup} return state; }`;
+		const start = source.indexOf('state.count;');
+		expect(() => slotHooks(plain, '/src/useCounter.ts')).toThrow(RENDER_SNAPSHOT_MUTATION);
+		expect(compileToVolarMappings(source, '/src/App.tsrx').diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_SNAPSHOT_MUTATION,
+				severity: 'error',
+				start: expect.objectContaining({ offset: start }),
+				end: expect.objectContaining({ offset: start + 'state.count'.length }),
+			}),
+		);
+	});
+});
+
+describe('Strong mode nondeterministic render calls', () => {
+	it.each([
+		[
+			'memo-wrapped arrows',
+			'import { memo } from "octane"; export const App = memo(() => <div>{Date.now()}</div>);',
+		],
+		[
+			'aliased memo imports',
+			'import { memo as cached } from "octane"; export const App = cached(() => <div>{Date.now()}</div>);',
+		],
+		[
+			'memo-wrapped null output',
+			'import { memo } from "octane"; export const App = memo(() => { Date.now(); return null; });',
+		],
+		[
+			'memo-wrapped named callbacks',
+			'import { memo } from "octane"; const render = () => <div>{Date.now()}</div>; export const App = memo(render);',
+		],
+		[
+			'namespace lazy wrappers',
+			'import * as Octane from "octane"; export const App = Octane.lazy(() => <div>{Date.now()}</div>);',
+		],
+		[
+			'wrapped default exports',
+			'import { memo } from "octane"; export default memo(() => <div>{Date.now()}</div>);',
+		],
+		['anonymous default arrows', 'export default () => <div>{Date.now()}</div>;'],
+		[
+			'anonymous default functions',
+			'export default function() { return <div>{Date.now()}</div>; }',
+		],
+	])('enforces nondeterministic render calls in %s', (_label, source) => {
+		expect(() => compile(source, '/src/App.tsx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsx')).toThrow(RENDER_IMPURE_CALL);
+	});
+
+	it('does not treat shadowed memo utilities or lazy module loaders as component bodies', () => {
+		const source = `"use strong";
+import { lazy } from 'octane';
+const memo = (callback) => callback;
+const App = memo(() => <div>{Date.now()}</div>);
+const Deferred = lazy(() => { Date.now(); return import('./Deferred'); });
+export function Controls() { return <button onClick={App}>Create preview</button>; }`;
+		expect(() => compile(source, '/src/App.tsx')).not.toThrow();
+	});
+
+	it('keeps uppercase initialization and event helpers outside render', () => {
+		const source = `"use strong";
+import { useState } from 'octane';
+function InitialTime() { return Date.now(); }
+function Clock() { this.started = Date.now(); }
+export function App() {
+  const [time] = useState(InitialTime);
+  return <button onClick={() => new Clock()}>{time}</button>;
+}`;
+		expect(() => compile(source, '/src/App.tsx')).not.toThrow();
+	});
+
+	it.each(['Date.now()', 'Math.random()', 'performance.now()', 'new Date()', 'Date()'])(
+		'rejects %s in render without changing compatibility mode',
+		(expression) => {
+			const source = `export function App() @{ const value = ${expression}; <div>{value as string}</div> }`;
+			expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+			expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+				RENDER_IMPURE_CALL,
+			);
+		},
+	);
+
+	it('follows synchronous module helpers but leaves event-only helpers legal', () => {
+		const helper = 'function readClock() { return Date["now"](); }';
+		const render = `"use strong"; ${helper} export function App() @{ const value = readClock(); <div>{value as string}</div> }`;
+		const event = `"use strong"; ${helper} export function App() @{ <button onClick={readClock}>Read clock</button> }`;
+		expect(() => compile(render, '/src/App.tsrx')).toThrow(RENDER_IMPURE_CALL);
+		expect(() => compile(event, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('allows diagnostic logging, deterministic dates, and lexically shadowed globals', () => {
+		const source = `"use strong";
+export function App({ Math, Date, performance }) @{
+  const value = Math.random() + Date.now() + performance.now();
+  console.log(value);
+  <div />
+}
+export function Fixed() @{ const date = new Date(0); <div>{date.getTime() as string}</div> }`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('allows standard calls in events, effects, and deferred callbacks', () => {
+		const source = `"use strong";
+import { useEffect } from 'octane';
+export function App() @{
+  useEffect(() => { Date.now(); Math.random(); performance.now(); }, []);
+  setTimeout(() => new Date(), 0);
+  <button onClick={() => Date.now()}>Read clock</button>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('allows time and randomness in lazy state initializers but not memo calculations', () => {
+		// React permits non-idempotent state initialization; ordinary render
+		// calculations still have to be repeatable for the same inputs.
+		// https://react.dev/reference/rules/components-and-hooks-must-be-pure
+		const source = `"use strong";
+import { useState, useReducer, useMemo } from 'octane';
+function initialTime() { return Date.now(); }
+export function App() @{
+  const [date] = useState(() => new Date());
+  const [time] = useState(initialTime);
+  const [seed] = useState(() => Math.random());
+  const [stamp] = useReducer((value) => value, null, () => performance.now());
+  <div />
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		const memo = source.replace('const [time] = useState(initialTime);', 'useMemo(initialTime, []);');
+		expect(() => compile(memo, '/src/App.tsrx')).toThrow(RENDER_IMPURE_CALL);
+	});
+
+	it('enforces named custom hooks in plain modules and JSX components', () => {
+		const plain = '"use strong"; export function useClock() { return Date.now(); }';
+		const jsx = '"use strong"; export const App = () => <div>{Math.random()}</div>;';
+		expect(() => slotHooks(plain, '/src/useClock.ts')).toThrow(RENDER_IMPURE_CALL);
+		expect(() => compile(jsx, '/src/App.tsx')).toThrow(RENDER_IMPURE_CALL);
+		expect(compileToVolarMappings(jsx, '/src/App.tsx').diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_IMPURE_CALL, severity: 'error' }),
+		);
+	});
+});
 
 function stateComponent(setup: string, imports = 'useState'): string {
 	return `import { ${imports} } from 'octane';

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -13,7 +13,9 @@ const EFFECT_EVENT_DEPENDENCY = 'OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY';
 const DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
 
 describe('Strong mode immutable render inputs', () => {
-	const component = (setup: string) => `import { useState, useReducer, useLinkedState } from 'octane';
+	const component = (
+		setup: string,
+	) => `import { useState, useReducer, useLinkedState } from 'octane';
 export function App(props) @{
   ${setup}
   <div />
@@ -105,7 +107,8 @@ export function App(props) @{
 	});
 
 	it('allows local copies, shadowed hooks, and snapshot methods without an array proof', () => {
-		const source = component(`const [state] = useState({ count: 0, sort() { return 1; }, set() { return 2; } });
+		const source =
+			component(`const [state] = useState({ count: 0, sort() { return 1; }, set() { return 2; } });
   const [items] = useState([2, 1]);
   const copy = { ...state };
   copy.count++;
@@ -280,7 +283,10 @@ export function App() @{
   <div />
 }`;
 		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
-		const memo = source.replace('const [time] = useState(initialTime);', 'useMemo(initialTime, []);');
+		const memo = source.replace(
+			'const [time] = useState(initialTime);',
+			'useMemo(initialTime, []);',
+		);
 		expect(() => compile(memo, '/src/App.tsrx')).toThrow(RENDER_IMPURE_CALL);
 	});
 
@@ -2956,11 +2962,11 @@ export function App() {
 		expect(() => compile(source, '/src/App.tsx')).toThrow(RENDER_STATE_UPDATE);
 	});
 
-	it('does not ban nondeterministic render values', () => {
+	it('keeps opaque crypto methods outside the bounded purity diagnostics', () => {
 		const source = `"use strong";
 export function App() @{
-  const value = Date.now() + Math.random() + crypto.randomUUID();
-  <p>{value as string}</p>
+	  const value = crypto.randomUUID();
+	  <p>{value as string}</p>
 }`;
 
 		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import { createElement, flushSync, hydrateRoot, use, type OctaneNode } from '../src/index.js';
 import { act, mount } from './_helpers';
@@ -43,6 +43,23 @@ import {
 	setExternal,
 	setNestedConditionalActivityMode,
 } from './_fixtures/for.tsrx';
+import {
+	CapturedSnapshotList,
+	ContextArgumentMethodList,
+	RefMethodList,
+	SnapshotCalculation,
+	SnapshotMethodList,
+	WrappedSnapshotCalculation,
+	type SnapshotRow,
+} from './_fixtures/for-strong.tsrx';
+import { ComputedHookMappedRows, SnapshotMappedList } from './_fixtures/for-strong.tsx';
+import {
+	AliasedRefMethodRows,
+	ComputedHookMethodRows,
+	DestructuredRefMethodRows,
+	RefArgumentMethodRows,
+} from './_fixtures/for-strong-hooks.tsrx';
+import { TupleGetterMethodRows } from './_fixtures/for-strong-getter.tsrx';
 
 const labels = (r: ReturnType<typeof mount>) => r.findAll('li').map((li) => li.textContent);
 
@@ -207,12 +224,12 @@ describe('forBlock — a plain-callee projection stays reactive to its real inpu
 	});
 });
 
-describe('forBlock — render-time calls defeat the survivor short-circuit', () => {
-	it('a body calling an item method re-runs on every parent render (React parity)', () => {
+describe('forBlock — live methods in compatibility mode', () => {
+	it('keeps live item methods reactive in compatibility mode', () => {
 		// The TanStack Table header pattern: stable item refs whose methods read
 		// mutable state (`header.column.getIsSorted()`). Neither the item ref nor
 		// any dep changes, so a PURE/DEP-PURE skip would freeze the output — the
-		// compiler must classify call-bearing bodies as NORMAL.
+		// compatibility compiler must keep these bodies live.
 		const r = mount(CallBodyList);
 		expect(r.findAll('.cb-row').map((li) => li.textContent)).toEqual(['r1:tick0', 'r2:tick0']);
 
@@ -238,6 +255,205 @@ describe('forBlock — render-time calls defeat the survivor short-circuit', () 
 		]);
 		r.unmount();
 		setExternal('tick0');
+	});
+});
+
+describe('Strong list methods preserve snapshot and event semantics', () => {
+	const row = (id: number, label: string): SnapshotRow => ({
+		id,
+		label,
+		read(prefix) {
+			return prefix + this.label;
+		},
+	});
+
+	it.each([
+		['keyed templates', SnapshotMethodList],
+		['returned JSX', SnapshotMappedList],
+	])('updates snapshots, arguments, and captured callbacks in %s', (_dialect, Component) => {
+		const items = [row(1, 'apple'), row(2, 'banana')];
+		const selected: string[] = [];
+		const onSelect = (item: SnapshotRow) => selected.push('first:' + item.label);
+		const r = mount(Component, { items, prefix: 'old:', onSelect });
+		const original = r.findAll('li');
+		const editor = r.find('input') as HTMLInputElement;
+		editor.value = 'my draft';
+		const text = () => r.findAll('.snapshot-label').map((element) => element.textContent);
+		expect(text()).toEqual(['old:apple', 'old:banana']);
+
+		const appended = [...items, row(3, 'cherry')];
+		r.update(Component, { items: appended, prefix: 'old:', onSelect });
+		expect(text()).toEqual(['old:apple', 'old:banana', 'old:cherry']);
+		expect(r.findAll('li').slice(0, 2)).toEqual(original);
+		expect(r.find('input')).toBe(editor);
+		expect(editor.value).toBe('my draft');
+		r.click('li[data-id="1"] button');
+
+		r.update(Component, { items: appended, prefix: 'new:', onSelect });
+		expect(text()).toEqual(['new:apple', 'new:banana', 'new:cherry']);
+		const latestSelect = (item: SnapshotRow) => selected.push('latest:' + item.label);
+		r.update(Component, { items: appended, prefix: 'new:', onSelect: latestSelect });
+		r.click('li[data-id="1"] button');
+		expect(selected).toEqual(['first:apple', 'latest:apple']);
+
+		const replacement = row(1, 'apricot');
+		const reordered = [appended[2]!, replacement, items[1]!];
+		r.update(Component, { items: reordered, prefix: 'new:', onSelect: latestSelect });
+		expect(text()).toEqual(['new:cherry', 'new:apricot', 'new:banana']);
+		expect(r.findAll('li')[1]).toBe(original[0]);
+		expect(r.findAll('li')[2]).toBe(original[1]);
+		r.click('li[data-id="1"] button');
+		expect(selected).toEqual(['first:apple', 'latest:apple', 'latest:apricot']);
+
+		r.update(Component, { items: [replacement], prefix: 'last:', onSelect: latestSelect });
+		expect(text()).toEqual(['last:apricot']);
+		expect(r.find('li')).toBe(original[0]);
+		r.update(Component, { items: [], prefix: 'last:', onSelect: latestSelect });
+		expect(r.findAll('.snapshot-label')).toHaveLength(0);
+		r.update(Component, { items, prefix: 'restored:', onSelect });
+		expect(text()).toEqual(['restored:apple', 'restored:banana']);
+		r.unmount();
+	});
+
+	it('keeps appended items when an original row removes itself using the captured list', () => {
+		const diagnostic = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const r = mount(CapturedSnapshotList);
+		try {
+			const original = r.findAll('.captured-row');
+			const text = () => r.findAll('.captured-row span').map((element) => element.textContent);
+			r.click('#captured-append');
+			expect(text()).toEqual(['apple', 'banana', 'cherry', 'item 4']);
+			expect(r.findAll('.captured-row').slice(0, 3)).toEqual(original);
+			r.click('.captured-row[data-id="1"] button');
+			expect(text()).toEqual(['banana', 'cherry', 'item 4']);
+
+			r.click('#captured-prepend');
+			r.click('#captured-reverse');
+			expect(text()).toEqual(['item 4', 'cherry', 'banana', 'item 5']);
+			expect(r.findAll('.captured-row')[2]).toBe(original[1]);
+			r.click('.captured-row[data-id="2"] button');
+			expect(text()).toEqual(['item 4', 'cherry', 'item 5']);
+			r.click('#captured-clear');
+			expect(r.find('.captured-empty').textContent).toBe('Empty');
+			r.click('#captured-append');
+			expect(text()).toEqual(['item 6']);
+		} finally {
+			r.unmount();
+			diagnostic.mockRestore();
+		}
+	});
+
+	it('keeps hooks in method arguments and ref-backed receivers live', () => {
+		const items = [row(1, 'apple'), row(2, 'banana')];
+		const context = mount(ContextArgumentMethodList, { items, prefix: 'first:' });
+		expect(labels(context)).toEqual(['first:apple', 'first:banana']);
+		context.update(ContextArgumentMethodList, { items, prefix: 'second:' });
+		expect(labels(context)).toEqual(['second:apple', 'second:banana']);
+		context.unmount();
+
+		const refItems = [{ id: 1, current: { read: () => 'first' } }];
+		const refs = mount(RefMethodList, { items: refItems });
+		expect(labels(refs)).toEqual(['first']);
+		refItems[0]!.current = { read: () => 'second' };
+		refs.update(RefMethodList, { items: refItems });
+		expect(labels(refs)).toEqual(['second']);
+		refs.unmount();
+	});
+
+	it.each([
+		['keyed templates', ComputedHookMethodRows],
+		['returned JSX', ComputedHookMappedRows],
+	])('keeps computed hook methods live in %s', (_dialect, Component) => {
+		const context = mount(Component, { value: 'first' });
+		expect(labels(context)).toEqual(['first']);
+		context.update(Component, { value: 'second' });
+		expect(labels(context)).toEqual(['second']);
+		context.update(Component, { value: 'third' });
+		expect(labels(context)).toEqual(['third']);
+		context.unmount();
+	});
+
+	it('keeps state getters inside stable method objects live', () => {
+		const getter = mount(TupleGetterMethodRows);
+		expect(labels(getter)).toEqual(['0']);
+		getter.click('#tuple-method-bump');
+		expect(labels(getter)).toEqual(['1']);
+		getter.click('#tuple-method-bump');
+		expect(labels(getter)).toEqual(['2']);
+		getter.unmount();
+	});
+
+	it.each([
+		['direct ref arguments', RefArgumentMethodRows],
+		['ref value aliases', AliasedRefMethodRows],
+		['destructured ref values', DestructuredRefMethodRows],
+	])('observes event mutations through %s', (_shape, Component) => {
+		const refs = mount(Component);
+		expect(labels(refs)).toEqual(['first']);
+		refs.click('#mutate-ref');
+		expect(labels(refs)).toEqual(['second']);
+		refs.unmount();
+	});
+
+	it.each([
+		['direct methods', SnapshotCalculation],
+		['same-module wrappers', WrappedSnapshotCalculation],
+	])('updates calculations through %s when any input changes', (_shape, Component) => {
+		const first = row(1, 'apple');
+		const formatter = { read: (item: SnapshotRow, prefix: string) => prefix + item.label };
+		const r = mount(Component, { item: first, prefix: 'first:', formatter });
+		expect(r.find('p').textContent).toBe('first:apple');
+		r.update(Component, { item: first, prefix: 'next:', formatter });
+		expect(r.find('p').textContent).toBe('next:apple');
+		const replacement = row(1, 'apricot');
+		r.update(Component, { item: replacement, prefix: 'next:', formatter });
+		expect(r.find('p').textContent).toBe('next:apricot');
+		r.update(Component, {
+			item: replacement,
+			prefix: 'next:',
+			formatter: { read: (item: SnapshotRow) => item.label + '!' },
+		});
+		expect(r.find('p').textContent).toBe('apricot!');
+		r.unmount();
+	});
+
+	it('adopts Strong method rows and preserves edits and current handlers after hydration', () => {
+		const items = [row(1, 'apple'), row(2, 'banana')];
+		const selected: string[] = [];
+		const props = {
+			items,
+			prefix: 'server:',
+			onSelect: (item: SnapshotRow) => selected.push(item.label),
+		};
+		const server = loadServerFixture('packages/octane/tests/_fixtures/for-strong.tsrx', {
+			compileOptions: { hmr: false, dev: false },
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.SnapshotMethodList, props).html;
+		const original = Array.from(container.querySelectorAll('li'));
+		const editor = container.querySelector('input')!;
+		editor.value = 'typed before hydration';
+		const root = hydrateRoot(container, SnapshotMethodList, props);
+		flushSync(() => {});
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(original);
+		expect(container.querySelector('input')).toBe(editor);
+		expect(editor.value).toBe('typed before hydration');
+
+		flushSync(() => root.render(SnapshotMethodList, {
+			...props,
+			items: [row(1, 'apricot'), items[1]!],
+			prefix: 'client:',
+		}));
+		expect(Array.from(container.querySelectorAll('.snapshot-label')).map((el) => el.textContent)).toEqual([
+			'client:apricot',
+			'client:banana',
+		]);
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(original);
+		(container.querySelector('button') as HTMLButtonElement).click();
+		expect(selected).toEqual(['apricot']);
+		root.unmount();
+		container.remove();
 	});
 });
 

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -440,15 +440,16 @@ describe('Strong list methods preserve snapshot and event semantics', () => {
 		expect(container.querySelector('input')).toBe(editor);
 		expect(editor.value).toBe('typed before hydration');
 
-		flushSync(() => root.render(SnapshotMethodList, {
-			...props,
-			items: [row(1, 'apricot'), items[1]!],
-			prefix: 'client:',
-		}));
-		expect(Array.from(container.querySelectorAll('.snapshot-label')).map((el) => el.textContent)).toEqual([
-			'client:apricot',
-			'client:banana',
-		]);
+		flushSync(() =>
+			root.render(SnapshotMethodList, {
+				...props,
+				items: [row(1, 'apricot'), items[1]!],
+				prefix: 'client:',
+			}),
+		);
+		expect(
+			Array.from(container.querySelectorAll('.snapshot-label')).map((el) => el.textContent),
+		).toEqual(['client:apricot', 'client:banana']);
 		expect(Array.from(container.querySelectorAll('li'))).toEqual(original);
 		(container.querySelector('button') as HTMLButtonElement).click();
 		expect(selected).toEqual(['apricot']);

--- a/packages/rsbuild-plugin-octane/README.md
+++ b/packages/rsbuild-plugin-octane/README.md
@@ -108,8 +108,15 @@ export default defineConfig({
 ```
 
 You can also pass `pluginOctane({ strong: true })`. The plugin option takes
-priority over the app config. Dependencies are unaffected unless they begin a
-module with `"use strong"`.
+priority over the app config. Strong mode opts application code into immutable
+render snapshots and pure render projections. The compiler rejects detectable
+state, ref, Effect Event, snapshot-mutation, and nondeterministic-render
+violations; production client builds may also reuse eligible statically named
+receiver methods while their snapshot inputs remain unchanged.
+
+Dependencies retain compatibility behavior unless they begin a module with
+`"use strong"`. Strong analysis is bounded: imported live accessors do not
+become immutable merely because their caller opts in.
 
 App mode currently serves from the root path and uses Rsbuild's default asset
 prefix. Keep `server.base` at `/` and `output.assetPrefix` at `auto` or `/`; for

--- a/packages/rspack-plugin-octane/README.md
+++ b/packages/rspack-plugin-octane/README.md
@@ -55,15 +55,20 @@ Source maps, module layers, compiler metadata, and watched package manifests
 are preserved in both modes. Worker startup has a fixed cost, so very small
 builds may be faster with `parallel: false`.
 
-Set `strong: true` to reject state updates during rendering, state updates from
-effects, and ref writes during rendering in your application code:
+Set `strong: true` to opt application code into Strong mode's immutable
+render-snapshot and pure-render contract. The compiler rejects detectable state,
+ref, Effect Event, snapshot-mutation, and nondeterministic-render violations;
+production client builds may also reuse eligible statically named receiver
+methods while their snapshot inputs remain unchanged:
 
 ```js
 new OctaneRspackPlugin({ strong: true });
 ```
 
-Dependencies keep their existing behavior. Any module can opt in on its own by
-putting `"use strong"` before its imports.
+Dependencies keep their existing compatibility behavior. Any module can opt in
+on its own by putting `"use strong"` before its imports. Strong analysis is
+bounded: imported live accessors do not become immutable just because their
+caller opts in.
 
 The experimental `renderers` option accepts the same declarative registry,
 filename rules, and module/export boundary metadata as `compiler.renderers` in

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -153,7 +153,7 @@ export const docsMeta: DocMeta[] = [
 				title: 'Keep editable state in sync with useLinkedState',
 				level: 3,
 			},
-			{ id: 'strong-mode', title: 'Catch state mistakes with Strong mode', level: 3 },
+			{ id: 'strong-mode', title: 'Enforce render snapshots with Strong mode', level: 3 },
 			{ id: 'lists-and-conditions', title: 'Lists and conditions' },
 			{ id: 'context', title: 'Sharing data with context' },
 			{ id: 'refs-and-effects', title: 'Refs and effects' },

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -148,9 +148,9 @@ requirements, and optional fallbacks.
 
 <h2 id="strong-mode">Strong mode</h2>
 
-Strong mode asks the compiler to reject state, ref, and Effect Event patterns
-that make a component harder to follow. It is off by default, so you can try it
-in one file:
+Strong mode opts into immutable render snapshots and asks the compiler to reject
+detectable state, ref, Effect Event, and purity violations. It is off by default,
+so you can try it in one file:
 
 ```tsx
 'use strong';
@@ -209,6 +209,11 @@ A Strong module cannot:
   (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
 - Include a statically known Effect Event in explicit hook dependencies
   (`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`).
+- Mutate a provable state snapshot while rendering
+  (`OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION`).
+- Read a known clock or random source directly while rendering, such as
+  `Date.now()` or `Math.random()` (`OCTANE_STRONG_RENDER_IMPURE_CALL`). Lazy state
+  initialization may still capture an initial timestamp or random value.
 
 These checks follow provable synchronous calls through local helpers,
 `useCallback` and `useEffectEvent` results, and functions returned by analyzable
@@ -219,6 +224,14 @@ arrays retain their existing meaning and are never rewritten.
 Factories with unknown return values or complex control flow remain opaque.
 Dependency checks follow literal arrays, including statically selected or spread
 literals; they do not assume an aliased or externally produced array is unchanged.
+
+Production client builds may also memoize statically named member calls such as
+`item.format(prefix)`. Their receivers and inputs must be immutable snapshots;
+an opaque method must not return changing state behind the same receiver. Hooks,
+ref-backed reads, and unsupported call shapes stay conservative. Keep consumers
+of live library accessors in compatibility mode, or pass a snapshot into a
+separate Strong component. See
+[the memoization contract](/docs/differences-from-react#strong-mode).
 
 Use `useLinkedState` when state should reset or adjust after an input changes.
 Event handlers may update state normally. Genuinely deferred callbacks, effect

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -295,7 +295,7 @@ On the first render, `previous` is `undefined`. When the source changes, it is
 Like `useState`, the hook also offers an optional third tuple item, `getValue`, for
 reading the latest value inside an async or delayed callback.
 
-<h3 id="strong-mode">Catch state mistakes with Strong mode</h3>
+<h3 id="strong-mode">Enforce render snapshots with Strong mode</h3>
 
 Strong mode is an optional immutable render-snapshot contract with compiler
 checks. Add `"use strong"` before a module's

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -297,7 +297,8 @@ reading the latest value inside an async or delayed callback.
 
 <h3 id="strong-mode">Catch state mistakes with Strong mode</h3>
 
-Strong mode is an optional compiler check. Add `"use strong"` before a module's
+Strong mode is an optional immutable render-snapshot contract with compiler
+checks. Add `"use strong"` before a module's
 imports to try it one file at a time, or set `compiler: { strong: true }` in
 `octane.config.ts` to cover your application.
 
@@ -318,6 +319,13 @@ also follows provable calls through `useCallback`, `useEffectEvent`, and functio
 returned by analyzable `useMemo` factories. A statically known Effect Event cannot
 be called during render or listed in explicit hook dependencies. These hooks
 remain supported, and other explicit dependency lists keep their existing meaning.
+
+Strong also rejects detectable state-snapshot mutations and direct clock or
+random reads during render. Lazy state initialization may still obtain an
+initial value. Production client builds can memoize statically named render
+methods under the snapshot contract; imported methods with hidden mutable state
+must stay in a compatibility-mode consumer. See
+[Strong mode and memoization](/docs/differences-from-react#strong-mode).
 
 Event handlers can still update state. Genuinely deferred callbacks, effect
 cleanup, effects that synchronize external systems, and refs for DOM nodes or

--- a/website/src/content/docs/differences-from-react.mdx
+++ b/website/src/content/docs/differences-from-react.mdx
@@ -97,8 +97,8 @@ valid.
 
 <h2 id="strong-mode">Strong mode is optional</h2>
 
-Strong mode helps catch state and ref patterns that React applications sometimes
-use as workarounds. Enable it for a single module with `"use strong"` before its
+Strong mode opts into immutable render snapshots and helps catch detectable
+state, ref, and purity violations. Enable it for a single module with `"use strong"` before its
 imports, or across your application with `compiler: { strong: true }` in
 `octane.config.ts`.
 
@@ -114,6 +114,33 @@ Use `useLinkedState` when editable state should follow a changing prop. Event
 handlers, genuinely deferred callbacks, effect cleanup, effects that synchronize
 external systems, and normal DOM or timer refs remain supported. Installed
 dependencies keep their existing behavior unless they opt in themselves.
+
+Strong also rejects render-time mutations of provable state snapshots and
+direct reads of known clocks or random sources, such as `Date.now()` and
+`Math.random()`. Events, effects, and lazy state initializers may obtain these
+values. The checks follow supported aliases and synchronous helpers, but cannot
+prove arbitrary imported code pure.
+
+Default compatibility mode conservatively reevaluates method calls: a stable
+receiver can hide changing state. React Compiler also identifies APIs with
+interior mutability, including TanStack Table v8, as
+[incompatible with memoization](https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library).
+
+In a Strong module, statically named render methods such as `item.format(prefix)`
+assert that unchanged receivers and inputs produce the same value. Production
+client builds can then reuse eligible regions and keyed rows. Hooks, ref-backed
+reads, dynamic methods, and opaque callback arguments remain conservative. Keep
+live library accessors in a compatibility-mode consumer, or pass an actual
+snapshot into a separate Strong component; opting in does not make a library's
+live objects immutable.
+
+Keys preserve surviving DOM nodes, not an exact evaluation count. A diagnostic
+`console.log` no longer disqualifies an otherwise eligible Strong row, but a
+handler such as `() => setItems(items.filter(...))` still captures `items`.
+Appending changes that capture, so the row must receive its current handler.
+Strong mode preserves those closure semantics. Logging can therefore differ
+across production, development, HMR, and profiling builds and is not a commit
+counter.
 
 <h2 id="events-and-dom">Events come from the browser</h2>
 

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -148,12 +148,12 @@ describe('docs search ranking', () => {
 		}
 	});
 
-	it('deep links Strong-mode searches to the build configuration guide', async () => {
+	it('deep links Strong-mode searches to the render contract guide', async () => {
 		const index = await loadSearchIndex();
 		const [top] = searchDocs(index, 'strong mode');
 
 		expect(top).toBeDefined();
-		expect(top.slug).toBe('build-tools');
+		expect(top.slug).toBe('differences-from-react');
 		expect(top.id).toBe('strong-mode');
 	});
 


### PR DESCRIPTION
## Summary

- Allow statically named receiver methods to participate in production DOM memoization when a module opts into Strong mode's immutable snapshot and pure render contract. Keep compatibility, development, profiling, server, and universal paths conservative.
- Retain fallbacks for visible hooks, live refs and state getters, callback hazards, and opaque globals. Add bounded Strong diagnostics for detectable state snapshot mutations and nondeterministic render calls.
- Add list, callback, ref, hook, calculation, and hydration regression cases; deterministic method-call benchmark controls; documentation; and an Octane patch changeset.

Addresses #846. The reported remove callback captures the entire current list, so replacing that list must still refresh surviving rows' handlers. This change does not promise that every original row body can be skipped in that example.

## Validation

**Intentionally opened as an unvalidated draft, as requested. This is not ready to merge.**

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Targeted `for.test.ts` and `compiler/strong-mode.test.ts` suites in the applicable development and production projects
- [ ] `node benchmarks/bench.mjs --ratios template-call-memo`
- [ ] Complete `pnpm sync`

Dependency installation was blocked by the configured registry's security policy for `@tsrx/core@0.1.61` and `@tsrx/ripple@0.1.62`. Test and typecheck attempts did not reach execution; the benchmark could not start with the incomplete dependency tree. No test, typecheck, formatting, benchmark, or CI success is claimed.

The required sync was attempted without triggering another dependency download. It reached `cli:data` and stopped because `prettier` was unavailable. The generators that ran produced no additional Git diff.

Earlier static checks passed: `node --check` on the two modified compiler JavaScript files and the benchmark runners, plus `git diff --check`. These establish syntax and whitespace only, not behavioral correctness or performance.

## Risk / follow-ups

- Install approved dependencies, complete sync and formatting, run the relevant correctness suites and baseline/candidate benchmarks, and obtain green current-head CI before marking ready.
- Strong mode's method purity and immutable snapshot contract is an opt-in assertion; diagnostics do not prove whole-program purity.
- Conservative name-based alias handling and retained state tuple fallbacks may decline otherwise safe optimizations.
- No measured performance improvement is claimed. The new regression cases and benchmark guards remain unexecuted.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790354451&installation_model_id=432790&pr_number=862&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F862&signature=5e2a53bc087c109e50500cf8746974d97d2a4b8ff979420eb381aa976b88694c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production memoization semantics for Strong modules and expand compiler purity rules; incorrect alias or capture analysis could cause stale UI, though compatibility mode and conservative fallbacks limit blast radius.
> 
> **Overview**
> **Strong mode** now treats opted-in modules as an **immutable render-snapshot** contract: production client builds can **memoize statically named receiver calls** (e.g. `row.read(suffix)`) and reuse keyed list rows when inputs and captures are unchanged. **Compatibility mode** still treats member calls as live and does not apply this fast path.
> 
> The compiler adds **bounded Strong diagnostics** for provable **state-snapshot mutations** (`OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION`) and **direct clock/random reads during render** (`OCTANE_STRONG_RENDER_IMPURE_CALL`), with hook/ref/callback guards so hooks, refs, opaque globals, and callback arguments stay conservative. Docs clarify that **keys preserve DOM identity**, **`console.log` in rows does not block Strong reuse**, and **handlers that close over the parent list** still force survivor updates.
> 
> A new **`template-call-memo`** benchmark (runner manifest, ratio baselines, MCP exposure) counts receiver invocations for Strong vs compatibility. Regression coverage spans list/capture/ref/hook scenarios, expanded `strong-mode` compiler tests, and Apollo `useQuery` rejecting Strong when it mutates snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fd1dbfc76a25041f712e0a4d3f4a4034146652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->