### PR TITLE
(perf) Make floating tree navigation linear

### DIFF
--- a/.changeset/fast-floating-tree-navigation.md
+++ b/.changeset/fast-floating-tree-navigation.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/floating-ui': patch
+---
+
+Make virtual nested-menu navigation find the deepest open node with one indexed tree traversal.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -244,6 +244,7 @@ internally, get their own baseline and guard namespace.
 | `application-composition` | application-composition | none (builds) | lifecycle resources, large forms, store fan-out, async recovery, form submission, and navigation teardown in one app |
 | `scaling-curves` | scaling-curves | none (builds) | independently correctness-gated controlled updates at 8, 32, 96, 256, and 512 components |
 | `router-dispatch` | router-dispatch | none (Node-only) | app-core static, wrong-method, and dynamic matching across 1,000-route tables |
+| `floating-tree-navigation` | floating-tree-navigation | none (Node-only) | Floating UI deepest-open-node lookup on deep chains, equal-depth forks, and a root-only control, with exact previous-behavior and deterministic node-read gates |
 | `manifest-cache-invalidation` | manifest-cache-invalidation | none (Node-only) | shared-compiler source invalidation across 129 and 5,001 cached nearest-manifest decisions, plus a required manifest-scan control |
 | `vite-client-assets` | vite-client-assets | none (Node-only) | route asset mapping across 100 and 1,000 entries sharing a 500-chunk manifest graph, plus a shallow control |
 | `effectful-list` | effectful-list | Octane + reference frameworks | effect/ref cleanup churn |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -480,6 +480,30 @@
     "note": "Same-process lowercase method misses through 1,000 server routes, normalized per candidate. Re-normalizing the request method for every route measured at 0.31x the dynamic control; one dispatch-level normalization measured at 0.07x. The 0.2 ceiling leaves timing headroom while catching repeated method normalization."
   },
   {
+    "suite": "floating-tree-navigation",
+    "op": "node_reads",
+    "target": "indexed-deep-chain",
+    "reference": "previous-deep-chain",
+    "maxRatio": 0.01,
+    "note": "Deterministic indexed reads for the production deepest-open-node lookup versus the exact previous recursive descendant expansion. The full 16-node chain measured 32 reads versus 1,048,576; the 0.01 ceiling leaves more than 300x headroom while requiring work to remain linear on the virtual-keyboard-navigation path."
+  },
+  {
+    "suite": "floating-tree-navigation",
+    "op": "node_reads",
+    "target": "indexed-equal-depth-fork",
+    "reference": "previous-equal-depth-fork",
+    "maxRatio": 0.05,
+    "note": "Deterministic indexed reads for two equal-depth open branches, with node identity pinned to the first tree-order leaf. The full fixture measured 33 reads versus 17,373; the 0.05 ceiling leaves more than 26x headroom while catching repeated all-descendant expansion."
+  },
+  {
+    "suite": "floating-tree-navigation",
+    "op": "lookup",
+    "target": "indexed-deep-chain",
+    "reference": "previous-deep-chain",
+    "maxRatio": 0.25,
+    "note": "Same-process warmed lookup time for production versus the exact previous algorithm on a 16-node open chain. One full run measured 0.000848 ms versus 7.419794 ms; the deterministic node-read guard is primary, and the 0.25 ceiling leaves broad timing headroom while requiring the indexed traversal's advantage to remain visible."
+  },
+  {
     "suite": "vite-client-assets",
     "op": "asset_map",
     "target": "routes-1000-deep",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -407,6 +407,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Floating UI's virtual nested-menu routing: exact previous behavior versus
+		// production on deep and branching trees, with deterministic node-read counts.
+		name: 'floating-tree-navigation',
+		cwd: 'floating-tree-navigation',
+		servers: [],
+		iter: { normal: 8, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Shared-compiler watched-path invalidation after nearest-package
 		// decisions have been cached for small and large source trees.
 		name: 'manifest-cache-invalidation',

--- a/benchmarks/floating-tree-navigation/README.md
+++ b/benchmarks/floating-tree-navigation/README.md
@@ -1,0 +1,21 @@
+# Floating tree navigation benchmark
+
+This Node-only suite exercises the private `@octanejs/floating-ui` helper that routes virtual
+keyboard navigation to the deepest open floating node. It compares the production helper with the
+exact previous algorithm on a deep chain, an equal-depth fork, and a root-only control.
+
+Every target must return the same node object as the previous algorithm. A proxy around the input
+array counts actual indexed node reads by each implementation, providing deterministic scaling
+evidence without adding profiling branches to production code. Timings warm both implementations
+and alternate their order across samples; deterministic work is the primary regression signal.
+
+At the full 16-node chain size used by the ratio guard, the previous algorithm performs 1,048,576
+indexed node reads while the production helper performs 32. The root-only control remains two reads
+for both implementations.
+
+Run the suite through the unified runner:
+
+```bash
+node benchmarks/bench.mjs --quick --ratios floating-tree-navigation
+node benchmarks/bench.mjs --ratios floating-tree-navigation
+```

--- a/benchmarks/floating-tree-navigation/run.mjs
+++ b/benchmarks/floating-tree-navigation/run.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { getDeepestNode } from '../../packages/floating-ui/src/utils/nodes.ts';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const iterations = Number.parseInt(process.argv[2] ?? '8', 10);
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Floating tree navigation iterations must be a positive integer');
+}
+
+const fullSize = iterations <= 3 ? 12 : 16;
+const lookupsPerSample = iterations <= 3 ? 2 : 4;
+
+function node(id, parentId, open = true) {
+	return { id, parentId, context: { open } };
+}
+
+function createChain(size) {
+	return Array.from({ length: size }, (_, index) =>
+		node(`chain-${index}`, index === 0 ? null : `chain-${index - 1}`),
+	);
+}
+
+function createFork(depth) {
+	const root = node('fork-root', null);
+	const nodes = [root];
+	for (let level = 1; level <= depth; level++) {
+		nodes.push(
+			node(`left-${level}`, level === 1 ? root.id : `left-${level - 1}`),
+			node(`right-${level}`, level === 1 ? root.id : `right-${level - 1}`),
+		);
+	}
+	return nodes;
+}
+
+function previousGetNodeChildren(nodes, id) {
+	const directChildren = nodes.filter((entry) => entry.parentId === id && entry.context?.open);
+	return directChildren.flatMap((child) => [child, ...previousGetNodeChildren(nodes, child.id)]);
+}
+
+function previousGetDeepestNode(nodes, id) {
+	let deepestNodeId;
+	let maxDepth = -1;
+	function findDeepest(nodeId, depth) {
+		if (depth > maxDepth) {
+			deepestNodeId = nodeId;
+			maxDepth = depth;
+		}
+		for (const child of previousGetNodeChildren(nodes, nodeId)) {
+			findDeepest(child.id, depth + 1);
+		}
+	}
+	findDeepest(id, 0);
+	return nodes.find((entry) => entry.id === deepestNodeId);
+}
+
+function countNodeReads(nodes, lookup, rootId) {
+	let reads = 0;
+	const counted = new Proxy(nodes, {
+		get(target, property, receiver) {
+			if (typeof property === 'string' && /^(0|[1-9]\d*)$/.test(property)) reads++;
+			return Reflect.get(target, property, receiver);
+		},
+	});
+	return { result: lookup(counted, rootId), reads };
+}
+
+const correctnessFixtures = [
+	{ name: 'root-only', nodes: [node('root', null)], rootId: 'root' },
+	{
+		name: 'closed-branch',
+		nodes: [
+			node('root', null),
+			node('closed', 'root', false),
+			node('hidden', 'closed'),
+			node('visible', 'root'),
+		],
+		rootId: 'root',
+	},
+	{
+		name: 'missing-root',
+		nodes: [node('child', 'missing'), node('leaf', 'child')],
+		rootId: 'missing',
+	},
+	{ name: 'equal-depth-fork', nodes: createFork(4), rootId: 'fork-root' },
+];
+
+for (const fixture of correctnessFixtures) {
+	assert.equal(
+		getDeepestNode(fixture.nodes, fixture.rootId),
+		previousGetDeepestNode(fixture.nodes, fixture.rootId),
+		`${fixture.name} changed deepest-node identity`,
+	);
+}
+
+const scenarios = [
+	{ name: 'deep-chain', nodes: createChain(fullSize), rootId: 'chain-0' },
+	{ name: 'equal-depth-fork', nodes: createFork(Math.floor(fullSize / 2)), rootId: 'fork-root' },
+	{ name: 'root-only', nodes: [node('root', null)], rootId: 'root' },
+];
+const implementations = [
+	{ name: 'previous', lookup: previousGetDeepestNode },
+	{ name: 'indexed', lookup: getDeepestNode },
+];
+
+function sample(implementation, scenario, repetitions) {
+	let checksum = '';
+	const started = performance.now();
+	for (let index = 0; index < repetitions; index++) {
+		checksum = implementation.lookup(scenario.nodes, scenario.rootId)?.id ?? '';
+	}
+	const elapsed = performance.now() - started;
+	assert.ok(checksum, `${implementation.name}/${scenario.name} returned no node`);
+	return elapsed / repetitions;
+}
+
+const samples = new Map();
+for (const scenario of scenarios) {
+	for (const implementation of implementations) {
+		const key = `${implementation.name}-${scenario.name}`;
+		samples.set(key, []);
+		sample(implementation, scenario, lookupsPerSample);
+	}
+}
+
+for (let iteration = 0; iteration < iterations; iteration++) {
+	const implementationOrder = iteration % 2 === 0 ? implementations : implementations.toReversed();
+	const scenarioOrder = iteration % 2 === 0 ? scenarios : scenarios.toReversed();
+	for (const scenario of scenarioOrder) {
+		for (const implementation of implementationOrder) {
+			const repetitions = scenario.name === 'root-only' ? 20_000 : lookupsPerSample;
+			samples
+				.get(`${implementation.name}-${scenario.name}`)
+				.push(sample(implementation, scenario, repetitions));
+		}
+	}
+}
+
+const targets = [];
+for (const scenario of scenarios) {
+	const expected = previousGetDeepestNode(scenario.nodes, scenario.rootId);
+	for (const implementation of implementations) {
+		const key = `${implementation.name}-${scenario.name}`;
+		const counted = countNodeReads(scenario.nodes, implementation.lookup, scenario.rootId);
+		assert.equal(counted.result, expected, `${key} changed node identity`);
+		const lookup = timingStatForJson(summarizeSamples(samples.get(key)));
+		const nodeReads = deterministicStatForJson(deterministicCount(counted.reads));
+		targets.push({
+			name: key,
+			ops: { lookup, node_reads: nodeReads },
+			meta: {
+				nodes: scenario.nodes.length,
+				rootId: scenario.rootId,
+				resultId: counted.result?.id,
+				correctness: 'pass',
+			},
+		});
+		console.log(
+			`PASS floating-tree-navigation/${key}: ${counted.reads.toLocaleString()} node reads, ` +
+				`${lookup.score.toFixed(6)}ms/lookup`,
+		);
+	}
+}
+
+const payload = { suite: 'floating-tree-navigation', iterations, targets };
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}

--- a/docs/plans/2026-08-27-2339-floating-tree-navigation-performance-plan.md
+++ b/docs/plans/2026-08-27-2339-floating-tree-navigation-performance-plan.md
@@ -1,0 +1,198 @@
+---
+title: Floating Tree Navigation Performance - Plan
+type: perf
+date: 2026-08-27
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Floating Tree Navigation Performance - Plan
+
+## Goal Capsule
+
+Make `@octanejs/floating-ui` resolve the deepest open node in a nested floating tree without repeatedly walking the same descendants. The result must be measurably faster on representative deep and branching trees, preserve the existing tree-order and open-state semantics used by virtual list navigation, and avoid the performance areas already covered by the author's recent `(perf)` pull requests.
+
+---
+
+## Product Contract
+
+### Summary
+
+`getDeepestNode()` currently asks `getNodeChildren()` for every descendant of the current node, then recursively repeats that all-descendant search for each returned node. Descendant subtrees are therefore revisited many times. `useListNavigation()` invokes this helper in its virtual nested-menu keyboard path before routing navigation to the active deepest open node. Build direct-child relationships once and traverse eligible nodes once so lookup cost follows the tree size rather than the number of repeatedly expanded descendant paths.
+
+### Problem Frame
+
+- The source-owned hotspot is `packages/floating-ui/src/utils/index.ts`; the user-visible caller is `packages/floating-ui/src/useListNavigation.ts`.
+- The implementation is adapted from the pinned `@floating-ui/react@0.27.19` source under `packages/floating-ui/upstream/`. The vendored upstream snapshot is provenance and must not be edited.
+- A recent pull-request audit found open or recently merged performance work in Radix collection ordering, Visx categorical scales, Lynx handle retirement/commit drain, scheduler depth prefixes, manifest scanning, compiler reachability and memo witnesses, text roots, form diagnostics, list upgrades, JSX return analysis, Vite assets, router dispatch, component hoisting, Rspack/Rsbuild messaging, host-prop sorting, TSRX diagnostics, stream boundary scanning, generated names, and hydration templates. Floating UI tree navigation is a distinct owner and execution path.
+- The hypothesis is load-bearing: if an exact-old-versus-candidate benchmark does not show a useful scaling improvement without a material small-tree regression, discard the attempt and select a different hotspot rather than shipping speculative churn.
+
+### Requirements
+
+- R1. Replace repeated all-descendant expansion in `getDeepestNode()` with a direct-child index and a single traversal of eligible open descendants.
+- R2. Preserve existing results for root-only trees, closed branches, multiple branches of equal depth, missing roots, and the current first-in-tree-order tie behavior.
+- R3. Preserve the caller contract in `useListNavigation()` and add no public package API.
+- R4. Commit a deterministic benchmark that compares the exact former algorithm with the production candidate, checks result equivalence, and guards representative scaling ratios.
+- R5. Measure the unmodified baseline before accepting the implementation. If the benchmark disproves the hypothesis or exposes a meaningful small-input regression, remove the attempt and move to another target.
+- R6. Keep the pinned upstream source and provenance metadata unchanged; the optimization belongs only in the adapted Octane package source.
+- R7. Add a patch changeset for the user-facing `@octanejs/floating-ui` performance improvement.
+- R8. Start from the latest `origin/main` in the dedicated `/private/tmp/octane-perf-Texa6w` worktree and do not reuse or overwrite unrelated checkout state.
+
+### Scope Boundaries
+
+In scope:
+
+- The internal Floating UI node helper used by virtual nested list navigation.
+- A production-importing deterministic benchmark, benchmark registration, ratio baseline, documentation, focused correctness coverage, and package release metadata.
+- Existing Floating UI package, parity, formatting, type, synchronization, and CI gates.
+
+Out of scope:
+
+- Changes to Floating UI behavior, keyboard semantics, dynamic-child divergence policy, or public exports.
+- General rewrites of `getNodeChildren()`, `getNodeAncestors()`, `useListNavigation()`, or other tree consumers unless measurement proves they are required for this hotspot.
+- Changes to the vendored upstream tree or any performance topic covered by the author's audited recent pull requests.
+
+### Success Criteria
+
+- The benchmark demonstrates linear-style traversal work and a useful elapsed-time improvement on representative deep and branching trees versus the exact former implementation.
+- Candidate and former implementations return the same node identity for every deterministic correctness fixture.
+- Small/root-only inputs show no material regression beyond benchmark tolerance.
+- Focused Floating UI tests, relevant parity tests, scoped typechecks, repository synchronization, and required CI checks pass.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Extract the private node-tree helpers to `packages/floating-ui/src/utils/nodes.ts` and re-export them from `packages/floating-ui/src/utils/index.ts`. This mirrors the pinned upstream organization, keeps import sites stable, and lets the Node 22 benchmark import the production TypeScript helper directly without adding a public package export.
+- KTD2. Construct a `parentId -> direct children` index in input order, then walk only open direct children while tracking depth. Use an iterative traversal to avoid both repeated subtree expansion and call-stack growth on deeply nested menus.
+- KTD3. Preserve deterministic ties by visiting children in the same depth-first tree order as the former recursion and updating the result only at a strictly greater depth. Preserve first-match node identity where duplicate IDs are encountered rather than silently redefining malformed-tree behavior.
+- KTD4. Put performance assertions in the repository benchmark/ratio system, not in an ordinary correctness test. The benchmark will retain the former algorithm as a local reference oracle, validate output identity before timing, and use deterministic node-inspection counts as the primary scaling proof. Timing samples will warm both implementations, alternate execution order, and use the repository's summary helpers so JIT order and single-sample noise cannot decide the gate.
+- KTD5. Treat benchmark validation as a decision gate. An implementation that does not satisfy the evidence thresholds is abandoned without leaving helper extraction, dead benchmark code, or a changeset behind.
+
+### Assumptions
+
+- Floating tree node IDs are normally unique, as expected by the package APIs; compatibility handling for duplicate IDs is retained because the existing helper implicitly chooses the first matching node.
+- The representative risk is virtual navigation through deeply nested or substantially branching open menus, not a change in render or scheduler behavior.
+- Node 22.22.2 or later is available, matching the package engine requirement and supporting direct type-stripped import of the isolated TypeScript helper.
+- Additive benchmark registry edits may need a straightforward rebase if another open performance pull request lands first; this does not create product-scope overlap.
+
+### Research
+
+- Repository source and comments are authoritative. `packages/floating-ui/src/utils/index.ts` exposes the repeated descendant expansion; `packages/floating-ui/src/useListNavigation.ts` shows the keyboard-navigation call site.
+- `packages/floating-ui/UPSTREAM.md` pins `@floating-ui/react@0.27.19`, and `packages/floating-ui/upstream/packages/react/src/utils/nodes.ts` confirms the inherited algorithm and provenance.
+- `docs/react-parity-testing.md` and `docs/differences-from-react.md` define the binding and Octane divergence constraints. No external research is load-bearing because the optimization is internal and semantics are locally pinned.
+- `.agents/memories/testing.md` requires deterministic benchmarks/ratio guards for optimization claims and behavior-boundary tests for correctness.
+- No applicable prior solution document or requirements-only plan exists for this hotspot.
+
+---
+
+## Implementation Units
+
+### Unit 1: Prove the hotspot and establish a regression guard
+
+Files:
+
+- `benchmarks/floating-tree-navigation/run.mjs`
+- `benchmarks/floating-tree-navigation/README.md`
+- `benchmarks/bench.mjs`
+- `benchmarks/README.md`
+- `benchmarks/baselines/ratios.json`
+- `packages/octane-mcp-server/src/index.js`
+- `packages/octane-mcp-server/README.md`
+
+Work:
+
+- Add deterministic root-only, closed-branch, equal-depth, missing-root, deep-chain, and branching-tree fixtures.
+- Embed the exact former helper as the comparison oracle and import the production helper from `packages/floating-ui/src/utils/nodes.ts` once Unit 2 creates it.
+- Validate node identity before timing either implementation.
+- Instrument equivalent node inspections in both implementations and make that deterministic count the primary scaling guard.
+- Warm both implementations, alternate candidate/reference order across samples, and record summarized elapsed-time ratios at quick and full sizes; choose timing thresholds from repeated local baseline runs rather than a single favorable sample.
+- Register and document the suite through the same benchmark and MCP inventory surfaces as other deterministic performance suites.
+
+Decision gate:
+
+- First run the comparison with an isolated candidate implementation and the current production algorithm. Continue only if representative deep/branching inputs show a useful improvement and root-only/small inputs stay within an acceptable tolerance. Otherwise delete the experiment and return to hotspot selection.
+
+### Unit 2: Make deepest-node lookup single-pass
+
+Files:
+
+- `packages/floating-ui/src/utils/nodes.ts`
+- `packages/floating-ui/src/utils/index.ts`
+- `packages/floating-ui/src/useListNavigation.ts`
+- `packages/floating-ui/tests/components.test.ts`
+- `benchmarks/floating-tree-navigation/run.mjs`
+
+Work:
+
+- Move the existing private node-tree helpers into the focused module and retain the current barrel exports so callers do not change contracts.
+- Implement `getDeepestNode()` with an input-order direct-child index and iterative depth-first traversal of open nodes.
+- Keep the root fallback, closed-subtree exclusion, first-deepest tie choice, missing-root behavior, and first-match identity semantics explicit in the implementation.
+- Add or extend a focused package test only where a realistic nested-navigation behavior boundary is not already covered. Do not use an implementation-detail unit test as the performance proof.
+- Re-run the deterministic comparison and tune only the minimal data structure needed to pass the evidence gate.
+
+### Unit 3: Preserve binding evidence and release quality
+
+Files:
+
+- `packages/floating-ui/tests/upstream-original.test.ts`
+- `packages/floating-ui/tests/adapted-original.test.ts`
+- `packages/floating-ui/tests/adapted-divergences.test.ts`
+- `packages/floating-ui/tests/differential/parity.test.ts`
+- `packages/floating-ui/tests/browser/positioning.browser.test.ts`
+- `packages/floating-ui/audit/**`
+- `.changeset/<generated-performance-name>.md`
+
+Work:
+
+- Run the existing upstream, adapted, differential, and browser parity lanes relevant to virtual nested list navigation; do not convert documented expected failures merely to make the optimization look covered.
+- Regenerate or update evidence only if the repository parity tooling requires it; avoid unrelated snapshot churn.
+- Add a patch changeset describing the faster nested Floating UI navigation lookup.
+- Run scoped formatting, type checks, synchronization, tests, and then current-head CI through the LFG shipping tail.
+
+---
+
+## Verification Contract
+
+### Performance and correctness evidence
+
+- `node benchmarks/floating-tree-navigation/run.mjs 3`
+- `node benchmarks/bench.mjs --quick --ratios floating-tree-navigation`
+- `node benchmarks/bench.mjs --ratios floating-tree-navigation`
+- Confirm all oracle fixtures return the same node object under former and production implementations.
+- Confirm full-size deep-chain and branching ratios meet the committed guard and root-only/small ratios remain within the accepted tolerance.
+
+### Package and parity evidence
+
+- `pnpm vitest run --project floating-ui packages/floating-ui/tests/nodes.test.ts`
+- Run the repository-provided Floating UI upstream, adapted, differential, and browser parity commands discovered during implementation for the virtual nested-navigation scope.
+- `pnpm --filter @octanejs/floating-ui typecheck`
+- `pnpm typecheck:files packages/floating-ui benchmarks/floating-tree-navigation packages/octane-mcp-server`
+
+### Repository gates
+
+- `pnpm format:files:check packages/floating-ui benchmarks/floating-tree-navigation benchmarks/bench.mjs benchmarks/README.md benchmarks/baselines/ratios.json packages/octane-mcp-server .changeset`
+- `pnpm sync`
+- `pnpm test`
+- Verify `git diff --check`, generated inventories, changeset status, and current-head CI after rebasing onto the latest default branch immediately before push if `origin/main` advanced.
+
+### Manual behavior check
+
+- Exercise a nested virtual menu with multiple open and closed branches. Home/End and directional navigation must continue targeting the same deepest open menu as before, including equal-depth branch ties.
+
+---
+
+## Definition of Done
+
+- The measured hypothesis passes the benchmark gate; otherwise this plan is abandoned and no experimental residue remains.
+- `getDeepestNode()` visits eligible tree relationships once instead of recursively expanding all descendants at every level.
+- Existing node identity, open-state, tree-order, and keyboard-navigation behavior is preserved.
+- The deterministic suite is registered, documented, reproducible, and guarded by committed ratios.
+- The pinned upstream snapshot remains unchanged and binding evidence remains truthful.
+- A patch changeset exists for `@octanejs/floating-ui`.
+- The branch is based on the latest default branch, does not duplicate the author's recent performance PRs, and has no unrelated worktree changes.
+- The pull request is created with required branding and summary markers, review findings are resolved or durably tracked, and all relevant current-head CI checks are green.

--- a/packages/floating-ui/audit/test-classifications.json
+++ b/packages/floating-ui/audit/test-classifications.json
@@ -22,6 +22,11 @@
       "reason": "Port-authored component, portal, focus, composite, and transition coverage under Octane."
     },
     {
+      "path": "packages/floating-ui/tests/nodes.test.ts",
+      "disposition": "octane-only-framework-contract",
+      "reason": "Port-authored floating-tree navigation coverage for the Octane binding's internal helper behavior."
+    },
+    {
       "path": "packages/floating-ui/tests/differential/parity.test.ts",
       "disposition": "react-octane-differential",
       "oracle": "Runs the TwoTooltips fixture against pinned @floating-ui/react@0.27.19 and @octanejs/floating-ui."

--- a/packages/floating-ui/src/utils/index.ts
+++ b/packages/floating-ui/src/utils/index.ts
@@ -12,7 +12,9 @@ import type { Octane } from 'octane/jsx-runtime';
 import type { Dimensions } from '@floating-ui/dom';
 
 import { subSlot } from '../internal';
-import type { Delay, FloatingNodeType, MutableRefObject, ReferenceType } from '../types';
+import type { Delay, MutableRefObject } from '../types';
+
+export { getDeepestNode, getNodeAncestors, getNodeChildren } from './nodes';
 
 /**
  * The OBJECT form of octane's `style` prop — the port's analog of
@@ -153,54 +155,6 @@ export function getFloatingFocusElement(
 		? floatingElement
 		: floatingElement.querySelector<HTMLElement>('[' + FOCUSABLE_ATTRIBUTE + ']') ||
 				floatingElement;
-}
-
-export function getNodeChildren<RT extends ReferenceType = ReferenceType>(
-	nodes: Array<FloatingNodeType<RT>>,
-	id: string | undefined,
-	onlyOpenChildren = true,
-): Array<FloatingNodeType<RT>> {
-	const directChildren = nodes.filter(
-		(node) => node.parentId === id && (!onlyOpenChildren || node.context?.open),
-	);
-	return directChildren.flatMap((child) => [
-		child,
-		...getNodeChildren(nodes, child.id, onlyOpenChildren),
-	]);
-}
-export function getDeepestNode<RT extends ReferenceType = ReferenceType>(
-	nodes: Array<FloatingNodeType<RT>>,
-	id: string | undefined,
-): FloatingNodeType<RT> | undefined {
-	let deepestNodeId: string | undefined;
-	let maxDepth = -1;
-	function findDeepest(nodeId: string | undefined, depth: number) {
-		if (depth > maxDepth) {
-			deepestNodeId = nodeId;
-			maxDepth = depth;
-		}
-		const children = getNodeChildren(nodes, nodeId);
-		children.forEach((child) => {
-			findDeepest(child.id, depth + 1);
-		});
-	}
-	findDeepest(id, 0);
-	return nodes.find((node) => node.id === deepestNodeId);
-}
-export function getNodeAncestors<RT extends ReferenceType = ReferenceType>(
-	nodes: Array<FloatingNodeType<RT>>,
-	id: string | undefined,
-): Array<FloatingNodeType<RT>> {
-	let allAncestors: Array<FloatingNodeType<RT>> = [];
-	let currentParentId = nodes.find((node) => node.id === id)?.parentId;
-	while (currentParentId) {
-		const currentNode = nodes.find((node) => node.id === currentParentId);
-		currentParentId = currentNode?.parentId;
-		if (currentNode) {
-			allAncestors = allAncestors.concat(currentNode);
-		}
-	}
-	return allAncestors;
 }
 
 export function stopEvent(event: Event): void {

--- a/packages/floating-ui/src/utils/nodes.ts
+++ b/packages/floating-ui/src/utils/nodes.ts
@@ -1,0 +1,75 @@
+// Ported from @floating-ui/react/utils/nodes. Kept separate from the DOM and
+// hook helpers so tree algorithms can be exercised without a browser runtime.
+import type { FloatingNodeType, ReferenceType } from '../types';
+
+export function getNodeChildren<RT extends ReferenceType = ReferenceType>(
+	nodes: Array<FloatingNodeType<RT>>,
+	id: string | undefined,
+	onlyOpenChildren = true,
+): Array<FloatingNodeType<RT>> {
+	const directChildren = nodes.filter(
+		(node) => node.parentId === id && (!onlyOpenChildren || node.context?.open),
+	);
+	return directChildren.flatMap((child) => [
+		child,
+		...getNodeChildren(nodes, child.id, onlyOpenChildren),
+	]);
+}
+
+export function getDeepestNode<RT extends ReferenceType = ReferenceType>(
+	nodes: Array<FloatingNodeType<RT>>,
+	id: string | undefined,
+): FloatingNodeType<RT> | undefined {
+	const childrenByParent = new Map<string | null | undefined, Array<FloatingNodeType<RT>>>();
+	for (const node of nodes) {
+		if (!node.context?.open) continue;
+		const siblings = childrenByParent.get(node.parentId);
+		if (siblings) {
+			siblings.push(node);
+		} else {
+			childrenByParent.set(node.parentId, [node]);
+		}
+	}
+
+	let deepestNodeId = id;
+	let maxDepth = 0;
+	const stack: Array<[FloatingNodeType<RT>, number]> = [];
+	const rootChildren = childrenByParent.get(id);
+	if (rootChildren) {
+		for (let index = rootChildren.length - 1; index >= 0; index--) {
+			stack.push([rootChildren[index], 1]);
+		}
+	}
+
+	while (stack.length) {
+		const [node, depth] = stack.pop()!;
+		if (depth > maxDepth) {
+			deepestNodeId = node.id;
+			maxDepth = depth;
+		}
+		const children = childrenByParent.get(node.id);
+		if (children) {
+			for (let index = children.length - 1; index >= 0; index--) {
+				stack.push([children[index], depth + 1]);
+			}
+		}
+	}
+
+	return nodes.find((node) => node.id === deepestNodeId);
+}
+
+export function getNodeAncestors<RT extends ReferenceType = ReferenceType>(
+	nodes: Array<FloatingNodeType<RT>>,
+	id: string | undefined,
+): Array<FloatingNodeType<RT>> {
+	let allAncestors: Array<FloatingNodeType<RT>> = [];
+	let currentParentId = nodes.find((node) => node.id === id)?.parentId;
+	while (currentParentId) {
+		const currentNode = nodes.find((node) => node.id === currentParentId);
+		currentParentId = currentNode?.parentId;
+		if (currentNode) {
+			allAncestors = allAncestors.concat(currentNode);
+		}
+	}
+	return allAncestors;
+}

--- a/packages/floating-ui/tests/nodes.test.ts
+++ b/packages/floating-ui/tests/nodes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { FloatingNodeType } from '../src/types';
+import { getDeepestNode } from '../src/utils/nodes';
+
+type TestNode = FloatingNodeType & { id: string };
+
+function node(id: string, parentId: string | null, open = true): TestNode {
+	return {
+		id,
+		parentId,
+		context: { open } as FloatingNodeType['context'],
+	};
+}
+
+describe('@octanejs/floating-ui — floating tree nodes', () => {
+	it('returns the root when it has no open descendants', () => {
+		const root = node('root', null);
+		expect(getDeepestNode([root], root.id)).toBe(root);
+	});
+
+	it('ignores descendants behind a closed branch', () => {
+		const root = node('root', null);
+		const closed = node('closed', root.id, false);
+		const hidden = node('hidden', closed.id);
+		const visible = node('visible', root.id);
+		expect(getDeepestNode([root, closed, hidden, visible], root.id)).toBe(visible);
+	});
+
+	it('keeps the first tree-order node when branches tie for depth', () => {
+		const root = node('root', null);
+		const first = node('first', root.id);
+		const second = node('second', root.id);
+		const secondLeaf = node('second-leaf', second.id);
+		const firstLeaf = node('first-leaf', first.id);
+		expect(getDeepestNode([root, first, second, secondLeaf, firstLeaf], root.id)).toBe(firstLeaf);
+	});
+
+	it('can start from a parent id whose node is not registered', () => {
+		const child = node('child', 'missing');
+		const leaf = node('leaf', child.id);
+		expect(getDeepestNode([child, leaf], 'missing')).toBe(leaf);
+	});
+});

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -163,7 +163,7 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `controlled-form`, `external-store-fanout`, `external-store-integrations`,
 `scheduler-responsiveness`, `suspense-recovery`, `event-delegation`,
 `application-composition`, `scaling-curves`, `dev-form-diagnostics`,
-`behavior-root-events`, `router-dispatch`, `manifest-cache-invalidation`, `vite-client-assets`, `activity`, `streaming-ssr`, `streaming-backpressure`,
+`behavior-root-events`, `router-dispatch`, `floating-tree-navigation`, `manifest-cache-invalidation`, `vite-client-assets`, `activity`, `streaming-ssr`, `streaming-backpressure`,
 `compiler-throughput`, `tsrx-component-graph`, `codegen-size`, `hook-memo`,
 `template-call-memo`, `bundle-size`, `bundle-reachability`, `three-renderer`,
 `three-bundle-size`, …)

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -71,6 +71,7 @@ export const BENCHMARK_SUITES = [
 	'scheduler-depth',
 	'behavior-root-events',
 	'router-dispatch',
+	'floating-tree-navigation',
 	'manifest-cache-invalidation',
 	'vite-client-assets',
 	'store-selector-fanout',


### PR DESCRIPTION
## Summary

- Make Floating UI's deepest-node lookup linear in the size of the open subtree.
- Preserve existing tree-order tie breaking and duplicate-ID identity behavior.
- Add focused regression tests plus a benchmark with complexity and timing guards.

## Why

`getDeepestNode()` previously called recursive descendant discovery once for every discovered node. On deep open trees that repeatedly revisited the same subtrees, turning a navigation lookup into exponential work.

For the 16-node deep-chain benchmark, the previous implementation performs 1,048,576 input-node reads per lookup; the indexed traversal performs 32. Warmed timing drops from 7.419794 ms/lookup to 0.000848 ms/lookup on the benchmark run used to validate this change.

## Changes

- Index open children by parent once, then traverse iteratively.
- Push children in reverse input order so equal-depth ties still choose the first tree-order node.
- Keep the final ID lookup to preserve the prior first-match behavior for duplicate IDs.
- Add root-only, closed-branch, equal-depth tie, and missing-root tests.
- Register the new benchmark, ratio guards, documentation, and MCP benchmark inventory entry.
- Add a patch changeset for `@octanejs/floating-ui`.

Plan: `docs/plans/2026-08-27-2339-floating-tree-navigation-performance-plan.md`

## Validation

- `pnpm --filter @octanejs/floating-ui test` — passed (4 files, 18 tests, including provenance and differential checks)
- `pnpm --filter @octanejs/floating-ui typecheck` — passed
- `pnpm run typecheck` — passed across the repository
- `pnpm --filter @octanejs/floating-ui test:browser` — passed (1/1)
- `pnpm --filter @octanejs/octane-mcp-server test` — passed (2 files, 43 tests)
- `node benchmarks/bench.mjs --quick --ratios floating-tree-navigation` — passed
- Full benchmark ratio guards — passed
- 100,000 randomized old-vs-new differential fixtures — passed
- `pnpm sync` — passed; generated outputs current
- Scoped formatting checks for all changed files — passed
- `git diff --check` — passed

The repo-wide `pnpm format:check` wrapper was not completed: after `pnpm sync`, the dependency-status wrapper tried to recreate this disposable worktree's `node_modules`, and its network request was unavailable. The scoped formatting gate for every changed file passed. The full root `pnpm test` was not run; affected package, parity, browser, MCP, typecheck, and benchmark gates are listed above.

## Risk

Low. This is a private Floating UI helper refactor with differential coverage for return identity and ordering semantics. The main risk is traversal-order drift, covered by focused tie tests and randomized differential comparison.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper with preserved semantics, focused tests, randomized differential checks, and benchmark guards; main risk is tie-breaking or duplicate-ID identity drift on edge trees.
> 
> **Overview**
> **Replaces exponential deepest-node discovery** in `@octanejs/floating-ui` with a single-pass lookup used by virtual nested-menu keyboard routing in `useListNavigation`.
> 
> `getDeepestNode()` no longer calls recursive all-descendant expansion at every step. It **builds an index of open direct children by parent** (input order), then **walks the tree iteratively** with children pushed in reverse so equal-depth ties still pick the first tree-order node. `getNodeChildren` / `getNodeAncestors` move to **`utils/nodes.ts`** and stay re-exported from the barrel so callers are unchanged.
> 
> Adds **`nodes.test.ts`** for root-only, closed branches, depth ties, and missing-root behavior; a **Node-only `floating-tree-navigation` benchmark** that compares the old algorithm to production on deep chains and forks (deterministic indexed **node-read** counts plus timing); **ratio guards** in `ratios.json`; runner/MCP/docs registration; and a **patch changeset** for `@octanejs/floating-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c310462e92b8c465e57cd7f5561b3fda218be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790485076&installation_model_id=432790&pr_number=882&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F882&signature=e241b19ea8b616c0fc537d10613cbc7e23b54a075667249762dda4c5768ec052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->