### PR TITLE
fix(website): make hero console output observable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ packages/spring/.pristine-vite-cache/
 !packages/resizable-panels/upstream-artifact/dist/**
 # Pristine vitest cache for monaco-editor upstream suite
 packages/monaco-editor/.vite-pristine/
+
+# Local product ideation artifacts are working notes, not repository content.
+docs/ideation/

--- a/website/src/components/HeroDemo.tsrx
+++ b/website/src/components/HeroDemo.tsrx
@@ -15,7 +15,11 @@ interface TerminalEntry {
 	message: string;
 }
 
-function Counter(props: { paused: boolean; onLog: (message: string) => void }) @{
+function Counter(props: {
+	paused: boolean;
+	onIncrement: () => void;
+	onLog: (message: string) => void;
+}) @{
 	const [count, setCount] = useState(0);
 
 	if (!props.paused) {
@@ -27,7 +31,14 @@ function Counter(props: { paused: boolean; onLog: (message: string) => void }) @
 
 	// Scoped styles are per-component, so the button's CSS lives HERE: in
 	// HeroDemo's <style> the hashed selector would never match this node.
-	<button type="button" class="demo-count" onClick={() => setCount(count + 1)}>
+	<button
+		type="button"
+		class="demo-count"
+		onClick={() => {
+			props.onIncrement();
+			setCount(count + 1);
+		}}
+	>
 		<span class="demo-count-label">Count</span>
 		<span class="demo-count-value">{`${count}`}</span>
 
@@ -118,7 +129,7 @@ export function HeroDemo() @{
 	<div class="demo-shell">
 		<div class="demo">
 			<span class="demo-badge">Live</span>
-			<Counter paused={paused} onLog={appendLog} />
+			<Counter paused={paused} onIncrement={jumpToLatest} onLog={appendLog} />
 			<label class="demo-toggle">
 				<input
 					type="checkbox"
@@ -129,12 +140,12 @@ export function HeroDemo() @{
 			</label>
 		</div>
 
-		<section class="demo-terminal" aria-label="Effect console">
+		<section class="demo-terminal" aria-label="Console">
 			<header class="demo-terminal-header">
-				<span class="demo-terminal-title">Effect console</span>
+				<span class="demo-terminal-title">Console</span>
 				<span class={['demo-terminal-status', paused ? 'paused' : 'running']}>{(paused
-					? 'Paused'
-					: 'Running') as string}</span>
+					? 'Effect paused'
+					: 'Effect active') as string}</span>
 				@if (!followingTail) {
 					<button type="button" class="demo-terminal-jump" onClick={jumpToLatest}>
 						Latest ↓
@@ -205,7 +216,7 @@ export function HeroDemo() @{
 				display: flex;
 				align-items: center;
 				gap: 0.55rem;
-				min-height: 1.8rem;
+				height: 2rem;
 				padding: 0.35rem 0.85rem;
 				border-bottom: 1px solid rgba(255, 255, 255, 0.055);
 			}
@@ -240,13 +251,15 @@ export function HeroDemo() @{
 				box-shadow: none;
 			}
 			.demo-terminal-jump {
-				padding: 0.12rem 0.42rem;
+				height: 1.25rem;
+				padding: 0 0.42rem;
 				border: 1px solid var(--border);
 				border-radius: 9999px;
 				background: var(--surface);
 				color: var(--text-secondary);
 				font: inherit;
 				font-size: 0.62rem;
+				line-height: 1;
 				cursor: pointer;
 			}
 			.demo-terminal-jump:hover {
@@ -263,11 +276,29 @@ export function HeroDemo() @{
 				overflow-y: auto;
 				overscroll-behavior: contain;
 				scrollbar-gutter: stable;
+				scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+				scrollbar-width: thin;
 				padding: 0.45rem 0.85rem;
 				color: #d6deeb;
 				font-family: ui-monospace, Menlo, Consolas, monospace;
 				font-size: 0.72rem;
 				line-height: 1.55;
+			}
+			.demo-terminal-body::-webkit-scrollbar {
+				width: 0.65rem;
+			}
+			.demo-terminal-body::-webkit-scrollbar-track {
+				background: transparent;
+			}
+			.demo-terminal-body::-webkit-scrollbar-thumb {
+				border: 3px solid transparent;
+				border-radius: 9999px;
+				background: rgba(255, 255, 255, 0.2);
+				background-clip: padding-box;
+			}
+			.demo-terminal-body::-webkit-scrollbar-thumb:hover {
+				background: rgba(255, 255, 255, 0.34);
+				background-clip: padding-box;
 			}
 			.demo-terminal-line {
 				display: flex;

--- a/website/src/components/HeroDemo.tsrx
+++ b/website/src/components/HeroDemo.tsrx
@@ -1,11 +1,19 @@
 // The live twin of the hero's code sample (content/home-sample.mdx): the same
 // component, running. Its `useEffect` sits behind the same `if (!props.paused)`
 // condition the sample shows — and logs to the console exactly as the sample
-// promises, plus a visible log line so "a hook can sit behind a condition" is
-// something the reader can watch happen without opening devtools. Toggle
-// `paused` and the effect stops firing while the state hook below it keeps its
-// slot.
-import { useState, useEffect } from 'octane';
+// promises, plus a bounded effect console so "a hook can sit behind a condition"
+// is something the reader can watch happen without opening devtools. Toggle
+// `paused` and the effect console stops receiving lines while the state hook
+// below it keeps its slot.
+import { useCallback, useEffect, useRef, useState } from 'octane';
+
+const MAX_TERMINAL_ENTRIES = 50;
+const TERMINAL_BOTTOM_TOLERANCE = 4;
+
+interface TerminalEntry {
+	id: number;
+	message: string;
+}
 
 function Counter(props: { paused: boolean; onLog: (message: string) => void }) @{
 	const [count, setCount] = useState(0);
@@ -77,31 +85,92 @@ function Counter(props: { paused: boolean; onLog: (message: string) => void }) @
 
 export function HeroDemo() @{
 	const [paused, setPaused] = useState(false);
-	const [log, setLog] = useState('count is now 0');
+	const [entries, setEntries] = useState<TerminalEntry[]>([]);
+	const [followingTail, setFollowingTail] = useState(true);
+	const terminalRef = useRef<HTMLDivElement | null>(null);
+	const nextEntryId = useRef(0);
 
-	<div class="demo">
-		<span class="demo-badge">Live</span>
-		<Counter paused={paused} onLog={setLog} />
-		<label class="demo-toggle">
-			<input
-				type="checkbox"
-				checked={paused}
-				onInput={(event: Event) => setPaused((event.target as HTMLInputElement).checked)}
-			/>
-			<span>paused</span>
-		</label>
-		<code class="demo-log">
-			{paused ? '// effect skipped' : '// ' + log}
-		</code>
+	const appendLog = useCallback((message: string) => {
+		const entry = { id: nextEntryId.current++, message };
+		setEntries((current) => [...current, entry].slice(-MAX_TERMINAL_ENTRIES));
+	});
+
+	const newestEntry = entries.at(-1);
+	useEffect(() => {
+		if (!newestEntry || !followingTail) return;
+		const terminal = terminalRef.current;
+		if (terminal) terminal.scrollTop = terminal.scrollHeight;
+	});
+
+	const onTerminalScroll = (event: Event) => {
+		const terminal = event.currentTarget as HTMLDivElement;
+		const distanceFromBottom = terminal.scrollHeight - terminal.scrollTop - terminal.clientHeight;
+		const atBottom = distanceFromBottom <= TERMINAL_BOTTOM_TOLERANCE;
+		setFollowingTail(atBottom);
+	};
+
+	const jumpToLatest = () => {
+		setFollowingTail(true);
+		const terminal = terminalRef.current;
+		if (terminal) terminal.scrollTop = terminal.scrollHeight;
+	};
+
+	<div class="demo-shell">
+		<div class="demo">
+			<span class="demo-badge">Live</span>
+			<Counter paused={paused} onLog={appendLog} />
+			<label class="demo-toggle">
+				<input
+					type="checkbox"
+					checked={paused}
+					onInput={(event: Event) => setPaused((event.currentTarget as HTMLInputElement).checked)}
+				/>
+				<span>Pause effect</span>
+			</label>
+		</div>
+
+		<section class="demo-terminal" aria-label="Effect console">
+			<header class="demo-terminal-header">
+				<span class="demo-terminal-title">Effect console</span>
+				<span class={['demo-terminal-status', paused ? 'paused' : 'running']}>{(paused
+					? 'Paused'
+					: 'Running') as string}</span>
+				@if (!followingTail) {
+					<button type="button" class="demo-terminal-jump" onClick={jumpToLatest}>
+						Latest ↓
+					</button>
+				}
+			</header>
+			<div
+				class="demo-terminal-body"
+				ref={terminalRef}
+				role="log"
+				aria-live="polite"
+				aria-relevant="additions"
+				tabIndex={0}
+				onScroll={onTerminalScroll}
+			>
+				@for (const entry of entries; key entry.id) {
+					<code class="demo-terminal-line">
+						<span class="demo-terminal-prompt" aria-hidden="true">›</span>
+						<span>{entry.message as string}</span>
+					</code>
+				} @empty {
+					<span class="demo-terminal-empty">Waiting for the effect…</span>
+				}
+			</div>
+		</section>
 
 		<style>
+			.demo-shell {
+				border-top: 1px solid var(--border);
+				background: var(--surface-subtle);
+			}
 			.demo {
 				display: flex;
 				align-items: center;
 				gap: 0.75rem;
 				padding: 0.75rem 1rem;
-				border-top: 1px solid var(--border);
-				background: var(--surface-subtle);
 			}
 			.demo-badge {
 				flex: none;
@@ -128,14 +197,111 @@ export function HeroDemo() @{
 				accent-color: var(--accent);
 				cursor: pointer;
 			}
-			.demo-log {
-				min-width: 0;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
+			.demo-terminal {
+				border-top: 1px solid var(--border);
+				background: rgba(7, 9, 12, 0.72);
+			}
+			.demo-terminal-header {
+				display: flex;
+				align-items: center;
+				gap: 0.55rem;
+				min-height: 1.8rem;
+				padding: 0.35rem 0.85rem;
+				border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+			}
+			.demo-terminal-title {
 				color: var(--text-secondary);
-				font-size: 0.78rem;
-				opacity: 0.85;
+				font-size: 0.6rem;
+				font-weight: 700;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+			}
+			.demo-terminal-status {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.3rem;
+				margin-left: auto;
+				color: var(--text-secondary);
+				font-size: 0.62rem;
+				font-weight: 600;
+				letter-spacing: 0.04em;
+				text-transform: uppercase;
+			}
+			.demo-terminal-status::before {
+				content: '';
+				width: 0.38rem;
+				height: 0.38rem;
+				border-radius: 9999px;
+				background: #57ab5a;
+				box-shadow: 0 0 0.45rem rgba(87, 171, 90, 0.55);
+			}
+			.demo-terminal-status.paused::before {
+				background: #dfab25;
+				box-shadow: none;
+			}
+			.demo-terminal-jump {
+				padding: 0.12rem 0.42rem;
+				border: 1px solid var(--border);
+				border-radius: 9999px;
+				background: var(--surface);
+				color: var(--text-secondary);
+				font: inherit;
+				font-size: 0.62rem;
+				cursor: pointer;
+			}
+			.demo-terminal-jump:hover {
+				color: var(--text);
+				border-color: var(--accent);
+			}
+			.demo-terminal-jump:focus-visible,
+			.demo-terminal-body:focus-visible {
+				outline: 2px solid var(--accent-hover);
+				outline-offset: -2px;
+			}
+			.demo-terminal-body {
+				height: 4.75rem;
+				overflow-y: auto;
+				overscroll-behavior: contain;
+				scrollbar-gutter: stable;
+				padding: 0.45rem 0.85rem;
+				color: #d6deeb;
+				font-family: ui-monospace, Menlo, Consolas, monospace;
+				font-size: 0.72rem;
+				line-height: 1.55;
+			}
+			.demo-terminal-line {
+				display: flex;
+				gap: 0.45rem;
+				min-width: max-content;
+				animation: terminal-line-in 0.14s ease-out;
+			}
+			.demo-terminal-prompt {
+				color: var(--accent-text);
+				font-weight: 700;
+			}
+			.demo-terminal-empty {
+				color: var(--text-secondary);
+				opacity: 0.65;
+			}
+			@keyframes terminal-line-in {
+				from {
+					opacity: 0;
+					transform: translateY(0.2rem);
+				}
+				to {
+					opacity: 1;
+					transform: translateY(0);
+				}
+			}
+			@media (max-width: 560px) {
+				.demo {
+					flex-wrap: wrap;
+				}
+			}
+			@media (prefers-reduced-motion: reduce) {
+				.demo-terminal-line {
+					animation: none;
+				}
 			}
 		</style>
 	</div>

--- a/website/tests/hero-demo.test.ts
+++ b/website/tests/hero-demo.test.ts
@@ -58,7 +58,7 @@ describe('hero live counter', () => {
 		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 1'));
 
 		fireEvent.click(paused);
-		await waitFor(() => expect(terminalStatus()).toBe('Paused'));
+		await waitFor(() => expect(terminalStatus()).toBe('Effect paused'));
 
 		// The conditional effect is gone, but useState below it still counts.
 		fireEvent.click(button);
@@ -67,7 +67,7 @@ describe('hero live counter', () => {
 
 		// Unpausing brings the effect back, and it reports the current count.
 		fireEvent.click(paused);
-		await waitFor(() => expect(terminalStatus()).toBe('Running'));
+		await waitFor(() => expect(terminalStatus()).toBe('Effect active'));
 		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 2'));
 	});
 
@@ -90,7 +90,7 @@ describe('hero live counter', () => {
 		expect(demoLogs()).toEqual([]);
 	});
 
-	it('follows new output until the reader scrolls back', async () => {
+	it('returns to the latest output when Count or Latest is clicked', async () => {
 		const { button, jumpToLatest, logLines, terminal } = mountDemo();
 
 		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 0'));
@@ -109,8 +109,12 @@ describe('hero live counter', () => {
 
 		fireEvent.click(button);
 		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 2'));
-		expect(terminal.scrollTop).toBe(40);
+		expect(terminal.scrollTop).toBe(240);
+		expect(jumpToLatest()).toBeNull();
 
+		terminal.scrollTop = 40;
+		fireEvent.scroll(terminal);
+		await waitFor(() => expect(jumpToLatest()).toBeTruthy());
 		fireEvent.click(jumpToLatest()!);
 		expect(terminal.scrollTop).toBe(240);
 		expect(jumpToLatest()).toBeNull();

--- a/website/tests/hero-demo.test.ts
+++ b/website/tests/hero-demo.test.ts
@@ -16,44 +16,63 @@ function mountDemo() {
 	const utils = render(HeroDemo as any);
 	const button = utils.container.querySelector<HTMLButtonElement>('.demo-count')!;
 	const count = () => utils.container.querySelector('.demo-count-value')!.textContent!.trim();
-	const log = () => utils.container.querySelector('.demo-log')!.textContent!.trim();
+	const logLines = () =>
+		Array.from(utils.container.querySelectorAll('.demo-terminal-line')).map((line) =>
+			line.textContent!.trim(),
+		);
+	const terminal = utils.container.querySelector<HTMLElement>('.demo-terminal-body')!;
+	const terminalStatus = () =>
+		utils.container.querySelector('.demo-terminal-status')!.textContent!.trim();
+	const jumpToLatest = () =>
+		utils.container.querySelector<HTMLButtonElement>('.demo-terminal-jump');
 	const paused = utils.container.querySelector<HTMLInputElement>('.demo-toggle input')!;
-	return { ...utils, button, consoleLog, count, log, paused };
+	return {
+		...utils,
+		button,
+		consoleLog,
+		count,
+		jumpToLatest,
+		logLines,
+		paused,
+		terminal,
+		terminalStatus,
+	};
 }
 
 describe('hero live counter', () => {
-	it('counts up, and the effect reports each new value', async () => {
-		const { button, count, log } = mountDemo();
+	it('appends each effect result to a terminal history', async () => {
+		const { button, count, logLines } = mountDemo();
 
 		expect(count()).toBe('0');
-		await waitFor(() => expect(log()).toBe('// count is now 0'));
+		await waitFor(() => expect(logLines()).toEqual(['›count is now 0']));
 
 		fireEvent.click(button);
 		await waitFor(() => expect(count()).toBe('1'));
-		await waitFor(() => expect(log()).toBe('// count is now 1'));
+		await waitFor(() => expect(logLines()).toEqual(['›count is now 0', '›count is now 1']));
 	});
 
-	it('stops running the effect while paused — but the state hook keeps its slot', async () => {
-		const { button, count, log, paused } = mountDemo();
+	it('preserves the last output while the effect is paused and catches up when resumed', async () => {
+		const { button, count, logLines, paused, terminalStatus } = mountDemo();
 
 		fireEvent.click(button);
-		await waitFor(() => expect(log()).toBe('// count is now 1'));
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 1'));
 
 		fireEvent.click(paused);
-		await waitFor(() => expect(log()).toBe('// effect skipped'));
+		await waitFor(() => expect(terminalStatus()).toBe('Paused'));
 
 		// The conditional effect is gone, but useState below it still counts.
 		fireEvent.click(button);
 		await waitFor(() => expect(count()).toBe('2'));
-		expect(log()).toBe('// effect skipped');
+		expect(logLines().at(-1)).toBe('›count is now 1');
 
 		// Unpausing brings the effect back, and it reports the current count.
 		fireEvent.click(paused);
-		await waitFor(() => expect(log()).toBe('// count is now 2'));
+		await waitFor(() => expect(terminalStatus()).toBe('Running'));
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 2'));
 	});
 
 	it('logs to the console exactly as the sample promises', async () => {
-		const { button, consoleLog, count, log, paused } = mountDemo();
+		const { button, consoleLog, count, logLines, paused } = mountDemo();
 		const demoLogs = () =>
 			consoleLog.mock.calls.filter((args) => args[0] === 'count is now').map((args) => args[1]);
 
@@ -64,10 +83,48 @@ describe('hero live counter', () => {
 
 		// While paused the effect is skipped entirely — no console output either.
 		fireEvent.click(paused);
-		await waitFor(() => expect(log()).toBe('// effect skipped'));
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 1'));
 		consoleLog.mockClear();
 		fireEvent.click(button);
 		await waitFor(() => expect(count()).toBe('2'));
 		expect(demoLogs()).toEqual([]);
+	});
+
+	it('follows new output until the reader scrolls back', async () => {
+		const { button, jumpToLatest, logLines, terminal } = mountDemo();
+
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 0'));
+		Object.defineProperties(terminal, {
+			clientHeight: { configurable: true, value: 80 },
+			scrollHeight: { configurable: true, value: 240 },
+			scrollTop: { configurable: true, value: 0, writable: true },
+		});
+
+		fireEvent.click(button);
+		await waitFor(() => expect(terminal.scrollTop).toBe(240));
+
+		terminal.scrollTop = 40;
+		fireEvent.scroll(terminal);
+		await waitFor(() => expect(jumpToLatest()).toBeTruthy());
+
+		fireEvent.click(button);
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 2'));
+		expect(terminal.scrollTop).toBe(40);
+
+		fireEvent.click(jumpToLatest()!);
+		expect(terminal.scrollTop).toBe(240);
+		expect(jumpToLatest()).toBeNull();
+	});
+
+	it('bounds the retained terminal history', async () => {
+		const { button, count, logLines } = mountDemo();
+
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 0'));
+		for (let value = 1; value <= 55; value++) fireEvent.click(button);
+
+		await waitFor(() => expect(count()).toBe('55'));
+		await waitFor(() => expect(logLines().at(-1)).toBe('›count is now 55'));
+		expect(logLines()).toHaveLength(50);
+		expect(logLines()[0]).toBe('›count is now 6');
 	});
 });


### PR DESCRIPTION
## Summary

The homepage hero now presents the sample's `console.log` results in a bounded Console instead of a comment-like status. Readers can watch the conditional effect pause and resume, inspect scrollback, and return to the latest output without the demo changing height.

Local `docs/ideation/` working notes are ignored so design artifacts do not enter the repository.

## Validation

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `./node_modules/.bin/vitest run website/tests/hero-demo.test.ts --reporter=verbose --silent=false` (5 passed)
- [x] website TSRX typecheck: `./node_modules/.bin/tsrx-tsc --noEmit -p website/tsconfig.json`
- [x] targeted formatting: `./website/node_modules/.bin/prettier --check website/src/components/HeroDemo.tsrx website/tests/hero-demo.test.ts`
- [x] website production build: `./node_modules/.bin/vite build --configLoader runner` from `website/`
- [x] browser exercise: count, pause/resume, scrollback, Latest, follow mode, and desktop/mobile layout

Full repository tests and repo-wide formatting/typecheck were not run locally; CI covers those gates.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site demo and test-only changes; no auth, data, or shared runtime APIs affected.
> 
> **Overview**
> The homepage **HeroDemo** no longer shows a single ellipsis-style `//` log line. Effect output from the sample’s `console.log` now accumulates in a **fixed-height Console** panel with scrollback (capped at **50** lines), a running/paused status, and **Latest ↓** when the user scrolls away from the tail.
> 
> **Count** still drives the conditional `useEffect`, but it also re-enables tail-follow and scrolls to the newest line; pausing stops new lines while **preserving history** (no more `// effect skipped` placeholder). Layout splits controls and terminal via `demo-shell`, with basic a11y (`role="log"`, `aria-live`) and reduced-motion handling.
> 
> **`.gitignore`** now excludes local **`docs/ideation/`** working notes. **`hero-demo.test.ts`** is updated for the terminal UI and adds coverage for tail-follow, jump-to-latest, and the 50-entry cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7eabfc21c4a6415639f1a74dc7b7a6dc2427ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790542336&installation_model_id=432790&pr_number=898&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F898&signature=a8b1fab0bc3a30ff5a8774c94085d54a72e175306455ec5c9568e38331d765a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->