### PR TITLE
(perf) Skip ordinary manifest cache scans

### DIFF
--- a/.changeset/fast-manifest-cache-invalidation.md
+++ b/.changeset/fast-manifest-cache-invalidation.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Skip manifest-cache scans for ordinary watched source changes while preserving package-manifest, full-reset, and diagnostic invalidation behavior. Expose the accompanying manifest-cache invalidation benchmark through the Octane MCP benchmark tool.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -214,6 +214,7 @@ internally, get their own baseline and guard namespace.
 | `application-composition` | application-composition | none (builds) | lifecycle resources, large forms, store fan-out, async recovery, form submission, and navigation teardown in one app |
 | `scaling-curves` | scaling-curves | none (builds) | independently correctness-gated controlled updates at 8, 32, 96, 256, and 512 components |
 | `router-dispatch` | router-dispatch | none (Node-only) | app-core static, wrong-method, and dynamic matching across 1,000-route tables |
+| `manifest-cache-invalidation` | manifest-cache-invalidation | none (Node-only) | shared-compiler source invalidation across 129 and 5,001 cached nearest-manifest decisions, plus a required manifest-scan control |
 | `vite-client-assets` | vite-client-assets | none (Node-only) | route asset mapping across 100 and 1,000 entries sharing a 500-chunk manifest graph, plus a shallow control |
 | `effectful-list` | effectful-list | Octane + reference frameworks | effect/ref cleanup churn |
 | `activity` | activity | none (builds) | same-source Octane/React Activity lifecycle, hidden/nested work, retained state/effects/DOM, cold-vs-used ordinary-ref controls, and optional-runtime bundle reachability |

--- a/benchmarks/baselines/local/manifest-cache-invalidation.json
+++ b/benchmarks/baselines/local/manifest-cache-invalidation.json
@@ -1,0 +1,88 @@
+{
+  "suite": "manifest-cache-invalidation",
+  "iterations": 8,
+  "targets": [
+    {
+      "name": "ordinary-small-cache",
+      "ops": {
+        "invalidate": {
+          "score": 0.0005589624999999956,
+          "median": 0.0005549164999999902,
+          "min": 0.0005411459999999977,
+          "mean": 0.0005536328124999948,
+          "p95": 0.0005633750000000078,
+          "sd": 0.000008351460714559248,
+          "rme": 1.2613243278589408,
+          "scoreRme": 0.8937399310613884,
+          "warmupRatio": 0.9848751928796654,
+          "samples": 8,
+          "p99": 0.0005633750000000078
+        }
+      },
+      "meta": {
+        "directories": 128,
+        "cacheEntries": 129,
+        "invalidationsPerSample": 2000,
+        "classification": "none",
+        "dependencies": 1,
+        "missingDependencies": 1,
+        "correctness": "pass"
+      }
+    },
+    {
+      "name": "ordinary-large-cache",
+      "ops": {
+        "invalidate": {
+          "score": 0.0005599291999999877,
+          "median": 0.0005650210000000016,
+          "min": 0.0005402919999999938,
+          "mean": 0.000560651124999989,
+          "p95": 0.0005802499999999781,
+          "sd": 0.000013942861744449817,
+          "rme": 2.0794351201605563,
+          "scoreRme": 2.5773541422221617,
+          "warmupRatio": 1.000134124099972,
+          "samples": 8,
+          "p99": 0.0005802499999999781
+        }
+      },
+      "meta": {
+        "directories": 5000,
+        "cacheEntries": 5001,
+        "invalidationsPerSample": 2000,
+        "classification": "none",
+        "dependencies": 1,
+        "missingDependencies": 1,
+        "correctness": "pass"
+      }
+    },
+    {
+      "name": "manifest-large-cache",
+      "ops": {
+        "invalidate": {
+          "score": 0.049195637400000006,
+          "median": 0.04920847900000001,
+          "min": 0.04547291649999997,
+          "mean": 0.048596335812499995,
+          "p95": 0.04921549999999996,
+          "sd": 0.0013189077801943738,
+          "rme": 2.269326879504432,
+          "scoreRme": 0.05867209947987396,
+          "warmupRatio": 0.9806417448714665,
+          "samples": 8,
+          "p99": 0.04921549999999996
+        }
+      },
+      "meta": {
+        "directories": 5000,
+        "cacheEntries": 5001,
+        "invalidationsPerSample": 2000,
+        "classification": "none",
+        "dependencies": 1,
+        "missingDependencies": 1,
+        "correctness": "pass"
+      }
+    }
+  ],
+  "harnessExit": 0
+}

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -488,6 +488,22 @@
     "note": "Same-process Vite asset mapping over route entries that share one 500-chunk graph and produce the same one-file CSS result. Rewalking the graph for every route measured at 10.16x for 1,000 versus 100 routes; bounded complete-result caching measured at 3.24x. The 6x ceiling leaves timing headroom while catching restoration of the route-count times graph-size traversal."
   },
   {
+    "suite": "manifest-cache-invalidation",
+    "op": "invalidate",
+    "target": "ordinary-large-cache",
+    "reference": "ordinary-small-cache",
+    "maxRatio": 1.5,
+    "note": "Same-process shared-compiler source invalidation after 129 versus 5,001 nearest-manifest decisions. The original whole-cache scan measured 34.8x at the large size, while rejecting non-manifest paths before cache traversal measured 1.00x. The 1.5 ceiling leaves timing headroom while catching cache-size-dependent ordinary invalidation."
+  },
+  {
+    "suite": "manifest-cache-invalidation",
+    "op": "invalidate",
+    "target": "ordinary-large-cache",
+    "reference": "manifest-large-cache",
+    "maxRatio": 0.2,
+    "note": "Same-process invalidation across 5,001 cached manifest decisions with identical cache-preservation checks. The original ordinary path measured at parity with the required package-manifest scan, while the manifest-name gate measured at 0.01x. The 0.2 ceiling preserves more than 10x timing headroom while catching loss of the ordinary-source fast path."
+  },
+  {
     "suite": "external-store-fanout",
     "op": "broad_write",
     "target": "octane-tsrx",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -363,6 +363,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Shared-compiler watched-path invalidation after nearest-package
+		// decisions have been cached for small and large source trees.
+		name: 'manifest-cache-invalidation',
+		cwd: 'manifest-cache-invalidation',
+		servers: [],
+		iter: { normal: 8, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Node-only Vite manifest traversal across many routes that converge on
 		// one deep shared chunk graph, plus a shallow-graph control.
 		name: 'vite-client-assets',

--- a/benchmarks/manifest-cache-invalidation/README.md
+++ b/benchmarks/manifest-cache-invalidation/README.md
@@ -1,0 +1,13 @@
+# Manifest cache invalidation benchmark
+
+This Node-only benchmark measures the shared compiler's watched-path invalidation cost after nearest-package decisions have been cached for many source directories.
+
+It compares ordinary source invalidation with small and large cache populations, plus a non-matching `package.json` invalidation against the large cache. The manifest scenario is a semantic control: it must retain the full dependency scan because any cache entry may depend on that manifest path.
+
+Run it through the unified benchmark driver:
+
+```bash
+node benchmarks/bench.mjs --quick manifest-cache-invalidation
+```
+
+The runner creates temporary package roots, populates caches before timing, alternates scenario order, checks that invalidation preserves every cached decision, and removes the fixtures afterward.

--- a/benchmarks/manifest-cache-invalidation/run.mjs
+++ b/benchmarks/manifest-cache-invalidation/run.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_ROOT = process.env.OCTANE_MANIFEST_CACHE_ROOT
+	? path.resolve(process.env.OCTANE_MANIFEST_CACHE_ROOT)
+	: path.resolve(HERE, '../..');
+const { createOctaneCompiler } = await import(
+	pathToFileURL(path.join(SOURCE_ROOT, 'packages/octane/src/compiler/bundler.js')).href
+);
+
+const SMALL_DIRECTORIES = 128;
+const LARGE_DIRECTORIES = 5_000;
+const INVALIDATIONS_PER_SAMPLE = 2_000;
+const iterations = Number.parseInt(process.argv[2] ?? '8', 10);
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Manifest cache invalidation iterations must be a positive integer');
+}
+
+function createFixture(name, directoryCount, changedName) {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), `octane-manifest-invalidation-${name}-`));
+	const manifest = path.join(root, 'package.json');
+	fs.writeFileSync(manifest, JSON.stringify({ name: `fixture-${name}`, private: true }));
+	const compiler = createOctaneCompiler({ root, strong: true, hmr: false, dev: false });
+	let lastResult = null;
+	for (let index = 0; index < directoryCount; index++) {
+		lastResult = compiler.transform('', path.join(root, `source-${index}`, 'empty.ts'), {
+			strong: true,
+			hmr: false,
+			dev: false,
+		});
+	}
+	const cacheEntries = compiler.manifestRuleCache.size;
+	assert.equal(cacheEntries, directoryCount + 1, `${name} populated an unexpected cache size`);
+	assert.equal(lastResult?.kind, 'none', `${name} changed empty-source classification`);
+	assert.deepEqual(lastResult?.dependencies, [manifest], `${name} lost its owning manifest`);
+	return {
+		name,
+		root,
+		compiler,
+		cacheEntries,
+		changedPath: path.join(root, 'changed', changedName) + '?watch=1#update',
+		samples: [],
+		meta: {
+			directories: directoryCount,
+			cacheEntries,
+			invalidationsPerSample: INVALIDATIONS_PER_SAMPLE,
+			classification: lastResult.kind,
+			dependencies: lastResult.dependencies.length,
+			missingDependencies: lastResult.missingDependencies.length,
+			correctness: 'pass',
+		},
+		dispose() {
+			fs.rmSync(root, { recursive: true, force: true });
+		},
+	};
+}
+
+function sampleFixture(fixture) {
+	const started = performance.now();
+	for (let index = 0; index < INVALIDATIONS_PER_SAMPLE; index++) {
+		fixture.compiler.invalidate(fixture.changedPath);
+	}
+	const elapsed = performance.now() - started;
+	assert.equal(
+		fixture.compiler.manifestRuleCache.size,
+		fixture.cacheEntries,
+		`${fixture.name} invalidation changed a non-matching cache`,
+	);
+	return elapsed / INVALIDATIONS_PER_SAMPLE;
+}
+
+const fixtures = [];
+const rows = [];
+let failure;
+
+try {
+	fixtures.push(createFixture('ordinary-small-cache', SMALL_DIRECTORIES, 'source.ts'));
+	fixtures.push(createFixture('ordinary-large-cache', LARGE_DIRECTORIES, 'source.ts'));
+	fixtures.push(createFixture('manifest-large-cache', LARGE_DIRECTORIES, 'package.json'));
+
+	for (let warmup = 0; warmup < 2; warmup++) {
+		for (const fixture of warmup % 2 === 0 ? fixtures : fixtures.toReversed()) {
+			sampleFixture(fixture);
+		}
+	}
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		for (const fixture of iteration % 2 === 0 ? fixtures : fixtures.toReversed()) {
+			fixture.samples.push(sampleFixture(fixture));
+		}
+	}
+
+	for (const fixture of fixtures) {
+		const invalidate = timingStatForJson(summarizeSamples(fixture.samples), { p99: true });
+		rows.push({ name: fixture.name, ops: { invalidate }, meta: fixture.meta });
+		console.log(
+			`PASS manifest-cache-invalidation/${fixture.name}: ${invalidate.score.toFixed(6)}ms/invalidation ` +
+				`across ${fixture.cacheEntries.toLocaleString()} cached directories`,
+		);
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL manifest-cache-invalidation/${failure}`);
+} finally {
+	for (const fixture of fixtures) fixture.dispose();
+}
+
+const payload = {
+	suite: 'manifest-cache-invalidation',
+	iterations,
+	targets: rows,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+
+if (failure) process.exitCode = 1;

--- a/docs/plans/2026-08-27-0321-perf-manifest-cache-invalidation-plan.md
+++ b/docs/plans/2026-08-27-0321-perf-manifest-cache-invalidation-plan.md
@@ -1,0 +1,176 @@
+---
+title: Manifest Cache Invalidation - Plan
+type: perf
+date: 2026-08-27
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Manifest Cache Invalidation - Plan
+
+## Goal Capsule
+
+- **Objective:** Octane developers working in large projects no longer pay a project-wide manifest-cache traversal for each ordinary watched source change.
+- **Means:** Reject changed paths that cannot name a package manifest before scanning the shared compiler caches (KTD1).
+- **Authority:** The user request and its non-duplication/evidence constraints outrank this plan. Current `origin/main` source and tests outrank summaries. Measured benchmark evidence outranks source-level intuition.
+- **Execution profile:** Baseline-first optimization on a dedicated branch created from `origin/main` at `cfa753bcd`; one focused pull request.
+- **Stop conditions:** Abandon this target if the baseline does not reproduce cache-size-dependent ordinary invalidation work, if a cache can depend on a non-`package.json` path, or if the candidate fails the performance threshold in KTD3. Select and plan a different non-overlapping target instead of weakening the evidence bar.
+- **Tail ownership:** Implementation, regression proof, benchmark integration, review fixes, repository synchronization, pull request creation, and current-head CI.
+
+## Product Contract
+
+### Summary
+
+Remove needless manifest-cache membership scans from ordinary compiler watch invalidations while preserving every manifest change, full-reset, and diagnostic-generation behavior.
+
+### Problem Frame
+
+The Vite compiler adapter calls the shared compiler invalidation entry point for every watched path. The shared compiler then walks every cached nearest-package decision and searches its dependency arrays, even when the changed path is an ordinary source module. Repository inspection shows those cache dependencies are package manifests, so the common source-edit path pays work that cannot change the cache result. The cost grows with the number of cached source directories and their manifest lookup depth.
+
+This target is separate from the recent author-owned performance pull requests for scheduler depth, TypeScript text roots, compiler reachability and hoist analysis, Vite client assets, app routing, SSR boundary pruning, diagnostics, generated names, and queue drains.
+
+### Requirements
+
+**Performance and evidence**
+
+- R1. The optimization must remove manifest-cache traversal from ordinary non-manifest path invalidation in the shared compiler owner.
+- R2. A same-machine baseline and candidate run must show that ordinary invalidation no longer scales with the populated manifest cache and meets KTD3.
+- R3. If R2 fails because the hypothesis is wrong, discard the attempt and select a different non-overlapping performance target.
+
+**Behavior preservation**
+
+- R4. An exact package manifest change must still evict every nearest-package and discovery entry that depends on that present or previously missing manifest.
+- R5. A full invalidation without a path must still clear both manifest and discovery caches.
+- R6. Every path invalidation must still begin a new compiler diagnostic generation, including non-manifest changes that skip cache work.
+- R7. Query and hash suffix cleanup must occur before the manifest-path classification so bundler-decorated manifest IDs retain current behavior.
+
+**Repository delivery**
+
+- R8. The change must include behavioral compiler coverage, a benchmark with semantic controls, a durable ratio guard, and an Octane patch changeset.
+- R9. The pull request must remain distinct from the recent performance work identified during planning and must be refreshed against the live default branch before readiness.
+
+### Key Decisions
+
+- **Non-overlapping target** (session-settled: user-directed — chosen over duplicating or extending a recent author-owned performance pull request: the user required a distinct performance improvement). Governs R1, R9.
+- **Evidence controls shipment** (session-settled: user-directed — chosen over keeping or shipping a disproven optimization hypothesis: the user required moving to another target when measurement falsifies the idea). Governs R2, R3.
+- **Fresh isolated worktree** (session-settled: user-directed — chosen over implementing on the stale, already-occupied performance checkout: the user required the latest default branch and a different worktree when work conflicts). Governs R9.
+
+### Scope Boundaries
+
+- Optimize shared compiler invalidation only. Do not redesign the manifest-cache representation or add a retained reverse index.
+- Preserve adapter call sites so Vite and Rspack continue reporting changes through the same compiler contract.
+- Do not modify the compiler transform, renderer, TypeScript project, scheduler, runtime, SSR, or client-asset hot paths covered by recent performance work.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Use a cold manifest-name gate in the shared invalidation owner.** Resolve and clean the changed path as today, preserve the diagnostic-generation reset, handle full invalidation first, and then return before cache iteration unless the basename is `package.json`. Source inspection shows both `manifestRuleCache` and `discoveryCache` metadata contain only present or missing package-manifest paths.
+- KTD2. **Keep adapters ignorant of cache internals.** Place the optimization in `packages/octane/src/compiler/bundler.js` so every adapter receives the same behavior and future callers cannot accidentally miss the fast path.
+- KTD3. **Guard the improvement with same-process scaling and scan controls.** The benchmark will populate small and large nearest-manifest caches, alternate ordinary-source invalidation across both sizes, and retain a non-matching `package.json` invalidation at the large size that must still scan. After warmup, the candidate large-cache ordinary-source score must be no more than 1.5x the small-cache ordinary-source score and no more than 20% of the large manifest-scan control score. Main should fail both ratios because every path performs the same cache-size-dependent scan.
+- KTD4. **Prove preserved behavior at the public compiler boundary.** Extend the existing bundler compiler suite to show that an ordinary source invalidation leaves a cached package decision stable, an exact manifest invalidation refreshes it, and a full invalidation still clears it. Benchmark-only assertions do not replace this contract coverage.
+
+### Assumptions
+
+- Every dependency and missing-dependency path retained by the two affected caches is an exact `package.json` path. Execution must re-audit all metadata producers before applying KTD1.
+- A cache population representative of a large project will make the baseline scan/control parity and the candidate fast-path separation exceed timing noise. If it does not, R3 applies.
+- The new Node-only benchmark should follow the existing runner, baseline, MCP discovery, and documentation conventions used by `router-dispatch`, `tsrx-nesting-diagnostics`, and the recent compiler performance suites.
+
+### Sequencing
+
+Capture the baseline with the new harness before editing production compiler source. Add the functional regression and production fast path next. Integrate the measured candidate into the ratio registry and generated repository surfaces only after the final benchmark remains decisive.
+
+### Sources and Research
+
+- `packages/octane/src/compiler/vite.js` calls compiler invalidation from `watchChange` for every watched ID.
+- `packages/octane/src/compiler/bundler.js` constructs nearest-package and discovery metadata exclusively from `package.json` candidates, then linearly scans that metadata on every path invalidation.
+- `packages/octane/tests/compiler/bundler-compiler.test.ts` contains the existing missing-manifest creation and cache-refresh scenario to extend.
+- `benchmarks/README.md`, `benchmarks/bench.mjs`, and `benchmarks/baselines/ratios.json` define Node-only benchmark registration, result shape, and same-machine ratio enforcement.
+- Recent author-owned performance pull requests #842, #843, #845, #850, #851, #856-#861, #863, #865, #868, and #871-#873 established the excluded overlap set.
+
+## Implementation Units
+
+### U1. Reproduce manifest-cache invalidation scaling
+
+- **Goal:** Add a Node-only benchmark that isolates ordinary invalidation traversal from required manifest invalidation traversal and capture the current-main baseline.
+- **Requirements:** R2, R3, R8.
+- **Dependencies:** None.
+- **Files:**
+  - `benchmarks/manifest-cache-invalidation/README.md`
+  - `benchmarks/manifest-cache-invalidation/run.mjs`
+  - `benchmarks/bench.mjs`
+- **Approach:**
+  1. Populate compiler instances with small and large sets of project-owned source-directory manifest decisions without including setup work in the timed samples.
+  2. Warm every scenario, alternate their sample order, and report normalized invalidation cost with the shared statistics helpers.
+  3. Use ordinary source paths at both cache sizes as the scaling scenarios and a non-matching `package.json` path against the large cache as the required-scan control.
+  4. Verify cache population and post-sample compiler behavior so a faster result cannot come from clearing the workload or skipping all invalidation semantics.
+- **Execution note:** Run and retain the baseline result before any production-source edit. If the two baseline paths do not show comparable scan cost, stop this target under R3.
+- **Patterns to follow:** `benchmarks/router-dispatch/run.mjs`, `benchmarks/tsrx-nesting-diagnostics/run.mjs`, and `benchmarks/lib/stats.mjs`.
+- **Test scenarios:**
+  - Populate the configured small and large cached source-directory sets, run ordinary invalidations, and require both cache populations and compiler classification checksums to remain intact.
+  - Run non-matching manifest invalidations against the large populated cache and require the same semantic checksum while retaining the scan control.
+  - Alternate scenario order across iterations and reject non-positive iteration input so warmup or order bias cannot manufacture the result.
+- **Verification:** The unified runner emits valid JSON for all three scenarios, the semantic controls pass, and the baseline large/small ordinary ratio and ordinary/control ratio both fail KTD3 by decisive margins.
+
+### U2. Skip impossible cache invalidations
+
+- **Goal:** Add the smallest shared-compiler fast path and regression coverage for the preserved invalidation contract.
+- **Requirements:** R1, R4, R5, R6, R7, R8.
+- **Dependencies:** U1.
+- **Files:**
+  - `packages/octane/src/compiler/bundler.js`
+  - `packages/octane/tests/compiler/bundler-compiler.test.ts`
+  - `.changeset/fast-manifest-cache-invalidation.md`
+- **Approach:** Apply KTD1 in the owning invalidation method without changing cache shapes or adapter behavior. Extend the existing cache-refresh scenario per KTD4, including decorated manifest IDs if the public path accepts them.
+- **Execution note:** Add the behavioral assertion before the fast path. Deliberately apply an over-broad skip or clear to confirm the new assertion fails, then restore the intended implementation.
+- **Patterns to follow:** The current `invalidate` control flow in `packages/octane/src/compiler/bundler.js` and the temporary project fixtures in `packages/octane/tests/compiler/bundler-compiler.test.ts`.
+- **Test scenarios:**
+  - With a cached inherited package decision, create a nearer package manifest and invalidate an ordinary source file; the cached decision remains in force until the manifest itself is reported changed.
+  - Report that new manifest with a query or hash suffix; the next transform refreshes ownership and observes the new package rule.
+  - Populate both cache families, request a full invalidation without a path, and observe fresh package discovery on the next public compiler operation.
+  - Produce a compiler diagnostic, invalidate an unrelated non-manifest path, and confirm the next generation may report the diagnostic again.
+- **Verification:** The focused compiler suite passes in development, the new behavior-preservation test has been observed failing under a deliberate broken implementation, and the change introduces no new retained state or common transform-path work.
+
+### U3. Make the performance result durable
+
+- **Goal:** Register the final candidate result in the repository benchmark and release surfaces.
+- **Requirements:** R2, R8, R9.
+- **Dependencies:** U2.
+- **Files:**
+  - `benchmarks/baselines/local/manifest-cache-invalidation.json`
+  - `benchmarks/baselines/ratios.json`
+  - `benchmarks/README.md`
+  - `packages/octane-mcp-server/src/index.js`
+  - `packages/octane-mcp-server/README.md`
+  - Files generated by `pnpm sync`
+- **Approach:** Record the candidate baseline, add the KTD3 ratio guard, expose the suite through the established benchmark discovery surfaces, and include all relevant generated updates from repository synchronization.
+- **Patterns to follow:** The benchmark registrations and MCP allowlists for `router-dispatch`, `tsrx-nesting-diagnostics`, `vite-client-assets`, and `text-type-roots`.
+- **Test scenarios:**
+  - Run the candidate suite through the unified runner with ratio enforcement; the ordinary path satisfies KTD3 and both semantic controls remain equal.
+  - Re-run after all review edits so the reported candidate is not a stale intermediate measurement.
+- **Verification:** The standalone and unified benchmark paths agree, ratio enforcement passes, repository synchronization is clean, and no generated inventory omits the new suite.
+
+## Verification Contract
+
+| Gate | Applies to | Done signal |
+| --- | --- | --- |
+| `node benchmarks/bench.mjs --quick manifest-cache-invalidation` before U2 | U1 | Baseline small/large ordinary and large manifest-control scores pass semantic checks and both comparison ratios fail KTD3. |
+| Focused Vitest run for `packages/octane/tests/compiler/bundler-compiler.test.ts` | U2 | The new preservation scenario and adjacent compiler invalidation coverage pass. |
+| `node benchmarks/bench.mjs --quick --ratios manifest-cache-invalidation` after U2 and after final review | U1-U3 | The large ordinary score is at most 1.5x the small ordinary score and at most 20% of the large manifest-control score; all correctness metadata passes. |
+| `pnpm format:files:check` on changed paths | U1-U3 | Every authored change matches repository formatting. |
+| `pnpm typecheck:files` on changed paths | U2-U3 | Compiler and test types pass with the repository toolchain. |
+| `pnpm sync` | U3 | Generated outputs are current and the worktree remains explainably clean. |
+| Relevant root test and typecheck gates selected by final diff | U1-U3 | No shared compiler, benchmark-runner, MCP, or package regression remains. |
+| Current-head pull request CI and review | U1-U3 | Required and relevant checks pass, actionable review feedback is resolved, the live base is incorporated, and GitHub reports no merge blocker. |
+
+## Definition of Done
+
+- R1-R9 are satisfied and U1-U3 meet their verification outcomes.
+- Baseline and final candidate results use the same harness, cache population, warmup, iteration policy, Node runtime, and machine state.
+- The final candidate meets KTD3 by a margin larger than observed variance. Otherwise the target is abandoned under R3 and is not shipped.
+- Manifest, full-reset, decorated-ID, and diagnostic-generation behaviors remain covered at the public compiler boundary.
+- The Octane patch changeset, benchmark documentation, ratio guard, MCP discovery, and synchronized generated files are included where repository conventions require them.
+- The final diff contains no experimental counters, alternate implementations, temporary benchmark probes, or abandoned-attempt code.
+- The branch is refreshed against the live default branch before readiness, the worktree is clean after validation, and current-head CI is green.

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -163,7 +163,7 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `controlled-form`, `external-store-fanout`, `external-store-integrations`,
 `scheduler-responsiveness`, `suspense-recovery`, `event-delegation`,
 `application-composition`, `scaling-curves`, `dev-form-diagnostics`,
-`behavior-root-events`, `router-dispatch`, `vite-client-assets`, `activity`, `streaming-ssr`, `streaming-backpressure`,
+`behavior-root-events`, `router-dispatch`, `manifest-cache-invalidation`, `vite-client-assets`, `activity`, `streaming-ssr`, `streaming-backpressure`,
 `compiler-throughput`, `tsrx-component-graph`, `codegen-size`, `hook-memo`,
 `template-call-memo`, `bundle-size`, `bundle-reachability`, `three-renderer`,
 `three-bundle-size`, …)

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -69,6 +69,7 @@ export const BENCHMARK_SUITES = [
 	'dev-form-diagnostics',
 	'behavior-root-events',
 	'router-dispatch',
+	'manifest-cache-invalidation',
 	'vite-client-assets',
 	'store-selector-fanout',
 	'hook-store-composition',

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -530,6 +530,10 @@ class OctaneBundlerCompiler {
 			return;
 		}
 		const changed = nodePath.resolve(cleanModuleId(path));
+		// Both cache families retain only present or missing package manifests.
+		// Ordinary source edits still start a diagnostic generation above, but
+		// cannot invalidate either cache.
+		if (nodePath.basename(changed) !== 'package.json') return;
 		for (const [directory, entry] of this.manifestRuleCache) {
 			if (entry.dependencies.includes(changed) || entry.missingDependencies.includes(changed)) {
 				this.manifestRuleCache.delete(directory);

--- a/packages/octane/tests/compiler/bundler-compiler.test.ts
+++ b/packages/octane/tests/compiler/bundler-compiler.test.ts
@@ -1284,7 +1284,9 @@ export const Indirect = indirect(Host);
 			// Cached nearest-manifest decisions are stable until the bundler reports
 			// a watched change.
 			expect(compiler.transform(HOOK, id)?.kind).toBe('slots');
-			compiler.invalidate(sourceManifest);
+			compiler.invalidate(id);
+			expect(compiler.transform(HOOK, id)?.kind).toBe('slots');
+			compiler.invalidate(sourceManifest + '?watch=1#created');
 			const refreshed = compiler.transform(HOOK, id);
 			expect(refreshed?.kind).toBe('none');
 			expect(refreshed?.dependencies).toContain(sourceManifest);
@@ -1340,7 +1342,8 @@ export const Indirect = indirect(Host);
 			);
 			writeFileSync(join(packageRoot, 'index.js'), 'export const value = 1;\n');
 
-			const discovered = createOctaneCompiler({ root }).discoverSourceDependencies();
+			const compiler = createOctaneCompiler({ root });
+			const discovered = compiler.discoverSourceDependencies();
 			const resolvedPackageRoot = realpathSync(packageRoot);
 			expect(discovered.packages).toEqual(['raw-octane']);
 			expect(discovered.viteOptimizeDepsExclusions).toEqual([
@@ -1357,6 +1360,11 @@ export const Indirect = indirect(Host);
 			expect(discovered.missingDependencies).toContain(
 				join(realpathSync(root), 'node_modules/missing-child/package.json'),
 			);
+
+			writeFileSync(projectManifest, JSON.stringify({ name: 'app', private: true }));
+			expect(compiler.discoverSourceDependencies().packages).toEqual(['raw-octane']);
+			compiler.invalidate();
+			expect(compiler.discoverSourceDependencies().packages).toEqual([]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- Skip both manifest-cache traversals when a watched path cannot name `package.json`.
- Preserve diagnostic-generation reset, full invalidation, decorated manifest IDs, and exact manifest eviction.
- Add a Node benchmark, local baseline, durable scaling/control ratios, and MCP benchmark discovery.

## Why

Vite reports every watched source change to the shared compiler. The compiler previously searched every cached nearest-package and discovery dependency for each ordinary source edit even though those caches retain only present or missing `package.json` paths. In a 5,001-entry cache, the old path measured about 0.049 ms per invalidation; the fast path measures about 0.00055 ms.

This target is distinct from recent author-owned performance PRs covering TypeScript project roots, compiler reachability/hoisting, Vite client assets, scheduler depth, app routing, SSR boundary scans, diagnostics, generated names, and event queues.

Plan: `docs/plans/2026-08-27-0321-perf-manifest-cache-invalidation-plan.md`

## Changes

- Add the manifest-name gate in the shared bundler compiler owner.
- Extend public compiler tests for ordinary, decorated-manifest, and full invalidation behavior; retain the existing diagnostic-generation regression.
- Add `manifest-cache-invalidation` to the unified benchmark runner, ratio registry, baseline, documentation, and MCP server allowlist.
- Add patch changesets for `octane` and `@octanejs/mcp-server`.

## Validation

- [x] `node node_modules/prettier/bin/prettier.cjs --check .`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — prechecks passed, but the unrestricted aggregate Vitest run failed in unrelated Jotai localStorage, Markdown crosswalk, and resizable-panels tests, then left unrelated browser/native projects running; it was terminated after the failure set stabilized.
- [x] targeted tests: `CI=true pnpm exec vitest run packages/octane/tests/compiler/bundler-compiler.test.ts packages/octane/tests/compiler/native-change-compiler.test.ts --silent=false` (2 files, 63 tests)
- [x] targeted tests: `CI=true pnpm exec vitest run --project octane-mcp-server --silent=false` (2 files, 43 tests)
- [x] `node benchmarks/bench.mjs --quick --ratios manifest-cache-invalidation` (2/2 guards pass; 0.000546 ms large ordinary vs 0.048841 ms manifest control in the final run)
- [x] `pnpm sync`
- [x] `pnpm changeset:check`

## Risk / follow-ups

- The fast path depends on the audited invariant that both cache families retain only present or missing package-manifest paths. The code comment and semantic benchmark control make that constraint explicit.
- Current-head GitHub CI remains the authoritative broad integration gate.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411051&installation_model_id=432790&pr_number=874&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F874&signature=6898ab7adcb7d7d8124d2ac1475e3e2ff20e5dec47747a3f91c2f60b79b8c806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every Vite watch still hits shared `invalidate`; an incorrect early return could leave stale package-boundary caches in dev, though behavior is covered by compiler tests and benchmark semantic controls.
> 
> **Overview**
> **Ordinary watched source changes no longer walk the shared compiler’s manifest caches.** In `bundler.js`, path invalidation still clears diagnostics and handles full resets as before, but after resolving the changed ID it returns immediately unless the basename is `package.json`, so Vite’s per-file `watchChange` traffic avoids O(cache-size) scans that cannot affect entries whose dependencies are only manifests.
> 
> **Regression and perf guardrails ship with the fix.** `bundler-compiler.test.ts` now asserts that invalidating a source file leaves cached nearest-package decisions in place until a manifest (including query/hash decorated IDs) is reported, and that parameterless invalidation still clears discovery. A new Node-only `manifest-cache-invalidation` benchmark, local baseline, two ratio guards in `ratios.json`, runner/MCP registration, and patch changesets document and enforce flat ordinary invalidation cost versus retained manifest-scan behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a9d72e1caf5b5b792ebef797f7a30dcc0a86b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->