### PR TITLE
refactor(compiler): remove retired AST emit helpers

### DIFF
--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -422,31 +422,6 @@ function inheritGeneratedOrigin(root, origin) {
 	return root;
 }
 
-function mapAstCow(value, replace) {
-	if (!value || typeof value !== 'object') return value;
-	if (Array.isArray(value)) {
-		let output = null;
-		for (let index = 0; index < value.length; index++) {
-			const mapped = mapAstCow(value[index], replace);
-			if (output === null && mapped !== value[index]) output = value.slice(0, index);
-			if (output !== null && mapped !== null) output.push(mapped);
-		}
-		return output ?? value;
-	}
-	const replacement = replace(value);
-	if (replacement !== undefined) return replacement;
-	let output = null;
-	for (const [key, child] of Object.entries(value)) {
-		if (AST_SKIP_KEYS.has(key)) continue;
-		const mapped = mapAstCow(child, replace);
-		if (mapped !== child) {
-			if (output === null) output = { ...value };
-			output[key] = mapped;
-		}
-	}
-	return output ?? value;
-}
-
 function jsonValueToAst(value, origin) {
 	const valueOrigin =
 		value && typeof value === 'object' && value[PLAN_ORIGIN] ? value[PLAN_ORIGIN] : origin;

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -7520,53 +7520,6 @@ function encodeMappings(decodedLines) {
 	return groups.join(';');
 }
 
-function buildSourceMap(source, sourceName, segments) {
-	const byLine = new Map();
-	let maxLine = -1;
-	for (const s of segments) {
-		if (s.genLine < 0) continue;
-		let arr = byLine.get(s.genLine);
-		if (!arr) byLine.set(s.genLine, (arr = []));
-		arr.push(s);
-		if (s.genLine > maxLine) maxLine = s.genLine;
-	}
-	let prevSrcLine = 0;
-	let prevSrcCol = 0;
-	const groups = [];
-	for (let line = 0; line <= maxLine; line++) {
-		const arr = byLine.get(line);
-		if (!arr) {
-			groups.push('');
-			continue;
-		}
-		// Sort by generated column and drop duplicates at the same column.
-		arr.sort((a, b) => a.genCol - b.genCol);
-		let prevGenCol = 0;
-		let lastGenCol = -1;
-		let group = '';
-		for (const s of arr) {
-			if (s.genCol === lastGenCol) continue;
-			lastGenCol = s.genCol;
-			// Fields: [genColumn, sourceIndex, sourceLine, sourceColumn] as deltas.
-			// genColumn resets per line; sourceIndex is always 0 (single source).
-			group +=
-				(group ? ',' : '') +
-				encodeVlq([s.genCol - prevGenCol, 0, s.srcLine0 - prevSrcLine, s.srcCol0 - prevSrcCol]);
-			prevGenCol = s.genCol;
-			prevSrcLine = s.srcLine0;
-			prevSrcCol = s.srcCol0;
-		}
-		groups.push(group);
-	}
-	return {
-		version: 3,
-		sources: [sourceName],
-		sourcesContent: [source],
-		names: [],
-		mappings: groups.join(';'),
-	};
-}
-
 /**
  * Dev-only source location for a construct, as a `[line, column]` pair (1-based line,
  * 0-based column — matches the AST). Returns `undefined` when not in dev OR the node has

--- a/packages/octane/tests/compiler/compiler-ast-emit-audit.test.ts
+++ b/packages/octane/tests/compiler/compiler-ast-emit-audit.test.ts
@@ -89,10 +89,11 @@ describe('compiler AST emit architecture', () => {
 		expect(violations).toEqual([]);
 	});
 
-	it('has no retired generated-text or source-map compatibility layer', () => {
+	it('has no retired AST emit compatibility layer', () => {
 		const retiredNames = [
 			'addSourceMapNeedles',
 			'applyMappedReplacements',
+			'buildSourceMap',
 			'composeSourceMaps',
 			'expandDomRendererRegions',
 			'generatedText',
@@ -101,6 +102,11 @@ describe('compiler AST emit architecture', () => {
 			'retargetRuntimeImport',
 			'sourceMapFromOrigins',
 		];
+		const retiredDefinitionsByFile = new Map([
+			// Renderer-boundary and hydrate transforms still own live walkers with
+			// this name. Universal lowering has no copy-on-write rewrite pass left.
+			['compile-universal.js', ['mapAstCow']],
+		]);
 		const retiredProperties = [
 			'__styleRemap',
 			'__universalValidationRemap',
@@ -111,9 +117,17 @@ describe('compiler AST emit architecture', () => {
 		const violations: string[] = [];
 
 		for (const { code, path } of sources) {
+			const relativePath = displayPath(path);
 			for (const name of retiredNames) {
 				violations.push(
 					...locations(path, code, new RegExp(`\\b${name}\\s*\\(`, 'g')).map(
+						(location) => `${location}: ${name}`,
+					),
+				);
+			}
+			for (const name of retiredDefinitionsByFile.get(relativePath) ?? []) {
+				violations.push(
+					...locations(path, code, new RegExp(`\\bfunction\\s+${name}\\s*\\(`, 'g')).map(
 						(location) => `${location}: ${name}`,
 					),
 				);


### PR DESCRIPTION
## Summary

- Remove the unreachable legacy `buildSourceMap` helper from the main TSRX compiler.
- Remove the unreachable copy-on-write `mapAstCow` helper from the universal TSRX compiler.
- Extend the AST emit architecture audit so both retired helpers stay out of their former modules.

The AST emit migration superseded both paths, but their definitions remained in authored source with no callers. This removes 73 dead lines (2,099 source bytes) without changing compiler output.

## Validation

- [ ] `pnpm format:check` (scoped check used instead)
- [ ] `pnpm typecheck` (scoped check used instead)
- [ ] `pnpm test` (targeted compiler matrix used instead; full matrix runs in CI)
- [x] targeted tests: 6 compiler suites, 294 tests passed, covering the architecture audit, source maps, AST immutability, inspect segments, template origins, and universal compiler capabilities
- [x] regression control: the architecture audit failed before source removal and identified both retired definitions
- [x] `pnpm typecheck:files packages/octane/src/compiler/compile-universal.js packages/octane/src/compiler/compile.js packages/octane/tests/compiler/compiler-ast-emit-audit.test.ts`
- [x] `pnpm format:files:check packages/octane/src/compiler/compile-universal.js packages/octane/src/compiler/compile.js packages/octane/tests/compiler/compiler-ast-emit-audit.test.ts`
- [x] `pnpm sync`
- [x] esbuild comparison against `origin/main`: unminified and minified compiler bundles are byte-for-byte identical, including gzip size and SHA-256

## Risk / follow-ups

Low risk: the removed functions had no references, and bundled output is unchanged. No changeset is included because this is an internal source cleanup with no package behavior or public API change.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790376734&installation_model_id=432790&pr_number=870&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F870&signature=3fde83280a35858432d819174acc849a37946a3cb3595c17af1b585ccf6867f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal dead-code removal with no callers and unchanged bundled output; audit-only enforcement beyond source deletion.
> 
> **Overview**
> Removes **dead AST emit compatibility code** left behind after the migration: `buildSourceMap` from the main TSRX compiler (`compile.js`) and copy-on-write `mapAstCow` from universal lowering (`compile-universal.js`). Neither helper had callers; compiler bundles stay byte-identical.
> 
> The **AST emit architecture audit** is tightened so these names cannot creep back: `buildSourceMap` is treated like other retired emit helpers globally, while `mapAstCow` is only forbidden as a **definition** in `compile-universal.js` (renderer-boundary code still uses its own live `mapAstCow`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2239f656ffe7a292e7d8343b708867f101786fc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->