### PR TITLE
perf(compiler): cache TSRX renderer matching

### DIFF
--- a/.changeset/cache-tsrx-renderer-matching.md
+++ b/.changeset/cache-tsrx-renderer-matching.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Reuse normalized renderer configuration and compiled filename matchers across
+TSRX module classifications. Compiler integrations that retain normalized
+options no longer repeat renderer validation, signature serialization, brace
+expansion, and regular-expression construction for every source file.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -277,6 +277,7 @@ internally, get their own baseline and guard namespace.
 | `tsrx-component-graph` | tsrx-component-graph | none (Node-only) | 2,400-component live-import propagation with dependent-first vs dependency-first declarations |
 | `tsrx-jsx-return-branches` | tsrx-jsx-return-branches | none (Node-only) | client/server compile and bundler classification for 120/480 conditional-return components, with lowering/export controls and a same-sized ineligible parse/print control |
 | `tsrx-nesting-diagnostics` | tsrx-nesting-diagnostics | none (Node-only) | development TSRX compilation at 500 and 2,000 invalid HTML sites, with parsed diagnostic count/order controls and a per-diagnostic scaling guard |
+| `tsrx-renderer-selection` | tsrx-renderer-selection | none (Node-only) | ordered filename-to-renderer classification with semantic checksums, comparing retained normalized config against equivalent raw revalidation |
 | `tsrx-native-change-analysis` | tsrx-native-change-analysis | none (Node-only) | native-onChange analysis plus client/server compilation for 500/4,000 hostless JSX sites, paired with an AST-identical marker control that conservatively forces the scan |
 | `bundle-size` | bundle-size | none (builds) | shipped JS bytes: production builds of js-framework, TodoMVC, chat-stream, and weather-app, normalized minify, raw/gzip/brotli |
 | `bundle-reachability` | bundle-size | none (builds and executes in jsdom) | isolated public feature imports, exact production-bundle behavior, forbidden-module reachability, and committed raw/gzip/brotli budgets |

--- a/benchmarks/baselines/local/tsrx-renderer-selection.json
+++ b/benchmarks/baselines/local/tsrx-renderer-selection.json
@@ -1,0 +1,53 @@
+{
+  "suite": "tsrx-renderer-selection",
+  "iterations": 3,
+  "targets": [
+    {
+      "name": "raw-config",
+      "ops": {
+        "resolve": {
+          "score": 15.411208000000002,
+          "median": 15.411208000000002,
+          "min": 15.274124999999998,
+          "mean": 15.500291666666664,
+          "p95": 15.815541999999994,
+          "sd": 0.28148715196671337,
+          "rme": 4.511587922482647,
+          "scoreRme": 4.511587922482647,
+          "warmupRatio": 1,
+          "samples": 3
+        }
+      },
+      "meta": {
+        "callsPerSample": 512,
+        "cases": 16,
+        "checksum": 2178790725,
+        "correctness": "pass"
+      }
+    },
+    {
+      "name": "normalized-config",
+      "ops": {
+        "resolve": {
+          "score": 15.766833000000005,
+          "median": 15.766833000000005,
+          "min": 15.275834000000003,
+          "mean": 15.717722333333336,
+          "p95": 16.110500000000002,
+          "sd": 0.41949460792045096,
+          "rme": 6.630518471700335,
+          "scoreRme": 6.630518471700335,
+          "warmupRatio": 1,
+          "samples": 3
+        }
+      },
+      "meta": {
+        "callsPerSample": 512,
+        "cases": 16,
+        "checksum": 2178790725,
+        "correctness": "pass"
+      }
+    }
+  ],
+  "harnessExit": 0
+}

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -456,6 +456,14 @@
     "note": "Same-process development TSRX compilation with every emitted nesting validation parsed and checked. The original repeated serialization and whole-array scan measured 1.59x per invalid site at 2,000 versus 500 sites, while plan-local Set membership measured 1.07x. The 1.3x ceiling leaves timing headroom while catching the quadratic path."
   },
   {
+    "suite": "tsrx-renderer-selection",
+    "op": "resolve",
+    "target": "normalized-config",
+    "reference": "raw-config",
+    "maxRatio": 0.5,
+    "note": "Same-process filename classification across ordered renderer rules with exact matching checksums. The parent implementation redundantly normalized and compiled globs for retained normalized input, measuring 1.02x versus raw revalidation. Reusing validated config and compiled matchers measured below 0.1x; the 0.5 ceiling leaves more than 5x timing headroom while catching restoration of either repeated path."
+  },
+  {
     "suite": "tsrx-native-change-analysis",
     "op": "analysis",
     "target": "hostless-4000",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -886,6 +886,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Ordered filename-to-renderer classification with one retained normalized
+		// config versus equivalent raw revalidation in the same process.
+		name: 'tsrx-renderer-selection',
+		cwd: 'tsrx-renderer-selection',
+		servers: [],
+		iter: { normal: 9, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Native onChange analysis on hostless TSRX at two sizes, paired with an
 		// AST-identical large source whose ignored marker conservatively forces the scan.
 		name: 'tsrx-native-change-analysis',

--- a/benchmarks/tsrx-renderer-selection/README.md
+++ b/benchmarks/tsrx-renderer-selection/README.md
@@ -1,0 +1,23 @@
+# TSRX renderer selection
+
+Measure repeated filename-to-renderer classification through the public
+`octane/compiler/renderers` entry. The workload uses one realistic ordered
+configuration with early and late matches, exclusions, defaults, brace expansion,
+character classes, Windows separators, and bundler suffixes.
+
+The two targets perform the same classifications and must produce the same
+renderer-ID checksum:
+
+- `raw-config` passes mutable configuration and intentionally pays validation on
+  every resolution.
+- `normalized-config` reuses one validated configuration, matching compiler and
+  language-tool integrations that retain normalized options across many modules.
+
+```bash
+node benchmarks/bench.mjs --quick tsrx-renderer-selection
+node benchmarks/bench.mjs --quick --ratios tsrx-renderer-selection
+```
+
+A regression in the normalized target points at renderer configuration reuse or
+glob matcher retention. A checksum failure means the targets stopped doing the
+same semantic work, so the timing result is rejected.

--- a/benchmarks/tsrx-renderer-selection/run.mjs
+++ b/benchmarks/tsrx-renderer-selection/run.mjs
@@ -1,0 +1,165 @@
+import fs from 'node:fs';
+import {
+	normalizeRendererConfig,
+	resolveRendererForFile,
+} from '../../packages/octane/src/compiler/renderers.js';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const iterations = Number.parseInt(process.argv[2] ?? '9', 10);
+const repetitions = iterations <= 3 ? 32 : 96;
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('TSRX renderer-selection iterations must be a positive integer');
+}
+
+const rawConfig = {
+	registry: {
+		canvas: { module: '@octanejs/canvas/renderer', capabilities: ['pointer-events'] },
+		gpu: { module: '@octanejs/gpu/renderer', text: 'ignore' },
+		native: { module: '@octanejs/native/renderer', text: 'host' },
+		object: '@octanejs/object/renderer',
+		three: '@octanejs/three/renderer',
+	},
+	rules: [
+		{
+			include: 'src/scenes/**/*.{tsrx,tsx}',
+			exclude: ['**/*.native.tsrx', '**/*.object.tsrx'],
+			renderer: 'three',
+		},
+		{
+			include: ['packages/**/objects/*.[jt]srx', 'src/scenes/**/*.object.tsrx'],
+			renderer: 'object',
+		},
+		{
+			include: 'src/native/**/[A-Z]*.{tsrx,tsx}',
+			exclude: ['**/*.stories.*', '**/*.test.*'],
+			renderer: 'native',
+		},
+		{ include: 'packages/**/renderer?.{tsrx,tsx}', renderer: 'canvas' },
+		{ include: '**/*.shader.{tsrx,tsx}', renderer: 'gpu' },
+		{ include: '**/*.{mobile,native}.tsrx', renderer: 'native' },
+		{ include: '**/*.{model,object}.tsrx', renderer: 'object' },
+		{ include: '**/*.{scene,three}.tsrx', renderer: 'three' },
+	],
+};
+
+const cases = [
+	['/src/scenes/Hero.tsrx', 'three'],
+	['/src/scenes/Hero.object.tsrx', 'object'],
+	[String.raw`\src\scenes\Nested\Hero.tsx?worker`, 'three'],
+	['/src/native/View.tsrx#client', 'native'],
+	['/src/native/View.test.tsrx', 'dom'],
+	['/packages/editor/renderer1.tsx?raw', 'canvas'],
+	['/packages/editor/rendererA.tsrx#dev', 'canvas'],
+	['/src/effects/water.shader.tsrx', 'gpu'],
+	['/src/mobile/Shell.mobile.tsrx', 'native'],
+	['/src/models/Tree.model.tsrx', 'object'],
+	['/src/world/Level.scene.tsrx', 'three'],
+	['/src/App.tsrx', 'dom'],
+	['./src/scenes/../App.tsrx', 'dom'],
+	['#virtual/Scene.three.tsrx?import', 'three'],
+	['/src/scenes/Skip.native.tsrx', 'native'],
+	['/packages/view/objects/Widget.tsrx', 'object'],
+];
+
+function mixChecksum(checksum, id) {
+	for (let index = 0; index < id.length; index++) {
+		checksum = Math.imul(checksum ^ id.charCodeAt(index), 16_777_619);
+	}
+	return checksum >>> 0;
+}
+
+function expectedChecksum() {
+	let checksum = 2_166_136_261;
+	for (let repetition = 0; repetition < repetitions; repetition++) {
+		for (const [, expected] of cases) checksum = mixChecksum(checksum, expected);
+	}
+	return checksum;
+}
+
+const expected = expectedChecksum();
+
+function resolveWorkload(config) {
+	let checksum = 2_166_136_261;
+	for (let repetition = 0; repetition < repetitions; repetition++) {
+		for (const [filename] of cases) {
+			checksum = mixChecksum(checksum, resolveRendererForFile(config, filename).id);
+		}
+	}
+	return checksum;
+}
+
+function measure(config) {
+	const started = performance.now();
+	const checksum = resolveWorkload(config);
+	const elapsed = performance.now() - started;
+	if (checksum !== expected) {
+		throw new Error(`renderer checksum changed: expected ${expected}, received ${checksum}`);
+	}
+	return elapsed;
+}
+
+const rows = new Map([
+	['raw-config', []],
+	['normalized-config', []],
+]);
+let failure;
+
+try {
+	for (const [filename, expectedId] of cases) {
+		const actualId = resolveRendererForFile(rawConfig, filename).id;
+		if (actualId !== expectedId) {
+			throw new Error(`${filename} resolved to ${actualId}; expected ${expectedId}`);
+		}
+	}
+
+	const normalizedConfig = normalizeRendererConfig(rawConfig);
+	measure(rawConfig);
+	measure(normalizedConfig);
+
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		const order =
+			iteration % 2 === 0
+				? ['raw-config', 'normalized-config']
+				: ['normalized-config', 'raw-config'];
+		for (const name of order) {
+			rows.get(name).push(measure(name === 'raw-config' ? rawConfig : normalizedConfig));
+		}
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL tsrx-renderer-selection/${failure}`);
+}
+
+const targets = [...rows].map(([name, samples]) => ({
+	name,
+	ops: samples.length === 0 ? {} : { resolve: timingStatForJson(summarizeSamples(samples)) },
+	meta: {
+		callsPerSample: repetitions * cases.length,
+		cases: cases.length,
+		checksum: expected,
+		correctness: failure ? 'fail' : 'pass',
+	},
+}));
+
+if (!failure) {
+	for (const target of targets) {
+		console.log(
+			`PASS tsrx-renderer-selection/${target.name}: ${target.ops.resolve.score.toFixed(3)}ms ` +
+				`(${target.meta.callsPerSample} classifications, checksum ${target.meta.checksum})`,
+		);
+	}
+}
+
+const payload = {
+	suite: 'tsrx-renderer-selection',
+	iterations,
+	targets,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+
+if (failure) process.exitCode = 1;

--- a/docs/plans/2026-08-28-0755-perf-cache-tsrx-renderer-matching-plan.md
+++ b/docs/plans/2026-08-28-0755-perf-cache-tsrx-renderer-matching-plan.md
@@ -1,0 +1,221 @@
+---
+title: Cache TSRX Renderer Matching - Plan
+type: perf
+date: 2026-08-28
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Cache TSRX Renderer Matching - Plan
+
+## Goal Capsule
+
+- **Objective:** Octane compiler integrations classify many source modules faster while every file keeps the same renderer assignment and diagnostics.
+- **Means:** Reuse validated renderer configuration and precompiled filename matchers through weak sidecar metadata (KTD1, KTD2).
+- **Authority:** The user request and observable renderer-selection behavior outrank this plan; this plan outranks implementation convenience.
+- **Execution profile:** Measure first, make the smallest compiler-owned change, and preserve raw-config validation and browser compatibility.
+- **Stop conditions:** Do not ship this target if a same-environment baseline cannot show a repeatable improvement outside timing noise, if the parent implementation passes the new regression guard, or if renderer behavior changes. Remove abandoned code and return to TSRX performance target discovery instead.
+- **Tail ownership:** The autonomous shipping pipeline owns review, commit, PR creation, and current-head CI.
+
+---
+
+## Product Contract
+
+### Summary
+
+Cache renderer-selection work that is invariant across files so compiler integrations stop rebuilding frozen config data and glob regular expressions for every TSRX module.
+
+### Problem Frame
+
+`OctaneBundlerCompiler` normalizes renderer configuration once when an integration is constructed, but `resolveRendererForFile` normalizes that already frozen configuration again for each file classification. The same call also expands braces and recompiles glob expressions while walking the ordered rules. Builds therefore repeat validation, sorting, freezing, signature serialization, allocation, and regular-expression construction even though the renderer configuration has not changed.
+
+This path is separate from the recent compiler performance work on native-change analysis, conditional JSX return indexing, reachability propagation, component-hoist references, memo-witness propagation, nesting diagnostics, and generated-name allocation.
+
+### Requirements
+
+**Performance**
+
+- R1. Renderer selection for a configuration normalized by this module must reuse its validation result and compiled rule matchers across file classifications.
+- R2. A dedicated same-process benchmark must show the normalized reuse path is at least twice as fast as raw revalidation while both paths produce the same semantic checksum.
+- R3. The benchmark guard must fail on the parent implementation and pass on the optimized implementation under the same quick-run policy.
+
+**Compatibility**
+
+- R4. Raw, mutable, cloned, or foreign normalized-looking configuration must continue through ordinary validation so edits and invalid values are never hidden by the cache.
+- R5. Default selection, declaration-order precedence, exclusions, brace expansion, character classes, Windows separators, query suffixes, hash suffixes, renderer descriptors, and error timing must remain unchanged.
+- R6. Normalized renderer configuration must remain frozen, deterministic, serializable data with the same public keys and signature version.
+- R7. The dependency-free browser compiler subpath must remain free of Node-only imports and must compile successfully.
+
+**Delivery**
+
+- R8. The change must include an `octane` patch changeset, repository benchmark registration, targeted compiler tests, and current-head CI evidence.
+
+### Success Criteria
+
+- The dedicated quick benchmark reports identical semantic checksums for raw and normalized inputs and satisfies the R2 ratio on repeated same-process samples.
+- Existing compiler-throughput and renderer-selection tests remain green with deep-equal renderer descriptors and unchanged diagnostics.
+- The final diff contains no experiments from a rejected hypothesis and does not overlap the recent compiler performance PR surfaces listed in Sources & Research.
+
+### Scope Boundaries
+
+- Optimize only renderer configuration reuse and filename-rule matching in the TSRX compiler and its integrations.
+- Do not cache mutable raw configuration by object identity.
+- Do not change the renderer config schema, signature ABI, glob syntax, rule ordering, compiler output, runtime behavior, or bundler ownership policy.
+- Do not fold adjacent `vite.js` metadata membership scans or other compiler audit findings into this change.
+
+### Acceptance Examples
+
+- AE1. Covers R1, R4, R5. Given one module-owned normalized config and many filenames, resolving each filename uses the same public rules and returns the same descriptors as resolving equivalent raw config.
+- AE2. Covers R4, R5. Given a raw config that changes between calls, the next resolution observes the new rule or raises the new validation error instead of using stale metadata.
+- AE3. Covers R4, R6. Given a JSON-cloned normalized config, resolution revalidates it and produces the same signature and renderer assignment without relying on non-serializable public fields.
+- AE4. Covers R5. Given overlapping include and exclude patterns with brace expansion, the first non-excluded rule still wins for POSIX, Windows, query-suffixed, and hash-suffixed filenames.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Brand only module-owned normalized objects in a weak sidecar.** `resolveRendererForFile` may bypass normalization only for objects produced by the current module instance. Raw objects and normalized-looking objects from another module instance take the existing validation path, which protects R4 without exposing a public brand.
+- KTD2. **Keep compiled glob matchers in weak sidecar metadata.** Normalization continues to publish string patterns, frozen registry data, and the existing signature. Private regular expressions live beside the normalized object and share its lifetime, which protects R5-R7.
+- KTD3. **Compile matchers during eager pattern validation.** The normalization pass remains the point where malformed braces and character classes fail. It retains the compiled result instead of reconstructing it during every file match.
+- KTD4. **Use a same-run public-API ratio guard.** The benchmark compares repeated resolution with one normalized config against equivalent raw revalidation, verifies a shared semantic checksum, and records baseline and candidate results before setting the final guard within the R2 ceiling.
+
+### Assumptions
+
+- Bundler, Volar, TypeScript, Rspack, and Rsbuild integrations retain one normalized renderer config for at least one classification generation, as current constructors and option normalization show.
+- Weak sidecars match configuration lifetime and cannot retain configuration after its consumer releases it.
+- Renderer selection is measurable in isolation with enough rules and filenames to exceed timer noise without turning the benchmark into a synthetic behavior unlike integration use.
+- External research is not load-bearing because the repository owns the glob grammar, config ABI, compiler integrations, and benchmark conventions.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Raw or foreign config] --> B[Validate and canonicalize]
+  B --> C[Frozen serializable config]
+  B --> D[Weak compiled-matcher sidecar]
+  C --> E[Resolve file]
+  D --> E
+  F[Module-owned normalized config] --> G{Weak brand present}
+  G -->|yes| E
+  G -->|no| B
+  E --> H[Ordered include and exclude match]
+  H --> I[Frozen renderer descriptor]
+```
+
+The public configuration remains data-only. The weak brand selects the fast path, and the weak matcher sidecar supplies only derived private state. Missing sidecar metadata always falls back to validation rather than guessing that an object is safe.
+
+### Sequencing
+
+Establish a parent-commit baseline and semantic checksum before changing compiler code. Implement the weak metadata path only after the benchmark proves it can detect the redundant work. Finish with integration, browser-bundle, and repository-wide verification.
+
+### System-Wide Impact
+
+The hot path is shared by bundler transforms, client-reference classification, CSS-module proof discovery, Volar compilation, TypeScript projects, and Rspack/Rsbuild option normalization. The optimization changes compiler CPU and allocation only. It must not change emitted programs, renderer ownership, server/client selection, runtime state, or published configuration data.
+
+### Risks & Dependencies
+
+- **False branding:** Treating structurally similar external data as trusted could hide mutations or invalid values. The brand therefore uses module-owned weak identity only.
+- **Missing matcher metadata:** A normalized object may cross a serialization or module-copy boundary. The resolver must revalidate when private metadata is absent.
+- **Benchmark overfitting:** A benchmark with only non-matching rules could reward a path unlike real projects. The corpus must include early matches, late matches, exclusions, defaults, and varied filename suffixes, with one semantic checksum across both inputs.
+- **Timing noise:** The harness must warm up both cases, interleave or balance sample order, and use enough classifications for the R2 ratio to remain stable in quick mode.
+- **Browser compatibility:** `renderers.js` is imported by browser consumers. The implementation may use standard weak collections and regular expressions but no Node APIs.
+
+### Sources & Research
+
+- `packages/octane/src/compiler/renderers.js` owns normalization, glob parsing, filename normalization, and renderer resolution.
+- `packages/octane/src/compiler/bundler.js` normalizes once in `OctaneBundlerCompiler` and resolves the retained config in several per-file paths.
+- `packages/octane/src/compiler/volar.js` also normalizes before resolving, proving the redundant normalized-input path is not bundler-only.
+- `packages/octane/tests/compiler/renderer-config.test.ts` defines config, glob, and descriptor behavior; `packages/octane/tests/compiler/browser-compiler-bundle.test.ts` protects the dependency-free browser entry.
+- `benchmarks/bench.mjs`, `benchmarks/baselines/ratios.json`, and `benchmarks/tsrx-nesting-diagnostics/` provide the benchmark registration, same-process sampling, semantic-control, baseline, and ratio-guard patterns.
+- Recent non-overlapping compiler performance PRs: [#883](https://github.com/octanejs/octane/pull/883), [#875](https://github.com/octanejs/octane/pull/875), [#872](https://github.com/octanejs/octane/pull/872), [#863](https://github.com/octanejs/octane/pull/863), [#859](https://github.com/octanejs/octane/pull/859), [#857](https://github.com/octanejs/octane/pull/857), and [#850](https://github.com/octanejs/octane/pull/850).
+
+---
+
+## Implementation Units
+
+### U1. Prove normalized renderer-selection waste
+
+- **Goal:** Add a deterministic benchmark that isolates repeated renderer selection and records a trustworthy parent baseline.
+- **Requirements:** R2, R3, R5.
+- **Dependencies:** None.
+- **Files:** `benchmarks/tsrx-renderer-selection/run.mjs`, `benchmarks/tsrx-renderer-selection/README.md`, `benchmarks/bench.mjs`, `benchmarks/README.md`, `benchmarks/baselines/local/tsrx-renderer-selection.json`, `benchmarks/baselines/ratios.json`, `packages/octane-mcp-server/src/index.js`, `packages/octane-mcp-server/README.md`.
+- **Approach:**
+  1. Exercise `normalizeRendererConfig` and `resolveRendererForFile` through the public compiler subpath with a realistic ordered rule set containing early matches, late matches, exclusions, defaults, brace expansions, and filename suffix normalization.
+  2. Measure repeated resolution of one normalized config against equivalent raw revalidation in the same process and compute one renderer-ID checksum for each target.
+  3. Capture the parent-commit result before production edits. Add the ratio guard only after the old path is shown to fail and repeated candidate samples fit within R2.
+  4. Register and document the suite through the same runner and MCP surfaces as the neighboring TSRX compiler benchmarks.
+- **Execution note:** Record the baseline before editing `renderers.js`. If the normalized path is not repeatably faster outside noise, remove this benchmark attempt and return to TSRX target discovery.
+- **Patterns to follow:** `benchmarks/tsrx-nesting-diagnostics/run.mjs`, `benchmarks/bench.mjs`, `benchmarks/baselines/ratios.json`, `packages/octane-mcp-server/src/index.js`.
+- **Test scenarios:**
+  - Resolve a balanced corpus with raw and normalized config; assert both targets produce the same deterministic renderer-ID checksum before timing is accepted.
+  - Run quick samples repeatedly; assert the parent implementation fails the planned normalized-to-raw ratio and the candidate stays below the R2 ceiling.
+  - Corrupt the corpus or expected classification count; assert the benchmark fails instead of reporting a performance result with a broken semantic control.
+- **Verification:** The suite is listed by the benchmark runner and MCP registry, writes a committed local baseline, reports passing semantic metadata, and catches the parent implementation through its ratio guard.
+
+### U2. Reuse validated config and compiled matchers
+
+- **Goal:** Remove per-file normalization and glob compilation for module-owned normalized config without weakening validation or changing renderer results.
+- **Requirements:** R1, R4-R7.
+- **Dependencies:** U1.
+- **Files:** `packages/octane/src/compiler/renderers.js`, `packages/octane/tests/compiler/renderer-config.test.ts`, `packages/octane/tests/compiler/browser-compiler-bundle.test.ts`.
+- **Approach:**
+  1. Attach a weak identity brand and weak compiled-rule metadata when normalization succeeds, while keeping the returned object frozen and data-only per KTD1-KTD3.
+  2. Let the resolver use the sidecar only for module-owned normalized objects. Send every other input through the current validation and canonicalization path.
+  3. Match precompiled regular expressions in existing declaration order and preserve the current include-then-exclude behavior and descriptor construction.
+  4. Keep malformed-pattern errors eager and keep the browser entry dependency-free.
+- **Execution note:** Implement against the established benchmark signal, then rerun the parent/candidate comparison before accepting cleanup or abstraction beyond the sidecar.
+- **Patterns to follow:** Existing frozen normalization in `packages/octane/src/compiler/renderers.js`; cache lifetime and invalidation guidance in `.agents/memories/core-engineering.md`; observation-boundary rules in `.agents/memories/testing.md`.
+- **Test scenarios:**
+  - Covers AE1. Resolve early, late, excluded, and default matches from one normalized config and compare the full descriptors with raw-config resolution.
+  - Covers AE2. Mutate a raw rule between resolutions and verify the next call observes it; replace it with a malformed pattern and verify eager validation still throws.
+  - Covers AE3. JSON-clone a normalized config and verify resolution revalidates the clone, preserves its signature, and returns the same renderer without public cache fields.
+  - Covers AE4. Resolve brace-expanded and character-class patterns for POSIX, Windows, query-suffixed, and hash-suffixed names; verify first-match precedence and exclusions remain unchanged.
+  - Bundle the browser compiler entry and verify no Node builtin or non-browser dependency becomes reachable.
+- **Verification:** Focused compiler tests pass, normalized config remains deeply frozen and serializable, raw mutation remains visible, invalid patterns fail at normalization, and renderer descriptors are unchanged.
+
+### U3. Validate the compiler integration and release surface
+
+- **Goal:** Demonstrate the optimization in representative compiler workflows and prepare the user-facing package change for release.
+- **Requirements:** R2, R3, R7, R8.
+- **Dependencies:** U1, U2.
+- **Files:** `.changeset/cache-tsrx-renderer-matching.md`, generated files produced by `pnpm sync` if any.
+- **Approach:**
+  1. Add an `octane` patch changeset that describes faster renderer selection without promising unsupported end-to-end build percentages.
+  2. Run the dedicated ratio suite, the existing compiler-throughput quick suite, focused renderer and bundler tests, browser-bundle coverage, scoped typecheck, formatting, and sync.
+  3. Run the full repository test and typecheck gates before push, then rely on current-head CI for the complete supported matrix.
+- **Patterns to follow:** Recent compiler performance changesets and the verification commands in the repository instructions.
+- **Test scenarios:**
+  - Classify the same renderer corpus through direct resolver and bundler-owned normalized config paths; verify the renderer sequence is identical.
+  - Run the existing quick compiler-throughput suite and verify every target retains its semantic pass marker and executable non-empty output.
+  - Run `pnpm sync` and verify generated inventories and benchmark registries are clean after regeneration.
+- **Verification:** The changeset describes the measured scope, targeted and full local gates pass, generated changes are committed, and the PR reaches green current-head CI.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Required outcome |
+| --- | --- | --- |
+| Renderer performance | `node benchmarks/bench.mjs --quick --ratios tsrx-renderer-selection` | Semantic checksums match; the normalized-to-raw ratio satisfies R2 and the parent control fails R3. |
+| Renderer behavior | `./node_modules/.bin/vitest run packages/octane/tests/compiler/renderer-config.test.ts packages/octane/tests/compiler/bundler-renderer-boundaries.test.ts packages/octane/tests/compiler/browser-compiler-bundle.test.ts --reporter=verbose` | Raw, normalized, cloned, glob, descriptor, bundler, and browser-entry scenarios pass. |
+| General compiler signal | `node benchmarks/bench.mjs --quick compiler-throughput` | All compiler targets report semantic success and non-empty executable output. |
+| Scoped static checks | `pnpm typecheck:files packages/octane/src/compiler/renderers.js packages/octane/tests/compiler/renderer-config.test.ts benchmarks/tsrx-renderer-selection` | Changed compiler, test, and benchmark sources typecheck. |
+| Scoped formatting | `pnpm format:files:check packages/octane/src/compiler/renderers.js packages/octane/tests/compiler/renderer-config.test.ts benchmarks/tsrx-renderer-selection benchmarks/bench.mjs benchmarks/README.md packages/octane-mcp-server/src/index.js packages/octane-mcp-server/README.md .changeset` | All changed authored files match repository formatting. |
+| Generated state | `pnpm sync` | Required generated artifacts are updated and the second run is clean. |
+| Repository gates | `pnpm test` and `pnpm typecheck` | Full local suites pass before push, or any environment-only failure is isolated with concrete evidence and CI remains authoritative. |
+| Diff hygiene | `git diff --check` | No whitespace errors or abandoned experiment remain. |
+
+---
+
+## Definition of Done
+
+- U1 is complete when the benchmark proves semantic parity, records a parent baseline, and the parent fails a stable ratio guard that the optimized path passes.
+- U2 is complete when module-owned normalized configs reuse weak sidecars, all untrusted inputs retain eager validation, and public renderer data and results stay unchanged.
+- U3 is complete when the patch changeset, benchmark registration, generated state, local verification, PR, and current-head CI are complete.
+- The final PR does not modify the recent performance areas named in Sources & Research.
+- The measured claim is limited to renderer selection and is supported by reproducible baseline and candidate evidence.
+- Any failed hypothesis code, benchmark variant, cache, helper, or test is removed before completion.

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -165,7 +165,7 @@ one manifest suite by name (`js-framework`, `todomvc`, `weather-app`,
 `application-composition`, `scaling-curves`, `dev-form-diagnostics`,
 `behavior-root-events`, `router-dispatch`, `floating-tree-navigation`, `manifest-cache-invalidation`, `vite-client-assets`, `activity`, `streaming-ssr`, `streaming-backpressure`,
 `compiler-throughput`, `tsrx-component-graph`, `codegen-size`, `hook-memo`,
-`template-call-memo`, `bundle-size`, `bundle-reachability`, `three-renderer`,
+`template-call-memo`, `tsrx-renderer-selection`, `bundle-size`, `bundle-reachability`, `three-renderer`,
 `three-bundle-size`, …)
 or every suite with `all`; `quick` selects the reduced-iteration smoke pass. The
 suite list mirrors the runner manifest and `node benchmarks/bench.mjs --list`.

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -109,6 +109,7 @@ export const BENCHMARK_SUITES = [
 	'tsrx-jsx-return-branches',
 	'text-type-roots',
 	'tsrx-nesting-diagnostics',
+	'tsrx-renderer-selection',
 	'tsrx-native-change-analysis',
 	'bundle-size',
 	'bundle-reachability',

--- a/packages/octane/src/compiler/renderers.js
+++ b/packages/octane/src/compiler/renderers.js
@@ -36,6 +36,7 @@ const VALIDATION_KEYS = new Set([
 ]);
 const HOST_NAME = /^[a-z][A-Za-z0-9_$-]*$/;
 const HOST_PROP_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$:.-]*\*?$/;
+const COMPILED_RULES_BY_CONFIG = new WeakMap();
 
 function configError(message) {
 	return new Error(`octane/compiler/renderers: ${message}`);
@@ -404,21 +405,34 @@ function normalizePattern(value, path) {
 		throw configError(`${path} must not traverse outside the project with "..".`);
 	}
 
-	// Parse now so malformed braces/classes fail during config loading rather
-	// than producing a bundler-specific answer later.
-	for (const expanded of expandBraces(pattern, path)) compileGlob(expanded, path);
-	return pattern;
+	// Compile now so malformed braces/classes fail during config loading rather
+	// than producing a bundler-specific answer later. The compiled expressions
+	// stay private because renderer config is serializable public data.
+	return {
+		pattern,
+		matchers: expandBraces(pattern, path).map((expanded) => compileGlob(expanded, path)),
+	};
 }
 
 function normalizePatternList(value, path, optional = false) {
-	if (value === undefined && optional) return [];
+	if (value === undefined && optional) return { patterns: [], matchers: [] };
 	const input = typeof value === 'string' ? [value] : value;
-	if (optional && Array.isArray(input) && input.length === 0) return [];
+	if (optional && Array.isArray(input) && input.length === 0) {
+		return { patterns: [], matchers: [] };
+	}
 	if (!Array.isArray(input) || input.length === 0) {
 		throw configError(`${path} must be a glob string or a non-empty array of glob strings.`);
 	}
-	const patterns = input.map((pattern, index) => normalizePattern(pattern, `${path}[${index}]`));
-	return [...new Set(patterns)].sort();
+	const matchersByPattern = new Map();
+	for (let index = 0; index < input.length; index++) {
+		const { pattern, matchers } = normalizePattern(input[index], `${path}[${index}]`);
+		matchersByPattern.set(pattern, matchers);
+	}
+	const patterns = [...matchersByPattern.keys()].sort();
+	return {
+		patterns,
+		matchers: patterns.flatMap((pattern) => matchersByPattern.get(pattern)),
+	};
 }
 
 function findClosingBrace(pattern, start, path) {
@@ -532,8 +546,11 @@ function normalizeFilename(filename) {
 	return segments.join('/');
 }
 
-function matchesPattern(filename, pattern, path) {
-	return expandBraces(pattern, path).some((expanded) => compileGlob(expanded, path).test(filename));
+function matchesAny(filename, matchers) {
+	for (const matcher of matchers) {
+		if (matcher.test(filename)) return true;
+	}
+	return false;
 }
 
 function stableSignature(value) {
@@ -603,6 +620,7 @@ export function normalizeRendererConfig(input = {}) {
 	if (!Array.isArray(rawRules)) {
 		throw configError('compiler.renderers.rules must be an array.');
 	}
+	const compiledRules = [];
 	const rules = rawRules.map((rawRule, index) => {
 		const path = `compiler.renderers.rules[${index}]`;
 		if (!isRecord(rawRule)) throw configError(`${path} must be an object.`);
@@ -613,10 +631,18 @@ export function normalizeRendererConfig(input = {}) {
 				`${path}.renderer references unknown renderer ${JSON.stringify(renderer)}.`,
 			);
 		}
+		const include = normalizePatternList(rawRule.include, `${path}.include`);
+		const exclude = normalizePatternList(rawRule.exclude, `${path}.exclude`, true);
+		compiledRules.push(
+			Object.freeze({
+				include: Object.freeze(include.matchers),
+				exclude: Object.freeze(exclude.matchers),
+			}),
+		);
 		return Object.freeze({
 			renderer,
-			include: Object.freeze(normalizePatternList(rawRule.include, `${path}.include`)),
-			exclude: Object.freeze(normalizePatternList(rawRule.exclude, `${path}.exclude`, true)),
+			include: Object.freeze(include.patterns),
+			exclude: Object.freeze(exclude.patterns),
 		});
 	});
 
@@ -663,13 +689,15 @@ export function normalizeRendererConfig(input = {}) {
 			),
 		),
 	});
-	return Object.freeze({
+	const normalized = Object.freeze({
 		default: defaultRenderer,
 		registry: Object.freeze(registry),
 		rules: Object.freeze(rules),
 		boundaries,
 		signature,
 	});
+	COMPILED_RULES_BY_CONFIG.set(normalized, Object.freeze(compiledRules));
+	return normalized;
 }
 
 /**
@@ -681,16 +709,20 @@ export function normalizeRendererConfig(input = {}) {
  * @param {string} filename Canonical module ID (for example `/src/App.tsrx`)
  */
 export function resolveRendererForFile(config, filename) {
-	const normalized = normalizeRendererConfig(config);
+	let normalized = config;
+	let compiledRules = COMPILED_RULES_BY_CONFIG.get(config);
+	if (compiledRules === undefined) {
+		normalized = normalizeRendererConfig(config);
+		compiledRules = COMPILED_RULES_BY_CONFIG.get(normalized);
+	}
 	const normalizedFilename = normalizeFilename(filename);
 	let id = normalized.default;
 
 	for (let index = 0; index < normalized.rules.length; index++) {
 		const rule = normalized.rules[index];
-		const path = `compiler.renderers.rules[${index}]`;
-		if (!rule.include.some((pattern) => matchesPattern(normalizedFilename, pattern, path)))
-			continue;
-		if (rule.exclude.some((pattern) => matchesPattern(normalizedFilename, pattern, path))) continue;
+		const matchers = compiledRules[index];
+		if (!matchesAny(normalizedFilename, matchers.include)) continue;
+		if (matchesAny(normalizedFilename, matchers.exclude)) continue;
 		id = rule.renderer;
 		break;
 	}

--- a/packages/octane/tests/compiler/renderer-config.test.ts
+++ b/packages/octane/tests/compiler/renderer-config.test.ts
@@ -276,6 +276,51 @@ describe('renderer configuration', () => {
 		expect(resolveRendererFromBundler(config, '/src/App.tsrx').id).toBe('dom');
 	});
 
+	it('preserves renderer selection across normalized, cloned, and mutable input', () => {
+		const config = {
+			registry: {
+				object: '@octanejs/object-renderer',
+				three: '@octanejs/three/renderer',
+			},
+			rules: [
+				{
+					include: 'src/scenes/**/*.{tsrx,tsx}',
+					exclude: '**/*.object.tsrx',
+					renderer: 'three',
+				},
+				{ include: '**/*.object.tsrx', renderer: 'object' },
+			],
+		};
+		const normalized = normalizeRendererConfig(config);
+		const cloned = JSON.parse(JSON.stringify(normalized));
+		const filenames = [
+			'/src/scenes/Hero.tsrx',
+			String.raw`\src\scenes\Hero.object.tsrx?raw`,
+			'/src/App.tsrx#client',
+		];
+
+		const expectedIds = ['three', 'object', 'dom'];
+		for (const input of [config, normalized, cloned]) {
+			expect(filenames.map((filename) => resolveRendererForFile(input, filename).id)).toEqual(
+				expectedIds,
+			);
+		}
+		expect(Object.keys(normalized)).toEqual([
+			'default',
+			'registry',
+			'rules',
+			'boundaries',
+			'signature',
+		]);
+
+		config.rules[0].renderer = 'object';
+		expect(resolveRendererForFile(config, '/src/scenes/Hero.tsrx').id).toBe('object');
+		config.rules[0].include = '**/*.{tsrx}';
+		expect(() => resolveRendererForFile(config, '/src/scenes/Hero.tsrx')).toThrow(
+			/braces must contain two or more/,
+		);
+	});
+
 	it('produces a stable cache signature without erasing semantic rule order', () => {
 		const first = normalizeRendererConfig({
 			registry: { three: '@octanejs/three/renderer', object: '/src/object-renderer.js' },


### PR DESCRIPTION
## Summary

TSRX compiler integrations now reuse validated renderer configuration and compiled glob matchers across file classifications. Raw, mutable, cloned, and foreign configuration still takes the validation path, while the public normalized configuration remains frozen and serializable.

| Renderer-selection target | Parent baseline | Current branch |
| --- | ---: | ---: |
| Raw configuration | 15.411 ms | 14.312 ms |
| Retained normalized configuration | 15.767 ms | 0.503 ms |
| Normalized / raw ratio | 1.02x | 0.04x |

The committed ratio guard requires the normalized path to remain at or below 0.5x of raw revalidation and verifies the same renderer-ID checksum for both targets.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 26,895 of 26,896 tests passed locally; one unrelated Volar case exceeded its 5s timeout under full parallel load, then passed alone in 1.5s
- [x] targeted tests:
  - renderer configuration, bundler boundaries, browser compiler bundle, and MCP benchmark registry: 4 files / 28 tests passed
  - `node benchmarks/bench.mjs --quick --ratios tsrx-renderer-selection`
  - `node benchmarks/bench.mjs --quick compiler-throughput`
  - `pnpm sync` (clean generated state)

## Risk / follow-ups

The cache trusts only normalized objects produced by the current module instance. Serialized or cross-module copies fall back to validation, so the optimization does not extend trust across identity boundaries. Current-head CI is the authoritative full-suite result for the local timeout noted above.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516215&installation_model_id=432790&pr_number=889&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F889&signature=d1671b9852d69f04648a1a029e1553e722ec53433e1b918f2b7e6f0dc7f789c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a shared per-file compiler hot path used by bundler and language-tool integrations; behavior is intended to be identical with fallback when cache metadata is absent, but mis-caching could mis-classify modules.
> 
> **Overview**
> **TSRX filename-to-renderer classification** no longer re-validates config or rebuilds glob regexes on every module when integrations pass an already-normalized `compiler.renderers` object (e.g. bundler/Volar paths that call `normalizeRendererConfig` once).
> 
> `renderers.js` now **compiles include/exclude matchers during normalization**, stores them in a **`WeakMap` sidecar** on the frozen config, and **`resolveRendererForFile`** uses that cache when the config object is module-owned; raw, mutated, or JSON-cloned configs still go through full validation. Matching semantics and public config shape are unchanged.
> 
> Adds the **`tsrx-renderer-selection`** benchmark (semantic checksum + **≤0.5×** normalized-vs-raw ratio guard), MCP/runner registration, an **`octane` patch changeset**, compiler tests for normalized/cloned/mutable inputs, and an implementation plan doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b50d48d2e8b98b200dac3587ee7f5005d0ef2b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->