### PR TITLE
fix(xyflow): isolate color mode hook slots

### DIFF
--- a/.changeset/calm-flows-glow.md
+++ b/.changeset/calm-flows-glow.md
@@ -1,0 +1,5 @@
+---
+"@octanejs/xyflow": patch
+---
+
+Keep system color mode updates responsive by isolating their state and effect hook slots.

--- a/packages/xyflow/audit/adapted-runtime.json
+++ b/packages/xyflow/audit/adapted-runtime.json
@@ -15,6 +15,11 @@
       "fullName": "@octanejs/xyflow — manual hook slots combines general and viewport helpers in useReactFlow"
     },
     {
+      "id": "runtime:b1cfd919f323ecbc",
+      "file": "packages/xyflow/tests/conformance/connection-slots.test.ts",
+      "fullName": "@octanejs/xyflow — manual hook slots keeps color mode state and subscription in distinct slots"
+    },
+    {
       "id": "runtime:e7a43d130a00df47",
       "file": "packages/xyflow/tests/conformance/connection-slots.test.ts",
       "fullName": "@octanejs/xyflow — manual hook slots keeps node and edge state callbacks independent"

--- a/packages/xyflow/audit/react-parity.json
+++ b/packages/xyflow/audit/react-parity.json
@@ -28,8 +28,8 @@
     }
   },
   "adaptedRuntimeSummary": {
-    "inventoryEntries": 8,
-    "uniqueIdentities": 8,
+    "inventoryEntries": 9,
+    "uniqueIdentities": 9,
     "duplicateEntriesWithinLanes": 0,
     "identitiesSharedAcrossLanes": 0
   },
@@ -60,17 +60,17 @@
         {
           "path": "packages/xyflow/audit/adapted-runtime.json",
           "role": "support",
-          "sha256": "780ae2b1ae93a494226338af031a85206024e7a023c061245fa0300585680a6d"
+          "sha256": "0c90b54e68bac770daa9c2aaa0acb57a578e978d4e587500eff890269bf9d533"
         },
         {
           "path": "packages/xyflow/tests/conformance/connection-slots.test.ts",
           "role": "support",
-          "sha256": "185fbc3b243f72816627ef2e2166e721038a27239727acdf66a9c7cb91679793"
+          "sha256": "1363a340993ec3d6f9dc7744272e72c8db09dabfbe4bd4d561a724c819d55389"
         },
         {
           "path": "packages/xyflow/tests/_fixtures/connection-slots.tsrx",
           "role": "support",
-          "sha256": "b311e245eb5a3b7b2c76f96ca05350e95f99bc230b2ed40b1bde2f498103c27d"
+          "sha256": "02dfe8e94ed3986e59be313526483c1f7ae297f3de0052ad25eadd180382b517"
         }
       ]
     },

--- a/packages/xyflow/src/hooks/useColorModeClass.ts
+++ b/packages/xyflow/src/hooks/useColorModeClass.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'octane';
-import { resolveHookSlot } from './slot';
+import { resolveHookSlot, subSlot } from './slot';
 import type { ColorMode, ColorModeClass } from '@xyflow/system';
 
 function getMediaQuery() {
@@ -20,7 +20,7 @@ export function useColorModeClass(colorMode: ColorMode, ...rest: [slot?: symbol]
 	const slot = resolveHookSlot(rest);
 	const [colorModeClass, setColorModeClass] = useState<ColorModeClass | null>(
 		colorMode === 'system' ? null : colorMode,
-		slot,
+		subSlot(slot, 'state'),
 	);
 
 	useEffect(
@@ -43,7 +43,7 @@ export function useColorModeClass(colorMode: ColorMode, ...rest: [slot?: symbol]
 			};
 		},
 		[colorMode],
-		slot,
+		subSlot(slot, 'effect'),
 	);
 
 	return colorModeClass !== null ? colorModeClass : getMediaQuery()?.matches ? 'dark' : 'light';

--- a/packages/xyflow/tests/_fixtures/connection-slots.tsrx
+++ b/packages/xyflow/tests/_fixtures/connection-slots.tsrx
@@ -1,5 +1,6 @@
 import {
 	ReactFlowProvider,
+	ReactFlow,
 	experimental_useOnEdgesChangeMiddleware as useExperimentalOnEdgesChangeMiddleware,
 	experimental_useOnNodesChangeMiddleware as useExperimentalOnNodesChangeMiddleware,
 	useHandleConnections,
@@ -44,6 +45,14 @@ export function ConnectionSlotProbe() {
 	return <ReactFlowProvider initialNodes={nodes} initialEdges={edges}>
 		<ConnectionCounts />
 	</ReactFlowProvider>;
+}
+
+export function ColorModeSlotProbe() {
+	return <div style={{ width: '320px', height: '240px' }}>
+		<ReactFlowProvider>
+			<ReactFlow nodes={[]} edges={[]} colorMode="system" />
+		</ReactFlowProvider>
+	</div>;
 }
 
 function ViewportChangeCallbacks() {

--- a/packages/xyflow/tests/conformance/connection-slots.test.ts
+++ b/packages/xyflow/tests/conformance/connection-slots.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'octane';
 import { flushEffects, mount } from '../../../octane/tests/_helpers';
 import {
+	ColorModeSlotProbe,
 	ConnectionSlotProbe,
 	MiddlewareSlotProbe,
 	NodesEdgesStateSlotProbe,
@@ -15,6 +17,44 @@ describe('@octanejs/xyflow — manual hook slots', () => {
 		root?.unmount();
 		root = undefined;
 		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it('keeps color mode state and subscription in distinct slots', () => {
+		let matches = false;
+		let listener: EventListener | undefined;
+		const mediaQuery = {
+			get matches() {
+				return matches;
+			},
+			media: '(prefers-color-scheme: dark)',
+			onchange: null,
+			addEventListener(_type: string, next: EventListenerOrEventListenerObject) {
+				listener = typeof next === 'function' ? next : next.handleEvent.bind(next);
+			},
+			removeEventListener() {},
+			addListener() {},
+			removeListener() {},
+			dispatchEvent() {
+				return true;
+			},
+		} as MediaQueryList;
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn(() => mediaQuery),
+		);
+
+		root = mount(ColorModeSlotProbe);
+		flushEffects();
+
+		const flow = root.container.querySelector('.react-flow');
+		expect(flow?.classList.contains('light')).toBe(true);
+
+		matches = true;
+		flushSync(function dispatchColorModeChange() {
+			listener?.(new Event('change'));
+		});
+		expect(flow?.classList.contains('dark')).toBe(true);
 	});
 
 	it('keeps repeated connection hook calls independent', () => {


### PR DESCRIPTION
## Summary
- isolate the XYFlow system color mode state and effect into distinct manual hook slots
- add live `matchMedia` regression coverage and lock it into the adapted runtime inventory
- follow up on the valid review finding discovered as #624 merged

## Test plan
- [x] `pnpm vitest run packages/xyflow/tests/conformance/connection-slots.test.ts --silent=false`
- [x] `node scripts/react-parity/harness.mjs run-required --manifest packages/xyflow/audit/react-parity.json`
- [x] `pnpm exec tsrx-tsc --noEmit -p packages/xyflow/tsconfig.json`
- [x] `pnpm react-parity:validate`
- [x] `pnpm packages:pack:check`
- [x] `pnpm sync`

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hook-slot fix in internal color-mode logic with new conformance coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **system** `colorMode` not updating the flow’s light/dark class when `prefers-color-scheme` changes under Octane’s manual hook slots.
> 
> `useColorModeClass` now routes `useState` and `useEffect` through separate `subSlot` identities (`'state'` and `'effect'`) instead of sharing one slot, so the `matchMedia` listener can update state without colliding with the effect slot.
> 
> Adds a conformance regression (`ColorModeSlotProbe` + stubbed `matchMedia`) that asserts `.react-flow` flips from `light` to `dark` on a synthetic media change, and registers that test in the adapted runtime inventory (9 tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d02bb24c8927b38846c9c92e6848bad93c662a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790523915&installation_model_id=432790&pr_number=893&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F893&signature=57a27463053d47d6573b4e01f2a6b74cd48d71b6c4a75c4dfcc9f4c39a3111f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->