### PR TITLE
fix(lynx): serialize cross-thread transport payloads

### DIFF
--- a/.changeset/lynx-transport-json-boundary.md
+++ b/.changeset/lynx-transport-json-boundary.md
@@ -1,0 +1,27 @@
+---
+'@octanejs/lynx': patch
+---
+
+The Lynx transport now owns encoding, so nothing live crosses a thread. Every
+`ContextProxy` send site encodes and every receive site decodes, which means
+the receiver is handed its own ordinary local data by construction rather than
+a composite built on the other thread. On device that composite could arrive as
+a `LEPUS_TAG_LEPUS_REF`, where reads and `Object.keys` work but `Reflect.ownKeys`
+throws and `Object(v) !== v`; a string cannot be a host-backed reference on any
+engine. The engine lifecycle entry — `__RenderPage`, `__UpdatePage`,
+`__UpdateGlobalProps`, whose sender is the native engine and cannot be asked to
+encode — is materialized on arrival through the same codec, so a malformed
+engine record is one dropped record with a diagnostic naming the field instead
+of a torn-down page lifetime.
+
+The codec owns the value domain: `undefined` travels as a sentinel and comes
+back as `undefined`, `__proto__` is an own data property on both sides of the
+wire whatever the engine's `JSON.parse` does with it, and a `bigint`, non-finite
+number, function, symbol, `Date`, `Map`, or class instance is refused at the
+sender, which is the last place that still knows what the value was. A payload
+that literally contains a sentinel round-trips unchanged, and a cyclic value is
+named where it closed rather than exhausting the stack.
+
+Wire payloads are unchanged to the byte: a clean message encodes as exactly its
+own JSON inside a constant 4-byte envelope, measured across the lynx-table gates
+at 1k and 10k rows (create at 10k: 341,647 B to 341,651 B).

--- a/benchmarks/lynx-render/workload.ts
+++ b/benchmarks/lynx-render/workload.ts
@@ -21,6 +21,7 @@ import {
 	LYNX_TRANSPORT_RENDERER,
 } from '../../packages/lynx/src/core/protocol.js';
 import type { LynxElementEventListener } from '../../packages/lynx/src/core/papi.js';
+import { decodeLynxTransportValue } from '../../packages/lynx/src/core/transport-codec.js';
 import { BenchApp, EmptyApp, type BenchRow } from './src/App.lynx.tsrx';
 
 interface FakeNode {
@@ -427,8 +428,11 @@ function transportMetrics(harness: Harness): LynxTransportMetrics {
 	let compactAcknowledgements = 0;
 	const sharedPrograms = new Set<object>();
 	for (const event of harness.transportMessages) {
-		if (event.data === null || typeof event.data !== 'object') continue;
-		const message = event.data as {
+		// Decoded, not read: the transport encodes, so `event.data` is the string
+		// the receiver parses. Reading it raw would count zero commands and no
+		// acknowledgements while still producing a number.
+		if (typeof event.data !== 'string') continue;
+		const message = decodeLynxTransportValue(event.data) as {
 			readonly type?: unknown;
 			readonly encoding?: unknown;
 			readonly batch?: {

--- a/benchmarks/lynx-table/stages/instrument-source.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.mjs
@@ -48,7 +48,7 @@ export function instrumentLynxStageSources(repositoryRoot) {
 			return replaceOnce(
 				next,
 				`\tprofile.commands += record.batch?.commands?.length ?? 0;
-\ttry {
+\tprofile.bytes += encoded.length;
 `,
 				`\tconst commands = record.batch?.commands ?? [];
 \tprofile.commands += commands.length;
@@ -80,7 +80,7 @@ export function instrumentLynxStageSources(repositoryRoot) {
 \t\t\tmeasured.publicHandleCommands = (measured.publicHandleCommands ?? 0) + 1;
 \t\t}
 \t}
-\ttry {
+\tprofile.bytes += encoded.length;
 `,
 				file,
 			);
@@ -98,7 +98,9 @@ export function instrumentLynxStageSources(repositoryRoot) {
 \t\tcommands: 0,
 \t\tbytes: 0,
 \t\tselfcheckMs: 0,
+\t\tencodeMs: 0,
 \t\tdispatchMs: 0,
+\t\tdecodeMs: 0,
 \t\tvalidateMs: 0,
 \t\tprepareMs: 0,
 \t\tprepareCheckMs: 0,
@@ -260,7 +262,9 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 \t\t\t\t\tcommands: 0,
 \t\t\t\t\tbytes: 0,
 \t\t\t\t\tselfcheckMs: 0,
+\t\t\t\t\tencodeMs: 0,
 \t\t\t\t\tdispatchMs: 0,
+\t\t\t\t\tdecodeMs: 0,
 \t\t\t\t\tvalidateMs: 0,
 \t\t\t\t\tprepareMs: 0,
 \t\t\t\t\tprepareCheckMs: 0,
@@ -309,7 +313,9 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 \t\tcommands: 0,
 \t\tbytes: 0,
 \t\tselfcheckMs: 0,
+\t\tencodeMs: 0,
 \t\tdispatchMs: 0,
+\t\tdecodeMs: 0,
 \t\tvalidateMs: 0,
 \t\tprepareMs: 0,
 \t\tprepareCheckMs: 0,
@@ -452,12 +458,12 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 			);
 			next = replaceOnce(
 				next,
-				`\t\t\tprofile.selfcheckMs += startedDispatch - startedSelfCheck;
-\t\t\tprofileOutboundMessage(profile, message);
+				`\t\t\tprofile.selfcheckMs += startedEncode - startedSelfCheck;
+\t\t\tprofileOutboundMessage(profile, message, encoded);
 \t\t\treturn;
 `,
-				`\t\t\tprofile.selfcheckMs += startedDispatch - startedSelfCheck;
-\t\t\tprofileOutboundMessage(profile, message);
+				`\t\t\tprofile.selfcheckMs += startedEncode - startedSelfCheck;
+\t\t\tprofileOutboundMessage(profile, message, encoded);
 \t\t\tif ((message as { readonly type?: unknown }).type === 'commit' && replayStartedAt !== null) {
 \t\t\t\tprofile.bgReplayMs = (profile.bgReplayMs ?? 0) + startedSelfCheck - replayStartedAt;
 \t\t\t\treplayStartedAt = null;

--- a/benchmarks/lynx-table/workload.ts
+++ b/benchmarks/lynx-table/workload.ts
@@ -20,6 +20,7 @@ import type {
 } from '../../packages/lynx/src/core/protocol.js';
 import type { LynxElementEventListener } from '../../packages/lynx/src/core/papi.js';
 import type { LynxWireProfile } from '../../packages/lynx/src/core/profiling.js';
+import { decodeLynxTransportValue } from '../../packages/lynx/src/core/transport-codec.js';
 import { App } from './app/src/App.lynx.tsrx';
 
 interface FakeNode {
@@ -77,7 +78,12 @@ function createContextPair(): {
 			if (list.length === 0) own.delete(type);
 		},
 		dispatchEvent(event) {
-			const data = event.data as {
+			// The transport encodes, so what crosses is a string. Observing it
+			// means decoding it, the same as the receiver does — reading
+			// `event.data` directly would silently report every message as
+			// `<unknown>` with no commands, which is a measurement that looks
+			// like a result.
+			const data = decodeLynxTransportValue(event.data) as {
 				type?: unknown;
 				batch?: { commands?: readonly { op?: unknown }[] };
 				handles?: readonly { op?: unknown }[];

--- a/packages/lynx/src/core/background-lifecycle.ts
+++ b/packages/lynx/src/core/background-lifecycle.ts
@@ -10,6 +10,7 @@ import {
 	type LynxContextProxyEvent,
 	type LynxDataLifecycleMessage,
 } from './protocol.js';
+import { decodeLynxTransportValue, type LynxStructuredValue } from './transport-codec.js';
 
 const MAX_QUEUED_LIFECYCLE_MESSAGES = 128;
 
@@ -219,10 +220,25 @@ export function prepareLynxBackgroundLifecycleReceiver(
 
 	let state!: BackgroundLifecycleState;
 	const receive = (event: LynxContextProxyEvent): void => {
-		if (!state.active || lifecycleMessageType(event.data) === null) return;
+		if (!state.active) return;
+		// This listener shares `LYNX_MAIN_TO_BACKGROUND_EVENT` with the transport's
+		// own receiver, so both decode the same payload independently. That is a
+		// second `JSON.parse` per inbound message rather than per node: the heavy
+		// direction is background-to-main, which has a single receiver, and this
+		// one carries acknowledgements and native events.
+		let data: LynxStructuredValue;
+		try {
+			data = decodeLynxTransportValue(event.data);
+		} catch {
+			// The transport's own receiver shares this event and reports the failure.
+			// This listener only wants lifecycle messages; reporting here as well
+			// would double every diagnostic on the channel.
+			return;
+		}
+		if (lifecycleMessageType(data) === null) return;
 		let message;
 		try {
-			message = validateLynxBackgroundInboundMessage(event.data);
+			message = validateLynxBackgroundInboundMessage(data);
 		} catch (error) {
 			report(state, error, 'Octane Lynx received malformed background lifecycle data.');
 			return;

--- a/packages/lynx/src/core/profiling.ts
+++ b/packages/lynx/src/core/profiling.ts
@@ -35,8 +35,12 @@ export interface LynxWireProfile {
 	bytes: number;
 	/** Background: dev-mode outbound self-check time. */
 	selfcheckMs: number;
+	/** Background: transport encode time, the walk plus `JSON.stringify`. */
+	encodeMs: number;
 	/** Background: ContextProxy dispatch (structured clone + delivery) time. */
 	dispatchMs: number;
+	/** Main: transport decode time, `JSON.parse` plus any unescaping walk. */
+	decodeMs: number;
 	/** Main: inbound protocol validation time. */
 	validateMs: number;
 	/** Main: prepareLynxHostBatch staging time. */
@@ -77,7 +81,9 @@ export function lynxWireProfile(): LynxWireProfile {
 		commands: 0,
 		bytes: 0,
 		selfcheckMs: 0,
+		encodeMs: 0,
 		dispatchMs: 0,
+		decodeMs: 0,
 		validateMs: 0,
 		prepareMs: 0,
 		applyMs: 0,
@@ -94,16 +100,19 @@ export function lynxWireProfile(): LynxWireProfile {
 	});
 }
 
-/** Count one outbound message; commits also add commands and JSON bytes. */
-export function profileOutboundMessage(profile: LynxWireProfile, message: unknown): void {
+/**
+ * Count one outbound message; commits also add commands and exact wire bytes.
+ * `encoded` is the string the transport is about to dispatch, so measuring it
+ * cannot disagree with what was actually sent.
+ */
+export function profileOutboundMessage(
+	profile: LynxWireProfile,
+	message: unknown,
+	encoded: string,
+): void {
 	const record = message as { type?: unknown; batch?: { commands?: readonly unknown[] } };
 	if (record.type !== 'commit') return;
 	profile.commits += 1;
 	profile.commands += record.batch?.commands?.length ?? 0;
-	try {
-		profile.bytes += JSON.stringify(message).length;
-	} catch {
-		// Wire messages are serializable by contract; a failure here must not
-		// turn a measurement run into a commit failure.
-	}
+	profile.bytes += encoded.length;
 }

--- a/packages/lynx/src/core/transport-codec.ts
+++ b/packages/lynx/src/core/transport-codec.ts
@@ -1,0 +1,391 @@
+/**
+ * The Lynx transport's encoding boundary.
+ *
+ * ## Why this file exists
+ *
+ * `ContextProxy` transports generic Lynx values, not strings. A composite sent
+ * through it can arrive in LepusNG as `LEPUS_TAG_LEPUS_REF`: a host-backed
+ * engine value that answers `typeof`, reads, `Object.keys`, spread, and
+ * `JSON.stringify`, but is not an ordinary receiver-realm object. On it,
+ * `Reflect.ownKeys` throws, `Object(v) !== v`, and the prototype is `null`.
+ * Reproduced on iOS and Android; see issue #152.
+ *
+ * Octane read those values with `Object.getOwnPropertyNames`, which performs
+ * `ToObject` and therefore coerced the bridge value into something enumerable.
+ * That accident was load-bearing for the whole native lifetime of the package.
+ * Replacing it with the non-coercing `Reflect.ownKeys` removed the accident and
+ * broke the renderer on device — the defect was never the new call, it was that
+ * a bridged value reached receiver code at all.
+ *
+ * So the transport, and only the transport, owns materialization:
+ *
+ * - **`LynxValue`** — the generic native value algebra (`lynx_value`).
+ * - **`LynxValueRef`** — a JS-visible native-backed composite, e.g. `LEPUS_REF`.
+ * - **`LynxStructuredValue`** — data materialized into the receiving realm as
+ *   ordinary arrays and objects.
+ *
+ * The invariant this module exists to hold: **a `LynxValueRef` never escapes
+ * the transport layer.** Everything above the transport sees only
+ * `LynxStructuredValue`.
+ *
+ * ## What this codec is responsible for, and what it is not
+ *
+ * It owns exactly the cases where `JSON` would **silently** change meaning:
+ *
+ * | value | what plain JSON does | what this does |
+ * | --- | --- | --- |
+ * | `undefined` | drops the key entirely | sentinel, key preserved |
+ * | `NaN` / `±Infinity` | writes `null` | throws |
+ * | `bigint` | throws, with an unhelpful message | throws, naming the path |
+ * | function / symbol | drops the key entirely | throws |
+ * | `__proto__` key | engine-dependent on parse | own data property, always |
+ * | `Date` / `Map` / instance | rewritten or emptied silently | throws |
+ *
+ * The one lossiness it accepts rather than refuses is a `null` prototype, which
+ * JSON cannot express and which `JSON.parse` returns as `Object.prototype`.
+ * `host-props.ts` already treats both as the same ordinary bag, so the receiver
+ * cannot tell, and refusing would reject `Object.create(null)` data that is
+ * otherwise perfectly plain.
+ *
+ * `undefined` is not hypothetical: it is what a worklet closure capture holds
+ * before its first assignment, and dropping the key turns a captured
+ * `undefined` into an absent property.
+ *
+ * This is **not** a schema. Narrowing a payload to the command ABI — op
+ * discriminants, ranges, lengths, references, shape — stays in `protocol.ts`,
+ * which runs after decode on values this codec has already proved are ordinary
+ * local data.
+ *
+ * ## Escaping
+ *
+ * Two escapes, both keyed on `U+0000`, which no engine treats specially and
+ * which JSON represents exactly:
+ *
+ * - a string equal to `"\u0000undefined"` means `undefined`; any real string
+ *   that starts with `U+0000` gains one more, and decode removes it. So a
+ *   payload containing the sentinel spelling round-trips as itself.
+ * - the key `__proto__` travels as `"\u0000proto"`, restored on decode through
+ *   `Object.defineProperty` so it is an own data property on every engine
+ *   rather than whatever that engine's `JSON.parse` decides. Real keys of the
+ *   form `\u0000*proto` gain one more `U+0000`, symmetrically.
+ *
+ * ## Envelope
+ *
+ * The wire form is `[flags, payload]`. `flags` is `0` when nothing was escaped,
+ * which is the overwhelmingly common case, and then decode is a single
+ * `JSON.parse` with no walk of its own — the cost of the escape machinery is
+ * paid only by payloads that actually use it. Four bytes buy that.
+ */
+import { LYNX_DEVELOPMENT } from './environment.js';
+
+/** The generic native value algebra a Lynx host can carry. */
+export type LynxValue = unknown;
+
+/**
+ * A JS-visible native-backed composite, such as LepusNG's `LEPUS_REF`. It is
+ * not an ordinary receiver-realm object and must never leave the transport.
+ */
+export type LynxValueRef = object;
+
+/** Data materialized into the receiving realm as ordinary arrays and objects. */
+export type LynxStructuredValue = unknown;
+
+const NUL = '\u0000';
+const UNDEFINED_SENTINEL = `${NUL}undefined`;
+const PROTO_KEY = '__proto__';
+const ESCAPED_PROTO_KEY = `${NUL}proto`;
+
+/** `\u0000+proto`, the family the proto escape has to stay clear of. */
+function isProtoEscapeFamily(key: string): boolean {
+	if (key.charCodeAt(0) !== 0) return false;
+	let index = 1;
+	while (key.charCodeAt(index) === 0) index++;
+	return key.length - index === 5 && key.endsWith('proto');
+}
+
+function codecError(path: string, message: string): TypeError {
+	return new TypeError(`Octane Lynx transport value at ${path} ${message}`);
+}
+
+/** Name a refused composite by its constructor, so the message says which kind. */
+function describeConstructor(value: object): string {
+	const name: unknown = (value as { constructor?: { name?: unknown } }).constructor?.name;
+	return typeof name === 'string' && name.length > 0 ? name : 'non-plain object';
+}
+
+/**
+ * How deep a payload may nest before the codec names it rather than recursing.
+ *
+ * `prepare` is recursive, so a cycle is unbounded depth from its point of view,
+ * and without a limit it exhausts the stack — a `RangeError` with no path, which
+ * is a worse diagnostic than the `TypeError` plain `JSON.stringify` would have
+ * produced. An on-path `Set` would distinguish a true cycle from deep nesting,
+ * but it costs an add and a delete per composite on the first-screen path, which
+ * is the one walk this codec exists to keep cheap. A depth counter costs one
+ * integer compare, names the path where it gave up, and is reached only by a
+ * payload no receiver could use: nothing Octane sends nests past single digits,
+ * and a hand-built value this deep is a defect either way.
+ */
+const MAX_PREPARE_DEPTH = 512;
+
+interface PrepareState {
+	escaped: boolean;
+	/** Development only: every composite seen, to notice a DAG before JSON expands it. */
+	readonly seen: Map<object, number> | null;
+	aliases: number;
+}
+
+/**
+ * Return `value` itself when it is already JSON-safe, and a rewritten mirror
+ * only when something below it needed escaping.
+ *
+ * Copy-on-write matters here: a first-screen batch is tens of thousands of
+ * nodes and essentially never contains an escape, so the common path walks the
+ * tree once and allocates nothing.
+ */
+function prepare(value: unknown, path: string, state: PrepareState, depth = 0): unknown {
+	switch (typeof value) {
+		case 'string':
+			if (value.charCodeAt(0) !== 0) return value;
+			state.escaped = true;
+			return NUL + value;
+		case 'number':
+			if (Number.isFinite(value)) return value;
+			throw codecError(path, `is ${String(value)}, which JSON would write as null.`);
+		case 'boolean':
+			return value;
+		case 'undefined':
+			state.escaped = true;
+			return UNDEFINED_SENTINEL;
+		case 'bigint':
+			throw codecError(path, 'is a bigint, which the Lynx wire does not carry.');
+		case 'function':
+			throw codecError(path, 'is a function, which JSON would drop silently.');
+		case 'symbol':
+			throw codecError(path, 'is a symbol, which JSON would drop silently.');
+		default:
+			break;
+	}
+	if (value === null) return null;
+
+	if (depth >= MAX_PREPARE_DEPTH) {
+		throw codecError(
+			path,
+			`nests deeper than ${MAX_PREPARE_DEPTH} levels, which is either a cycle or a structure the wire cannot carry.`,
+		);
+	}
+	const composite = value as object;
+	if (state.seen !== null) {
+		const count = state.seen.get(composite);
+		if (count === undefined) state.seen.set(composite, 1);
+		else {
+			state.seen.set(composite, count + 1);
+			state.aliases++;
+		}
+	}
+
+	if (Array.isArray(composite)) {
+		let mirror: unknown[] | null = null;
+		for (let index = 0; index < composite.length; index++) {
+			const before = composite[index];
+			const after = prepare(before, `${path}[${index}]`, state, depth + 1);
+			if (mirror === null) {
+				if (after === before) continue;
+				mirror = composite.slice(0, index);
+			}
+			mirror.push(after);
+		}
+		return mirror ?? composite;
+	}
+
+	// Ordinary objects and arrays only. A `Date`, `Map`, `Set`, or class instance
+	// has no own enumerable keys to walk, so it would pass through this function
+	// untouched and then be rewritten by `JSON.stringify` — into an ISO string
+	// via `toJSON`, or into `{}` — with the receiver given no way to notice. That
+	// is the same shape of defect as the one this module exists to end, so it is
+	// refused at the sender, which is the last place that still knows what the
+	// value was.
+	const prototype = Object.getPrototypeOf(composite);
+	if (prototype !== Object.prototype && prototype !== null) {
+		throw codecError(
+			path,
+			`is a ${describeConstructor(composite)}, which JSON would rewrite into something else.`,
+		);
+	}
+
+	const record = composite as Record<string, unknown>;
+	// One enumeration, reused for both the key rewrite and the value walk. The
+	// keys have to be seen to be escaped, and no `JSON.stringify` replacer can
+	// rename a key — it is handed the key but can only replace the value.
+	const keys = Object.keys(record);
+	let mirror: Record<string, unknown> | null = null;
+	for (let index = 0; index < keys.length; index++) {
+		const key = keys[index]!;
+		const escapedKey =
+			key === PROTO_KEY ? ESCAPED_PROTO_KEY : isProtoEscapeFamily(key) ? NUL + key : key;
+		const before = record[key];
+		const after = prepare(before, `${path}.${key}`, state, depth + 1);
+		if (mirror === null) {
+			if (escapedKey === key && after === before) continue;
+			state.escaped = true;
+			mirror = {};
+			for (let earlier = 0; earlier < index; earlier++) {
+				const done = keys[earlier]!;
+				mirror[done] = record[done];
+			}
+		} else if (escapedKey !== key) {
+			state.escaped = true;
+		}
+		mirror[escapedKey] = after;
+	}
+	return mirror ?? record;
+}
+
+/**
+ * Undo `prepare`. Only ever called for a payload whose flags say it escaped.
+ *
+ * Depth-capped on the same terms as `prepare`, and for the same reason: this
+ * recurses, and `JSON.parse` is happy to hand back a structure deeper than the
+ * stack. Anything this codec encoded is already under the limit, so the branch
+ * is reached only by a payload some other writer produced.
+ */
+function restore(value: unknown, depth = 0): unknown {
+	if (typeof value === 'string') {
+		if (value.charCodeAt(0) !== 0) return value;
+		return value === UNDEFINED_SENTINEL ? undefined : value.slice(1);
+	}
+	if (value === null || typeof value !== 'object') return value;
+	if (depth >= MAX_PREPARE_DEPTH) {
+		throw new TypeError(
+			`Octane Lynx transport received a payload nesting deeper than ${MAX_PREPARE_DEPTH} levels.`,
+		);
+	}
+	if (Array.isArray(value)) {
+		for (let index = 0; index < value.length; index++) {
+			value[index] = restore(value[index], depth + 1);
+		}
+		return value;
+	}
+	// Rebuilt rather than renamed in place: renaming while iterating lets an
+	// early restoration land on a snapshot key the loop has not reached yet —
+	// `"\u0000\u0000proto"` restores to `"\u0000proto"`, which is exactly the
+	// escaped `__proto__` entry still pending — clobbering it and then
+	// double-restoring the clobbered value. The escape is injective, so writing
+	// each final name into a fresh record is order-independent by construction.
+	const record = value as Record<string, unknown>;
+	const rebuilt: Record<string, unknown> = {};
+	for (const key of Object.keys(record)) {
+		const restored = restore(record[key], depth + 1);
+		if (key === ESCAPED_PROTO_KEY) {
+			// Defined rather than assigned: `rebuilt.__proto__ = x` is a prototype
+			// write on any engine whose `Object.prototype` still carries the
+			// accessor, and this has to be an own data property on every engine.
+			Object.defineProperty(rebuilt, PROTO_KEY, {
+				configurable: true,
+				enumerable: true,
+				value: restored,
+				writable: true,
+			});
+		} else if (isProtoEscapeFamily(key)) {
+			rebuilt[key.slice(1)] = restored;
+		} else {
+			rebuilt[key] = restored;
+		}
+	}
+	return rebuilt;
+}
+
+/**
+ * How many aliased composites a payload may contain before development says so.
+ *
+ * JSON has no back-references, so a shared subtree is expanded once per
+ * reference. None of the current senders produce one — measured across the
+ * whole lynx suite at the four send sites — and a payload that started to would
+ * grow multiplicatively rather than linearly, which is worth a diagnostic long
+ * before it is worth a wire format that can express sharing.
+ */
+const ALIAS_REPORT_THRESHOLD = 32;
+
+/**
+ * Encode a message for delivery across the Lynx channel.
+ *
+ * @param onDiagnostic receives development-only findings that are not faults.
+ */
+export function encodeLynxTransportValue(
+	value: LynxValue,
+	onDiagnostic?: (error: Error) => void,
+): string {
+	const state: PrepareState = {
+		escaped: false,
+		seen: LYNX_DEVELOPMENT ? new Map<object, number>() : null,
+		aliases: 0,
+	};
+	const payload = prepare(value, '$', state);
+	if (LYNX_DEVELOPMENT && state.aliases >= ALIAS_REPORT_THRESHOLD && onDiagnostic !== undefined) {
+		onDiagnostic(
+			new Error(
+				`Octane Lynx encoded a message sharing ${state.aliases} composite references; JSON has no back-references, so each is expanded once per reference.`,
+			),
+		);
+	}
+	return JSON.stringify([state.escaped ? 1 : 0, payload]);
+}
+
+/**
+ * Decode a message delivered across the Lynx channel into receiver-local
+ * ordinary data.
+ *
+ * Throws when handed anything but this codec's own output — including a live
+ * composite, which is the shape that reaches here when a sender has not been
+ * routed through {@link encodeLynxTransportValue}.
+ */
+export function decodeLynxTransportValue(text: LynxValue): LynxStructuredValue {
+	if (typeof text !== 'string') {
+		throw new TypeError(
+			`Octane Lynx transport received ${text === null ? 'null' : typeof text} where the wire carries a string. An unencoded value may be a host-backed reference, which the receiver must never reflect on.`,
+		);
+	}
+	let envelope: unknown;
+	try {
+		envelope = JSON.parse(text) as unknown;
+	} catch (error) {
+		throw new TypeError(
+			`Octane Lynx transport received a payload that is not JSON: ${(error as Error).message}`,
+		);
+	}
+	if (!Array.isArray(envelope) || envelope.length !== 2) {
+		throw new TypeError('Octane Lynx transport received a payload with no codec envelope.');
+	}
+	const flags: unknown = envelope[0];
+	if (flags !== 0 && flags !== 1) {
+		throw new TypeError(`Octane Lynx transport received unknown codec flags ${String(flags)}.`);
+	}
+	return flags === 0 ? envelope[1] : restore(envelope[1]);
+}
+
+/**
+ * Materialize a value that entered Octane from outside the transport.
+ *
+ * The engine lifecycle events — `__RenderPage`, `__UpdatePage`,
+ * `__UpdateGlobalProps` — arrive on the same `ContextProxy` machinery as a
+ * transport message, but their sender is the native engine, which cannot be
+ * asked to encode. So they are the one inbound payload nobody has encoded, and
+ * the invariant that a {@link LynxValueRef} never escapes the transport layer
+ * would be false with that entry left open: everything downstream of it is
+ * written for ordinary local data.
+ *
+ * Encoding and immediately decoding is the materializer. It is deliberately
+ * this codec rather than a bare `JSON.parse(JSON.stringify(value))`, so that a
+ * host-originated record lands in the same value domain as every other message
+ * — `undefined` survives, `__proto__` becomes an own data property on every
+ * engine rather than whichever one `JSON.parse` happens to produce, and a
+ * `bigint` or non-finite number is named where it entered instead of failing
+ * later at the send site that would have carried it.
+ *
+ * The residual is the `Array.isArray` dispatch, which decides array from object
+ * here exactly as it already does in the tuple check this feeds — a value that
+ * lied about being an array would have been rejected there too.
+ */
+export function localizeLynxHostValue(value: LynxValue): LynxStructuredValue {
+	return decodeLynxTransportValue(encodeLynxTransportValue(value));
+}

--- a/packages/lynx/src/core/transport.ts
+++ b/packages/lynx/src/core/transport.ts
@@ -12,6 +12,11 @@ import {
 } from 'octane/universal/native';
 import { LYNX_PROFILE, lynxWireProfile, profileOutboundMessage } from './profiling.js';
 import {
+	decodeLynxTransportValue,
+	encodeLynxTransportValue,
+	type LynxStructuredValue,
+} from './transport-codec.js';
+import {
 	applyLynxHostAttachments,
 	invalidateLynxClientContainer,
 	isLynxClientEventTarget,
@@ -323,6 +328,9 @@ export function createLynxBackgroundTransport(
 			report(error, 'Octane Lynx could not finalize background worklet lifetimes.');
 		}
 	};
+	const reportEncodingDiagnostic = (error: Error): void => {
+		report(error);
+	};
 
 	const dispatch = (message: Parameters<typeof validateLynxBackgroundOutboundMessage>[0]) => {
 		if (closedError !== null) throw closedError;
@@ -330,15 +338,21 @@ export function createLynxBackgroundTransport(
 			const profile = lynxWireProfile();
 			const startedSelfCheck = performance.now();
 			const validated = selfCheckLynxBackgroundOutboundMessage(message);
+			const startedEncode = performance.now();
+			const encoded = encodeLynxTransportValue(validated, reportEncodingDiagnostic);
 			const startedDispatch = performance.now();
-			context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: validated });
+			context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: encoded });
 			profile.dispatchMs += performance.now() - startedDispatch;
-			profile.selfcheckMs += startedDispatch - startedSelfCheck;
-			profileOutboundMessage(profile, message);
+			profile.encodeMs += startedDispatch - startedEncode;
+			profile.selfcheckMs += startedEncode - startedSelfCheck;
+			profileOutboundMessage(profile, message, encoded);
 			return;
 		}
 		const validated = selfCheckLynxBackgroundOutboundMessage(message);
-		context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: validated });
+		context.dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: encodeLynxTransportValue(validated, reportEncodingDiagnostic),
+		});
 	};
 
 	const wireError = (value: unknown, fallback: string) => {
@@ -665,7 +679,10 @@ export function createLynxBackgroundTransport(
 				...identity,
 				type: 'terminal-dispose',
 			});
-			context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: message });
+			context.dispatchEvent({
+				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+				data: encodeLynxTransportValue(message, reportEncodingDiagnostic),
+			});
 		} catch (disposeError) {
 			queueTerminalDisposeRetry(
 				report(
@@ -1321,14 +1338,30 @@ export function createLynxBackgroundTransport(
 	};
 
 	function receive(event: LynxContextProxyEvent): void {
-		if (isRootIndependentDataMessage(event.data)) return;
+		// Decode before anything reads the payload. `event.data` is whatever the
+		// host handed across, and on device that can be a native-backed reference
+		// that throws on `Reflect.ownKeys` and answers `Object(v) !== v`; every
+		// read below is written for ordinary local data, so the materialization
+		// has to happen first or not at all.
+		let data: LynxStructuredValue;
+		try {
+			data = decodeLynxTransportValue(event.data);
+		} catch (error) {
+			if (closedError !== null && terminalDisposeIdentity === null) return;
+			// Nothing in an undecodable payload is safe to reflect on, so unlike a
+			// schema failure there is no identity to recover and no pending call to
+			// reject against — it can only be reported and dropped.
+			report(error, 'Octane Lynx received an inbound message it could not decode.');
+			return;
+		}
+		if (isRootIndependentDataMessage(data)) return;
 		if (closedError !== null && terminalDisposeIdentity === null) return;
 		let message: LynxBackgroundInboundMessage;
 		try {
-			message = validateLynxBackgroundInboundMessage(event.data);
+			message = validateLynxBackgroundInboundMessage(data);
 		} catch (error) {
 			const normalized = report(error, 'Octane Lynx received a malformed inbound message.');
-			rejectExpectedMalformed(event.data, normalized);
+			rejectExpectedMalformed(data, normalized);
 			return;
 		}
 		if (message.type === 'page-destroy') {

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -84,6 +84,12 @@ import {
 import { createLynxElementPAPI, type LynxElementPAPI, type LynxElementRef } from './core/papi.js';
 import { LYNX_PROFILE, lynxWireProfile } from './core/profiling.js';
 import {
+	decodeLynxTransportValue,
+	encodeLynxTransportValue,
+	localizeLynxHostValue,
+	type LynxStructuredValue,
+} from './core/transport-codec.js';
+import {
 	createReplaceableLynxMainThreadWorkletRegistry,
 	createUnavailableLynxMainThreadWorkletRegistry,
 	subscribeLynxMainThreadWorkletFeature,
@@ -242,30 +248,20 @@ function lifecycleTuple(
 			`Octane Lynx engine lifecycle expected ${JSON.stringify(expectedType)}, received ${JSON.stringify(event.type)}.`,
 		);
 	}
-	if (!Array.isArray(event.data) || event.data.length !== length) {
+	// The engine sent this, not Octane's transport, so it is the one inbound
+	// payload nothing has encoded. Materialize it before anything reflects on
+	// it: every read below is written for ordinary local data, and a
+	// host-backed reference answers some of those reads and throws on others.
+	const data = localizeLynxHostValue(event.data);
+	if (!Array.isArray(data) || data.length !== length) {
 		throw new TypeError(`Octane Lynx ${expectedType} data must be an exact ${length}-item tuple.`);
 	}
-	const names = Object.getOwnPropertyNames(event.data);
-	if (names.length !== length + 1 || hasOwnSymbolFields(event.data)) {
-		throw new TypeError(
-			`Octane Lynx ${expectedType} data must be a dense tuple without extra fields.`,
-		);
-	}
-	const tuple: unknown[] = [];
-	for (let index = 0; index < length; index++) {
-		const descriptor = Object.getOwnPropertyDescriptor(event.data, String(index));
-		if (
-			descriptor === undefined ||
-			!descriptor.enumerable ||
-			!Object.prototype.hasOwnProperty.call(descriptor, 'value')
-		) {
-			throw new TypeError(
-				`Octane Lynx ${expectedType} data[${index}] must be an enumerable data property.`,
-			);
-		}
-		tuple.push(descriptor.value);
-	}
-	return tuple;
+	// Materialization is also normalization: JSON output is always a dense
+	// ordinary array with exactly its index properties as plain enumerable data
+	// fields and no symbols, so the structural checks the pre-encoding version
+	// of this function ran here can never fire again. A hole in the raw tuple
+	// arrives as null and is judged by each caller's per-element validation.
+	return data;
 }
 
 function lifecycleBooleanOption(
@@ -654,10 +650,16 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		lifecycleClosed = true;
 		report(value, fallback);
 	};
+	const reportEncodingDiagnostic = (error: Error): void => {
+		report(error);
+	};
 
 	const dispatch = (message: LynxBackgroundInboundMessage): void => {
 		const validated = selfCheckLynxBackgroundInboundMessage(message);
-		context.dispatchEvent({ type: LYNX_MAIN_TO_BACKGROUND_EVENT, data: validated });
+		context.dispatchEvent({
+			type: LYNX_MAIN_TO_BACKGROUND_EVENT,
+			data: encodeLynxTransportValue(validated, reportEncodingDiagnostic),
+		});
 	};
 
 	const dispatchLifecycleMessage = (message: LynxLifecycleMessage): void => {
@@ -2479,18 +2481,33 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 
 	function receive(event: LynxContextProxyEvent): void {
 		if (closed) return;
+		// Decode before anything reads the payload. `event.data` is whatever the
+		// host handed across, and on device that can be a native-backed reference
+		// that throws on `Reflect.ownKeys` and answers `Object(v) !== v`; every
+		// read below, including the recovery path, is written for ordinary local
+		// data, so the materialization has to happen first or not at all.
+		const startedDecode = LYNX_PROFILE ? performance.now() : 0;
+		let data: LynxStructuredValue;
+		try {
+			data = decodeLynxTransportValue(event.data);
+			if (LYNX_PROFILE) lynxWireProfile().decodeMs += performance.now() - startedDecode;
+		} catch (error) {
+			// Nothing in an undecodable payload is safe to reflect on, so unlike a
+			// schema failure there is no identity to recover and no pending call to
+			// settle against — it can only be reported and dropped.
+			report(error, 'Octane Lynx received an outbound message it could not decode.');
+			return;
+		}
 		let message: ReturnType<typeof validateLynxBackgroundOutboundMessage>;
 		const startedValidate = LYNX_PROFILE ? performance.now() : 0;
 		try {
-			message = validateLynxBackgroundOutboundMessage(event.data);
+			message = validateLynxBackgroundOutboundMessage(data);
 			if (LYNX_PROFILE) lynxWireProfile().validateMs += performance.now() - startedValidate;
 		} catch (error) {
 			const normalized = report(error, 'Octane Lynx received a malformed outbound message.');
-			const identity = recoverIdentity(event.data);
+			const identity = recoverIdentity(data);
 			const raw =
-				event.data !== null && typeof event.data === 'object'
-					? (event.data as Record<string, unknown>)
-					: null;
+				data !== null && typeof data === 'object' ? (data as Record<string, unknown>) : null;
 			if (
 				identity !== null &&
 				raw !== null &&

--- a/packages/lynx/tests/_fixtures/lynx-wire.ts
+++ b/packages/lynx/tests/_fixtures/lynx-wire.ts
@@ -1,0 +1,88 @@
+/**
+ * The wire, as a test has to see it.
+ *
+ * Once the transport owns encoding, the `data` crossing a `ContextProxy` is a
+ * string. So a test standing in for the other thread has to put a string on the
+ * wire, and a test reading what Octane sent has to take one off — the same two
+ * operations the real receiver performs, which is what keeps the harness an
+ * honest stand-in rather than a private channel with looser rules.
+ *
+ * The encoding rules themselves live in `src/core/transport-codec.ts` and are
+ * proved there. What lives here is the two directions, named for the role the
+ * test is playing, and the conforming proxy that refuses anything else.
+ */
+import {
+	decodeLynxTransportValue,
+	encodeLynxTransportValue,
+} from '../../src/core/transport-codec.js';
+import type { LynxContextProxy, LynxContextProxyEvent } from '../../src/core/protocol.js';
+
+/** What the other thread's transport would have put on the wire. */
+export function wire(message: unknown): string {
+	return encodeLynxTransportValue(message);
+}
+
+/**
+ * What the other thread's receiver takes off the wire.
+ *
+ * This throws on anything that is not this codec's output, so every test that
+ * reads a message is also asserting that a string was what crossed. That is
+ * most of the suite's coverage of the boundary, and it is why the conforming
+ * proxy below only has to add the sends nobody reads.
+ */
+export function unwire(data: unknown): unknown {
+	return decodeLynxTransportValue(data);
+}
+
+/** What a conforming proxy observed, so a run cannot pass by doing nothing. */
+export interface LynxWireConformance {
+	/** Payloads that crossed, in order, as they appeared on the wire. */
+	readonly crossings: string[];
+	/** Total bytes those payloads occupied. */
+	bytes(): number;
+}
+
+/**
+ * Wrap a `ContextProxy` so that nothing can cross it except this codec's
+ * output, and record what did.
+ *
+ * The proposition this pins is deliberately platform-independent: **the
+ * transport hands the receiver only receiver-local ordinary values.** It is not
+ * "`Reflect.ownKeys` throws on a bridged value" — that is one engine's symptom,
+ * reproducible only on a device, and a harness that simulated it would be
+ * asserting the symptom rather than the rule. A string cannot be a host-backed
+ * reference on any engine, so once every payload is a string the property holds
+ * by construction rather than by inspection.
+ */
+export function conformingContextProxy(delegate: LynxContextProxy): {
+	readonly context: LynxContextProxy;
+	readonly conformance: LynxWireConformance;
+} {
+	const crossings: string[] = [];
+	const conformance: LynxWireConformance = {
+		crossings,
+		bytes: () => crossings.reduce((total, payload) => total + payload.length, 0),
+	};
+	const context: LynxContextProxy = {
+		dispatchEvent(event: LynxContextProxyEvent): unknown {
+			if (typeof event.data !== 'string') {
+				throw new TypeError(
+					`Octane Lynx sent ${event.data === null ? 'null' : typeof event.data} on "${event.type}" where the wire carries a string. An unencoded value is a live composite, and on device that can be a host-backed reference the receiver must never reflect on.`,
+				);
+			}
+			// Decoding here is the strict half: a string that is not this codec's
+			// output would still be receiver-local, but it would mean a sender
+			// bypassed the transport, which is the same defect one step later.
+			decodeLynxTransportValue(event.data);
+			crossings.push(event.data);
+			return delegate.dispatchEvent(event);
+		},
+		addEventListener(type: string, listener: (event: LynxContextProxyEvent) => void): void {
+			delegate.addEventListener(type, listener);
+		},
+		removeEventListener(type: string, listener: (event: LynxContextProxyEvent) => void): void {
+			delegate.removeEventListener(type, listener);
+		},
+	};
+	return { context, conformance };
+}

--- a/packages/lynx/tests/background-list.test.ts
+++ b/packages/lynx/tests/background-list.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/core/protocol.js';
 import { NativeListLifecycleFixture } from './_fixtures/native-list-lifecycle.lynx.tsrx';
 import { NativeListFixture } from './_fixtures/native-list.lynx.tsrx';
+import { unwire } from './_fixtures/lynx-wire.js';
 
 interface NativeListItem {
 	readonly id: string;
@@ -268,7 +269,7 @@ describe.sequential('Lynx recycled list background integration', () => {
 				if (
 					failNextAttachment &&
 					event.type === LYNX_MAIN_TO_BACKGROUND_EVENT &&
-					(event.data as { readonly type?: unknown }).type === 'host-attachment'
+					(unwire(event.data) as { readonly type?: unknown }).type === 'host-attachment'
 				) {
 					failNextAttachment = false;
 					throw failure;

--- a/packages/lynx/tests/background-root.test.ts
+++ b/packages/lynx/tests/background-root.test.ts
@@ -49,6 +49,7 @@ import {
 	type LynxContextProxy,
 } from '../src/core/protocol.js';
 import { BackgroundRootFixture, ClassAliasFixture } from './_fixtures/background-root.lynx.tsrx';
+import { unwire, wire } from './_fixtures/lynx-wire.js';
 
 interface FixtureItem {
 	readonly id: string;
@@ -290,7 +291,7 @@ function sendLifecycleToBackground(env: LynxTestingEnv, message: Record<string, 
 	const context = backgroundContext();
 	env.switchToMainThread();
 	try {
-		context.dispatchEvent({ type: LYNX_MAIN_TO_BACKGROUND_EVENT, data: message });
+		context.dispatchEvent({ type: LYNX_MAIN_TO_BACKGROUND_EVENT, data: wire(message) });
 	} finally {
 		env.switchToBackgroundThread();
 	}
@@ -782,11 +783,11 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 						replayDestroy = false;
 						listener({
 							type,
-							data: {
+							data: wire({
 								protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 								renderer: LYNX_TRANSPORT_RENDERER,
 								type: 'page-destroy',
-							},
+							}),
 						});
 					}
 				},
@@ -852,7 +853,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 			env.switchToBackgroundThread();
 			const inbound: LynxBackgroundInboundMessage[] = [];
 			backgroundContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-				inbound.push(event.data as LynxBackgroundInboundMessage);
+				inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 			});
 			backgroundRoot = createLynxRoot();
 			const rendering = backgroundRoot.render(SimpleScene, { id: 'must-not-become-ready' });
@@ -932,7 +933,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		installEnvironment((target) => {
 			mainContext(target).addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-				inbound.push(event.data as LynxBackgroundInboundMessage);
+				inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 			});
 		});
 
@@ -980,7 +981,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const { dom, main } = installEnvironment(undefined, (delegate) =>
 			Object.freeze({
 				dispatchEvent(event) {
-					const data = event.data as {
+					const data = unwire(event.data) as {
 						type?: unknown;
 						handles?: readonly Record<string, unknown>[];
 					};
@@ -993,10 +994,15 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 					) {
 						corruptAcknowledgement = false;
 						const first = data.handles[0];
+						// A hostile wire: the message is rewritten in flight and put
+						// back on the channel encoded, because that is the only way
+						// anything reaches the receiver now. What this proves is
+						// unchanged — a payload that parses but does not match the
+						// schema has to be rejected, not adopted.
 						return delegate.dispatchEvent({
 							...event,
-							data: {
-								...(event.data as Record<string, unknown>),
+							data: wire({
+								...data,
 								handles: [
 									{
 										...first,
@@ -1006,7 +1012,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 										},
 									},
 								],
-							},
+							}),
 						});
 					}
 					return delegate.dispatchEvent(event);
@@ -1035,7 +1041,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const deliveryError = new Error('injected post-delivery commit failure');
 		let failCommit = true;
 		backgroundContext().addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			if (failCommit && (event.data as { type?: unknown }).type === 'commit') {
+			if (failCommit && (unwire(event.data) as { type?: unknown }).type === 'commit') {
 				failCommit = false;
 				throw deliveryError;
 			}
@@ -1069,7 +1075,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 					if (
 						failReadyReply &&
 						event.type === LYNX_MAIN_TO_BACKGROUND_EVENT &&
-						(event.data as { type?: unknown }).type === 'main-ready'
+						(unwire(event.data) as { type?: unknown }).type === 'main-ready'
 					) {
 						throw deliveryError;
 					}
@@ -1085,7 +1091,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		);
 		const deliveredTypes: string[] = [];
 		backgroundContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			const type = (event.data as { readonly type?: unknown }).type;
+			const type = (unwire(event.data) as { readonly type?: unknown }).type;
 			if (typeof type === 'string') deliveredTypes.push(type);
 		});
 		failReadyReply = true;
@@ -1274,7 +1280,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		const page = dom.window.document.querySelector('page')!;
 		const program = Object.freeze({
@@ -1310,13 +1316,13 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const send = (command: typeof range | typeof run, lazy = false): void => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					...identity(509, 1),
 					type: 'commit',
 					ack: LYNX_COMPACT_ACKNOWLEDGEMENT,
 					...(lazy ? { instances: LYNX_LAZY_PUBLIC_INSTANCES } : null),
 					batch: { renderer: 'lynx', version: 1, commands: [command] },
-				},
+				}),
 			});
 		};
 
@@ -1335,12 +1341,12 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				type: 'main-ready-request',
 				request: LYNX_CAPABILITY_READY_REQUEST_BASE + 19,
-			},
+			}),
 		});
 		const olderPeerReply = inbound.at(-1);
 		expect(olderPeerReply).toMatchObject({
@@ -1373,12 +1379,12 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(501, 1),
 				type: 'commit',
 				batch: {
@@ -1389,7 +1395,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 						{ op: 'insert', parent: null, id: 1, before: null },
 					],
 				},
-			},
+			}),
 		});
 		const page = dom.window.document.querySelector('page')!;
 		const survivor = page.querySelector('#survivor')!;
@@ -1397,7 +1403,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(501, 3),
 				type: 'commit',
 				batch: {
@@ -1408,7 +1414,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 						{ op: 'insert', parent: null, id: 2, before: 999 },
 					],
 				},
-			},
+			}),
 		});
 
 		expect(inbound.map((message) => message.type)).toEqual(['ack', 'complete', 'reject']);
@@ -1419,7 +1425,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(501, 4),
 				type: 'commit',
 				batch: {
@@ -1427,14 +1433,14 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 					version: 4,
 					commands: [{ op: 'update', id: 1, props: { id: 'survivor-next' } }],
 				},
-			},
+			}),
 		});
 		expect(page.querySelector('#survivor-next')).toBe(survivor);
 		expect(main.activeIdentity()).toMatchObject({ root: 501, version: 4 });
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: { ...identity(501, 4), type: 'dispose' },
+			data: wire({ ...identity(501, 4), type: 'dispose' }),
 		});
 		expect(page.innerHTML).toBe('');
 		expect(inbound.at(-1)?.type).toBe('dispose-ack');
@@ -1442,11 +1448,11 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(501, 5),
 				type: 'commit',
 				batch: { renderer: 'lynx', version: 5, commands: [] },
-			},
+			}),
 		});
 		expect(inbound.at(-1)).toMatchObject({ root: 501, version: 5, type: 'reject' });
 		expect(page.innerHTML).toBe('');
@@ -1457,7 +1463,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		const sendCommit = (
 			root: number,
@@ -1466,11 +1472,11 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		) => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					...identity(root, version),
 					type: 'commit',
 					batch: { renderer: 'lynx', version, commands },
-				},
+				}),
 			});
 		};
 
@@ -1492,7 +1498,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		expect(page.querySelector('#first-root')).not.toBeNull();
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: { ...identity(601, 1), type: 'dispose' },
+			data: wire({ ...identity(601, 1), type: 'dispose' }),
 		});
 		expect(inbound.at(-1)?.type).toBe('dispose-ack');
 		expect(page.innerHTML).toBe('');
@@ -1511,12 +1517,12 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(603, 1),
 				type: 'commit',
 				batch: {
@@ -1527,7 +1533,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 						{ op: 'insert', parent: null, id: 1, before: null },
 					],
 				},
-			},
+			}),
 		});
 
 		const page = dom.window.document.querySelector('page')!;
@@ -1536,7 +1542,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: { ...identity(603, 2), type: 'terminal-dispose' },
+			data: wire({ ...identity(603, 2), type: 'terminal-dispose' }),
 		});
 
 		expect(page.innerHTML).toBe('');
@@ -1735,7 +1741,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 				reenter = false;
 				context.dispatchEvent({
 					type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-					data: {
+					data: wire({
 						...identity(701, 3),
 						type: 'commit',
 						batch: {
@@ -1743,23 +1749,23 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 							version: 3,
 							commands: [{ op: 'update', id: 1, props: { id: 'reentrant' } }],
 						},
-					},
+					}),
 				});
 			};
 		});
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		const sendCommit = (version: number, commands: readonly Record<string, unknown>[]) => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					...identity(701, version),
 					type: 'commit',
 					batch: { renderer: 'lynx', version, commands },
-				},
+				}),
 			});
 		};
 
@@ -1799,7 +1805,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 					dispatchEvent(event) {
 						if (
 							event.type === LYNX_MAIN_TO_BACKGROUND_EVENT &&
-							(event.data as { type?: unknown }).type === 'complete'
+							(unwire(event.data) as { type?: unknown }).type === 'complete'
 						) {
 							throw deliveryError;
 						}
@@ -1816,13 +1822,13 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		expect(() => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					...identity(751, 1),
 					type: 'commit',
 					batch: {
@@ -1833,7 +1839,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 							{ op: 'insert', parent: null, id: 1, before: null },
 						],
 					},
-				},
+				}),
 			});
 		}).toThrow(deliveryError);
 		expect(inbound.map(({ type }) => type)).toEqual(['ack']);
@@ -1847,13 +1853,13 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(751, 1),
 				type: 'call-main',
 				call: 1,
 				worklet: { _wkltId: 'app:after-completion-fault' },
 				args: [],
-			},
+			}),
 		});
 		expect(inbound.at(-1)).toMatchObject({
 			type: 'call-main-error',
@@ -1862,7 +1868,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: { ...identity(751, 1), type: 'terminal-dispose' },
+			data: wire({ ...identity(751, 1), type: 'terminal-dispose' }),
 		});
 		expect(inbound.at(-1)?.type).toBe('dispose-ack');
 		expect(main.activeIdentity()).toBeNull();
@@ -1878,7 +1884,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 					if (
 						failDisposeAcknowledgement &&
 						event.type === LYNX_MAIN_TO_BACKGROUND_EVENT &&
-						(event.data as { type?: unknown }).type === 'dispose-ack'
+						(unwire(event.data) as { type?: unknown }).type === 'dispose-ack'
 					) {
 						throw deliveryError;
 					}
@@ -1895,11 +1901,11 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(761, 1),
 				type: 'commit',
 				batch: {
@@ -1910,14 +1916,14 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 						{ op: 'insert', parent: null, id: 1, before: null },
 					],
 				},
-			},
+			}),
 		});
 		failDisposeAcknowledgement = true;
 
 		expect(() => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: { ...identity(761, 1), type: 'dispose' },
+				data: wire({ ...identity(761, 1), type: 'dispose' }),
 			});
 		}).toThrow(deliveryError);
 		expect(main.activeIdentity()).toBeNull();
@@ -1927,7 +1933,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		failDisposeAcknowledgement = false;
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: { ...identity(761, 1), type: 'dispose' },
+			data: wire({ ...identity(761, 1), type: 'dispose' }),
 		});
 		expect(inbound.at(-1)?.type).toBe('dispose-ack');
 	});
@@ -1947,11 +1953,11 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				...identity(801, 1),
 				type: 'commit',
 				batch: {
@@ -1962,11 +1968,11 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 						{ op: 'insert', parent: null, id: 1, before: null },
 					],
 				},
-			},
+			}),
 		});
 		const dispose = { ...identity(801, 1), type: 'dispose' } as const;
 		failRemove = true;
-		context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: dispose });
+		context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: wire(dispose) });
 
 		expect(inbound.filter(({ type }) => type === 'dispose-ack')).toHaveLength(0);
 		expect(inbound.at(-1)).toMatchObject({
@@ -1984,7 +1990,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 			]),
 		);
 
-		context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: dispose });
+		context.dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: wire(dispose) });
 		expect(inbound.filter(({ type }) => type === 'dispose-ack')).toHaveLength(1);
 		expect(main.activeIdentity()).toBeNull();
 		expect(dom.window.document.querySelector('page')?.innerHTML).toBe('');
@@ -2066,7 +2072,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 			};
 		});
 		backgroundContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			const type = (event.data as { type?: unknown }).type;
+			const type = (unwire(event.data) as { type?: unknown }).type;
 			if (type === 'dispose-retry' || type === 'dispose-ack') timeline.push(`message:${type}`);
 		});
 		backgroundRoot = createLynxRoot();
@@ -2109,16 +2115,16 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		const sendCommit = (version: number, commands: readonly Record<string, unknown>[]) => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					...identity(777, version),
 					type: 'commit',
 					batch: { renderer: 'lynx', version, commands },
-				},
+				}),
 			});
 		};
 
@@ -2153,7 +2159,7 @@ describe.sequential('@octanejs/lynx background root in the official JS environme
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: { ...identity(777, 3), type: 'dispose' },
+			data: wire({ ...identity(777, 3), type: 'dispose' }),
 		});
 		expect(page.innerHTML).toBe('');
 		expect(inbound.at(-1)?.type).toBe('dispose-ack');

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -40,6 +40,7 @@ import {
 	type LynxBackgroundOutboundMessage,
 	type LynxContextProxy,
 } from '../src/core/protocol.js';
+import { unwire, wire } from './_fixtures/lynx-wire.js';
 
 interface SceneProps {
 	readonly id: string;
@@ -467,10 +468,10 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		const outbound: LynxBackgroundOutboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		mainContext().addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			outbound.push(event.data as LynxBackgroundOutboundMessage);
+			outbound.push(unwire(event.data) as LynxBackgroundOutboundMessage);
 		});
 		const effects: string[] = [];
 		const events: unknown[] = [];
@@ -544,7 +545,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		const dispatch = context.dispatchEvent.bind(context);
 		const clonedRuns: boolean[] = [];
 		context.dispatchEvent = (event) => {
-			const data = deserialize(serialize(event.data)) as unknown;
+			const data = deserialize(serialize(unwire(event.data))) as unknown;
 			if (
 				data !== null &&
 				typeof data === 'object' &&
@@ -561,7 +562,10 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 					);
 				}
 			}
-			return dispatch({ ...event, data });
+			// Re-dispatch what was actually sent. The observation above is a
+			// read of the wire, not a rewrite of it: handing the decoded object
+			// back would put a live composite on a channel that now carries text.
+			return dispatch(event);
 		};
 		backgroundRoot = createLynxRoot();
 		const rendering = backgroundRoot.render(BackgroundScene, props);
@@ -730,7 +734,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		const firstNode = dom.window.document.querySelector('#main-value');
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		main.markFirstScreenSyncReady();
 
@@ -740,14 +744,14 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		});
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 1,
 				version: 1,
 				type: 'commit',
 				batch: replacement.batch,
-			},
+			}),
 		});
 
 		expect(inbound.find((message) => message.type === 'ack')).toMatchObject({
@@ -769,13 +773,13 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		let queuedSecondCommit = false;
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			const message = event.data as LynxBackgroundInboundMessage;
+			const message = unwire(event.data) as LynxBackgroundInboundMessage;
 			inbound.push(message);
 			if (message.type !== 'ack' || message.version !== 1 || queuedSecondCommit) return;
 			queuedSecondCommit = true;
 			backgroundContext().dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
 					root: 1,
@@ -786,7 +790,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 						version: 2,
 						commands: [{ op: 'update', id: 1, props: { id: 'after-adoption' } }],
 					},
-				},
+				}),
 			});
 		});
 		main.markFirstScreenSyncReady();
@@ -794,14 +798,14 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		const initial = renderLynxFirstScreen(MainSingleHost, { id: 'first-screen' });
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 1,
 				version: 1,
 				type: 'commit',
 				batch: initial.batch,
-			},
+			}),
 		});
 
 		expect(inbound.filter((message) => message.type === 'ack')).toEqual([
@@ -815,13 +819,13 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 1,
 				version: 1,
 				type: 'adoption-ready',
-			},
+			}),
 		});
 
 		expect(main.firstScreenSnapshot()).toBeNull();
@@ -833,7 +837,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		const { main } = installEnvironment();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		main.markFirstScreenSyncReady();
@@ -867,7 +871,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		firstScreenRoot.render(MainSingleHost, { id: 'cleanup-retry' });
 
@@ -878,12 +882,12 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				type: 'main-ready-request',
 				request: 43,
-			},
+			}),
 		});
 		expect(dom.window.document.querySelector('#cleanup-retry')).toBeNull();
 		expect(main.firstScreenSnapshot()).toBeNull();
@@ -908,7 +912,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		expect(firstScreenRoot.render(FeedScene, {})).toBeNull();
@@ -923,12 +927,12 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				type: 'main-ready-request',
 				request: 51,
-			},
+			}),
 		});
 		// Declining settles readiness immediately, exactly as an entry that never
 		// rendered a first screen does, so the background is not left waiting.
@@ -949,7 +953,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		expect(firstScreenRoot.render(FeedScene, {})).toBeNull();
@@ -961,12 +965,12 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		allowCleanup = true;
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				type: 'main-ready-request',
 				request: 52,
-			},
+			}),
 		});
 
 		expect(dom.window.document.querySelector('#feed-shell')).toBeNull();
@@ -992,7 +996,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		expect(() => firstScreenRoot.render(MainSingleHost, { id: 'failed-capture' })).toThrow(
@@ -1004,24 +1008,24 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				type: 'main-ready-request',
 				request: 41,
-			},
+			}),
 		});
 		expect(dom.window.document.querySelector('#failed-capture')).not.toBeNull();
 		expect(inbound).toEqual([]);
 
 		backgroundContext().dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				type: 'main-ready-request',
 				request: 42,
-			},
+			}),
 		});
 
 		expect(dom.window.document.querySelector('#failed-capture')).toBeNull();
@@ -1042,7 +1046,7 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		firstScreenRoot.render(MainSingleHost, { id: 'terminal-retry' });
 		const dispose = {
@@ -1053,12 +1057,12 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 			type: 'terminal-dispose' as const,
 		};
 
-		backgroundContext().dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: dispose });
+		backgroundContext().dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: wire(dispose) });
 		expect(inbound.at(-1)).toMatchObject({ type: 'dispose-retry', root: 1, version: 1 });
 		expect(dom.window.document.querySelector('#terminal-retry')).not.toBeNull();
 		expect(main.firstScreenSnapshot()).not.toBeNull();
 
-		backgroundContext().dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: dispose });
+		backgroundContext().dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: wire(dispose) });
 		expect(inbound.at(-1)).toMatchObject({ type: 'dispose-ack', root: 1, version: 1 });
 		expect(dom.window.document.querySelector('#terminal-retry')).toBeNull();
 		expect(main.firstScreenSnapshot()).toBeNull();

--- a/packages/lynx/tests/host-props.test.ts
+++ b/packages/lynx/tests/host-props.test.ts
@@ -11,6 +11,7 @@ import {
 	normalizeLynxInlineStyle,
 	planLynxHostPropPatch,
 } from '../src/core/host-props.js';
+import { decodeLynxTransportValue, encodeLynxTransportValue } from '../src/core/transport-codec.js';
 import { attachThreadFunction } from '../src/core/worklets.js';
 
 function attributes(patch: ReturnType<typeof planLynxHostPropPatch>): Record<string, unknown> {
@@ -454,5 +455,47 @@ describe('Lynx host prop routing', () => {
 		expect(() =>
 			planLynxHostPropPatch('view', {}, { 'main-thread:gesture': { _wkltId: 'gesture' } }),
 		).toThrow(/not a supported Lynx host capability/);
+	});
+
+	// The fast path in `planLynxHostPropPatch` reads only own enumerable keys,
+	// so it is gated on the bag's prototype being this realm's `Object.prototype`
+	// or none — the proof that there is nothing else to read. The neighbouring
+	// test shows what that gate is worth: a bag with an inherited `id` and
+	// `style` must not take it.
+	//
+	// Now that props are decoded on the receiving thread, every bag the applier
+	// sees is `JSON.parse` output, which is always on the permissive side of that
+	// gate. What has to stay true is that nothing in a bag's own contents can put
+	// it back on the other side. `__proto__` is the case that could: the renderer
+	// defines it as data on the sending side, the codec restores it as data on
+	// the receiving side, and either end using assignment instead would make the
+	// object it names the bag's prototype — at which point the slow path reads an
+	// `id` and a `style` that nobody set onto the node.
+	it('keeps a decoded prop bag ordinary, so nothing it names becomes a channel', () => {
+		const sent: Record<string, unknown> = {};
+		Object.defineProperty(sent, '__proto__', {
+			configurable: true,
+			enumerable: true,
+			value: { id: 'injected', style: { width: '99px' } },
+			writable: true,
+		});
+		sent.class = 'row';
+
+		const delivered = decodeLynxTransportValue(encodeLynxTransportValue(sent)) as Record<
+			string,
+			unknown
+		>;
+		expect(Object.getPrototypeOf(delivered)).toBe(Object.prototype);
+		expect(Object.keys(delivered).sort()).toEqual(['__proto__', 'class']);
+
+		const patch = planLynxHostPropPatch('view', {}, delivered);
+		expect(patch.id).toBeUndefined();
+		expect(patch.inlineStyles).toBeUndefined();
+		expect(patch.classes?.value).toBe('row');
+		// It is an ordinary prop the host does not recognize, which is what a
+		// field named `__proto__` in someone's props always meant.
+		expect(patch.attributes).toEqual([
+			{ name: '__proto__', value: { id: 'injected', style: { width: '99px' } } },
+		]);
 	});
 });

--- a/packages/lynx/tests/main-thread-events.test.ts
+++ b/packages/lynx/tests/main-thread-events.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../src/core/protocol.js';
 import { encodeLynxPortalTargetId } from '../src/core/portal.js';
 import { activateLynxMainThreadWorklet, registerMainThreadWorklet } from '../src/core/worklets.js';
+import { unwire, wire } from './_fixtures/lynx-wire.js';
 
 type Handler = ((payload: unknown) => void) | null;
 
@@ -229,7 +230,7 @@ function captureMainMessages(): {
 	const context = backgroundContext();
 	const messages: LynxBackgroundInboundMessage[] = [];
 	const listener = (event: LynxContextProxyEvent) => {
-		messages.push(event.data as LynxBackgroundInboundMessage);
+		messages.push(unwire(event.data) as LynxBackgroundInboundMessage);
 	};
 	context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, listener);
 	return {
@@ -243,12 +244,12 @@ function captureMainMessages(): {
 function requestMainReady(context: LynxContextProxy, request: number): void {
 	context.dispatchEvent({
 		type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-		data: {
+		data: wire({
 			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 			renderer: LYNX_TRANSPORT_RENDERER,
 			type: 'main-ready-request',
 			request,
-		},
+		}),
 	});
 }
 
@@ -269,14 +270,14 @@ function dispatchCommit(
 ): void {
 	context.dispatchEvent({
 		type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-		data: {
+		data: wire({
 			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 			renderer: LYNX_TRANSPORT_RENDERER,
 			root,
 			version,
 			type: 'commit',
 			batch: { renderer: LYNX_TRANSPORT_RENDERER, version, commands },
-		},
+		}),
 	});
 }
 
@@ -357,7 +358,7 @@ describe.sequential('Lynx main-thread native event bridge', () => {
 				dispatchEvent(event) {
 					if (
 						event.type === LYNX_MAIN_TO_BACKGROUND_EVENT &&
-						(event.data as { readonly type?: unknown }).type === 'page-destroy'
+						(unwire(event.data) as { readonly type?: unknown }).type === 'page-destroy'
 					) {
 						throw deliveryError;
 					}
@@ -433,7 +434,7 @@ describe.sequential('Lynx main-thread native event bridge', () => {
 				Object.freeze({
 					dispatchEvent(event) {
 						if (event.type === LYNX_MAIN_TO_BACKGROUND_EVENT) {
-							const message = event.data as {
+							const message = unwire(event.data) as {
 								readonly root?: unknown;
 								readonly version?: unknown;
 								readonly type?: unknown;
@@ -485,7 +486,7 @@ describe.sequential('Lynx main-thread native event bridge', () => {
 		const context = backgroundContext();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		dispatchCommit(context, 90, 1, [
@@ -565,7 +566,7 @@ describe.sequential('Lynx main-thread native event bridge', () => {
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		let injectAt: 'complete' | 'reject' | null = 'complete';
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			const message = event.data as LynxBackgroundInboundMessage;
+			const message = unwire(event.data) as LynxBackgroundInboundMessage;
 			inbound.push(message);
 			if (message.type !== injectAt) return;
 			injectAt = null;
@@ -629,8 +630,14 @@ describe.sequential('Lynx main-thread native event bridge', () => {
 			detail: { phase: 'bind' },
 			target: { id: 'event-target', uid: 2, dataset: { source: 'target' } },
 		});
-		expect(Object.getPrototypeOf(received as object)).toBeNull();
+		// The background gets inert data, never the host's event object. A null
+		// prototype used to say so, but it said so only because the harness handed
+		// the same object across threads; the wire carries the payload as text
+		// now, so what arrives is an ordinary local object with none of the host's
+		// methods on it — which is the property that actually mattered.
+		expect(Object.getPrototypeOf(received as object)).toBe(Object.prototype);
 		expect(received).not.toHaveProperty('preventDefault');
+		expect(received).not.toHaveProperty('stopPropagation');
 
 		await backgroundRoot.render(EventScene, {
 			bindtap: () => log.push('bind:replacement'),
@@ -922,7 +929,7 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 			env.switchToBackgroundThread();
 			const inbound: LynxBackgroundInboundMessage[] = [];
 			backgroundContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-				inbound.push(event.data as LynxBackgroundInboundMessage);
+				inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 			});
 			backgroundRoot = createLynxRoot();
 			const rendering = backgroundRoot.render(EventScene, {});
@@ -939,7 +946,9 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 				}
 			).lynx.getJSContext();
 			context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-				outbound.push(event.data as { readonly type?: unknown; readonly request?: unknown });
+				outbound.push(
+					unwire(event.data) as { readonly type?: unknown; readonly request?: unknown },
+				);
 			});
 			const main = installLynxMainThread();
 			installed = { dom, main, registrations: [] };
@@ -997,7 +1006,7 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 			(delegate) =>
 				Object.freeze({
 					dispatchEvent(event) {
-						const data = event.data as { readonly type?: unknown };
+						const data = unwire(event.data) as { readonly type?: unknown };
 						if (data.type === 'page-data' && !reentered) {
 							reentered = true;
 							engine.dispatch('__UpdatePage', [{ sequence: 'reentrant' }, {}]);
@@ -1089,8 +1098,20 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 		const renderMessage = captured.messages[0];
 		expect(renderMessage?.type).toBe('page-data');
 		if (renderMessage?.type !== 'page-data') throw new Error('Expected page data.');
-		expect(Object.isFrozen(renderMessage.data)).toBe(true);
-		expect(Object.isFrozen(renderMessage.data.profile)).toBe(true);
+		// Freezing was how the main thread promised not to hand the background a
+		// live view of host data, and it survived only because the harness passed
+		// the same object across. The wire makes the promise structural instead:
+		// what arrives is the background's own tree, parsed from text, sharing
+		// nothing with the main thread — so writing to it reaches nobody.
+		expect(Object.getPrototypeOf(renderMessage.data)).toBe(Object.prototype);
+		expect(renderMessage.data).toEqual({ profile: { name: 'Ada' } });
+		(renderMessage.data as { profile: { name: string } }).profile.name = 'mutated';
+		const laterRender = captured.messages.find(
+			(message, index) => index > 0 && message.type === 'page-data',
+		);
+		expect(laterRender?.type === 'page-data' ? laterRender.data : null).not.toMatchObject({
+			profile: { name: 'mutated' },
+		});
 
 		globalThis.lynxTestingEnv.switchToMainThread();
 		engine.dispatch('__UpdatePage', [{ sequence: 'direct' }, {}]);
@@ -1102,7 +1123,7 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 		expect(main.diagnostics()).toEqual([]);
 	});
 
-	it('rejects malformed tuples and reloadTemplate without mutating the active host', () => {
+	it('normalizes engine lifecycle records at entry without mutating the active host', () => {
 		const engine = createEngineHarness();
 		const { dom, main } = installEnvironment((target) => installEngine(target, engine));
 		dispatchCommit(backgroundContext(), 121, 1, [
@@ -1135,20 +1156,66 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 		expect(() =>
 			engine.dispatch('__UpdatePage', [{ ignored: true }, { reloadTemplate: true }]),
 		).not.toThrow();
-		const symbolicTuple: unknown[] = [{ ignored: true }];
+		const symbolicTuple: unknown[] = [{ shape: 'normalized' }];
 		Object.defineProperty(symbolicTuple, Symbol('extra'), { value: true });
 		expect(() => engine.dispatch('__UpdateGlobalProps', symbolicTuple)).not.toThrow();
 
-		expect(getterRead).toBe(false);
+		// The engine is the one sender that cannot be asked to encode, so its
+		// records are materialized at the entry instead. That draws the line in a
+		// different place than rejecting every unusual shape did: a shape the
+		// materializer can express becomes ordinary local data and the update
+		// proceeds, and only what the value domain cannot carry is refused.
+		//
+		// An accessor is the visible edge of that. Copying a value means reading
+		// it, so the getter runs — once, here, inside the boundary's own
+		// try/catch, rather than at whatever later moment a lazy read happened to
+		// fall on. What the receiver gets is the ordinary `false` it returned.
+		expect(getterRead).toBe(true);
+		// A symbol-keyed field on the tuple was never readable by anything
+		// downstream, which is why it was rejected; materializing drops it, and
+		// what remains is a well-formed one-item tuple.
+		expect(captured.messages.map(({ type }) => type)).toEqual([
+			'main-ready',
+			'page-data',
+			'global-props',
+		]);
+		expect(captured.messages[1]).toMatchObject({ operation: 'update', data: { safe: true } });
+		expect(captured.messages[2]).toMatchObject({ patch: { shape: 'normalized' } });
 		expect(page.querySelector('#lifecycle-host')?.textContent).toBe('stable');
 		expect(main.activeIdentity()).toEqual(identity);
-		expect(captured.messages.map(({ type }) => type)).toEqual(['main-ready']);
 		const diagnostics = main.diagnostics().map(({ message }) => message);
 		expect(diagnostics.some((message) => message.includes('exact 2-item tuple'))).toBe(true);
-		expect(diagnostics.some((message) => message.includes('boolean data property'))).toBe(true);
-		expect(diagnostics.some((message) => message.includes('non-clone-safe'))).toBe(true);
 		expect(diagnostics.some((message) => message.includes('reloadTemplate'))).toBe(true);
-		expect(diagnostics.some((message) => message.includes('dense tuple'))).toBe(true);
+		// A function cannot be expressed, so it is refused — and named where it
+		// sits, which is the part a generic "non-clone-safe" report could not say.
+		expect(diagnostics.some((message) => message.includes('at $[0].invalid is a function'))).toBe(
+			true,
+		);
+	});
+
+	it('keeps the lifecycle channel alive when an engine record leaves the value domain', () => {
+		const engine = createEngineHarness();
+		const { main } = installEnvironment((target) => installEngine(target, engine));
+		const captured = captureMainMessages();
+		requestMainReady(backgroundContext(), 91);
+		const identity = main.activeIdentity();
+
+		// A `bigint` is the case that separates materializing at the entry from
+		// reflecting on the engine's value in place. Nothing between the entry and
+		// the wire used to look at it — the clone copies a bigint through — so it
+		// reached `dispatch`, where encoding refuses it, and a throw there is a
+		// failure to deliver an engine lifecycle update, which tears down the page
+		// lifetime. Refusing it where it entered makes it one dropped record.
+		globalThis.lynxTestingEnv.switchToMainThread();
+		expect(() => engine.dispatch('__UpdatePage', [{ count: 1n }, {}])).not.toThrow();
+		engine.dispatch('__UpdatePage', [{ count: 2 }, {}]);
+
+		expect(main.activeIdentity()).toEqual(identity);
+		expect(captured.messages.map(({ type }) => type)).toEqual(['main-ready', 'page-data']);
+		expect(captured.messages.at(-1)).toMatchObject({ data: { count: 2 } });
+		const diagnostics = main.diagnostics().map(({ message }) => message);
+		expect(diagnostics.some((message) => message.includes('at $[0].count is a bigint'))).toBe(true);
+		expect(diagnostics.some((message) => message.includes('could not deliver'))).toBe(false);
 	});
 
 	it('compacts an overflowing pre-ready lifecycle queue to authoritative current state', async () => {
@@ -1192,7 +1259,8 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 				Object.freeze({
 					dispatchEvent(event) {
 						const result = delegate.dispatchEvent(event);
-						if ((event.data as { readonly type?: unknown }).type === 'page-data') main?.close();
+						if ((unwire(event.data) as { readonly type?: unknown }).type === 'page-data')
+							main?.close();
 						return result;
 					},
 					addEventListener(type, listener) {
@@ -1231,7 +1299,7 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 			(delegate) =>
 				Object.freeze({
 					dispatchEvent(event) {
-						const data = event.data as {
+						const data = unwire(event.data) as {
 							readonly type?: unknown;
 							readonly data?: { readonly count?: unknown };
 						};
@@ -1278,7 +1346,7 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 			(delegate) =>
 				Object.freeze({
 					dispatchEvent(event) {
-						if ((event.data as { readonly type?: unknown }).type === 'page-data') {
+						if ((unwire(event.data) as { readonly type?: unknown }).type === 'page-data') {
 							throw deliveryError;
 						}
 						return delegate.dispatchEvent(event);
@@ -1331,7 +1399,7 @@ describe.sequential('Lynx main-thread engine lifecycle bridge', () => {
 			env.switchToBackgroundThread();
 			const inbound: LynxBackgroundInboundMessage[] = [];
 			backgroundContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-				inbound.push(event.data as LynxBackgroundInboundMessage);
+				inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 			});
 			backgroundRoot = createLynxRoot();
 			const rendering = backgroundRoot.render(EventScene, {});

--- a/packages/lynx/tests/milestone-7-integration.test.ts
+++ b/packages/lynx/tests/milestone-7-integration.test.ts
@@ -30,6 +30,7 @@ import * as mainRenderer from '../src/main-renderer.js';
 import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
 import * as backgroundRenderer from '../src/renderer.js';
 import type { LynxRoot } from '../src/root.js';
+import { unwire, wire } from './_fixtures/lynx-wire.js';
 
 const THREAD_SOURCE = `
 import { runOnMainThread, useMainThreadRef } from '@octanejs/lynx';
@@ -350,10 +351,10 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		const outbound: LynxBackgroundOutboundMessage[] = [];
 		environment.context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			outbound.push(event.data as LynxBackgroundOutboundMessage);
+			outbound.push(unwire(event.data) as LynxBackgroundOutboundMessage);
 		});
 		environment.context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		backgroundRoot = rootApi.createLynxRoot();
 		expect(environment.background.setupCapturedDeclaration()).toBe(9);
@@ -513,7 +514,7 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 		const environment = installEnvironment();
 		const outbound: LynxBackgroundOutboundMessage[] = [];
 		environment.context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			outbound.push(event.data as LynxBackgroundOutboundMessage);
+			outbound.push(unwire(event.data) as LynxBackgroundOutboundMessage);
 		});
 		backgroundRoot = rootApi.createLynxRoot();
 		await backgroundRoot.render(environment.background.StateRefScene, {});
@@ -527,7 +528,7 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 
 		environment.context.dispatchEvent({
 			type: LYNX_MAIN_TO_BACKGROUND_EVENT,
-			data: {
+			data: wire({
 				protocol: commit!.protocol,
 				renderer: commit!.renderer,
 				root: commit!.root,
@@ -537,7 +538,7 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 					name: 'Error',
 					message: 'Octane Lynx background transport was closed.',
 				},
-			},
+			}),
 		});
 		await flushMicrotasks();
 		await expect(backgroundRoot.unmount()).resolves.toBeUndefined();
@@ -565,10 +566,10 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 		const backgroundOutbound: LynxBackgroundOutboundMessage[] = [];
 		const mainOutbound: LynxBackgroundInboundMessage[] = [];
 		environment.context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			backgroundOutbound.push(event.data as LynxBackgroundOutboundMessage);
+			backgroundOutbound.push(unwire(event.data) as LynxBackgroundOutboundMessage);
 		});
 		environment.context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			mainOutbound.push(event.data as LynxBackgroundInboundMessage);
+			mainOutbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		backgroundRoot = rootApi.createLynxRoot();
 
@@ -606,10 +607,10 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 		const backgroundOutbound: LynxBackgroundOutboundMessage[] = [];
 		const mainOutbound: LynxBackgroundInboundMessage[] = [];
 		environment.context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			backgroundOutbound.push(event.data as LynxBackgroundOutboundMessage);
+			backgroundOutbound.push(unwire(event.data) as LynxBackgroundOutboundMessage);
 		});
 		environment.context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			mainOutbound.push(event.data as LynxBackgroundInboundMessage);
+			mainOutbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		backgroundRoot = rootApi.createLynxRoot();
 

--- a/packages/lynx/tests/milestone-8-integration.test.ts
+++ b/packages/lynx/tests/milestone-8-integration.test.ts
@@ -19,6 +19,7 @@ import { createLynxRoot, type LynxPublicHandle, type LynxRoot } from '../src/ind
 import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
 import * as firstScreen from '../src/main-renderer.js';
 import { LYNX_BACKGROUND_TO_MAIN_EVENT, type LynxContextProxy } from '../src/core/protocol.js';
+import { unwire, wire } from './_fixtures/lynx-wire.js';
 
 interface Deferred<Value> {
 	readonly promise: Promise<Value>;
@@ -524,7 +525,7 @@ describe.sequential('Lynx Milestone 8 retained integration', () => {
 					},
 					addEventListener(type, listener) {
 						const wrapped = (event: { readonly data: unknown }) => {
-							const message = event.data as {
+							const message = unwire(event.data) as {
 								readonly type?: unknown;
 								readonly batch?: {
 									readonly commands?: readonly Record<string, unknown>[];
@@ -537,10 +538,12 @@ describe.sequential('Lynx Milestone 8 retained integration', () => {
 								Array.isArray(message.batch?.commands)
 							) {
 								rejectNextCommit = false;
+								// The rewritten message goes back on the wire encoded,
+								// because that is the only form the receiver reads now.
 								listener({
 									...event,
-									data: {
-										...(event.data as Record<string, unknown>),
+									data: wire({
+										...(message as Record<string, unknown>),
 										batch: {
 											...(message.batch as Record<string, unknown>),
 											commands: [
@@ -548,7 +551,7 @@ describe.sequential('Lynx Milestone 8 retained integration', () => {
 												{ op: 'update', id: 999_999, props: { id: 'invalid' } },
 											],
 										},
-									},
+									}),
 								});
 								return;
 							}

--- a/packages/lynx/tests/protocol.test.ts
+++ b/packages/lynx/tests/protocol.test.ts
@@ -51,6 +51,7 @@ import {
 	type LynxTransportCommitMessage,
 } from '../src/core/protocol.js';
 import { createLynxBackgroundTransport } from '../src/core/transport.js';
+import { unwire, wire } from './_fixtures/lynx-wire.js';
 
 class FakeContextProxy implements LynxContextProxy {
 	readonly events: LynxContextProxyEvent[] = [];
@@ -75,7 +76,7 @@ class FakeContextProxy implements LynxContextProxy {
 	}
 
 	sendToBackground(data: unknown): void {
-		this.dispatchEvent({ type: LYNX_MAIN_TO_BACKGROUND_EVENT, data });
+		this.dispatchEvent({ type: LYNX_MAIN_TO_BACKGROUND_EVENT, data: wire(data) });
 	}
 }
 
@@ -242,7 +243,7 @@ function installMainHarness(
 	const generations = new Map<number, number>();
 	const types = new Map<number, string>();
 	context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-		const message = validateLynxBackgroundOutboundMessage(event.data);
+		const message = validateLynxBackgroundOutboundMessage(unwire(event.data));
 		if (message.type === 'main-ready-request') {
 			if (autoReady) {
 				context.sendToBackground({
@@ -785,7 +786,7 @@ describe('@octanejs/lynx transported protocol', () => {
 			const commits: LynxTransportCommitMessage[] = [];
 			const capabilitiesDuringAdoptionReady: boolean[] = [];
 			context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-				const message = validateLynxBackgroundOutboundMessage(event.data);
+				const message = validateLynxBackgroundOutboundMessage(unwire(event.data));
 				if (message.type === 'adoption-ready') {
 					capabilitiesDuringAdoptionReady.push(driver.capabilities?.templateProgramMount === true);
 					return;
@@ -1710,7 +1711,7 @@ describe('@octanejs/lynx transported protocol', () => {
 			context.events.some(
 				(event) =>
 					event.type === LYNX_BACKGROUND_TO_MAIN_EVENT &&
-					(event.data as { type?: unknown }).type === 'call-main',
+					(unwire(event.data) as { type?: unknown }).type === 'call-main',
 			),
 		).toBe(false);
 
@@ -1733,7 +1734,7 @@ describe('@octanejs/lynx transported protocol', () => {
 		main.acknowledge(mount, 'complete');
 		await mounted;
 		const callMessage = context.events
-			.map((event) => event.data)
+			.map((event) => unwire(event.data))
 			.find(
 				(message): message is ReturnType<typeof validateLynxBackgroundOutboundMessage> =>
 					(message as { type?: unknown }).type === 'call-main' &&
@@ -1765,7 +1766,7 @@ describe('@octanejs/lynx transported protocol', () => {
 		backgroundResult.saved = 'mutated';
 		expect(executed).toContainEqual(['app:save', 'record']);
 		const backgroundMessage = context.events
-			.map((event) => event.data)
+			.map((event) => unwire(event.data))
 			.find(
 				(message) =>
 					(message as { type?: unknown }).type === 'call-background-result' &&
@@ -1776,7 +1777,7 @@ describe('@octanejs/lynx transported protocol', () => {
 
 		const malformedResultCall = transport.callMain({ _wkltId: 'app:malformed-result' }, []);
 		const malformedResultMessage = context.events
-			.map((event) => event.data as { readonly type?: unknown; readonly call?: unknown })
+			.map((event) => unwire(event.data) as { readonly type?: unknown; readonly call?: unknown })
 			.find(
 				(message) =>
 					message.type === 'call-main' &&
@@ -1792,23 +1793,40 @@ describe('@octanejs/lynx transported protocol', () => {
 		await flushMicrotasks();
 		main.acknowledge(main.commits.at(-1)!, 'complete');
 		await updated;
+		// A function cannot reach the wire at all any more. The transport encodes
+		// before it dispatches, so a value JSON would drop is refused at the
+		// sender — the last place that still knows what it was — rather than
+		// arriving as a hostile payload for the receiver to walk.
+		expect(() =>
+			context.sendToBackground({
+				...identity(82, 1),
+				type: 'call-main-result',
+				call: malformedResultMessage.call,
+				value() {},
+			}),
+		).toThrow(/at \$\.value is a function/);
+
+		// What can still arrive is a payload that parses and then fails the
+		// schema, and that has to settle the pending call rather than hang it.
 		context.sendToBackground({
 			...identity(82, 1),
 			type: 'call-main-result',
 			call: malformedResultMessage.call,
-			value() {},
+			value: 'unreadable',
+			unexpected: true,
 		});
-		await expect(malformedResultCall.promise).rejects.toThrow(/non-serializable|clone-safe/);
+		await expect(malformedResultCall.promise).rejects.toThrow(/unknown field "unexpected"/);
 
 		context.sendToBackground({
 			...identity(82, 1),
 			type: 'call-background',
 			call: 20,
 			fn: { _jsFnId: 'app:malformed-call' },
-			args: [() => undefined],
+			args: [],
+			unexpected: true,
 		});
 		const malformedCallError = context.events
-			.map((event) => event.data as { readonly type?: unknown; readonly call?: unknown })
+			.map((event) => unwire(event.data) as { readonly type?: unknown; readonly call?: unknown })
 			.find((message) => message.type === 'call-background-error' && message.call === 20);
 		expect(malformedCallError).toMatchObject({ root: 82, version: 1 });
 
@@ -1866,7 +1884,7 @@ describe('@octanejs/lynx transported protocol', () => {
 
 		expect(executions).toEqual(['app:return', 'app:throw', 'app:pending']);
 		const settlements = context.events
-			.map((event) => event.data as { readonly type?: unknown; readonly call?: unknown })
+			.map((event) => unwire(event.data) as { readonly type?: unknown; readonly call?: unknown })
 			.filter(
 				(message) =>
 					message.type === 'call-background-result' || message.type === 'call-background-error',
@@ -1955,7 +1973,7 @@ describe('@octanejs/lynx transported protocol', () => {
 			context.events.some(
 				(event) =>
 					event.type === LYNX_BACKGROUND_TO_MAIN_EVENT &&
-					(event.data as { readonly type?: unknown }).type === 'terminal-dispose',
+					(unwire(event.data) as { readonly type?: unknown }).type === 'terminal-dispose',
 			),
 		).toBe(true);
 		const nextBatch: UniversalHostBatch = {
@@ -1990,7 +2008,7 @@ describe('@octanejs/lynx transported protocol', () => {
 
 		const terminalAttempts: UniversalTransportIdentity[] = [];
 		context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			const message = validateLynxBackgroundOutboundMessage(event.data);
+			const message = validateLynxBackgroundOutboundMessage(unwire(event.data));
 			if (message.type !== 'terminal-dispose') return;
 			terminalAttempts.push(commitIdentity(mount));
 			void Promise.resolve().then(() => {
@@ -2071,7 +2089,7 @@ describe('@octanejs/lynx transported protocol', () => {
 				context.events.filter(
 					(event) =>
 						event.type === LYNX_BACKGROUND_TO_MAIN_EVENT &&
-						(event.data as { readonly type?: unknown }).type === 'terminal-dispose',
+						(unwire(event.data) as { readonly type?: unknown }).type === 'terminal-dispose',
 				),
 			).toHaveLength(0);
 
@@ -2082,7 +2100,7 @@ describe('@octanejs/lynx transported protocol', () => {
 				context.events.filter(
 					(event) =>
 						event.type === LYNX_BACKGROUND_TO_MAIN_EVENT &&
-						(event.data as { readonly type?: unknown }).type === 'terminal-dispose',
+						(unwire(event.data) as { readonly type?: unknown }).type === 'terminal-dispose',
 				),
 			).toHaveLength(1);
 			context.sendToBackground({ ...commitIdentity(mount), type: 'dispose-ack' });
@@ -2142,7 +2160,10 @@ describe('@octanejs/lynx transported protocol', () => {
 		expect(transport.closedReason()).toBe(failure);
 		expect(container.getPublicHandle(1)).toBeNull();
 		expect(
-			context.events.map((event) => [event.type, (event.data as { readonly type?: unknown }).type]),
+			context.events.map((event) => [
+				event.type,
+				(unwire(event.data) as { readonly type?: unknown }).type,
+			]),
 		).toContainEqual([LYNX_BACKGROUND_TO_MAIN_EVENT, 'terminal-dispose']);
 	});
 
@@ -2167,7 +2188,7 @@ describe('@octanejs/lynx transported protocol', () => {
 		await transport.ready;
 		const readiness = context.events
 			.filter((event) => event.type === LYNX_BACKGROUND_TO_MAIN_EVENT)
-			.map((event) => event.data)
+			.map((event) => unwire(event.data))
 			.find((message): message is LynxMainReadyRequest =>
 				Boolean(
 					message !== null &&
@@ -2489,7 +2510,7 @@ describe('@octanejs/lynx transported protocol', () => {
 		};
 		queueAcceptedCall = () => queue('app:batch-accepted');
 		context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			const message = validateLynxBackgroundOutboundMessage(event.data);
+			const message = validateLynxBackgroundOutboundMessage(unwire(event.data));
 			if (message.type !== 'call-main') return;
 			delivered.push(message.call);
 			if (message.call === 1) queue('app:reentrant');
@@ -3585,7 +3606,7 @@ describe('@octanejs/lynx transported protocol', () => {
 		expect(directTransport.acceptedIdentity()).toMatchObject(directIdentity);
 		const outbound = directContext.events
 			.filter((entry) => entry.type === LYNX_BACKGROUND_TO_MAIN_EVENT)
-			.map((entry) => (entry.data as { type: string }).type);
+			.map((entry) => (unwire(entry.data) as { type: string }).type);
 		expect(outbound.filter((type) => type === 'commit')).toHaveLength(1);
 		expect(outbound.filter((type) => type === 'abort')).toHaveLength(1);
 
@@ -3600,7 +3621,7 @@ describe('@octanejs/lynx transported protocol', () => {
 		await expect(waitingApply).rejects.toThrow(/was aborted/);
 		const waitingOutbound = waitingContext.events
 			.filter((entry) => entry.type === LYNX_BACKGROUND_TO_MAIN_EVENT)
-			.map((entry) => (entry.data as { type: string }).type);
+			.map((entry) => (unwire(entry.data) as { type: string }).type);
 		expect(waitingOutbound).not.toContain('commit');
 		expect(waitingOutbound).not.toContain('abort');
 		waitingTransport.close();

--- a/packages/lynx/tests/runtime-compatibility.test.ts
+++ b/packages/lynx/tests/runtime-compatibility.test.ts
@@ -112,6 +112,10 @@ describe('Lynx runtime compatibility evidence', () => {
 				'src/core/profiling.ts',
 				'src/core/protocol.ts',
 				'src/core/renderer-id.ts',
+				// Issue #156 slice 1: the codec is in both graphs by design. Each
+				// thread encodes what it sends and decodes what it receives, so
+				// shared ownership of the encoding is the point rather than a leak.
+				'src/core/transport-codec.ts',
 				'src/core/transport.ts',
 				'src/core/worklets.ts',
 				'src/resource.ts',
@@ -138,6 +142,8 @@ describe('Lynx runtime compatibility evidence', () => {
 				'src/core/profiling.ts',
 				'src/core/protocol.ts',
 				'src/core/renderer-id.ts',
+				// Issue #156 slice 1: the other half of the shared codec above.
+				'src/core/transport-codec.ts',
 				'src/core/worklets.ts',
 				'src/main-renderer.ts',
 				'src/main-thread.ts',

--- a/packages/lynx/tests/thread-calls.test.ts
+++ b/packages/lynx/tests/thread-calls.test.ts
@@ -21,6 +21,7 @@ import {
 	type LynxMainThreadWorkletDescriptor,
 } from '../src/core/worklets.js';
 import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
+import { conformingContextProxy, unwire, wire } from './_fixtures/lynx-wire.js';
 
 let dom: JSDOM | null = null;
 let controller: LynxMainThreadController | null = null;
@@ -99,14 +100,14 @@ function dispatchCommit(
 ): void {
 	context.dispatchEvent({
 		type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-		data: {
+		data: wire({
 			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 			renderer: LYNX_TRANSPORT_RENDERER,
 			root,
 			version,
 			type: 'commit',
 			batch: { renderer: LYNX_TRANSPORT_RENDERER, version, commands },
-		},
+		}),
 	});
 }
 
@@ -207,9 +208,9 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				.filter(
 					(event) =>
 						event.type === LYNX_BACKGROUND_TO_MAIN_EVENT &&
-						(event.data as { type?: unknown }).type === 'main-call-publication',
+						(unwire(event.data) as { type?: unknown }).type === 'main-call-publication',
 				)
-				.map((event) => (event.data as { phase: unknown }).phase);
+				.map((event) => (unwire(event.data) as { phase: unknown }).phase);
 		expect(publicationPhases()).toEqual(['open', 'close', 'open', 'close']);
 
 		// The second publication purged the now-unowned cell. A steady-state call
@@ -254,14 +255,14 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const publish = (root: number, version: number, phase: 'open' | 'close'): void => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
 					root,
 					version,
 					type: 'main-call-publication',
 					phase,
-				},
+				}),
 			});
 		};
 
@@ -306,7 +307,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const context = install();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		const ref = createLynxMainThreadRefDescriptor('test:realm-stable-state', 0);
 		const retain = registerMainThreadWorklet('octane:retain-main-thread-ref-owner', {
@@ -324,7 +325,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const call = (root: number, id: number, worklet: LynxMainThreadWorkletDescriptor): void => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
 					root,
@@ -333,7 +334,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 					call: id,
 					worklet,
 					args: [],
-				},
+				}),
 			});
 		};
 		const mount = (root: number): void => {
@@ -356,13 +357,13 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 110,
 				version: 1,
 				type: 'terminal-dispose',
-			},
+			}),
 		});
 		mount(111);
 		call(111, 1, retain);
@@ -380,7 +381,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const context = install();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 
 		const queuedFn = { _jsFnId: 'app:load', _c: { label: 'before' } };
@@ -409,18 +410,18 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		dispatchCommit(context, 101, 2, [{ op: 'update', id: 1, props: { id: 'new' } }]);
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 999,
 				version: 1,
 				type: 'dispose',
-			},
+			}),
 		});
 		const result = { status: 'loaded' };
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: call.protocol,
 				renderer: call.renderer,
 				root: call.root,
@@ -428,7 +429,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				type: 'call-background-result',
 				call: call.call,
 				value: result,
-			},
+			}),
 		});
 		result.status = 'mutated';
 		const resolved = await queued.promise;
@@ -463,14 +464,14 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		let acknowledgementCall: ReturnType<LynxMainThreadController['callBackground']> | null = null;
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			const message = event.data as LynxBackgroundInboundMessage;
+			const message = unwire(event.data) as LynxBackgroundInboundMessage;
 			inbound.push(message);
 			if (message.type !== 'ack' || message.root !== 106 || message.version !== 2) return;
 			// ACK delivery can synchronously publish layout effects. A call created
 			// here must observe the terminal fault before it executes or queues.
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
 					root: 106,
@@ -479,7 +480,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 					call: 2,
 					worklet: { _wkltId: 'app:ack-reentrant' },
 					args: [],
-				},
+				}),
 			});
 			acknowledgementCall = controller!.callBackground({ _jsFnId: 'app:after-fault' }, []);
 		});
@@ -494,7 +495,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		);
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 106,
@@ -503,7 +504,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				call: 1,
 				worklet: { _wkltId: 'app:pending-at-fault' },
 				args: [],
-			},
+			}),
 		});
 
 		failSetId = true;
@@ -522,7 +523,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		});
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 106,
@@ -531,7 +532,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				call: 2,
 				worklet: { _wkltId: 'app:ack-reentrant' },
 				args: [],
-			},
+			}),
 		});
 		expect(
 			inbound.filter((message) => message.type === 'call-main-error' && message.call === 2),
@@ -539,7 +540,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 106,
@@ -548,7 +549,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				call: 3,
 				worklet: { _wkltId: 'app:late-after-fault' },
 				args: [],
-			},
+			}),
 		});
 		const lateBackground = controller!.callBackground({ _jsFnId: 'app:late-after-fault' }, []);
 		await expect(lateBackground.promise).rejects.toThrow('Octane Lynx main-thread root is faulted');
@@ -578,7 +579,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const context = install();
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		dispatchCommit(context, 105, 1, [
 			{ op: 'create', id: 1, type: 'view', props: {} },
@@ -591,9 +592,12 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				message.type === 'call-background' && message.fn._jsFnId === 'app:malformed-result',
 		)!;
 		dispatchCommit(context, 105, 2, [{ op: 'update', id: 1, props: { id: 'newer' } }]);
-		context.dispatchEvent({
-			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+		// A function cannot reach the wire at all any more. The transport encodes
+		// before it dispatches, so a value JSON would drop is refused at the
+		// sender — the last place that still knows what it was — rather than
+		// arriving as a hostile payload for the receiver to walk.
+		expect(() =>
+			wire({
 				protocol: call.protocol,
 				renderer: call.renderer,
 				root: call.root,
@@ -601,13 +605,30 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				type: 'call-background-result',
 				call: call.call,
 				value() {},
-			},
+			}),
+		).toThrow(/at \$\.value is a function/);
+
+		// What can still arrive is a payload that parses and then fails the
+		// schema, and the contract this test exists for is about that: an
+		// exact-identity call has to be settled rather than left hanging.
+		context.dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: wire({
+				protocol: call.protocol,
+				renderer: call.renderer,
+				root: call.root,
+				version: call.version,
+				type: 'call-background-result',
+				call: call.call,
+				value: 'unreadable',
+				unexpected: true,
+			}),
 		});
-		await expect(pending.promise).rejects.toThrow(/non-serializable|clone-safe/);
+		await expect(pending.promise).rejects.toThrow(/unknown field "unexpected"/);
 
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 105,
@@ -615,8 +636,9 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				type: 'call-main',
 				call: 8,
 				worklet: { _wkltId: 'app:malformed-call' },
-				args: [() => undefined],
-			},
+				args: [],
+				unexpected: true,
+			}),
 		});
 		expect(
 			inbound.find((message) => message.type === 'call-main-error' && message.call === 8),
@@ -630,7 +652,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		dispatchCommit(context, 102, 1, [
 			{ op: 'create', id: 1, type: 'view', props: {} },
@@ -643,7 +665,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		] as const) {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
 					root: 102,
@@ -652,7 +674,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 					call,
 					worklet: { _wkltId: id },
 					args: ['input'],
-				},
+				}),
 			});
 		}
 		await flushMicrotasks();
@@ -690,7 +712,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		]);
 		secondContext.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 103,
@@ -699,18 +721,18 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 				call: 9,
 				worklet: { _wkltId: 'app:slow' },
 				args: [],
-			},
+			}),
 		});
 		secondContext.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 103,
 				version: 1,
 				type: 'cancel-main',
 				call: 9,
-			},
+			}),
 		});
 		release('late');
 		await flushMicrotasks();
@@ -727,7 +749,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		});
 		const inbound: LynxBackgroundInboundMessage[] = [];
 		context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
-			inbound.push(event.data as LynxBackgroundInboundMessage);
+			inbound.push(unwire(event.data) as LynxBackgroundInboundMessage);
 		});
 		dispatchCommit(context, 104, 1, [
 			{ op: 'create', id: 1, type: 'view', props: {} },
@@ -737,7 +759,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		const call = (id: number, worklet: string): void => {
 			context.dispatchEvent({
 				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-				data: {
+				data: wire({
 					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
 					root: 104,
@@ -746,7 +768,7 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 					call: id,
 					worklet: { _wkltId: worklet },
 					args: [],
-				},
+				}),
 			});
 		};
 
@@ -759,14 +781,14 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		call(3, 'app:pending');
 		context.dispatchEvent({
 			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
-			data: {
+			data: wire({
 				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 				renderer: LYNX_TRANSPORT_RENDERER,
 				root: 104,
 				version: 1,
 				type: 'cancel-main',
 				call: 3,
-			},
+			}),
 		});
 		call(3, 'app:pending');
 		await flushMicrotasks();
@@ -791,5 +813,93 @@ describe.sequential('Lynx bidirectional thread calls', () => {
 		expect(
 			controller!.diagnostics().filter((error) => /duplicate main-thread call/.test(error.message)),
 		).toHaveLength(3);
+	});
+
+	// #156 asks whether the worklet argument path is string-safe end to end. It
+	// is, and not by a separate arrangement: `runOnMainThread` reaches
+	// `transport.callMain`, `runOnBackground` reaches the controller's
+	// `callBackground`, and both funnel into the same `dispatch` as every other
+	// message — so the arguments, the results, and the cancellations all ride
+	// the four encoded send sites. The strict proxy is what proves it rather
+	// than asserts it: it refuses anything that is not this codec's output, in
+	// either direction, for the whole scenario.
+	it('carries worklet call arguments and results as encoded strings in both directions', async () => {
+		dom = new JSDOM('<!doctype html><html><body></body></html>');
+		installLynxTestingEnv(globalThis, {
+			window: dom.window as unknown as Window & typeof globalThis,
+		});
+		const strict = conformingContextProxy(new AsyncFifoContextProxy());
+		globalThis.lynxTestingEnv.switchToMainThread();
+		controller = installLynxMainThread({ context: strict.context });
+		globalThis.lynxTestingEnv.switchToBackgroundThread();
+
+		const container = createLynxClientContainer();
+		const transport = createLynxBackgroundTransport(strict.context, container);
+		await transport.ready;
+		const echo = registerMainThreadWorklet('test:echo-call-argument', {}, function (...args) {
+			return { seen: (args[0] as { readonly label: string }).label };
+		});
+		const root = 156;
+		const identity = (version: number) => ({
+			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+			renderer: LYNX_TRANSPORT_RENDERER,
+			root,
+			version,
+		});
+
+		// Background to main. The argument is mutated the moment the call is
+		// made, so a wire that passed the live object would report the later
+		// value; what the worklet sees is what was sent.
+		const outbound = { label: 'sent' };
+		let call: ReturnType<typeof transport.callMain> | null = null;
+		await transport
+			.prepareBatch(
+				container,
+				{
+					renderer: LYNX_TRANSPORT_RENDERER,
+					version: 1,
+					commands: [
+						{ op: 'create', id: 1, type: 'view', props: { id: 'worklet-args' } },
+						{ op: 'insert', parent: null, id: 1, before: null },
+					] as UniversalHostCommand[],
+				} as UniversalHostBatch,
+				identity(1),
+			)
+			.apply(() => {
+				call = transport.callMain(echo, [outbound]);
+				outbound.label = 'mutated';
+			});
+		expect(await call!.promise).toEqual({ seen: 'sent' });
+
+		// Main to background, which is the direction #156 asked to be confirmed
+		// separately: it leaves through `main-thread.ts`, the fourth send site.
+		const inbound: unknown[] = [];
+		strict.context.addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(unwire(event.data));
+		});
+		const backgroundCall = controller!.callBackground({ _jsFnId: 'app:receive' }, [
+			{ label: 'from-main' },
+		]);
+		// This scenario installs no background function registry, so the call is
+		// refused on arrival. That it is refused *there* is the point: the
+		// message reached the background thread as a string and was decoded and
+		// dispatched before anything about the target was known.
+		await expect(backgroundCall.promise).rejects.toThrow(/no background function registry/);
+		expect(
+			inbound.filter(
+				(message) => (message as { readonly type?: unknown }).type === 'call-background',
+			),
+		).toEqual([
+			expect.objectContaining({
+				fn: { _jsFnId: 'app:receive' },
+				args: [{ label: 'from-main' }],
+			}),
+		]);
+
+		// The positive control, and the byte count the PR reports: nothing above
+		// can pass by never reaching the wire.
+		expect(strict.conformance.crossings.length).toBeGreaterThan(0);
+		expect(strict.conformance.bytes()).toBeGreaterThan(0);
+		await transport.dispose();
 	});
 });

--- a/packages/lynx/tests/transport-codec.test.ts
+++ b/packages/lynx/tests/transport-codec.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	decodeLynxTransportValue,
+	encodeLynxTransportValue,
+	localizeLynxHostValue,
+} from '../src/core/transport-codec.js';
+
+const NUL = '\u0000';
+
+/** Encode and decode, which is the only thing the rest of Octane may do. */
+function roundTrip(value: unknown): unknown {
+	return decodeLynxTransportValue(encodeLynxTransportValue(value));
+}
+
+describe('Lynx transport codec', () => {
+	// The receiver's whole reason for existing is that what it gets back is
+	// ordinary local data. Everything else in this file is a way that could stop
+	// being true.
+	it('returns ordinary receiver-local data for an ordinary payload', () => {
+		const message = {
+			protocol: 1,
+			renderer: 'lynx',
+			type: 'commit',
+			batch: { commands: [{ op: 'create', id: 4, props: { class: 'row', hidden: false } }] },
+			empty: {},
+			list: [1, 'two', true, null, [3, { four: 4 }]],
+		};
+		const decoded = roundTrip(message);
+		expect(decoded).toEqual(message);
+		expect(Object.getPrototypeOf(decoded)).toBe(Object.prototype);
+		expect(Object.getPrototypeOf((decoded as { batch: object }).batch)).toBe(Object.prototype);
+		// The decoded value is a distinct tree, not the one that was handed in:
+		// a codec that returned its input would pass every equality assertion
+		// here and still hand the receiver a bridged value on device.
+		expect(decoded).not.toBe(message);
+	});
+
+	// A worklet closure capture holds `undefined` before its first assignment.
+	// Plain `JSON.stringify` drops the key, so the receiver sees an absent
+	// property where the sender had a present one holding `undefined` — which is
+	// a different program, silently.
+	it('carries undefined as a present key rather than dropping it', () => {
+		const decoded = roundTrip({ _c: { initialValue: undefined }, after: 1 }) as {
+			_c: Record<string, unknown>;
+			after: number;
+		};
+		expect('initialValue' in decoded._c).toBe(true);
+		expect(decoded._c.initialValue).toBe(undefined);
+		expect(decoded.after).toBe(1);
+		expect(Object.keys(decoded._c)).toEqual(['initialValue']);
+		expect(roundTrip([undefined, 1])).toEqual([undefined, 1]);
+		expect((roundTrip([undefined, 1]) as unknown[]).length).toBe(2);
+	});
+
+	// The sentinel is a string, so a payload may contain it by coincidence. If
+	// escaping is wrong in either direction a user string turns into `undefined`
+	// or vice versa, which is the classic in-band signalling defect.
+	it('round-trips a payload that spells the sentinel itself', () => {
+		for (const spelling of [
+			`${NUL}undefined`,
+			`${NUL}${NUL}undefined`,
+			`${NUL}`,
+			`${NUL}${NUL}`,
+			`${NUL}proto`,
+			`${NUL}anything`,
+			`undefined`,
+		]) {
+			expect(roundTrip(spelling)).toBe(spelling);
+			expect(roundTrip({ at: spelling })).toEqual({ at: spelling });
+			expect(roundTrip([[spelling]])).toEqual([[spelling]]);
+			expect(roundTrip({ deep: { deeper: [spelling, undefined] } })).toEqual({
+				deep: { deeper: [spelling, undefined] },
+			});
+		}
+	});
+
+	// The adversarial ordering for the escape family: a record carrying both the
+	// literal escaped-proto spelling as a key and a real __proto__ key. Restoring
+	// by renaming in place lets the first key's restoration land on the second's
+	// still-encoded snapshot entry, losing one key and double-restoring the
+	// other; the round-trip must instead keep both, each with its own value.
+	it('round-trips a record whose keys collide with the proto escape family', () => {
+		const source: Record<string, unknown> = {};
+		source[`${NUL}proto`] = 'family';
+		Object.defineProperty(source, '__proto__', {
+			configurable: true,
+			enumerable: true,
+			value: 'realproto',
+			writable: true,
+		});
+		source[`${NUL}${NUL}proto`] = `${NUL}str`;
+		const decoded = roundTrip(source) as Record<string, unknown>;
+		expect(decoded[`${NUL}proto`]).toBe('family');
+		expect(Object.getOwnPropertyDescriptor(decoded, '__proto__')?.value).toBe('realproto');
+		expect(decoded[`${NUL}${NUL}proto`]).toBe(`${NUL}str`);
+		expect(Object.getPrototypeOf(decoded)).toBe(Object.prototype);
+		expect(Object.keys(decoded)).toHaveLength(3);
+	});
+
+	// `main-renderer.ts` deliberately keeps a spread `__proto__` as an own data
+	// property rather than a prototype write, so the wire has to preserve that
+	// decision rather than quietly making it again on the receiver's behalf.
+	it('restores a __proto__ key as an own data property and pollutes nothing', () => {
+		// A computed key, deliberately. `{ __proto__: v }` written out in source is
+		// a prototype write and produces no property at all, which is the very
+		// confusion this codec exists to keep off the wire — so the test must not
+		// fall into it while claiming to check it.
+		const decoded = roundTrip({ ['__proto__']: { polluted: true }, sibling: 1 }) as Record<
+			string,
+			unknown
+		>;
+		const descriptor = Object.getOwnPropertyDescriptor(decoded, '__proto__');
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.value).toEqual({ polluted: true });
+		expect(descriptor?.enumerable).toBe(true);
+		expect('get' in (descriptor as object)).toBe(false);
+		expect(Object.getPrototypeOf(decoded)).toBe(Object.prototype);
+		expect(decoded.sibling).toBe(1);
+		expect(({} as { polluted?: unknown }).polluted).toBe(undefined);
+		expect((Object.prototype as { polluted?: unknown }).polluted).toBe(undefined);
+	});
+
+	// The proto escape is itself a legal key, so it needs the same escape ladder
+	// the sentinel has, or a payload using it collides with the escape.
+	it('round-trips keys that collide with the proto escape', () => {
+		for (const key of [`${NUL}proto`, `${NUL}${NUL}proto`, `${NUL}${NUL}${NUL}proto`]) {
+			const decoded = roundTrip({ [key]: 'kept' }) as Record<string, unknown>;
+			expect(Object.keys(decoded)).toEqual([key]);
+			expect(decoded[key]).toBe('kept');
+			expect(Object.getOwnPropertyDescriptor(decoded, '__proto__')).toBe(undefined);
+		}
+	});
+
+	// JSON turns each of these into something else without saying so: a bigint
+	// throws with a message naming no path, and the rest are dropped or written
+	// as `null`. A loud refusal at the sender beats a quiet change at the
+	// receiver, because only the sender still knows what the value was.
+	it.each([
+		['a bigint', { at: { deep: 1n } }, /at \$\.at\.deep is a bigint/],
+		['NaN', { at: [Number.NaN] }, /at \$\.at\[0\] is NaN, which JSON would write as null/],
+		['Infinity', { at: Number.POSITIVE_INFINITY }, /at \$\.at is Infinity/],
+		['-Infinity', { at: Number.NEGATIVE_INFINITY }, /at \$\.at is -Infinity/],
+		['a function', { at: () => 1 }, /at \$\.at is a function/],
+		['a symbol', { at: Symbol('x') }, /at \$\.at is a symbol/],
+		// No own enumerable keys to walk, so each of these would sail through the
+		// escape pass and be rewritten by `JSON.stringify` alone.
+		['a Date', { at: new Date(0) }, /at \$\.at is a Date, which JSON would rewrite/],
+		['a Map', { at: new Map([['a', 1]]) }, /at \$\.at is a Map/],
+		['a Set', { at: new Set([1]) }, /at \$\.at is a Set/],
+		['a class instance', { at: new (class Widget {})() }, /at \$\.at is a Widget/],
+	])('refuses to encode %s, naming where it is', (_label, value, message) => {
+		expect(() => encodeLynxTransportValue(value)).toThrowError(message);
+	});
+
+	// The decoder is the last place that can notice a sender which was never
+	// routed through the encoder — and on device that unencoded value is exactly
+	// the bridged reference the receiver must not reflect on.
+	it('refuses anything that is not this codec output', () => {
+		expect(() => decodeLynxTransportValue({ type: 'commit' })).toThrowError(
+			/received object where the wire carries a string/,
+		);
+		expect(() => decodeLynxTransportValue(null)).toThrowError(/received null/);
+		expect(() => decodeLynxTransportValue(undefined)).toThrowError(/received undefined/);
+		expect(() => decodeLynxTransportValue('not json')).toThrowError(/is not JSON/);
+		expect(() => decodeLynxTransportValue('{"type":"commit"}')).toThrowError(/no codec envelope/);
+		expect(() => decodeLynxTransportValue('[0]')).toThrowError(/no codec envelope/);
+		expect(() => decodeLynxTransportValue('[2,{}]')).toThrowError(/unknown codec flags 2/);
+	});
+
+	// A generator rather than a list: escaping bugs live in the combinations —
+	// an escaped key holding an escaped string inside an array inside an escaped
+	// key — and those are exactly the cases nobody writes by hand.
+	it('round-trips every combination of the interesting values, nested', () => {
+		const leaves: unknown[] = [
+			undefined,
+			null,
+			0,
+			-1.5,
+			'',
+			'plain',
+			`${NUL}undefined`,
+			`${NUL}${NUL}undefined`,
+			`${NUL}proto`,
+			true,
+		];
+		const keys = ['plain', '__proto__', `${NUL}proto`, `${NUL}${NUL}proto`, `${NUL}undefined`];
+		const cases: unknown[] = [...leaves];
+		for (const key of keys) {
+			for (const leaf of leaves) {
+				cases.push({ [key]: leaf });
+				cases.push({ [key]: [leaf, { [key]: leaf }] });
+				cases.push([{ [key]: leaf }]);
+			}
+		}
+		expect(cases.length).toBe(160);
+		for (const value of cases) {
+			const decoded = roundTrip(value);
+			expect(decoded).toEqual(value);
+			// `toEqual` treats a missing key and a key holding `undefined` as the
+			// same thing, which is the exact distinction this codec exists to keep.
+			expect(describeShape(decoded)).toBe(describeShape(value));
+		}
+	});
+
+	// Whole-payload equality that, unlike `toEqual`, can see a dropped key and
+	// the difference between an own `__proto__` and a prototype write.
+	function describeShape(value: unknown): string {
+		if (value === undefined) return 'undefined';
+		if (value === null) return 'null';
+		if (typeof value !== 'object') return `${typeof value}:${JSON.stringify(value)}`;
+		if (Array.isArray(value)) return `[${value.map(describeShape).join(',')}]`;
+		const record = value as Record<string, unknown>;
+		const proto = Object.getPrototypeOf(record) === Object.prototype ? 'op' : 'other';
+		const own = Object.keys(record)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}=${describeShape(record[key])}`);
+		return `{${proto}|${own.join(',')}}`;
+	}
+
+	// JSON has no back-references, so a shared subtree is expanded once per
+	// reference. Nothing sends one today; development says so if that changes,
+	// because the growth is multiplicative rather than linear.
+	it('reports a payload that shares composites, in development', () => {
+		const shared = { a: 1 };
+		const diagnostics: Error[] = [];
+		encodeLynxTransportValue({ few: [shared, shared] }, (error) => void diagnostics.push(error));
+		expect(diagnostics).toEqual([]);
+
+		const many = Array.from({ length: 40 }, () => shared);
+		encodeLynxTransportValue({ many }, (error) => void diagnostics.push(error));
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]?.message).toMatch(/sharing 39 composite references/);
+		// It is a diagnostic, not a fault: the payload still encodes, expanded.
+		expect(roundTrip({ many })).toEqual({ many: Array.from({ length: 40 }, () => ({ a: 1 })) });
+	});
+
+	// The wire form is the contract between the two threads, and the acceptance
+	// this slice is measured against is that bytes are unchanged modulo the
+	// encoding. A clean payload is therefore exactly its own JSON, plus `[0,` and
+	// `]` — no reordering, no rewriting, no added fields.
+	it('writes a clean payload as its own JSON inside the envelope', () => {
+		const message = { batch: { commands: [{ op: 'create', id: 4, props: { class: 'row' } }] } };
+		expect(encodeLynxTransportValue(message)).toBe(`[0,${JSON.stringify(message)}]`);
+	});
+
+	// The flag is what lets decode be a single `JSON.parse` for the payloads that
+	// need nothing undone. Getting it wrong in the `0` direction delivers an
+	// escaped payload unrestored, so the receiver sees the sentinel as a string.
+	it('marks a payload that needed escaping', () => {
+		expect(JSON.parse(encodeLynxTransportValue({ a: undefined }))[0]).toBe(1);
+		expect(JSON.parse(encodeLynxTransportValue({ ['__proto__']: 1 }))[0]).toBe(1);
+		expect(JSON.parse(encodeLynxTransportValue({ a: `${NUL}x` }))[0]).toBe(1);
+		expect(JSON.parse(encodeLynxTransportValue({ [`${NUL}proto`]: 1 }))[0]).toBe(1);
+	});
+
+	// A value that entered from outside the transport has no encoded form to
+	// decode, so the codec is run in both directions on it. What has to come
+	// back is a tree the caller owns outright: the engine keeps whatever it kept,
+	// and nothing it still holds can reach the receiver afterwards.
+	// A cycle is the one input a sender can hand this codec that has no encoding
+	// at all. Plain `JSON.stringify` answers it with a named `TypeError`; a
+	// recursive walk that does not notice answers with a `RangeError` carrying no
+	// path, which is a worse diagnostic than the thing it replaced.
+	it('names a cyclic value rather than exhausting the stack', () => {
+		const direct: Record<string, unknown> = { name: 'root' };
+		direct.self = direct;
+		expect(() => encodeLynxTransportValue(direct)).toThrow(TypeError);
+		expect(() => encodeLynxTransportValue(direct)).toThrow(/at \$\.self(\.self)* nests deeper/);
+
+		// Reached through an array and at a distance, so the guard cannot be
+		// passing only for the shape that sits immediately under the root.
+		const parent: Record<string, unknown> = {};
+		const child: Record<string, unknown> = { parent };
+		parent.children = [child];
+		expect(() => encodeLynxTransportValue({ tree: parent })).toThrow(/nests deeper/);
+	});
+
+	it('carries a payload nested as deep as the wire allows', () => {
+		// One below the limit round-trips, so the guard is a ceiling on nesting
+		// rather than a cap that a legitimate payload could run into. Built
+		// iteratively: constructing it by recursion would prove nothing about the
+		// codec and would hit the stack first.
+		let deep: unknown = 'leaf';
+		for (let level = 0; level < 500; level++) deep = { level: deep };
+		const decoded = decodeLynxTransportValue(encodeLynxTransportValue(deep));
+		let walked = decoded;
+		for (let level = 0; level < 500; level++) walked = (walked as { level: unknown }).level;
+		expect(walked).toBe('leaf');
+	});
+
+	it('hands back a tree disjoint from the value that entered', () => {
+		const nested = { name: 'Ada' };
+		const entered = { profile: nested, tags: ['a'] };
+		const localized = localizeLynxHostValue(entered) as typeof entered;
+
+		expect(localized).toEqual({ profile: { name: 'Ada' }, tags: ['a'] });
+		expect(localized).not.toBe(entered);
+		expect(localized.profile).not.toBe(nested);
+		expect(localized.tags).not.toBe(entered.tags);
+
+		nested.name = 'mutated';
+		entered.tags.push('b');
+		expect(localized).toEqual({ profile: { name: 'Ada' }, tags: ['a'] });
+	});
+});

--- a/packages/lynx/tests/transport-conformance.test.ts
+++ b/packages/lynx/tests/transport-conformance.test.ts
@@ -1,0 +1,242 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installLynxTestingEnv, uninstallLynxTestingEnv } from '@lynx-js/testing-environment';
+import { JSDOM } from 'jsdom';
+import {
+	defineUniversalComponent,
+	universalPlan,
+	universalProps,
+	universalValue,
+} from 'octane/universal/native';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createLynxRoot, type LynxRoot } from '../src/index.js';
+import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
+import type { LynxContextProxy, LynxContextProxyEvent } from '../src/core/protocol.js';
+import { conformingContextProxy, unwire } from './_fixtures/lynx-wire.js';
+
+const LYNX_SRC = fileURLToPath(new URL('../src', import.meta.url));
+
+/** Every `.ts` under `src`, so a new send site cannot hide in a new file. */
+function sourceFiles(directory: string): string[] {
+	const found: string[] = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) found.push(...sourceFiles(path));
+		else if (entry.name.endsWith('.ts')) found.push(path);
+	}
+	return found.sort();
+}
+
+/** The `{ … }` immediately after each `dispatchEvent(`, brace-matched. */
+function dispatchEventArguments(source: string): string[] {
+	const found: string[] = [];
+	const pattern = /\bdispatchEvent\(\s*\{/g;
+	for (let match = pattern.exec(source); match !== null; match = pattern.exec(source)) {
+		let depth = 0;
+		let index = source.indexOf('{', match.index);
+		const start = index;
+		while (index < source.length) {
+			const character = source[index];
+			if (character === '{') depth++;
+			else if (character === '}') {
+				depth--;
+				if (depth === 0) break;
+			}
+			index++;
+		}
+		found.push(source.slice(start, index + 1));
+	}
+	return found;
+}
+
+describe('Lynx transport conformance', () => {
+	// The static half. A runtime probe only proves what it executed, and the
+	// claim being made is about every path, so the send sites are counted and
+	// read directly. Adding a fifth one, or dropping the encode from an existing
+	// one, is what this notices.
+	it('encodes at every send site in the package, and there are exactly four', () => {
+		const sites: string[] = [];
+		for (const file of sourceFiles(LYNX_SRC)) {
+			const source = readFileSync(file, 'utf8');
+			for (const argument of dispatchEventArguments(source)) {
+				// Only the two transport channels; a host PAPI dispatch is not ours.
+				if (!/LYNX_(?:MAIN_TO_BACKGROUND|BACKGROUND_TO_MAIN)_EVENT/.test(argument)) continue;
+				sites.push(`${relative(LYNX_SRC, file)}: ${argument.replace(/\s+/g, ' ')}`);
+			}
+		}
+		expect(sites).toHaveLength(4);
+		for (const site of sites) {
+			expect(site).toMatch(/data:\s*encoded\b|data:\s*encodeLynxTransportValue\(/);
+		}
+	});
+
+	// The receiving half of the same claim. `event.data` is whatever the other
+	// side handed across — a peer thread's encoded string, or, at the engine
+	// lifecycle entries, a value nobody encoded at all. Either way it is the one
+	// expression in the package that may be a host-backed reference, so reading
+	// it anywhere except as the argument to a materializer is the defect.
+	it('reads event.data only through a materializer, at every receive site', () => {
+		const reads: string[] = [];
+		for (const file of sourceFiles(LYNX_SRC)) {
+			for (const line of readFileSync(file, 'utf8').split('\n')) {
+				// Prose about the boundary is not a read of it. Comment lines are
+				// dropped whole, which leaves a trailing comment on a code line
+				// scanned — the conservative direction for a rule like this.
+				const code = line.trimStart();
+				if (code.startsWith('//') || code.startsWith('*') || code.startsWith('/*')) continue;
+				const pattern = /\bevent\.data\b/g;
+				for (let match = pattern.exec(line); match !== null; match = pattern.exec(line)) {
+					reads.push(`${relative(LYNX_SRC, file)}: ${line.slice(0, match.index).trimEnd()}`);
+				}
+			}
+		}
+		expect(reads).toHaveLength(4);
+		for (const read of reads) {
+			expect(read).toMatch(/(?:decodeLynxTransportValue|localizeLynxHostValue)\($/);
+		}
+	});
+
+	// The dynamic half, under traffic the static half cannot see: what a real
+	// mount, update, and teardown actually put on the channel.
+	describe('under a strict wire', () => {
+		let root: LynxRoot | null = null;
+		let main: LynxMainThreadController | null = null;
+		let dom: JSDOM | null = null;
+
+		afterEach(async () => {
+			globalThis.lynxTestingEnv?.switchToBackgroundThread();
+			await root?.unmount().catch(() => {});
+			root = null;
+			globalThis.lynxTestingEnv?.switchToMainThread();
+			main?.close();
+			main = null;
+			globalThis.lynxTestingEnv?.clearGlobal();
+			uninstallLynxTestingEnv(globalThis);
+			dom?.window.close();
+			dom = null;
+		});
+
+		it('carries only decodable strings across a real mount, update, and teardown', async () => {
+			dom = new JSDOM('<!doctype html><html><body></body></html>');
+			installLynxTestingEnv(globalThis, {
+				window: dom.window as unknown as Window & typeof globalThis,
+			});
+			const env = globalThis.lynxTestingEnv;
+
+			env.switchToMainThread();
+			const mainWire = conformingContextProxy(
+				(
+					globalThis as unknown as { lynx: { getJSContext(): LynxContextProxy } }
+				).lynx.getJSContext(),
+			);
+			main = installLynxMainThread({ context: mainWire.context });
+
+			env.switchToBackgroundThread();
+			const backgroundWire = conformingContextProxy(
+				(
+					globalThis as unknown as { lynx: { getJSContext(): LynxContextProxy } }
+				).lynx.getJSContext(),
+			);
+			root = createLynxRoot({ context: backgroundWire.context });
+
+			const plan = universalPlan('lynx', { kind: 'host', type: 'view', propsSlot: 0 });
+			const Scene = defineUniversalComponent('lynx', (props: { readonly id: string }) =>
+				universalValue(plan, [universalProps([['set', 'id', props.id]])]),
+			);
+
+			await root.render(Scene, { id: 'mounted' });
+			await root.flushTransport();
+			expect(dom.window.document.querySelector('#mounted')).not.toBeNull();
+
+			await root.render(Scene, { id: 'updated' });
+			await root.flushTransport();
+			expect(dom.window.document.querySelector('#updated')).not.toBeNull();
+
+			await root.unmount();
+			root = null;
+
+			// The positive control. A wrapper that was never reached would satisfy
+			// every assertion above it, which is exactly how a conformance harness
+			// quietly stops proving anything.
+			expect(backgroundWire.conformance.crossings.length).toBeGreaterThan(0);
+			expect(mainWire.conformance.crossings.length).toBeGreaterThan(0);
+			// Both directions were exercised, not just the loud one.
+			expect(backgroundWire.conformance.bytes()).toBeGreaterThan(0);
+			expect(mainWire.conformance.bytes()).toBeGreaterThan(0);
+		});
+
+		// The engine lifecycle entry is the one inbound path whose sender is the
+		// native engine rather than Octane's own transport, so it is the one place
+		// a value arrives unencoded. What it produces still has to leave on the
+		// same strict wire as everything else, which is what this drives.
+		it('carries what the engine handed in out across the same strict wire', async () => {
+			dom = new JSDOM('<!doctype html><html><body></body></html>');
+			installLynxTestingEnv(globalThis, {
+				window: dom.window as unknown as Window & typeof globalThis,
+			});
+			const env = globalThis.lynxTestingEnv;
+
+			env.switchToMainThread();
+			const engineListeners = new Map<string, Set<(event: LynxContextProxyEvent) => void>>();
+			const engine: LynxContextProxy = {
+				dispatchEvent(event: LynxContextProxyEvent): unknown {
+					for (const listener of [...(engineListeners.get(event.type) ?? [])]) listener(event);
+					return undefined;
+				},
+				addEventListener(type: string, listener: (event: LynxContextProxyEvent) => void): void {
+					let entries = engineListeners.get(type);
+					if (entries === undefined) engineListeners.set(type, (entries = new Set()));
+					entries.add(listener);
+				},
+				removeEventListener(type: string, listener: (event: LynxContextProxyEvent) => void): void {
+					engineListeners.get(type)?.delete(listener);
+				},
+			};
+			const mainThreadLynx = (
+				globalThis as unknown as {
+					lynx: { getJSContext(): LynxContextProxy; getEngine?: () => LynxContextProxy };
+				}
+			).lynx;
+			// Read during install, so it has to be in place before the controller.
+			mainThreadLynx.getEngine = () => engine;
+			const mainWire = conformingContextProxy(mainThreadLynx.getJSContext());
+			main = installLynxMainThread({ context: mainWire.context });
+
+			env.switchToBackgroundThread();
+			const backgroundWire = conformingContextProxy(
+				(
+					globalThis as unknown as { lynx: { getJSContext(): LynxContextProxy } }
+				).lynx.getJSContext(),
+			);
+			root = createLynxRoot({ context: backgroundWire.context });
+
+			const plan = universalPlan('lynx', { kind: 'host', type: 'view', propsSlot: 0 });
+			const Scene = defineUniversalComponent('lynx', (props: { readonly id: string }) =>
+				universalValue(plan, [universalProps([['set', 'id', props.id]])]),
+			);
+			// Lifecycle records queue until the threads have correlated, so a real
+			// mount is what lets them reach the wire at all.
+			await root.render(Scene, { id: 'lifecycle-host' });
+			await root.flushTransport();
+
+			env.switchToMainThread();
+			engine.dispatchEvent({
+				type: '__RenderPage',
+				data: [{ profile: { name: 'Ada' } }, { initPage: true }],
+			});
+			engine.dispatchEvent({ type: '__UpdateGlobalProps', data: [{ theme: 'dark' }] });
+
+			const delivered = mainWire.conformance.crossings.map(
+				(payload) => unwire(payload) as { readonly type?: unknown },
+			);
+			expect(delivered.filter((message) => message.type === 'page-data')).toEqual([
+				expect.objectContaining({ operation: 'replace', data: { profile: { name: 'Ada' } } }),
+			]);
+			expect(delivered.filter((message) => message.type === 'global-props')).toEqual([
+				expect.objectContaining({ patch: { theme: 'dark' } }),
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

On device, a composite sent through Lynx `ContextProxy` can arrive in LepusNG as a host-backed `LEPUS_TAG_LEPUS_REF`. The iOS and Android reproduction archived in [Huxpro/octane#152](https://github.com/Huxpro/octane/issues/152) shows the important shape: property reads, spread, and `JSON.stringify` work, but `Reflect.ownKeys` throws, `Object(value) !== value`, and the prototype is `null`. Before this change, that live bridged composite could reach `record()` in `core/protocol.ts:472`; the first `Reflect.ownKeys` there could therefore terminate the renderer.

The apparent historical success was accidental. The receive path also used `Object.getOwnPropertyNames`, whose `ToObject` coercion happened to turn this engine value into something enumerable. That coercion became load-bearing, while the four non-coercing `Reflect.ownKeys` validators at `core/protocol.ts:472`, `:768`, `:797`, and `:1206` exposed the underlying boundary defect. Changing individual reflection calls would only move the crash.

This PR removes the whole failure class: every Octane transport send encodes a string, and every receiver decodes before its first payload read. The native-engine lifecycle entry is the one sender Octane cannot encode, so it is localized immediately on arrival. The resulting invariant is that a `LynxValueRef` never escapes the transport layer; protocol, lifecycle, and worklet code only see receiver-local `LynxStructuredValue` data.

The codec is the implementation from [Huxpro/octane#164](https://github.com/Huxpro/octane/pull/164). It round-trips `undefined`, non-finite numbers, and `__proto__`-class keys without silent semantic changes; rejects unsupported/cyclic values at the sender; and includes the original type in encoding diagnostics. This deliberately does not include `new-lynx` validation modes, programs, or adoption work.

### Before / after

- Before: an unencoded bridged composite could reach `protocol.ts:472`, where the device reproduction throws at `Reflect.ownKeys`.
- After: the strict-wire fixture rejects every non-string crossing and decodes every observed string. A real mount, update, teardown, and native-engine lifecycle delivery all round-trip through that fixture. Static conformance tests also pin exactly four encoded send sites and exactly four materializing `event.data` reads, so a future bypass cannot hide on an unexecuted path.

### `getOwnPropertyNames` site audit

- Former `main-thread.ts:248` (`lifecycleTuple`): removed. Engine-owned `event.data` is first passed to `localizeLynxHostValue`; the resulting JSON materialization is already a dense ordinary array, so the old descriptor walk would be redundant.
- `core/lifecycle-data.ts:109`: retained. On the engine path its input descends from the localized lifecycle tuple; on the background path it descends from a decoded lifecycle message. It never receives raw `event.data`.
- `core/protocol.ts:599`: retained. Receive paths decode before validation, while sender self-checks inspect local source-realm values before encoding.
- `core/worklets.ts:152`: retained. Transport-delivered worklet descriptors are decoded before worklet validation; compiler-created descriptors are already local values.

The four `Reflect.ownKeys` sites in `core/protocol.ts` are intentionally retained for strict schema validation. They now operate only after decode (or on sender-local self-check values), which removes the host-backed receiver object rather than weakening validation.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] targeted tests:
  - `pnpm exec vitest run --project lynx` — 27 files, 393 tests
  - ported/integration subset — 12 files, 180 tests
  - `node --test benchmarks/lynx-table/stages/*.test.mjs` — 15 tests
  - upstream CI test matrix, `vitest.ci-sharded.config.js` shards 1/4 through 4/4 with the CI excludes — 1,791 files, 21,032 tests passed, 1 skipped
  - `pnpm changeset:check`
  - `pnpm sync` (clean; no generated drift)

The CI shards were limited to four workers and used a same-filesystem temporary directory on this host. This avoids unrelated 5-second CLI timeouts, root `/tmp` exhaustion, and cross-device `rename` failures without changing the test set or assertions.

## Risk / follow-ups

Both realms ship in one bundle, so the internal text envelope does not require wire-version negotiation. The envelope adds a constant four bytes to a clean JSON payload; profiling now measures the exact encoded length and reports encode/decode time separately.

This is Deliverable 1 from [Huxpro/octane#232](https://github.com/Huxpro/octane/issues/232). Standard Lynx performance entries are intentionally a separate PR, and the ART reference-table diagnosis is intentionally an issue without a patch.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790509522&installation_model_id=432790&pr_number=885&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F885&signature=fcdbca50ffa1d79f7e310fb006ca2e64d358727f95b0b1545e2f7715692feb27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes every Lynx main/background message path and engine lifecycle materialization; regressions would affect rendering and page lifetime, though conformance tests and broad suite updates narrow that surface.
> 
> **Overview**
> **Lynx cross-thread traffic is now always a string on the wire**, so receiver code never sees host-backed `LEPUS_REF` composites that break `Reflect.ownKeys` on device.
> 
> A new **`transport-codec`** module owns the boundary: outbound messages are encoded (with escapes for `undefined` and `__proto__`, refusal of JSON-lossy types, and a `[flags, payload]` envelope); inbound paths decode before validation. **`transport.ts`**, **`main-thread.ts`**, and **`background-lifecycle.ts`** wire this in at every send/receive site. Native engine lifecycle tuples (`__RenderPage`, etc.) use **`localizeLynxHostValue`** because the engine cannot encode.
> 
> **Profiling and benchmarks** count exact encoded byte length and separate encode/decode time. Tests and fixtures use **`wire`/`unwire`**, plus static conformance checks that pin four encoded send sites and materializing reads of `event.data`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2465719eefaa5756ee1b42fb570d70769f5239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->