### PR TITLE
fix(bench): make Lynx startup measurable on Native

### DIFF
--- a/benchmarks/lynx-table/app/src/App.lynx.tsrx
+++ b/benchmarks/lynx-table/app/src/App.lynx.tsrx
@@ -27,20 +27,28 @@ function countRowRender(): void {
 }
 
 // -- storms: N sequential state→render→DOM ticks from one click --------------
-// Each tick runs in its own macrotask (MessageChannel avoids the nested
-// setTimeout 4ms clamp) so every mutation goes through a full render cycle
-// instead of batching. Mirrors the Vue and React apps.
+// Each tick runs in its own task so every mutation goes through a full render
+// cycle instead of batching. Lynx for Web provides MessageChannel; Native may
+// not, so it falls back to the runtime's timer task queue. Mirrors the Vue and
+// React apps.
 const STORM_UPDATE_TICKS = 50;
 const STORM_SELECT_TICKS = 30;
 
-const _stormChannel = new MessageChannel();
+const _stormChannel =
+	typeof MessageChannel === 'function' ? new MessageChannel() : null;
 let _stormPending: (() => void) | null = null;
-_stormChannel.port1.onmessage = () => {
-	const cb = _stormPending;
-	_stormPending = null;
-	if (cb) cb();
-};
+if (_stormChannel !== null) {
+	_stormChannel.port1.onmessage = () => {
+		const cb = _stormPending;
+		_stormPending = null;
+		if (cb) cb();
+	};
+}
 function nextMacrotask(cb: () => void) {
+	if (_stormChannel === null) {
+		setTimeout(cb, 0);
+		return;
+	}
 	_stormPending = cb;
 	_stormChannel.port2.postMessage(0);
 }
@@ -74,6 +82,33 @@ function Row(props: RowProps) @{
 export function App() @{
 	const [rows, setRows] = useState<RowData[]>(INITIAL_ROWS);
 	const [selected, setSelected] = useState<number | undefined>(undefined);
+	const rowsRef = useRef<RowData[]>(rows);
+	rowsRef.current = rows;
+	const selectedRef = useRef<number | undefined>(selected);
+	selectedRef.current = selected;
+	(globalThis as
+		typeof globalThis & {
+			__LYNX_BENCH_SNAPSHOT__?: () => {
+				readonly rowCount: number;
+				readonly firstId: number | null;
+				readonly secondId: number | null;
+				readonly thirdId: number | null;
+				readonly row998Id: number | null;
+				readonly firstLabel: string | null;
+				readonly selectedId: number | null;
+			};
+		}).__LYNX_BENCH_SNAPSHOT__ = () => {
+		const current = rowsRef.current;
+		return {
+			rowCount: current.length,
+			firstId: current[0]?.id ?? null,
+			secondId: current[1]?.id ?? null,
+			thirdId: current[2]?.id ?? null,
+			row998Id: current[998]?.id ?? null,
+			firstLabel: current[0]?.label ?? null,
+			selectedId: selectedRef.current ?? null,
+		};
+	};
 
 	const run = useCallback(() => {
 		setRows(buildData());

--- a/benchmarks/lynx-table/app/src/index.ts
+++ b/benchmarks/lynx-table/app/src/index.ts
@@ -3,4 +3,83 @@ import { root } from '@octanejs/lynx';
 import { App } from './App.lynx.tsrx';
 import './app.css';
 
-void root.render(App);
+interface BenchmarkSnapshot {
+	readonly rowCount: number;
+	readonly firstId: number | null;
+	readonly secondId: number | null;
+	readonly thirdId: number | null;
+	readonly row998Id: number | null;
+	readonly firstLabel: string | null;
+	readonly selectedId: number | null;
+}
+
+interface NativeStartupReceipt {
+	readonly protocol: 'lynx-native-startup-v1';
+	readonly moduleStartMs: number;
+	readonly commitAckMs: number;
+	readonly firstFrameMs: number;
+	readonly secondFrameMs: number;
+	readonly renderEvidence: {
+		readonly kind: 'native-animation-frame';
+		readonly frames: 2;
+	};
+	readonly transportEvidence: {
+		readonly kind: 'octane-root.render';
+		readonly acknowledged: true;
+		readonly ackMs: number;
+	};
+	readonly postState: BenchmarkSnapshot;
+}
+
+type BenchmarkGlobal = typeof globalThis & {
+	__LYNX_BENCH_ERROR__?: string;
+	__LYNX_BENCH_SNAPSHOT__?: () => BenchmarkSnapshot;
+	__LYNX_BENCH_STARTUP__?: NativeStartupReceipt;
+};
+
+const benchmarkGlobal = globalThis as BenchmarkGlobal;
+const moduleStartMs = Date.now();
+const rendering = root.render(App);
+
+// The generated main-thread entry returns synchronously. Only the background
+// root returns the transport acknowledgement promise used by the producer
+// receipt, so the engine receives one receipt from the successful live root.
+if (rendering !== null && typeof rendering === 'object' && 'then' in rendering) {
+	void rendering.then(
+		() => {
+			const commitAckMs = Date.now();
+			lynx.requestAnimationFrame(() => {
+				const firstFrameMs = Date.now();
+				lynx.requestAnimationFrame(() => {
+					const secondFrameMs = Date.now();
+					const postState = benchmarkGlobal.__LYNX_BENCH_SNAPSHOT__?.();
+					if (postState === undefined) {
+						benchmarkGlobal.__LYNX_BENCH_ERROR__ =
+							'Octane Native startup completed without a semantic snapshot.';
+						return;
+					}
+					const receipt: NativeStartupReceipt = {
+						protocol: 'lynx-native-startup-v1',
+						moduleStartMs,
+						commitAckMs,
+						firstFrameMs,
+						secondFrameMs,
+						renderEvidence: { kind: 'native-animation-frame', frames: 2 },
+						transportEvidence: {
+							kind: 'octane-root.render',
+							acknowledged: true,
+							ackMs: commitAckMs,
+						},
+						postState,
+					};
+					benchmarkGlobal.__LYNX_BENCH_STARTUP__ = receipt;
+					console.log('__NATIVE_BENCH_STARTUP__', JSON.stringify(receipt));
+				});
+			});
+		},
+		(error: unknown) => {
+			benchmarkGlobal.__LYNX_BENCH_ERROR__ =
+				error instanceof Error ? (error.stack ?? error.message) : String(error);
+		},
+	);
+}

--- a/benchmarks/lynx-table/stages/native-fixture.test.mjs
+++ b/benchmarks/lynx-table/stages/native-fixture.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const benchmarkRoot = path.resolve(import.meta.dirname, '..');
+const appRoot = path.join(benchmarkRoot, 'app/src');
+
+test('runs the real table workload when Native does not expose MessageChannel', () => {
+	const output = execFileSync(
+		process.execPath,
+		[
+			'--import=data:text/javascript,delete%20globalThis.MessageChannel',
+			path.join(benchmarkRoot, 'run.mjs'),
+			'1',
+		],
+		{
+			cwd: path.resolve(benchmarkRoot, '../..'),
+			encoding: 'utf8',
+			env: { ...process.env, LYNX_TABLE_SCALES: '1000' },
+		},
+	);
+
+	assert.match(output, /rows=\s*1000/);
+	assert.match(output, /updateStorm=50c\/5000/);
+	assert.match(output, /selectStorm=30c\/60/);
+});
+
+test('keeps the Native startup receipt behind render ACK, two frames, and semantic state', () => {
+	const entry = fs.readFileSync(path.join(appRoot, 'index.ts'), 'utf8');
+	const app = fs.readFileSync(path.join(appRoot, 'App.lynx.tsrx'), 'utf8');
+
+	assert.match(entry, /protocol: 'lynx-native-startup-v1'/);
+	assert.match(entry, /void rendering\.then\([\s\S]*commitAckMs = Date\.now\(\)/);
+	assert.match(
+		entry,
+		/lynx\.requestAnimationFrame\([\s\S]*lynx\.requestAnimationFrame\([\s\S]*__LYNX_BENCH_STARTUP__ = receipt/,
+	);
+	assert.match(entry, /kind: 'octane-root\.render'/);
+	assert.match(entry, /postState,/);
+	for (const [field, expression] of Object.entries({
+		rowCount: 'current.length',
+		firstId: 'current[0]?.id ?? null',
+		secondId: 'current[1]?.id ?? null',
+		thirdId: 'current[2]?.id ?? null',
+		row998Id: 'current[998]?.id ?? null',
+		firstLabel: 'current[0]?.label ?? null',
+		selectedId: 'selectedRef.current ?? null',
+	})) {
+		assert.ok(app.includes(`${field}: ${expression}`), `missing ${field} snapshot evidence`);
+	}
+});


### PR DESCRIPTION
## Reproduction

The Native acceptance run in Huxpro/octane#199 loaded a clean Octane table bundle in LynxExplorer with `enable_perf_metrics=true`. Lynx emitted exactly one standard `loadBundle` pipeline entry, including `openTime`, `lynxFcp`, `totalFcp`, and `pipelineEnd`, but both Octane runtimes then failed during module evaluation:

```text
ReferenceError: MessageChannel is not defined
```

The required `lynx-native-startup-v1` producer receipt never appeared, so the benchmark correctly kept the cell as DNF rather than publishing the platform entry as a successful first screen.

The unconditional constructor is in the benchmark fixture, not the renderer scheduler: `benchmarks/lynx-table/app/src/App.lynx.tsrx` created its storm `MessageChannel` at module scope. Current `packages/octane/src/runtime.ts` already has its own `setTimeout` fallback.

## Accident history

The benchmark methodology previously recorded that Octane's custom renderer did not expose the common pipeline boundary, and its checked-in adapter consequently suppresses `Performance.getAllPerformanceEntries` for the current Octane entry. The #199 device run corrected that premise: the engine already stamps the standard entry once per `loadBundle`, even when the application subsequently fails.

That makes a renderer-side timing hook the wrong fix. It would risk a duplicate entry and would still allow a failed application to look successful. Acceptance has to remain the conjunction of the engine entry and a versioned producer receipt proving transport acknowledgement, two Native frames, and semantic row state.

The conflict with the original D2 plan is recorded before this change in Huxpro/octane#232: https://github.com/Huxpro/octane/issues/232#issuecomment-5452159896

## Remove the failure class

- use `MessageChannel` when the runtime provides it and the timer task queue otherwise;
- publish `lynx-native-startup-v1` only from the background root's thenable `root.render()` result, after its real transport acknowledgement and two Native animation frames;
- include the exact semantic row snapshot expected by the benchmark consumer;
- never publish a receipt from the synchronous main-thread first-screen entry;
- gate both properties with a regression test that deletes `MessageChannel` before running the real 1k table workload, including both storms, and pins the receipt ordering/shape.

No timing marker is added to `packages/lynx`. The engine owns the `loadBundle` entry. The direct first-screen path, decline to background command path, and adoption continue to use their existing renderer behavior; this patch does not import or alter that program/adoption machinery. The receipt source has a single publication site on the live background root, and the existing first-screen suite continues to cover direct paint/adoption and the documented native-list decline path.

This branch is based directly on `octanejs/octane@main`; the transport codec commit from #885 is not an ancestor and no codec, validation-mode, program, or adoption implementation is included.

## Validation

- production Lynx/Web table app build passed;
- built Native bundle: 492,871 bytes, SHA-256 `5f7646aca90fab3a6be72ec756018676f59b13bcf1d7649bb6d782f167b1a015`;
- real table workload with `globalThis.MessageChannel` deleted: 1k and 10k passed, including 50 update-storm and 30 select-storm commits;
- new Native fixture regression: 2/2;
- focused Lynx first-screen/main-renderer/runtime-compatibility: 44/44;
- pre-existing Lynx table stage files: 5/5;
- full upstream CI Vitest configuration, same four shards and excludes: 1,789 files, 21,001 tests, 1 skipped;
- `pnpm typecheck`;
- `pnpm format:check`;
- `pnpm sync` with no tracked drift;
- `pnpm changeset:check`.

## Exact-device acceptance: blocked

The branch's exact 492,871-byte bundle was fetched and opened on leased Sandbox device `aic-i18n-bd-fullport.byteintl.net:55864`, but acceptance failed rather than remained pending:

- `Performance.getAllPerformanceEntries` returned zero entries for this bundle, an archived Octane control, **and** a known-good `vue-vdom` control. That Explorer install (`versionName=1.0`, `versionCode=1`, installed 2026-08-20) does not expose the engine pipeline entry that #199's earlier image did.
- the Vue control emitted a valid versioned receipt, proving the consumer and receipt probe work.
- this branch installed the semantic snapshot, returned a thenable from `root.render()`, and then waited indefinitely for its transport acknowledgement. D1+D2 without any readiness change reproduced the timeout.

Follow-up isolation on a second device corrected the initial attribution:

- the immutable archived `0fc84da0` bundle (SHA-256 `1f3b252d…`) ACKed, but its preserved benchmark patch includes both a production string wire and a repeating correlated ready-request; it is not a fixture-only/current-main commit-range control;
- a correctly dependency-isolated `0fc84da0` checkout with this exact D2 patch still returned a thenable and never ACKed;
- restoring the original App stopped before the entry module because Native has no `MessageChannel`, confirming this PR's fallback is necessary; retaining the fallback while deleting the semantic snapshot block still hung, so the snapshot is not the cause;
- D2 plus only a 16 ms readiness retry still timed out (493,138 bytes, SHA-256 `1a337ac9…`);
- D1 + D2 + the identical readiness retry succeeded (499,299 bytes, SHA-256 `3decf55d…`) and emitted a valid `lynx-native-startup-v1` receipt: module `1787924596401`, ACK `1787924596456`, frames `1787924596463` / `1787924596480`, and the exact rows-0 semantic state.

The successful overlay proves two independent transport prerequisites: D1's encoded string wire and a separate listener-installation/readiness retry. Neither is the requested standard pipeline entry, and `Performance.getAllPerformanceEntries` remained empty. This PR contains neither prerequisite and does not import program/adoption work.

The conflicts, dependency-isolation correction, and orthogonal controls are recorded chronologically in Huxpro/octane#232, including [the fixture-control correction](https://github.com/Huxpro/octane/issues/232#issuecomment-5453180655) and [the final readiness result](https://github.com/Huxpro/octane/issues/232#issuecomment-5453265970). This PR remains Draft: it does not satisfy the required engine-entry + transport-ACK + two-frame acceptance, and no private ACK metric or synthetic pipeline marker is substituted.

Related: Huxpro/octane#199, Huxpro/octane#232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Lynx table benchmark fixture and its tests; no production renderer or auth/data paths are modified.
> 
> **Overview**
> Fixes Lynx Native benchmark acceptance by removing the module-load **`MessageChannel`** crash and emitting the **`lynx-native-startup-v1`** producer receipt the harness expects.
> 
> **Storm scheduling** in `App.lynx.tsrx` now creates **`MessageChannel`** only when it exists; **`nextMacrotask`** falls back to **`setTimeout(0)`** so update/select storms still run one commit per tick on Native.
> 
> **Startup measurement** moves into `index.ts`: after the background **`root.render()`** promise resolves, the app waits two **`lynx.requestAnimationFrame`** callbacks, reads **`__LYNX_BENCH_SNAPSHOT__`** (new refs + snapshot hook on **`App`**), and sets **`__LYNX_BENCH_STARTUP__`** / logs **`__NATIVE_BENCH_STARTUP__`** with transport ack timing and semantic row fields. Render failures set **`__LYNX_BENCH_ERROR__`**.
> 
> **`native-fixture.test.mjs`** regresses the no-**`MessageChannel`** 1k table run (including storms) and pins receipt ordering/shape against the entry and snapshot source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7378d00477a09ed33db28f5578e5c6b674b83f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790513602&installation_model_id=432790&pr_number=886&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F886&signature=557aaaddf96b4244d63ff4b860e17840172597c5656e86478901bab01565628c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
