### PR TITLE
perf(compiler): index component hoist references once

### DIFF
--- a/.changeset/fast-component-hoist-scan.md
+++ b/.changeset/fast-component-hoist-scan.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Index component references once when compiling component-heavy modules.
+
+Component declaration lowering now preserves the same client and server hoisting
+semantics without repeatedly sanitizing and scanning every growing source prefix.

--- a/benchmarks/tsrx-component-graph/README.md
+++ b/benchmarks/tsrx-component-graph/README.md
@@ -12,6 +12,11 @@ analysis should not care about that ordinary function-hoisting choice.
 Both variants require zero diagnostics and exactly 2,399 emitted live-binding
 witnesses before their samples count.
 
+The declaration orders also pin the compiler's component-hoisting decision.
+`dependent-first` has 2,399 real references above their declarations, while
+`dependency-first` has none. The harness verifies both counts so the compiler
+can index those references once without changing module-evaluation semantics.
+
 ```bash
 node benchmarks/bench.mjs --quick --ratios tsrx-component-graph
 node benchmarks/bench.mjs tsrx-component-graph

--- a/benchmarks/tsrx-component-graph/run.mjs
+++ b/benchmarks/tsrx-component-graph/run.mjs
@@ -38,16 +38,25 @@ function compileVariant(variant) {
 	const result = compile(variant.source, `${variant.name}.tsrx`, options);
 	const elapsed = performance.now() - started;
 	const witnesses = result.code.match(/const __memoDep[\w$]* = live;/g)?.length ?? 0;
+	const hoistedDeclarations =
+		result.code.match(/^(?:export )?function Component\d+\(/gm)?.length ?? 0;
+	const expectedHoistedDeclarations = variant.name === 'dependent-first' ? COMPONENTS - 1 : 0;
 	assert.equal(result.diagnostics.length, 0, `${variant.name} emitted compiler diagnostics`);
 	assert.equal(
 		witnesses,
 		COMPONENTS - 1,
 		`${variant.name} did not preserve every transitive live-binding witness`,
 	);
+	assert.equal(
+		hoistedDeclarations,
+		expectedHoistedDeclarations,
+		`${variant.name} changed its above-declaration component references`,
+	);
 	variant.meta = {
 		components: COMPONENTS,
 		callEdges: COMPONENTS - 1,
 		liveBindingWitnesses: witnesses,
+		hoistedDeclarations,
 		sourceBytes: Buffer.byteLength(variant.source),
 		outputBytes: Buffer.byteLength(result.code),
 		correctness: 'pass',

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8364,6 +8364,7 @@ function compileInternal(
 		// hookless lite path). Populated by the pre-pass below; read by
 		// makeCompCall to branch the call-site emit.
 		componentInfo: new Map(),
+		earlyComponentReferenceOffsets: collectEarlyComponentReferenceOffsets(source, ast.body),
 		profileComponents: [],
 		profileComponentIds: new Set(),
 		profileComponentCandidates: new Set(),
@@ -9616,6 +9617,7 @@ function compileServer(
 		nextFragId: 0,
 		nextHelperId: 0,
 		componentInfo: new Map(),
+		earlyComponentReferenceOffsets: collectEarlyComponentReferenceOffsets(source, ast.body),
 		descriptorChildrenBindings: collectDescriptorChildrenBindings(
 			ast,
 			options?.isDescriptorChildrenImport,
@@ -9836,14 +9838,7 @@ function compileServerComponent(node, ctx) {
 	// component referenced ABOVE its declaration keeps real function-declaration
 	// hoisting instead of a TDZ `const` binding. Server and client compiles must
 	// agree, or the same route module renders on one side and crashes on the other.
-	const ssrSourceBeforeNode =
-		typeof node.start === 'number' && typeof ctx.mapSource === 'string'
-			? stripNonReferenceText(ctx.mapSource.slice(0, node.start))
-			: '';
-	if (
-		ssrSourceBeforeNode !== '' &&
-		new RegExp(`\\b${name.replace(/\$/g, '\\$')}\\b`).test(ssrSourceBeforeNode)
-	) {
+	if (componentReferencedAboveDeclaration(ctx, node, name)) {
 		const declaration = isDefault ? b.export_default(fn) : isExported ? b.export(fn) : fn;
 		const nodes = [inheritOriginLoc(declaration, node)];
 		if (warmNode !== null) {
@@ -12953,6 +12948,57 @@ function stripNonReferenceText(source) {
 	);
 }
 
+const EARLY_COMPONENT_REFERENCE_SCAN =
+	/'(?:[^'\\\n]|\\.)*'|"(?:[^"\\\n]|\\.)*"|\/\/[^\n]*|\/\*[\s\S]*?\*\/|\b([A-Za-z_]\w*)\b/g;
+const PLAIN_EARLY_COMPONENT_NAME = /^[A-Za-z_]\w*$/;
+
+/**
+ * Record the first source occurrence of every ordinary component identifier in
+ * one module scan. Strings and comments stay invisible, while template literals
+ * deliberately remain visible for the TDZ-safety reason above.
+ */
+function collectEarlyComponentReferenceOffsets(source, body) {
+	const names = new Set();
+	for (const statement of body) {
+		const declaration =
+			statement.type === 'ExportNamedDeclaration' || statement.type === 'ExportDefaultDeclaration'
+				? statement.declaration
+				: statement;
+		if (
+			declaration?.id?.type === 'Identifier' &&
+			(isComponentFunction(declaration) || isReturnJsxFunction(declaration)) &&
+			PLAIN_EARLY_COMPONENT_NAME.test(declaration.id.name)
+		) {
+			names.add(declaration.id.name);
+		}
+	}
+	if (names.size === 0) return null;
+
+	const offsets = new Map();
+	for (const match of source.matchAll(EARLY_COMPONENT_REFERENCE_SCAN)) {
+		const name = match[1];
+		if (name !== undefined && names.has(name) && !offsets.has(name)) {
+			offsets.set(name, match.index);
+			if (offsets.size === names.size) break;
+		}
+	}
+	return offsets;
+}
+
+function componentReferencedAboveDeclaration(ctx, node, name) {
+	const start = node.start;
+	if (typeof start !== 'number' || typeof ctx.mapSource !== 'string') return false;
+	if (PLAIN_EARLY_COMPONENT_NAME.test(name)) {
+		const first = ctx.earlyComponentReferenceOffsets?.get(name);
+		return first !== undefined && first < start;
+	}
+	// Preserve the historical \b behavior for uncommon $, Unicode, and other
+	// parser-supported identifier spellings without taxing ordinary modules.
+	return new RegExp(`\\b${name.replace(/\$/g, '\\$')}\\b`).test(
+		stripNonReferenceText(ctx.mapSource.slice(0, start)),
+	);
+}
+
 // Attach definition metadata through the component's initializer rather than a
 // free-standing module mutation. The call-site annotation is valid because every
 // caller passes a freshly-created compiler function that cannot yet be observed;
@@ -13213,13 +13259,7 @@ function compileComponent(node, ctx, options) {
 	// function object, so the pre-declaration capture observes them before any
 	// render can run. Components without early references keep the `const` +
 	// PURE-initializer form, which bundlers can drop when unused.
-	const sourceBeforeNode =
-		typeof node.start === 'number' && typeof ctx.mapSource === 'string'
-			? stripNonReferenceText(ctx.mapSource.slice(0, node.start))
-			: '';
-	const referencedAboveDeclaration =
-		sourceBeforeNode !== '' &&
-		new RegExp(`\\b${name.replace(/\$/g, '\\$')}\\b`).test(sourceBeforeNode);
+	const referencedAboveDeclaration = componentReferencedAboveDeclaration(ctx, node, name);
 	if (referencedAboveDeclaration) {
 		if (owner !== null) {
 			for (const event of owner.delegatedEvents) ctx.unownedDelegatedEvents.add(event);

--- a/packages/octane/tests/component-hoisting.test.ts
+++ b/packages/octane/tests/component-hoisting.test.ts
@@ -91,6 +91,20 @@ describe('component hoisting — emission properties', () => {
 		expect(code).toContain('export function Chip(');
 	});
 
+	it('classifies multiple ordinary component names independently in both compile modes', () => {
+		const src =
+			'export const Registry = { component: Card2 };\n' +
+			"export const note = 'Unused3'; // Unused3 is still not a reference.\n" +
+			'function Card2() @{\n\t<p>card</p>\n}\n' +
+			'function Unused3() @{\n\t<p>unused</p>\n}\n' +
+			'export { Unused3 };\n';
+		for (const mode of ['client', 'server'] as const) {
+			const { code } = compile(src, 'App.tsrx', { mode });
+			expect(code).toMatch(/^function Card2\(/m);
+			expect(code).not.toMatch(/^function Unused3\(/m);
+		}
+	});
+
 	it('server compile mirrors the string-blindness (const form retained)', () => {
 		const src =
 			"export const Route = { path: '/Home' };\n" +


### PR DESCRIPTION
## Summary

- index component-name occurrences once per module instead of sanitizing and scanning every growing source prefix once per component
- preserve the existing client/server declaration-hoisting contract, including string/comment blindness and template-interpolation TDZ safety
- extend the 2,400-component graph benchmark with declaration-shape correctness guards

## Why

Component-heavy modules repeatedly answered the same lexical question for every component: “was this component referenced above its declaration?” Each answer sliced, sanitized, and regex-scanned a larger prefix of the module. A single indexed source pass removes that accidental quadratic work.

Clean same-machine A/B against the original base:

- dependent-first: 1096.258 ms → 819.938 ms (-25.2%)
- dependency-first: 1030.190 ms → 749.841 ms (-27.2%)

## Changes

- collect first reference offsets for ordinary top-level component names during compiler setup
- share the indexed decision between client and server lowering, retaining the historical fallback for uncommon identifier spellings
- cover independent real and string/comment-only names in both compile modes
- assert expected hoisted declaration counts in `tsrx-component-graph`
- add an `octane` patch changeset

## Validation

- [ ] `pnpm format:check` (scoped check run instead)
- [ ] `pnpm typecheck` (Octane source and typetest projects run instead)
- [ ] `pnpm test` (attempted locally; unrelated browser/localStorage/timing failures accumulated before the Vitest coordinator exhausted its 4 GB heap)
- [x] `pnpm sync`
- [x] `pnpm format:files:check benchmarks/tsrx-component-graph/README.md benchmarks/tsrx-component-graph/run.mjs packages/octane/src/compiler/compile.js packages/octane/tests/component-hoisting.test.ts .changeset/fast-component-hoist-scan.md`
- [x] `tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `tsgo --noEmit -p packages/octane/typetests/tsconfig.json`
- [x] targeted tests: 3 files / 25 tests passed for component hoisting and production bundles
- [x] `node benchmarks/bench.mjs --quick --ratios tsrx-component-graph`

## Risk / follow-ups

- Risk is limited to compiler declaration-shape classification. The focused tests pin client/server behavior, and the benchmark refuses samples unless both declaration orders emit the expected hoisted-function counts.
- Current-head CI should provide the repository-wide test result that the local browser/platform environment could not.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356103&installation_model_id=432790&pr_number=863&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F863&signature=a22f19f73219a2e81dc86f0fdd2718453ff94a5e7a80b4a68f5feabe503097b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler declaration-shape classification for every component module; wrong indexing would cause TDZ crashes or lost tree-shaking, though tests and benchmark guards target that contract.
> 
> **Overview**
> Replaces **per-component** prefix sanitizing and regex scans with a **single module pass** that records the first source offset of each top-level component name, then reuses that index when deciding whether to emit a hoisted `function` vs a `const` initializer on **both client and server** lowering.
> 
> Behavior stays the same for strings/comments (ignored), template interpolations (still count as references), and uncommon identifier spellings (still use the historical prefix scan). New hoisting tests cover **multi-name** classification in both modes; the **2,400-component graph benchmark** now asserts expected hoisted-declaration counts per declaration order so regressions in above-declaration detection fail the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a960e4b0b7f5048aaac175a7235d81a544dc751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->