### PR TITLE
perf(app-core): speed up router dispatch

### DIFF
--- a/.changeset/faster-app-router-dispatch.md
+++ b/.changeset/faster-app-router-dispatch.md
@@ -1,0 +1,8 @@
+---
+'@octanejs/app-core': patch
+'@octanejs/mcp-server': patch
+---
+
+Match static application routes without regular expressions and normalize each
+request method once per dispatch. Expose the accompanying router benchmark
+through the Octane MCP benchmark tool.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -213,6 +213,7 @@ internally, get their own baseline and guard namespace.
 | `behavior-root-events` | behavior-root-events | none (headless Chromium) | queued events across 1,000 and 8,000 distinct async behavior adoptions, with FIFO/exactly-once gates |
 | `application-composition` | application-composition | none (builds) | lifecycle resources, large forms, store fan-out, async recovery, form submission, and navigation teardown in one app |
 | `scaling-curves` | scaling-curves | none (builds) | independently correctness-gated controlled updates at 8, 32, 96, 256, and 512 components |
+| `router-dispatch` | router-dispatch | none (Node-only) | app-core static, wrong-method, and dynamic matching across 1,000-route tables |
 | `effectful-list` | effectful-list | Octane + reference frameworks | effect/ref cleanup churn |
 | `activity` | activity | none (builds) | same-source Octane/React Activity lifecycle, hidden/nested work, retained state/effects/DOM, cold-vs-used ordinary-ref controls, and optional-runtime bundle reachability |
 | `list-clear` | list-clear | Octane-only | keyed-list bulk clear by parent shape — the only coverage of the shared-parent path |

--- a/benchmarks/baselines/local/router-dispatch.json
+++ b/benchmarks/baselines/local/router-dispatch.json
@@ -1,0 +1,73 @@
+{
+  "suite": "router-dispatch",
+  "iterations": 8,
+  "targets": [
+    {
+      "name": "static-routes",
+      "ops": {
+        "dispatch_per_million_candidates": {
+          "score": 4.812541700000009,
+          "median": 4.792771000000016,
+          "min": 4.650374999999997,
+          "mean": 4.781546875000003,
+          "p95": 5.085125000000005,
+          "sd": 0.1390775286449359,
+          "rme": 2.43206231718327,
+          "scoreRme": 4.362483912916121,
+          "warmupRatio": 0.9782391288162742,
+          "samples": 8
+        }
+      },
+      "meta": {
+        "routes": 1000,
+        "matchesPerSample": 2000,
+        "correctness": "pass"
+      }
+    },
+    {
+      "name": "wrong-method-routes",
+      "ops": {
+        "dispatch_per_million_candidates": {
+          "score": 4.736533199999985,
+          "median": 4.7157080000000065,
+          "min": 4.576333499999919,
+          "mean": 4.727505124999989,
+          "p95": 4.957166499999971,
+          "sd": 0.1087274584318761,
+          "rme": 1.9230624130684284,
+          "scoreRme": 3.602716858090871,
+          "warmupRatio": 0.9952778542753629,
+          "samples": 8
+        }
+      },
+      "meta": {
+        "routes": 1000,
+        "matchesPerSample": 2000,
+        "correctness": "pass"
+      }
+    },
+    {
+      "name": "dynamic-routes",
+      "ops": {
+        "dispatch_per_million_candidates": {
+          "score": 65.01424580000003,
+          "median": 62.73302100000001,
+          "min": 57.64897900000002,
+          "mean": 66.91575518750003,
+          "p95": 91.08739600000001,
+          "sd": 10.849515590143366,
+          "rme": 13.557141101410519,
+          "scoreRme": 9.859193844709381,
+          "warmupRatio": 0.9461845514479534,
+          "samples": 8
+        }
+      },
+      "meta": {
+        "routes": 1000,
+        "matchesPerSample": 2000,
+        "correctness": "pass"
+      }
+    }
+  ],
+  "harnessExit": 0
+}

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -464,6 +464,22 @@
     "note": "Same-page production Chromium resume cost for FIFO queued events whose distinct async adoptions settle one at a time. The rejected per-resume compaction/full-scan path measured 6.05x per event at 8k versus 1k, while amortized compaction and constant-time pending bookkeeping measured 0.93x and 1.14x in verified quick runs. The 1.6x ceiling leaves browser timing headroom."
   },
   {
+    "suite": "router-dispatch",
+    "op": "dispatch_per_million_candidates",
+    "target": "static-routes",
+    "reference": "dynamic-routes",
+    "maxRatio": 0.2,
+    "note": "Same-process app-core dispatch through 1,000-route tables with exact route and parameter gates. RegExp matching for every static candidate measured at 0.44x the dynamic control; exact string matching measured at 0.08x. The 0.2 ceiling leaves more than 2x timing headroom while catching loss of the static matcher."
+  },
+  {
+    "suite": "router-dispatch",
+    "op": "dispatch_per_million_candidates",
+    "target": "wrong-method-routes",
+    "reference": "dynamic-routes",
+    "maxRatio": 0.2,
+    "note": "Same-process lowercase method misses through 1,000 server routes, normalized per candidate. Re-normalizing the request method for every route measured at 0.31x the dynamic control; one dispatch-level normalization measured at 0.07x. The 0.2 ceiling leaves timing headroom while catching repeated method normalization."
+  },
+  {
     "suite": "external-store-fanout",
     "op": "broad_write",
     "target": "octane-tsrx",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -354,6 +354,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Node-only app-core route matching across large static, method-miss,
+		// and dynamic route tables with cost normalized per candidate route.
+		name: 'router-dispatch',
+		cwd: 'router-dispatch',
+		servers: [],
+		iter: { normal: 8, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Selector-based fan-out: 512 subscribers read one store through a
 		// selector, then the parent re-renders 20 times with the store untouched.
 		// Reuses the news per-target toolchains with its own page, so the shared

--- a/benchmarks/router-dispatch/README.md
+++ b/benchmarks/router-dispatch/README.md
@@ -1,0 +1,19 @@
+# App-core router dispatch benchmark
+
+This Node-only suite measures `@octanejs/app-core` request matching across a
+1,000-route table. Each sample exercises one of three semantically gated paths:
+
+- a static route whose match is last in the table;
+- a lowercase wrong-method request rejected by every server route; and
+- a dynamic parameter route whose match is last in the table.
+
+The harness reports milliseconds per million candidate routes so the two fast
+paths can be compared with the unchanged dynamic route path in the same process.
+Correctness gates require the exact route identity, empty/static params, a null
+method miss, and decoded dynamic params.
+
+Run it through the unified harness:
+
+```bash
+node benchmarks/bench.mjs --quick --ratios router-dispatch
+```

--- a/benchmarks/router-dispatch/run.mjs
+++ b/benchmarks/router-dispatch/run.mjs
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import { createRouter } from '../../packages/app-core/src/server/router.js';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const iterations = Number.parseInt(process.argv[2] ?? '8', 10);
+const ROUTE_COUNT = 1_000;
+const MATCHES_PER_SAMPLE = 2_000;
+const WARMUP_MATCHES = 500;
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Router dispatch iterations must be a positive integer');
+}
+
+const staticRoutes = Array.from({ length: ROUTE_COUNT }, (_, index) => ({
+	type: 'render',
+	path: `/static-${index}`,
+}));
+const serverRoutes = Array.from({ length: ROUTE_COUNT }, (_, index) => ({
+	type: 'server',
+	path: `/api-${index}`,
+	methods: ['GET'],
+}));
+const dynamicRoutes = Array.from({ length: ROUTE_COUNT }, (_, index) => ({
+	type: 'render',
+	path: `/:value/dynamic-${index}`,
+}));
+
+const scenarios = [
+	{
+		name: 'static-routes',
+		router: createRouter(staticRoutes),
+		method: 'GET',
+		pathname: '/static-999',
+		verify(match) {
+			return match?.route === staticRoutes[999] && Object.keys(match.params).length === 0;
+		},
+	},
+	{
+		name: 'wrong-method-routes',
+		router: createRouter(serverRoutes),
+		method: 'post',
+		pathname: '/api-999',
+		verify(match) {
+			return match === null;
+		},
+	},
+	{
+		name: 'dynamic-routes',
+		router: createRouter(dynamicRoutes),
+		method: 'GET',
+		pathname: '/hello%20world/dynamic-999',
+		verify(match) {
+			return match?.route === dynamicRoutes[999] && match.params.value === 'hello world';
+		},
+	},
+];
+
+function runMatches(scenario, count) {
+	let checksum = 0;
+	const started = performance.now();
+	for (let index = 0; index < count; index++) {
+		checksum += scenario.verify(scenario.router.match(scenario.method, scenario.pathname)) ? 1 : 0;
+	}
+	return { elapsed: performance.now() - started, checksum };
+}
+
+const samples = new Map(scenarios.map((scenario) => [scenario.name, []]));
+for (const scenario of scenarios) {
+	const warmup = runMatches(scenario, WARMUP_MATCHES);
+	if (warmup.checksum !== WARMUP_MATCHES) {
+		throw new Error(`${scenario.name} warmup correctness failed: ${warmup.checksum}`);
+	}
+}
+
+for (let iteration = 0; iteration < iterations; iteration++) {
+	const order = iteration % 2 === 0 ? scenarios : [...scenarios].reverse();
+	for (const scenario of order) {
+		const sample = runMatches(scenario, MATCHES_PER_SAMPLE);
+		if (sample.checksum !== MATCHES_PER_SAMPLE) {
+			throw new Error(`${scenario.name} correctness failed: ${sample.checksum}`);
+		}
+		samples
+			.get(scenario.name)
+			.push((sample.elapsed * 1_000_000) / (MATCHES_PER_SAMPLE * ROUTE_COUNT));
+	}
+}
+
+const targets = scenarios.map((scenario) => {
+	const summary = summarizeSamples(samples.get(scenario.name));
+	console.log(
+		`PASS router-dispatch/${scenario.name}: ${summary.score.toFixed(3)}ms/million candidates`,
+	);
+	return {
+		name: scenario.name,
+		ops: { dispatch_per_million_candidates: timingStatForJson(summary) },
+		meta: {
+			routes: ROUTE_COUNT,
+			matchesPerSample: MATCHES_PER_SAMPLE,
+			correctness: 'pass',
+		},
+	};
+});
+
+const payload = {
+	suite: 'router-dispatch',
+	iterations,
+	targets,
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}

--- a/packages/app-core/src/server/router.js
+++ b/packages/app-core/src/server/router.js
@@ -14,20 +14,20 @@
 /**
  * @typedef {Object} CompiledRoute
  * @property {Route} route
- * @property {RegExp} pattern
+ * @property {string | RegExp} pattern
  * @property {string[]} paramNames
  * @property {number} specificity - Higher = more specific (static > param > catch-all)
  */
 
 /**
- * Convert a route path pattern to a RegExp
+ * Compile a route path into an exact string or capturing RegExp
  * Supports:
  * - Static segments: /about, /api/hello
  * - Named params: /posts/:id, /users/:userId/posts/:postId
  * - Catch-all: /docs/*slug
  *
  * @param {string} path
- * @returns {{ pattern: RegExp, paramNames: string[], specificity: number }}
+ * @returns {{ pattern: string | RegExp, paramNames: string[], specificity: number }}
  */
 function compilePath(path) {
 	/** @type {string[]} */
@@ -62,7 +62,9 @@ function compilePath(path) {
 		})
 		.join('/');
 
-	const pattern = new RegExp(`^${regexString || '/'}$`);
+	// Static paths are already exact matchers. Keep RegExp capture work for the
+	// parameter and catch-all routes that need it.
+	const pattern = paramNames.length === 0 ? path || '/' : new RegExp(`^${regexString || '/'}$`);
 	return { pattern, paramNames, specificity };
 }
 
@@ -98,24 +100,30 @@ export function createRouter(routes) {
 		 * @returns {RouteMatch | null}
 		 */
 		match(method, pathname) {
+			let normalizedMethod;
 			for (const { route, pattern, paramNames } of compiledRoutes) {
 				// Check method for ServerRoute
 				if (route.type === 'server') {
 					const methods = /** @type {ServerRoute} */ (route).methods;
-					if (!methods.includes(method.toUpperCase())) {
+					normalizedMethod ??= method.toUpperCase();
+					if (!methods.includes(normalizedMethod)) {
 						continue;
 					}
 				}
 
-				const match = pathname.match(pattern);
-				if (match) {
-					/** @type {Record<string, string>} */
-					const params = {};
-					for (let i = 0; i < paramNames.length; i++) {
-						params[paramNames[i]] = decodeURIComponent(match[i + 1]);
-					}
-					return { route, params };
+				if (typeof pattern === 'string') {
+					if (pathname === pattern) return { route, params: {} };
+					continue;
 				}
+
+				const match = pathname.match(pattern);
+				if (!match) continue;
+				/** @type {Record<string, string>} */
+				const params = {};
+				for (let i = 0; i < paramNames.length; i++) {
+					params[paramNames[i]] = decodeURIComponent(match[i + 1]);
+				}
+				return { route, params };
 			}
 			return null;
 		},

--- a/packages/app-core/tests/router.test.ts
+++ b/packages/app-core/tests/router.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { RenderRoute, ServerRoute, createRouter } from '../src/routes.js';
+
+describe('app-core request router', () => {
+	it('preserves static, parameter, catch-all, and method matching contracts', () => {
+		const staticRoute = new RenderRoute({ path: '/posts/new', entry: '/src/new.tsrx' });
+		const parameterRoute = new RenderRoute({ path: '/posts/:id', entry: '/src/post.tsrx' });
+		const catchAllRoute = new RenderRoute({ path: '/docs/*slug', entry: '/src/docs.tsrx' });
+		const rootRoute = new RenderRoute({ path: '/', entry: '/src/home.tsrx' });
+		const literalRoute = new RenderRoute({
+			path: '/files/report+(final).txt',
+			entry: '/src/file.tsrx',
+		});
+		const serverRoute = new ServerRoute({
+			path: '/api/posts',
+			methods: ['POST'],
+			handler: () => new Response(),
+		});
+		const router = createRouter([
+			parameterRoute,
+			catchAllRoute,
+			serverRoute,
+			staticRoute,
+			rootRoute,
+			literalRoute,
+		]);
+
+		expect(router.match('GET', '/')).toEqual({ route: rootRoute, params: {} });
+		expect(router.match('GET', '/posts/new')).toEqual({ route: staticRoute, params: {} });
+		expect(router.match('GET', '/files/report+(final).txt')).toEqual({
+			route: literalRoute,
+			params: {},
+		});
+		expect(router.match('GET', '/posts/hello%20world')).toEqual({
+			route: parameterRoute,
+			params: { id: 'hello world' },
+		});
+		expect(router.match('GET', '/docs/guides/setup')).toEqual({
+			route: catchAllRoute,
+			params: { slug: 'guides/setup' },
+		});
+		expect(router.match('post', '/api/posts')).toEqual({ route: serverRoute, params: {} });
+		expect(router.match('GET', '/api/posts')).toBeNull();
+	});
+});

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -163,7 +163,7 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `controlled-form`, `external-store-fanout`, `external-store-integrations`,
 `scheduler-responsiveness`, `suspense-recovery`, `event-delegation`,
 `application-composition`, `scaling-curves`, `dev-form-diagnostics`,
-`behavior-root-events`, `activity`, `streaming-ssr`, `streaming-backpressure`,
+`behavior-root-events`, `router-dispatch`, `activity`, `streaming-ssr`, `streaming-backpressure`,
 `compiler-throughput`, `tsrx-component-graph`, `codegen-size`, `hook-memo`,
 `template-call-memo`, `bundle-size`, `bundle-reachability`, `three-renderer`,
 `three-bundle-size`, …)

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -68,6 +68,7 @@ export const BENCHMARK_SUITES = [
 	'scaling-curves',
 	'dev-form-diagnostics',
 	'behavior-root-events',
+	'router-dispatch',
 	'store-selector-fanout',
 	'hook-store-composition',
 	'activity',


### PR DESCRIPTION
## Summary

- Match static app routes with exact string comparisons instead of running a regular expression for every candidate.
- Normalize the request method at most once per dispatch instead of once for every server-route candidate.
- Add a correctness-gated router benchmark, ratio guards, and MCP benchmark catalog exposure.

## Why

- The router was doing avoidable allocation and RegExp work in its hottest scan loop even when a route had no parameters.
- In the same 1,000-route harness, the stable before/after scores dropped from 31.127 to 4.813 ms per million static candidates (84.5%) and from 22.200 to 4.737 ms per million wrong-method candidates (78.7%). The dynamic-route control remains on the existing RegExp path.

## Changes

- Compile parameter-free paths to exact strings while preserving capturing RegExp matching for params and catch-alls.
- Lazily cache the uppercased request method on the first server-route candidate.
- Cover root, literal RegExp-special-character, decoded parameter, catch-all, lowercase method, and method-miss behavior.
- Register `router-dispatch` in the benchmark harness and MCP server, with same-process ratio guards against the dynamic control.

## Validation

- [ ] `pnpm format:check` (not run; scoped formatting passed)
- [ ] `pnpm typecheck` (not run; scoped app-core typecheck passed)
- [ ] `pnpm test` (not run; targeted suites passed)
- [x] targeted tests: app-core — 10 files, 113 tests passed; MCP server — 1 file, 15 tests passed
- [x] `node benchmarks/bench.mjs --quick --ratios router-dispatch` — 2/2 ratio guards passed
- [x] `CI=true pnpm sync`
- [x] `git diff --check`

## Risk / follow-ups

- Static matching remains exact and dynamic parameter decoding is unchanged. The benchmark correctness gates and regression test cover both paths; no follow-up is required.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title, with the type-prefixed head branch as a
fallback. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790361116&installation_model_id=432790&pr_number=865&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F865&signature=bd0e7ae5b1d4e92fd222634b2d901631e91201d9f9490cc9b72b1a54908c35eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized hot-path optimization in route matching with explicit tests and benchmarks; dynamic matching and param decoding behavior are unchanged.
> 
> **Overview**
> Speeds up `@octanejs/app-core` request routing by avoiding per-candidate RegExp work on static paths and by uppercasing the HTTP method at most once per `match()` call when scanning server routes.
> 
> **Router:** Parameter-free paths compile to an exact string and compare with `pathname === pattern`; routes with params or catch-alls still use capturing `RegExp`. Server-route method checks reuse a lazily computed `normalizedMethod` instead of calling `toUpperCase()` on every candidate.
> 
> **Regression coverage:** Adds a Node-only `router-dispatch` benchmark (1,000-route tables: static hit, wrong-method miss, dynamic params) with local baselines, ratio guards vs the dynamic path, harness registration, and `router-dispatch` in the Octane MCP `octane_benchmark` catalog. New Vitest coverage locks static, param, catch-all, literal special characters, and method matching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51c7fd7b9bf57ec444dda19d02631498cbeab76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->