### PR TITLE
test(bench): add synthetic workerd app workloads

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Test UIbench measurement failures
         run: node --test benchmarks/uibench/run.test.mjs
 
+      - name: Verify synthetic workerd app workloads
+        run: |
+          node --test benchmarks/ssr-workerd/app-workloads/verify.test.mjs
+          BENCH_ROUNDS=1 node benchmarks/ssr-workerd/app-workloads/run.mjs 1
+
       - name: Install Playwright Chromium
         run: pnpm --filter octane-js-framework-benchmarks exec playwright install --with-deps chromium
 

--- a/benchmarks/ssr-workerd/README.md
+++ b/benchmarks/ssr-workerd/README.md
@@ -67,6 +67,12 @@ introduce a discovery waterfall; the new investigation measures that too.
 
 ## Usage
 
+Two additional, standalone [synthetic app workloads](app-workloads/README.md)
+exercise a provider-heavy workspace bootstrap and a structured record/history
+page with nested streaming boundaries. They use invented data, request-scoped
+deduplication, and zero-delay/delayed/warm-data controls. Run them separately with
+`node app-workloads/run.mjs`; they are not included in the unified suite below.
+
 ```bash
 node run.mjs              # 10 cold iterations, builds first
 node run.mjs 5 --no-build # reuse dist/ + octane-app/dist

--- a/benchmarks/ssr-workerd/app-workloads/BASELINE.md
+++ b/benchmarks/ssr-workerd/app-workloads/BASELINE.md
@@ -1,0 +1,77 @@
+# Initial validation — 2026-08-29 (Europe/London)
+
+These measurements validate the new synthetic workloads. They are **not a
+framework before/after comparison**, a calibrated application profile, or a
+Cloudflare-adapter/deployed-edge performance claim. No runtime source changed.
+
+Environment: Apple M5 Max, macOS arm64, Node 26.4.0, Vite 8.1.5, Miniflare
+4.20260714.0, workerd 1.20260714.1, TSRX core 0.1.61; compatibility date
+2026-07-14. Framework revision: `96c86fcd97f4fe8a158e360a6c6af6b4411ed32c`.
+Combined worker: 67,994 bytes raw / 22,229 gzip, identical in all three runs.
+
+## Commands and retained evidence
+
+From the repository root:
+
+```bash
+BENCH_JSON=benchmarks/results/app-workloads-baseline-b.json node benchmarks/ssr-workerd/app-workloads/run.mjs 7
+BENCH_SCALE=4 BENCH_JSON=benchmarks/results/app-workloads-scale4.json node benchmarks/ssr-workerd/app-workloads/run.mjs 7
+BENCH_JSON=benchmarks/results/app-workloads-baseline-c.json node benchmarks/ssr-workerd/app-workloads/run.mjs 7
+```
+
+Each run contains eight cases × three rounds × seven samples: 168 measured
+requests, after two warmups per case and untimed correctness/cache priming.
+All **504 measured requests** passed the output and request-graph checks.
+All three raw reports remain in the ignored local results directory and carry
+individual samples, dependency events, environment and hashes. Their fixture,
+verifier, shared-helper, runtime and lockfile hashes match the final source.
+An earlier exploratory run was excluded after the verifier was reformatted;
+it is not the repeated-input evidence reported here.
+
+## Same-input repetitions
+
+Scale 1, base delay 15 ms, medians in milliseconds. B and C are separate fresh
+workerd runs of the **same code**, not baseline and optimized implementations.
+
+| Case | TTFB B / C | First content B / C | Completion B / C |
+| --- | ---: | ---: | ---: |
+| workspace/zero-delay | 1.49 / 2.75 | 3.01 / 4.86 | 3.21 / 4.89 |
+| workspace/io | 1.65 / 3.24 | 51.82 / 55.89 | 96.73 / 101.13 |
+| workspace/io-blocked-root | 34.73 / 39.80 | 51.42 / 58.46 | 96.52 / 102.06 |
+| workspace/warm-data | 1.18 / 3.65 | 1.94 / 4.89 | 2.10 / 4.92 |
+| history/zero-delay | 1.07 / 3.50 | 2.45 / 6.57 | 3.40 / 7.71 |
+| history/io | 1.14 / 3.22 | 34.99 / 42.67 | 97.28 / 108.64 |
+| history/io-blocked-root | 18.01 / 19.10 | 34.95 / 37.46 | 97.10 / 100.53 |
+| history/warm-data | 1.01 / 1.72 | 2.15 / 3.81 | 2.94 / 4.98 |
+
+The control distinguishes an early loading shell from primary data and full
+completion. Removing the outer boundary moves bootstrap waiting into TTFB;
+it does not remove data work. Warm-data removes backend calls intentionally
+and must not be described as an Octane runtime optimization.
+
+**Timing repeatability is insufficient for a 20% regression/improvement gate on
+this machine.** Some low-latency medians more than doubled between identical
+runs. Run C's history/io completion p95 was 152.63 ms, versus 98.11 ms in B;
+the cause of this variance was not isolated. Do not choose the faster run,
+treat the repeated-run difference as a code effect, or install absolute CI
+thresholds from these values. Use controlled, paired framework revisions and
+repeat runs before making a small latency claim. The weekly smoke gates only
+correctness, not these absolute timings.
+
+## Size and correctness controls
+
+At scale 4, workspace renders 192 navigation links and 72 tiles; history renders
+160 rows and 24 related items. Exact checked leaf counts grow from 267 → 1,059
+and 527 → 2,105 respectively. Streamed wire sizes grow from 42.6 → 155.8 KiB
+and 85.4 → 330.6 KiB. Unique backend calls remain seven/nine (zero for warm
+data), so this control increases tree/serialization work without extra data
+sources. Its timings are retained as diagnostics, not a scaling-ratio claim.
+
+The real-workerd preflights also passed shell-before-data, content-before-tail,
+concurrent cold/warm tenant isolation, changed-size cache-key isolation, complete
+draining and all eight cases. The oracle's 17 corruption/acceptance tests and
+61 existing CI-workflow tests passed. Benchmark typecheck and formatting passed
+using the locally available TSRX checker/formatter 0.3.120 with TypeScript 5.9.3
+and Prettier 3.9.6; the locked TSRX validation tools 0.3.126 were unavailable.
+Performance compilation used the exact installed TSRX core 0.1.61 and real new
+worktree framework source. Full remote CI has not been run for these additions.

--- a/benchmarks/ssr-workerd/app-workloads/Pages.tsrx
+++ b/benchmarks/ssr-workerd/app-workloads/Pages.tsrx
@@ -1,0 +1,232 @@
+import { createContext, use, useContext, type OctaneNode } from 'octane';
+import type { Item, Payload, Workload } from './data';
+
+type Props = { work: Workload };
+const Scope = createContext('missing');
+const Locale = createContext('missing');
+const Theme = createContext('missing');
+const Density = createContext('missing');
+const Zone = createContext('missing');
+const Collection = createContext('missing');
+
+function Providers(props: {
+	profile: Payload;
+	preferences: Payload;
+	collection: Payload;
+	children: OctaneNode;
+}) @{
+	<Scope.Provider value={props.profile.label}>
+		<Locale.Provider value={props.preferences.label + '/locale'}>
+			<Theme.Provider value={props.preferences.label + '/theme'}>
+				<Density.Provider value={props.preferences.label + '/density'}>
+					<Zone.Provider value={props.preferences.label + '/zone'}>
+						<Collection.Provider
+							value={props.collection.label}
+						>{props.children}</Collection.Provider>
+					</Zone.Provider>
+				</Density.Provider>
+			</Theme.Provider>
+		</Locale.Provider>
+	</Scope.Provider>
+}
+
+function ContextLabels(props: { prefix: string }) @{
+	const scope = useContext(Scope);
+	const locale = useContext(Locale);
+	const theme = useContext(Theme);
+	const density = useContext(Density);
+	const zone = useContext(Zone);
+	const collection = useContext(Collection);
+	<footer>
+		<span data-proof={props.prefix + '/scope'}>{scope as string}</span>
+		<span data-proof={props.prefix + '/locale'}>{locale as string}</span>
+		<span data-proof={props.prefix + '/theme'}>{theme as string}</span>
+		<span data-proof={props.prefix + '/density'}>{density as string}</span>
+		<span data-proof={props.prefix + '/zone'}>{zone as string}</span>
+		<span data-proof={props.prefix + '/collection'}>{collection as string}</span>
+	</footer>
+}
+
+function SharedProfile(props: Props & { prefix: string }) @{
+	// Repeated consumers deliberately share one request-owned promise. The
+	// cache is part of the workload, not an optimization of the SSR runtime.
+	const profile = use(props.work.load('profile'));
+	<span data-proof={props.prefix + '/profile'}>{profile.label as string}</span>
+}
+
+function ItemHeading(props: { item: Item; prefix: string }) @{
+	<header>
+		<h2 data-proof={props.prefix + '/title'}>{props.item.title as string}</h2>
+	</header>
+}
+
+function ItemBody(props: { item: Item; prefix: string }) @{
+	<div class="item-body">
+		<p data-proof={props.prefix + '/text'}>{props.item.text as string}</p>
+		<pre>
+			<code data-proof={props.prefix + '/code'}>{props.item.code as string}</code>
+		</pre>
+		<ul>
+			@for (const tag of props.item.tags; key tag) {
+				<li data-proof={props.prefix + '/' + tag}>{tag as string}</li>
+			}
+		</ul>
+	</div>
+}
+
+function Navigation(props: Props) @{
+	const data = use(props.work.load('navigation'));
+	<nav aria-label="Synthetic navigation">
+		<SharedProfile work={props.work} prefix="navigation" />
+		<ul>
+			@for (const item of data.items; key item.id) {
+				<li>
+					<a href={'#item-' + item.id} data-proof={'nav/' + item.id}>{item.title as string}</a>
+				</li>
+			}
+		</ul>
+	</nav>
+}
+
+function Tile(props: Props & { item: Item }) @{
+	const prefix = 'tile/' + props.item.id;
+	<article data-tile={props.item.id}>
+		<ItemHeading item={props.item} prefix={prefix} />
+		<ItemBody item={props.item} prefix={prefix} />
+		<SharedProfile work={props.work} prefix={prefix} />
+		<ContextLabels prefix={prefix} />
+	</article>
+}
+
+function Tiles(props: Props) @{
+	const data = use(props.work.load('tiles'));
+	<section data-content="workspace">
+		@for (const item of data.items; key item.id) {
+			<Tile work={props.work} item={item} />
+		}
+	</section>
+}
+
+function Summary(props: Props) @{
+	const data = use(props.work.load('summary'));
+	<aside>
+		<p data-proof="summary">{data.label as string}</p>
+	</aside>
+}
+
+function Workspace(props: Props) @{
+	props.work.stats.bootstrapPasses++;
+	const profile = use(props.work.load('profile'));
+	const preferences = use(props.work.load('preferences'));
+	const catalog = use(props.work.load('catalog'));
+	// This key really depends on a response; it cannot be prefetched as an
+	// independent bootstrap fetch without changing the workload.
+	const access = use(props.work.load('access:' + profile.next));
+	<Providers profile={profile} preferences={preferences} collection={catalog}>
+		<div class="workspace">
+			<p data-proof="access">{access.label as string}</p>
+			@try {
+				<Navigation work={props.work} />
+			} @pending {
+				<p class="pending">Navigation pending</p>
+			}
+			@try {
+				<Tiles work={props.work} />
+			} @pending {
+				<p class="pending">Tiles pending</p>
+			}
+			@try {
+				<Summary work={props.work} />
+			} @pending {
+				<p class="pending">Summary pending</p>
+			}
+		</div>
+	</Providers>
+}
+
+function Author(props: Props & { item: Item }) @{
+	const data = use(props.work.load('author:' + props.item.author));
+	<span data-proof={'row/' + props.item.id + '/author'}>{data.label as string}</span>
+}
+
+function HistoryRow(props: Props & { item: Item }) @{
+	const prefix = 'row/' + props.item.id;
+	<article data-row={props.item.id}>
+		<ItemHeading item={props.item} prefix={prefix} />
+		<ItemBody item={props.item} prefix={prefix} />
+		<SharedProfile work={props.work} prefix={prefix} />
+		<ContextLabels prefix={prefix} />
+		@try {
+			<Author work={props.work} item={props.item} />
+		} @pending {
+			<span class="pending">Author pending</span>
+		}
+	</article>
+}
+
+function HistoryRows(props: Props & { record: Payload }) @{
+	const data = use(props.work.load('history:' + props.record.next));
+	<section data-content="history">
+		@for (const item of data.items; key item.id) {
+			<HistoryRow work={props.work} item={item} />
+		}
+	</section>
+}
+
+function Related(props: Props) @{
+	const data = use(props.work.load('related'));
+	<aside>
+		<ul>
+			@for (const item of data.items; key item.id) {
+				<li data-proof={'related/' + item.id}>{item.title as string}</li>
+			}
+		</ul>
+	</aside>
+}
+
+function History(props: Props) @{
+	props.work.stats.bootstrapPasses++;
+	const profile = use(props.work.load('profile'));
+	const preferences = use(props.work.load('preferences'));
+	const record = use(props.work.load('record'));
+	<Providers profile={profile} preferences={preferences} collection={record}>
+		<div class="history">
+			<p data-proof="record">{record.label as string}</p>
+			@try {
+				<HistoryRows work={props.work} record={record} />
+			} @pending {
+				<p class="pending">History pending</p>
+			}
+			@try {
+				<Related work={props.work} />
+			} @pending {
+				<p class="pending">Related pending</p>
+			}
+		</div>
+	</Providers>
+}
+
+export function Page(props: Props) @{
+	<main>
+		<header>
+			<h1 data-shell="app">Synthetic workspace</h1>
+		</header>
+		@if (props.work.streamShell) {
+			@try {
+				<Content work={props.work} />
+			} @pending {
+				<p class="pending">Workspace pending</p>
+			}
+		} @else {
+			<Content work={props.work} />
+		}
+	</main>
+}
+
+function Content(props: Props) @{
+	@if (props.work.scenario === 'workspace') {
+		<Workspace work={props.work} />
+	} @else {
+		<History work={props.work} />
+	}
+}

--- a/benchmarks/ssr-workerd/app-workloads/README.md
+++ b/benchmarks/ssr-workerd/app-workloads/README.md
@@ -1,0 +1,109 @@
+# Synthetic app workloads in workerd
+
+Two application-shaped SSR benchmarks complement the smaller
+[fetch-patterns](../fetch-patterns/README.md) controls:
+
+| Workload | Invented default shape | Data dependencies |
+| --- | --- | --- |
+| `workspace` | Six consumed context providers, 48 navigation links, 18 rich tiles, a delayed summary, sibling streaming boundaries | Three independent bootstrap loads; profile → access; then navigation, tiles and summary. Seven unique backend calls. |
+| `history` | Six consumed context providers, 40 structured rows with headings, text, code, tags and context labels; six related items; nested per-row author boundaries | Three independent bootstrap loads; record → history → four shared authors; related items run alongside history. Nine unique backend calls. |
+
+[Initial validation and repeated-run results](BASELINE.md) include the observed
+noise; those local timings are not an absolute performance gate.
+
+These are original synthetic models of common application work, **not replicas
+or calibrated representations of a proprietary application**. Names, content,
+counts, schedules and schemas are invented. No private source, traces, endpoint
+names, credentials, production payloads or production measurements are inputs.
+A separately approved, sanitized workload profile would be needed to establish
+representativeness; this suite does not establish it by itself.
+
+The timed path is production-compiled `.tsrx` → `octane/server` → a real
+workerd response stream. A second local Worker supplies JSON via a service
+binding. No external service is contacted. This is **not** the app-core or
+Cloudflare adapter wrapper, a deployed-edge test, a browser/hydration test, a
+token-generation benchmark, or a CPU profiler. No framework optimization is
+implemented by adding these benchmarks.
+
+## Run
+
+From the repository root, with installed workspace dependencies:
+
+```bash
+node --test benchmarks/ssr-workerd/app-workloads/verify.test.mjs
+BENCH_ROUNDS=1 node benchmarks/ssr-workerd/app-workloads/run.mjs 1 # smoke
+node benchmarks/ssr-workerd/app-workloads/run.mjs 7               # baseline
+BENCH_SCALE=4 node benchmarks/ssr-workerd/app-workloads/run.mjs 7 # size control
+CASES=history BENCH_DELAY_MS=25 node benchmarks/ssr-workerd/app-workloads/run.mjs 7
+```
+
+The package also exposes `bench:app-workloads`, `bench:app-workloads:smoke` and
+`test:app-workloads`. This standalone suite is not run by the parent unified
+`ssr-workerd` command; the weekly/manual Bench workflow runs its oracle tests
+and all-case smoke separately. Results default to the ignored
+`benchmarks/results/ssr-workerd-app-workloads.json`; override with `BENCH_JSON`.
+Fixture/runtime/lockfile hashes, tool versions, worker raw/gzip bytes, individual
+samples and round numbers accompany the aggregates. Keep those inputs identical
+when comparing framework revisions. This suite contains no private reference
+implementation and makes no cross-framework speed claim.
+
+Each workload has four controls, not four different applications:
+
+- `zero-delay`: real fetch/JSON operations, no artificial timer delay. It is
+  still end-to-end wall time, not isolated renderer CPU time.
+- `io`: fresh request cache, base delay 15 ms. Summary/related and the fourth
+  author use 4× the base delay; the other authors use 1×, 2× and 3×. These are
+  controlled timer waits, not production service-latency estimates.
+- `io-blocked-root`: identical to `io` except the outer loading-shell boundary
+  is absent. The bootstrap now blocks TTFB; descendant boundaries still stream.
+  This exposes bootstrap costs that an immediate shell can otherwise hide.
+- `warm-data`: clear the bounded data cache, prime the same workload outside
+  timing, then measure a request with zero backend calls. Priming is explicit;
+  it is not a runtime speedup. The 128-entry, 60-second cache contains completed
+  JSON values, keyed by synthetic tenant, resource, scale and delay. Promises
+  stay request-local, including warm hits. Errors are not cached.
+
+All modes use stable request-scoped promises. Repeated profile and author
+consumers exercise deduplication without introducing the opaque parent-created
+promise stress pattern already covered by `fetch-patterns`. `BENCH_SCALE=1..4`
+multiplies links, tiles, rows and related items; provider depth and the number of
+unique data sources stay fixed. `BENCH_DELAY_MS=0..100` changes the delayed modes.
+
+## Metrics and correctness
+
+Two warmups precede three rounds of seven samples per case by default. Case
+order reverses in alternate rounds. All timed samples are retained; medians,
+means, spread and p95 are reported. Small deltas within the observed spread are
+inconclusive. The first requests and correctness preflights are not cold-start
+measurements.
+
+Timing starts before request dispatch and ends at stream EOF. Fetch startup,
+JSON parsing, fixture generation and SSR all remain inside that window. The
+consumer stores raw bytes and timestamps; it decodes and verifies only after
+timing. Requests disable compression to avoid measuring gzip buffering.
+
+- `ttfb`: first nonempty response-body chunk, including the synchronous shell.
+- `firstContent`: first chunk containing the primary section's first completed
+  tile/row title on the wire; the section can still be partial. A loading
+  placeholder does not qualify.
+- `total`: stream EOF, accepted only when all expected output is present.
+- Wire bytes/chunks, exact proof count, bootstrap attempts, loader calls, cache
+  hits and unique backend calls reveal work shifted beyond the first byte.
+
+Untimed backend gates hold **all data** until the consumer receives the shell,
+then separately hold **tail data** until primary content arrives. This proves
+incremental delivery without a wall-clock threshold. Every measured response
+must contain every expected leaf ID and escaped value exactly once, ordered
+items within each list, all six correct context values, and tenant-correct data.
+The stats gate checks dependency edges, overlapping independent bootstrap loads,
+expected backend calls, no errors and complete request draining. Concurrent
+tenant tests check cold and warm cache isolation and changed-size cache keys.
+Oracle tests deliberately remove, duplicate and corrupt output and dependency
+records.
+
+The shared stream decoder exposes boundary payloads for verification; it does
+not execute the browser adoption protocol or reconstruct final DOM hierarchy.
+Independent boundaries may arrive in any wire order. This suite verifies
+payload completeness, not browser placement, paint or interaction readiness.
+Diagnostic routes and gate state exist only for this local harness; do not
+deploy these Workers as application endpoints.

--- a/benchmarks/ssr-workerd/app-workloads/backend.js
+++ b/benchmarks/ssr-workerd/app-workloads/backend.js
@@ -1,0 +1,57 @@
+// Entirely invented data and schedules. This local service has no network
+// dependency, credentials, production schema or captured application payloads.
+const gates = new Map();
+const counts = { navigation: 48, tiles: 18, related: 6 };
+const delays = { profile: 1, preferences: 1, catalog: 1, summary: 4, related: 4 };
+
+export default {
+	async fetch(request) {
+		const url = new URL(request.url);
+		const q = url.searchParams;
+		const id = q.get('id');
+		if (url.pathname === '/release' || url.pathname === '/reset') {
+			let state = gates.get(id);
+			// The consumer can receive the shell before the first backend fetch
+			// registers its gate. Remember release for subsequent requests too.
+			if (!state && url.pathname === '/release') gates.set(id, (state = { released: true }));
+			if (state) state.released = true;
+			if (url.pathname === '/reset') gates.delete(id);
+			return new Response('ok');
+		}
+		const resource = q.get('resource');
+		const gate = q.get('gate');
+		const tail = resource === 'summary' || resource === 'related' || resource.startsWith('author:');
+		if (gate === 'shell' || (gate === 'tail' && tail)) {
+			let state = gates.get(id);
+			if (!state) gates.set(id, (state = { released: false }));
+			// Request-local timer promises keep the fetch alive. Sharing resolvers
+			// across Workers requests can cancel the originating request instead.
+			// Gates run only in untimed preflights, never the measured samples.
+			const deadline = Date.now() + 4000;
+			while (!state.released) {
+				if (Date.now() > deadline) return new Response('Gate was not released', { status: 504 });
+				await new Promise((resolve) => setTimeout(resolve, 1));
+			}
+		}
+		const factor = resource.startsWith('author:')
+			? Number(resource.slice(7)) + 1
+			: (delays[resource] ?? 1);
+		const delay = Number(q.get('delay')) * factor;
+		if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+		const count =
+			(resource.startsWith('history:') ? 40 : (counts[resource] ?? 0)) * Number(q.get('scale'));
+		const tenant = q.get('tenant');
+		return Response.json({
+			label: `${tenant}/${resource}`,
+			next: `${tenant}-detail`,
+			items: Array.from({ length: count }, (_, id) => ({
+				id,
+				title: `${tenant}/${resource}/item-${id}`,
+				text: `Synthetic entry ${id}: <tag> & "quoted" text.`,
+				code: `const value = ${id}; // </script> & example`,
+				tags: [`group-${id % 4}`, `state-${id % 3}`],
+				author: id % 4,
+			})),
+		});
+	},
+};

--- a/benchmarks/ssr-workerd/app-workloads/data.ts
+++ b/benchmarks/ssr-workerd/app-workloads/data.ts
@@ -1,0 +1,127 @@
+export type Scenario = 'workspace' | 'history';
+export interface Item {
+	id: number;
+	title: string;
+	text: string;
+	code: string;
+	tags: string[];
+	author: number;
+}
+export interface Payload {
+	label: string;
+	next: string;
+	items: Item[];
+}
+export interface Backend {
+	fetch(url: string): Promise<Response>;
+}
+export interface Stats {
+	bootstrapPasses: number;
+	loads: number;
+	requestHits: number;
+	dataHits: number;
+	backendCalls: number;
+	active: number;
+	maxActive: number;
+	events: { kind: 'start' | 'end'; resource: string }[];
+	errors: string[];
+	done: boolean;
+}
+export interface Workload {
+	scenario: Scenario;
+	streamShell: boolean;
+	stats: Stats;
+	jobs: Promise<Payload>[];
+	load(resource: string): Promise<Payload>;
+}
+
+// Only completed JSON values survive requests. No Response, request-owned
+// promise or tenant-independent cache key is retained across Workers requests.
+const dataCache = new Map<string, { value: Payload; expires: number }>();
+export function clearDataCache() {
+	dataCache.clear();
+}
+
+export function createWorkload(url: URL, backend: Backend): Workload {
+	const q = url.searchParams;
+	const scenario = q.get('scenario');
+	const scale = Number(q.get('scale') ?? 1);
+	const delay = Number(q.get('delay') ?? 15);
+	const tenant = q.get('tenant') ?? 'sample';
+	const id = q.get('id') ?? '';
+	const cache = q.get('cache') === 'data';
+	const gate = q.get('gate') ?? '';
+	if (scenario !== 'workspace' && scenario !== 'history') throw new Error('Invalid scenario');
+	if (!Number.isInteger(scale) || scale < 1 || scale > 4) throw new Error('Invalid scale');
+	if (!Number.isFinite(delay) || delay < 0 || delay > 100) throw new Error('Invalid delay');
+	if (!/^[a-z0-9-]{1,32}$/.test(tenant)) throw new Error('Invalid synthetic tenant');
+	if (!/^[a-z0-9-]{1,64}$/.test(id)) throw new Error('Invalid request id');
+	if (!['', 'shell', 'tail'].includes(gate)) throw new Error('Invalid gate');
+	const requestCache = new Map<string, Promise<Payload>>();
+	const jobs: Promise<Payload>[] = [];
+	const stats: Stats = {
+		bootstrapPasses: 0,
+		loads: 0,
+		requestHits: 0,
+		dataHits: 0,
+		backendCalls: 0,
+		active: 0,
+		maxActive: 0,
+		events: [],
+		errors: [],
+		done: false,
+	};
+	return {
+		scenario,
+		streamShell: q.get('streamShell') !== '0',
+		stats,
+		jobs,
+		load(resource) {
+			stats.loads++;
+			const existing = requestCache.get(resource);
+			if (existing) {
+				stats.requestHits++;
+				return existing;
+			}
+			const key = JSON.stringify([tenant, resource, scale, delay]);
+			const cached = cache && !gate ? dataCache.get(key) : undefined;
+			if (cached && cached.expires > Date.now()) {
+				stats.dataHits++;
+				const result = Promise.resolve(cached.value);
+				requestCache.set(resource, result);
+				return result;
+			}
+			stats.backendCalls++;
+			stats.active++;
+			stats.maxActive = Math.max(stats.maxActive, stats.active);
+			stats.events.push({ kind: 'start', resource });
+			const params = new URLSearchParams({
+				id,
+				tenant,
+				resource,
+				scale: String(scale),
+				delay: String(delay),
+				gate,
+			});
+			const job = backend
+				.fetch(`https://backend.local/?${params}`)
+				.then(async (response) => {
+					if (!response.ok) throw new Error(`Backend HTTP ${response.status}`);
+					const value = (await response.json()) as Payload;
+					if (cache && !gate) {
+						if (dataCache.size >= 128) dataCache.delete(dataCache.keys().next().value!);
+						dataCache.set(key, { value, expires: Date.now() + 60_000 });
+					}
+					return value;
+				})
+				.finally(() => {
+					stats.active--;
+					stats.events.push({ kind: 'end', resource });
+				});
+			job.catch((error) => stats.errors.push(String(error)));
+			requestCache.set(resource, job);
+			jobs.push(job);
+			return job;
+		},
+	};
+}

--- a/benchmarks/ssr-workerd/app-workloads/run.mjs
+++ b/benchmarks/ssr-workerd/app-workloads/run.mjs
@@ -1,0 +1,326 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { performance } from 'node:perf_hooks';
+import { createHash } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+import { createRequire } from 'node:module';
+import { build } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { Miniflare, Log, LogLevel } from 'miniflare';
+import { summarizeSamples } from '../../lib/stats.mjs';
+import { contentPresent, verifyGatePrefix, verifyOutput, verifyStats } from './verify.mjs';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(root, '../../..');
+const outDir = path.resolve(root, '../dist/app-workloads');
+const iterations = Number(process.argv[2] ?? 7);
+const rounds = Number(process.env.BENCH_ROUNDS ?? 3);
+const delay = Number(process.env.BENCH_DELAY_MS ?? 15);
+const scale = Number(process.env.BENCH_SCALE ?? 1);
+assert(Number.isInteger(iterations) && iterations > 0, 'Invalid iterations');
+assert(Number.isInteger(rounds) && rounds > 0, 'Invalid rounds');
+assert(Number.isFinite(delay) && delay >= 0 && delay <= 100, 'Invalid delay');
+assert(Number.isInteger(scale) && scale >= 1 && scale <= 4, 'Invalid scale');
+
+await build({
+	root,
+	configFile: false,
+	logLevel: 'warn',
+	plugins: [octane()],
+	build: { ssr: 'worker.ts', outDir, emptyOutDir: true, minify: true, target: 'esnext' },
+	ssr: { target: 'webworker', noExternal: true },
+});
+const compatibilityDate = '2026-07-14';
+const mf = new Miniflare({
+	log: new Log(LogLevel.ERROR),
+	defaultPersistRoot: path.join(outDir, '.miniflare'),
+	workers: [
+		{
+			name: 'render',
+			modules: true,
+			scriptPath: path.join(outDir, 'worker.js'),
+			modulesRules: [{ type: 'ESModule', include: ['**/*.js'], fallthrough: true }],
+			compatibilityDate,
+			compatibilityFlags: ['nodejs_compat'],
+			serviceBindings: { BACKEND: 'backend' },
+		},
+		{
+			name: 'backend',
+			modules: true,
+			scriptPath: path.join(root, 'backend.js'),
+			compatibilityDate,
+		},
+	],
+});
+
+const cases = ['workspace', 'history'].flatMap((scenario) => [
+	{ name: `${scenario}/zero-delay`, scenario, delay: 0, warm: false },
+	{ name: `${scenario}/io`, scenario, delay, warm: false },
+	{ name: `${scenario}/io-blocked-root`, scenario, delay, warm: false, streamShell: false },
+	{ name: `${scenario}/warm-data`, scenario, delay, warm: true },
+]);
+const selected = process.env.CASES
+	? cases.filter((config) =>
+			process.env.CASES.split(',').some((name) => config.name.includes(name)),
+		)
+	: cases;
+assert(selected.length > 0, 'No matching cases');
+let sequence = 0;
+
+async function dispatch(urlPath) {
+	return mf.dispatchFetch(`https://bench.local${urlPath}`, {
+		headers: { 'accept-encoding': 'identity' },
+	});
+}
+async function control(pathname) {
+	assert.equal(await (await dispatch(pathname)).text(), 'ok');
+}
+async function deadline(job) {
+	let timer;
+	try {
+		return await Promise.race([
+			job,
+			new Promise((_, reject) => {
+				timer = setTimeout(() => reject(new Error('Sample exceeded 10s')), 10_000);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function sample(config, tenant = 'sample', gate = '') {
+	const id = `request-${sequence++}`;
+	const sampleScale = config.scale ?? scale;
+	const params = new URLSearchParams({
+		id,
+		tenant,
+		scenario: config.scenario,
+		scale: String(sampleScale),
+		delay: String(config.delay),
+		cache: config.warm ? 'data' : 'request',
+		gate,
+		streamShell: config.streamShell === false ? '0' : '1',
+	});
+	const chunks = [];
+	let reader;
+	let gateReleased = false;
+	let gatedHtml = '';
+	const gateDecoder = new TextDecoder();
+	try {
+		// No loader preparation, fetching, parsing or data generation is hidden
+		// before this clock. Only an explicitly labelled warm-data prime is outside.
+		const start = performance.now();
+		const response = await dispatch(`/?${params}`);
+		assert(response.body, 'Missing response body');
+		reader = response.body.getReader();
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value?.byteLength) continue;
+			chunks.push({ ms: performance.now() - start, value });
+			// Untimed correctness preflights only. Timed samples retain raw bytes
+			// and do not decode/parse their HTML in the consumption loop.
+			if (gate && !gateReleased) {
+				gatedHtml += gateDecoder.decode(value, { stream: true });
+				if (verifyGatePrefix(gatedHtml, { scenario: config.scenario, gate })) {
+					await control(`/release?id=${id}`);
+					gateReleased = true;
+				}
+			}
+		}
+		const total = performance.now() - start;
+		reader.releaseLock();
+		reader = undefined;
+		assert.equal(response.status, 200);
+		assert(chunks.length > 0, 'Empty response');
+		if (gate) assert(gateReleased, 'Stream ended before gate release');
+
+		// All payload decoding and counters are outside the timed window.
+		const decoder = new TextDecoder();
+		let html = '';
+		let firstContent;
+		for (const chunk of chunks) {
+			html += decoder.decode(chunk.value, { stream: true });
+			if (firstContent === undefined && contentPresent(html, config.scenario))
+				firstContent = chunk.ms;
+		}
+		html += decoder.decode();
+		const output = verifyOutput(html, { scenario: config.scenario, tenant, scale: sampleScale });
+		assert(firstContent !== undefined, 'No primary content milestone');
+		let stats;
+		for (let poll = 0; poll < 200; poll++) {
+			stats = await (await dispatch(`/stats?id=${id}`)).json();
+			assert(stats, 'Missing request stats');
+			if (stats.done) break;
+			await new Promise((resolve) => setTimeout(resolve, 2));
+		}
+		assert(stats.done, 'Request work did not drain');
+		return {
+			ttfb: chunks[0].ms,
+			firstContent,
+			total,
+			wireBytes: chunks.reduce((sum, chunk) => sum + chunk.value.byteLength, 0),
+			chunkCount: chunks.length,
+			proofCount: output.proofCount,
+			...stats,
+		};
+	} finally {
+		if (gate) await control(`/reset?id=${id}`);
+		if (reader) await reader.cancel().catch(() => {});
+	}
+}
+
+async function runSample(config, tenant = 'sample') {
+	if (config.warm) {
+		await control('/clear-cache');
+		const prime = await deadline(sample(config, tenant));
+		verifyStats(prime, { ...config, tenant, warm: false });
+	}
+	const result = await deadline(sample(config, tenant));
+	verifyStats(result, { ...config, tenant });
+	return result;
+}
+
+const records = new Map(selected.map((config) => [config.name, []]));
+try {
+	await mf.ready;
+	for (const scenario of new Set(selected.map((config) => config.scenario))) {
+		const config = { scenario, delay: 0, warm: false };
+		// Backend response gates establish streaming without a flaky millisecond
+		// threshold: initial shell before all data; primary content before tail data.
+		for (const gate of ['shell', 'tail']) {
+			const result = await deadline(sample(config, 'gate-check', gate));
+			verifyStats(result, { ...config, tenant: 'gate-check' });
+		}
+		// Concurrent cold tenants, warm tenants and a changed input size are never
+		// inferred from timing: complete labels and the actual backend keys are checked.
+		await control('/clear-cache');
+		const isolation = { ...config, warm: true };
+		const tenants = ['tenant-a', 'tenant-b'];
+		const cold = await Promise.all(tenants.map((tenant) => deadline(sample(isolation, tenant))));
+		cold.forEach((result, index) => verifyStats(result, { ...config, tenant: tenants[index] }));
+		const warm = await Promise.all(tenants.map((tenant) => deadline(sample(isolation, tenant))));
+		warm.forEach((result, index) => verifyStats(result, { ...isolation, tenant: tenants[index] }));
+		const resized = { ...isolation, scale: scale === 4 ? 1 : scale + 1 };
+		verifyStats(await deadline(sample(resized, tenants[0])), { ...config, tenant: tenants[0] });
+		verifyStats(await deadline(sample(isolation, tenants[0])), {
+			...isolation,
+			tenant: tenants[0],
+		});
+		await control('/clear-cache');
+	}
+	for (const config of selected) for (let i = 0; i < 2; i++) await runSample(config);
+	for (let round = 0; round < rounds; round++) {
+		const ordered = round % 2 ? [...selected].reverse() : selected;
+		for (const config of ordered) {
+			for (let i = 0; i < iterations; i++)
+				records.get(config.name).push({ round, ...(await runSample(config)) });
+			console.error(`round ${round + 1}/${rounds}: ${config.name}`);
+		}
+	}
+} finally {
+	await mf.dispose();
+}
+
+const metrics = [
+	'ttfb',
+	'firstContent',
+	'total',
+	'wireBytes',
+	'chunkCount',
+	'proofCount',
+	'bootstrapPasses',
+	'loads',
+	'requestHits',
+	'dataHits',
+	'backendCalls',
+	'maxActive',
+];
+const results = selected.map((config) => {
+	const samples = records.get(config.name);
+	return {
+		config: { ...config, scale },
+		stats: Object.fromEntries(
+			metrics.map((key) => [
+				key,
+				summarizeSamples(
+					samples.map((s) => s[key]),
+					{ scoreMode: 'mean' },
+				),
+			]),
+		),
+		samples,
+	};
+});
+const worker = fs.readFileSync(path.join(outDir, 'worker.js'));
+const hash = (file) => createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+function version(name, resolver = import.meta.resolve) {
+	// Some dependencies intentionally do not export their package.json.
+	const resolved = resolver(name);
+	let directory = path.dirname(resolved.startsWith('file:') ? fileURLToPath(resolved) : resolved);
+	while (directory !== path.dirname(directory)) {
+		const manifest = path.join(directory, 'package.json');
+		if (fs.existsSync(manifest)) {
+			const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+			if (pkg.name === name) return pkg.version;
+		}
+		directory = path.dirname(directory);
+	}
+	throw new Error(`Could not record installed version: ${name}`);
+}
+const report = {
+	suite: 'ssr-workerd-app-workloads',
+	completedAt: new Date().toISOString(),
+	scope:
+		'Synthetic production-compiled Octane SSR in workerd with a local backend service binding; not the app-core/Cloudflare adapter wrapper, browser paint, hydration, or a production workload measurement.',
+	commit: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
+	fixtureSha256: Object.fromEntries(
+		[
+			'Pages.tsrx',
+			'data.ts',
+			'worker.ts',
+			'backend.js',
+			'run.mjs',
+			'verify.mjs',
+			'../../lib/stream-verify.mjs',
+			'../../lib/stats.mjs',
+		].map((file) => [file, hash(path.join(root, file))]),
+	),
+	runtimeSha256: hash(path.join(repo, 'packages/octane/src/runtime.server.ts')),
+	lockfileSha256: hash(path.join(repo, 'pnpm-lock.yaml')),
+	environment: {
+		node: process.version,
+		platform: os.platform(),
+		arch: os.arch(),
+		cpu: os.cpus()[0]?.model,
+		compatibilityDate,
+		vite: version('vite'),
+		miniflare: version('miniflare'),
+		workerd: version('workerd', createRequire(import.meta.resolve('miniflare')).resolve),
+		tsrx: version('@tsrx/core'),
+	},
+	iterations,
+	rounds,
+	delay,
+	scale,
+	warmupsPerCase: 2,
+	workerBytes: worker.byteLength,
+	workerGzipBytes: gzipSync(worker).byteLength,
+	results,
+};
+const destination =
+	process.env.BENCH_JSON ?? path.resolve(repo, 'benchmarks/results/ssr-workerd-app-workloads.json');
+fs.mkdirSync(path.dirname(destination), { recursive: true });
+fs.writeFileSync(destination, JSON.stringify(report, null, 2) + '\n');
+console.log('case                         TTFB ms  content ms  total ms  fetches  wire KiB');
+for (const { config, stats } of results) {
+	console.log(
+		`${config.name.padEnd(28)} ${stats.ttfb.median.toFixed(2).padStart(7)} ${stats.firstContent.median.toFixed(2).padStart(11)} ${stats.total.median.toFixed(2).padStart(9)} ${String(stats.backendCalls.median).padStart(8)} ${(stats.wireBytes.median / 1024).toFixed(1).padStart(9)}`,
+	);
+}
+console.log(`Raw samples: ${destination}`);

--- a/benchmarks/ssr-workerd/app-workloads/tsconfig.json
+++ b/benchmarks/ssr-workerd/app-workloads/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../fetch-patterns/tsconfig.json",
+  "include": ["./*.ts", "./*.tsrx"]
+}

--- a/benchmarks/ssr-workerd/app-workloads/verify.mjs
+++ b/benchmarks/ssr-workerd/app-workloads/verify.mjs
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { semanticHtmlForVerification } from '../../lib/stream-verify.mjs';
+
+// These are wire-payload checks, not a reconstruction of the final DOM. In
+// particular, nested/sibling boundary payloads may arrive outside their parent.
+const semantic = (html) =>
+	semanticHtmlForVerification('app-workloads', html).replace(/<!--[\s\S]*?-->/g, '');
+const attribute = (attrs, name) =>
+	attrs
+		.match(new RegExp(`(?:^|\\s)${name}=(?:"([^"]*)"|'([^']*)')`))
+		?.slice(1)
+		.find((v) => v !== undefined);
+const tags = (html, name) => [...html.matchAll(new RegExp(`<${name}\\b([^>]*)>`, 'g'))];
+const ids = (count) => Array.from({ length: count }, (_, i) => String(i));
+const scenarios = new Set(['workspace', 'history']);
+
+function decodeText(text) {
+	assert(!text.includes('<'), 'Proof text contains unescaped markup');
+	const entities = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+	return text.replace(/&(#x[\da-f]+|#\d+|amp|lt|gt|quot|apos);/gi, (match, entity) => {
+		if (entity[0] !== '#') return entities[entity.toLowerCase()];
+		const code =
+			entity[1].toLowerCase() === 'x' ? parseInt(entity.slice(2), 16) : Number(entity.slice(1));
+		return code <= 0x10ffff ? String.fromCodePoint(code) : match;
+	});
+}
+
+function proofEntries(html) {
+	const entries = [];
+	for (const match of html.matchAll(/<([a-z][\w:-]*)\b([^>]*)>([^<]*)<\/\1\s*>/gi)) {
+		const key = attribute(match[2], 'data-proof');
+		if (key !== undefined) entries.push([key, decodeText(match[3])]);
+	}
+	assert.equal(
+		entries.length,
+		[...html.matchAll(/\bdata-proof=/g)].length,
+		'Malformed proof element',
+	);
+	return entries;
+}
+
+export function contentPresent(html, scenario) {
+	assert(scenarios.has(scenario), 'Unknown scenario');
+	const decoded = semantic(html);
+	const prefix = scenario === 'workspace' ? 'tile' : 'row';
+	// A partial wire prefix can include the first item before the section closes.
+	// These fixtures have no nested sections; sibling payloads outside a closed
+	// primary section must not impersonate its first-content milestone.
+	const sections = decoded.matchAll(/<section\b([^>]*)>([\s\S]*?)(?:<\/section>|$)/g);
+	for (const section of sections) {
+		if (attribute(section[1], 'data-content') !== scenario) continue;
+		if (
+			new RegExp(
+				`<h2\\b[^>]*\\sdata-proof=(?:"${prefix}/0/title"|'${prefix}/0/title')[^>]*>[^<]+</h2>`,
+			).test(section[2])
+		)
+			return true;
+	}
+	return false;
+}
+
+// Untimed gate preflights wait for a complete milestone rather than assuming
+// any particular first-chunk framing. Tail payloads must still be withheld.
+export function verifyGatePrefix(html, { scenario, gate }) {
+	assert(scenarios.has(scenario), 'Unknown scenario');
+	assert(gate === 'shell' || gate === 'tail', 'Unknown gate');
+	const decoded = semantic(html);
+	const proofs = [...decoded.matchAll(/<[a-z][\w:-]*\b([^>]*)>/gi)]
+		.map((tag) => attribute(tag[1], 'data-proof'))
+		.filter((key) => key !== undefined);
+	if (gate === 'shell') {
+		assert.equal(proofs.length, 0, 'Data bypassed shell gate');
+		return [...decoded.matchAll(/<h1\b([^>]*)>([^<]+)<\/h1>/g)].some(
+			(match) =>
+				attribute(match[1], 'data-shell') === 'app' &&
+				decodeText(match[2]) === 'Synthetic workspace',
+		);
+	}
+	const tail =
+		scenario === 'workspace'
+			? (key) => key === 'summary'
+			: (key) => key.startsWith('related/') || /^row\/[^/]+\/author$/.test(key);
+	assert(!proofs.some(tail), 'Tail data arrived before gate release');
+	return contentPresent(html, scenario);
+}
+
+export function verifyOutput(html, { scenario, tenant, scale }) {
+	assert(scenarios.has(scenario), 'Unknown scenario');
+	assert(Number.isInteger(scale) && scale >= 1 && scale <= 4, 'Invalid scale');
+	const decoded = semantic(html);
+	const shells = [...decoded.matchAll(/<h1\b([^>]*)>([^<]*)<\/h1>/g)].filter(
+		(match) => attribute(match[1], 'data-shell') !== undefined,
+	);
+	assert.equal(shells.length, 1, 'Expected one nonempty shell');
+	assert.equal(attribute(shells[0][1], 'data-shell'), 'app');
+	assert.equal(decodeText(shells[0][2]), 'Synthetic workspace');
+	assert.equal([...decoded.matchAll(/\bdata-shell=/g)].length, 1, 'Duplicate or malformed shell');
+	const sections = [...decoded.matchAll(/<section\b([^>]*)>([\s\S]*?)<\/section>/g)].filter(
+		(match) => attribute(match[1], 'data-content') !== undefined,
+	);
+	assert.equal(sections.length, 1, 'Expected one content section');
+	assert.equal(attribute(sections[0][1], 'data-content'), scenario);
+	assert.equal([...decoded.matchAll(/\bdata-content=/g)].length, 1);
+	const expected = [];
+	const add = (key, value) => expected.push([key, value]);
+	const workspace = scenario === 'workspace';
+	const prefix = workspace ? 'tile' : 'row';
+	const resource = workspace ? 'tiles' : `history:${tenant}-detail`;
+	const count = (workspace ? 18 : 40) * scale;
+	for (let i = 0; i < count; i++) {
+		const key = `${prefix}/${i}`;
+		add(`${key}/title`, `${tenant}/${resource}/item-${i}`);
+		add(`${key}/text`, `Synthetic entry ${i}: <tag> & "quoted" text.`);
+		add(`${key}/code`, `const value = ${i}; // </script> & example`);
+		for (const tag of [`group-${i % 4}`, `state-${i % 3}`]) add(`${key}/${tag}`, tag);
+		add(`${key}/profile`, `${tenant}/profile`);
+		add(`${key}/scope`, `${tenant}/profile`);
+		for (const context of ['locale', 'theme', 'density', 'zone'])
+			add(`${key}/${context}`, `${tenant}/preferences/${context}`);
+		add(`${key}/collection`, `${tenant}/${workspace ? 'catalog' : 'record'}`);
+		if (!workspace) add(`${key}/author`, `${tenant}/author:${i % 4}`);
+	}
+	const listPrefix = workspace ? 'nav' : 'related';
+	const listCount = (workspace ? 48 : 6) * scale;
+	for (let i = 0; i < listCount; i++)
+		add(`${listPrefix}/${i}`, `${tenant}/${workspace ? 'navigation' : 'related'}/item-${i}`);
+	if (workspace) {
+		add('navigation/profile', `${tenant}/profile`);
+		add('access', `${tenant}/access:${tenant}-detail`);
+		add('summary', `${tenant}/summary`);
+	} else add('record', `${tenant}/record`);
+	const actual = proofEntries(decoded);
+	const byKey = ([a], [b]) => a.localeCompare(b);
+	assert.deepEqual([...actual].sort(byKey), expected.sort(byKey), 'Incorrect proof keys or values');
+	const itemIds = (fragment) =>
+		tags(fragment, 'article')
+			.map((tag) => attribute(tag[1], `data-${prefix}`))
+			.filter((id) => id !== undefined);
+	assert.deepEqual(itemIds(sections[0][2]), ids(count), 'Content item order');
+	assert.deepEqual(itemIds(decoded), ids(count), 'Unexpected content items');
+	assert.equal(
+		[...decoded.matchAll(/\bdata-(?:tile|row)=/g)].length,
+		count,
+		'Unexpected item markers',
+	);
+	const containers = [
+		...decoded.matchAll(
+			new RegExp(
+				`<${workspace ? 'nav' : 'aside'}\\b[^>]*>([\\s\\S]*?)</${workspace ? 'nav' : 'aside'}>`,
+				'g',
+			),
+		),
+	];
+	assert.equal(containers.length, 1, 'Expected one navigation/related container');
+	const lists = [...containers[0][1].matchAll(/<ul\b[^>]*>([\s\S]*?)<\/ul>/g)];
+	assert.equal(lists.length, 1, 'Expected one navigation/related list');
+	assert.deepEqual(
+		proofEntries(lists[0][1]).map(([key]) => key),
+		ids(listCount).map((id) => `${listPrefix}/${id}`),
+		'Navigation/related item order',
+	);
+	const present = contentPresent(html, scenario);
+	assert(present, 'Primary content title is outside its section');
+	return { proofCount: actual.length, contentPresent: present };
+}
+
+export function verifyStats(stats, { scenario, tenant, warm }) {
+	assert(scenarios.has(scenario), 'Unknown scenario');
+	const workspace = scenario === 'workspace';
+	const bootstrap = ['profile', 'preferences', workspace ? 'catalog' : 'record'];
+	const resources = workspace
+		? [...bootstrap, `access:${tenant}-detail`, 'navigation', 'tiles', 'summary']
+		: [
+				...bootstrap,
+				`history:${tenant}-detail`,
+				'related',
+				'author:0',
+				'author:1',
+				'author:2',
+				'author:3',
+			];
+	assert.deepEqual(stats.errors, [], 'Request errors');
+	assert.equal(stats.done, true, 'Request work did not finish');
+	assert.equal(stats.active, 0, 'Outstanding backend work');
+	assert(stats.requestHits > 0, 'Shared loaders did not deduplicate');
+	assert.equal(stats.backendCalls, warm ? 0 : resources.length, 'Backend call count');
+	assert.equal(stats.dataHits, warm ? resources.length : 0, 'Data cache hit count');
+	assert(Array.isArray(stats.events));
+	if (warm) {
+		assert.deepEqual(stats.events, [], 'Warm cache performed backend work');
+		return;
+	}
+	for (const event of stats.events) assert(['start', 'end'].includes(event.kind), 'Unknown event');
+	for (const kind of ['start', 'end'])
+		assert.deepEqual(
+			stats.events
+				.filter((event) => event.kind === kind)
+				.map((event) => event.resource)
+				.sort(),
+			[...resources].sort(),
+			`Missing or duplicate ${kind} resource`,
+		);
+	const index = (kind, resource) =>
+		stats.events.findIndex((event) => event.kind === kind && event.resource === resource);
+	for (const resource of resources)
+		assert(index('end', resource) > index('start', resource), 'End precedes start');
+	assert(
+		Math.max(...bootstrap.map((key) => index('start', key))) <
+			Math.min(...bootstrap.map((key) => index('end', key))),
+		'Independent bootstrap was serialized',
+	);
+	const dependencies = workspace
+		? [['profile', `access:${tenant}-detail`]]
+		: [
+				['record', `history:${tenant}-detail`],
+				...ids(4).map((id) => [`history:${tenant}-detail`, `author:${id}`]),
+			];
+	for (const [before, after] of dependencies)
+		assert(index('start', after) > index('end', before), `Dependency started early: ${after}`);
+}

--- a/benchmarks/ssr-workerd/app-workloads/verify.test.mjs
+++ b/benchmarks/ssr-workerd/app-workloads/verify.test.mjs
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { contentPresent, verifyGatePrefix, verifyOutput, verifyStats } from './verify.mjs';
+
+// Hand-authored wire fixtures: no renderer, backend-data helper, or compiler
+// output generates the expectations used to exercise this independent oracle.
+const escape = (value) =>
+	String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+const proof = (key, value, tag = 'span') => `<${tag} data-proof="${key}">${escape(value)}</${tag}>`;
+const shell = '<h1 data-shell="app">Synthetic workspace</h1>';
+const carrier = (html) =>
+	'<script type="application/json" data-octane-stream>' +
+	JSON.stringify(html).replaceAll('<', '\\u003c') +
+	'</script>';
+const options = (scenario, scale = 1) => ({ scenario, scale, tenant: 'tenant-a' });
+
+function fixture(
+	{ scenario, scale, tenant },
+	{ streamed = false, reverseItems = false, reverseList = false } = {},
+) {
+	const workspace = scenario === 'workspace';
+	const itemPrefix = workspace ? 'tile' : 'row';
+	const resource = workspace ? 'tiles' : `history:${tenant}-detail`;
+	const authors = [];
+	const items = Array.from({ length: (workspace ? 18 : 40) * scale }, (_, i) => {
+		const key = `${itemPrefix}/${i}`;
+		let body =
+			proof(`${key}/title`, `${tenant}/${resource}/item-${i}`, 'h2') +
+			proof(`${key}/text`, `Synthetic entry ${i}: <tag> & "quoted" text.`, 'p') +
+			proof(`${key}/code`, `const value = ${i}; // </script> & example`, 'code') +
+			proof(`${key}/group-${i % 4}`, `group-${i % 4}`, 'li') +
+			proof(`${key}/state-${i % 3}`, `state-${i % 3}`, 'li') +
+			proof(`${key}/profile`, `${tenant}/profile`);
+		for (const [name, value] of Object.entries({
+			scope: `${tenant}/profile`,
+			locale: `${tenant}/preferences/locale`,
+			theme: `${tenant}/preferences/theme`,
+			density: `${tenant}/preferences/density`,
+			zone: `${tenant}/preferences/zone`,
+			collection: `${tenant}/${workspace ? 'catalog' : 'record'}`,
+		}))
+			body += proof(`${key}/${name}`, value);
+		if (!workspace) authors.push(proof(`${key}/author`, `${tenant}/author:${i % 4}`));
+		return `<article data-${itemPrefix}="${i}">${body}</article>`;
+	});
+	if (reverseItems) items.reverse();
+	const links = Array.from({ length: (workspace ? 48 : 6) * scale }, (_, i) =>
+		proof(
+			`${workspace ? 'nav' : 'related'}/${i}`,
+			`${tenant}/${workspace ? 'navigation' : 'related'}/item-${i}`,
+			workspace ? 'a' : 'li',
+		),
+	);
+	if (reverseList) links.reverse();
+	const fragments = workspace
+		? [
+				proof('access', `${tenant}/access:${tenant}-detail`),
+				`<nav>${proof('navigation/profile', `${tenant}/profile`)}<ul>${links.join('')}</ul></nav>`,
+				`<section data-content="workspace">${items.join('')}</section>`,
+				proof('summary', `${tenant}/summary`),
+			]
+		: [
+				proof('record', `${tenant}/record`),
+				`<section data-content="history">${items.join('')}</section>`,
+				`<aside><ul>${links.join('')}</ul></aside>`,
+				...authors,
+			];
+	// Reverse sibling and nested-author payload arrival, never list order.
+	return shell + (streamed ? fragments.reverse().map(carrier).join('') : fragments.join(''));
+}
+
+function statsFixture({ scenario, tenant }, warm = false) {
+	const bootstrap = ['profile', 'preferences', scenario === 'workspace' ? 'catalog' : 'record'];
+	const remaining =
+		scenario === 'workspace'
+			? [`access:${tenant}-detail`, 'navigation', 'tiles', 'summary']
+			: [`history:${tenant}-detail`, 'related', 'author:0', 'author:1', 'author:2', 'author:3'];
+	const events = [
+		...bootstrap.map((resource) => ({ kind: 'start', resource })),
+		...bootstrap.map((resource) => ({ kind: 'end', resource })),
+		...remaining.flatMap((resource) => [
+			{ kind: 'start', resource },
+			{ kind: 'end', resource },
+		]),
+	];
+	return {
+		done: true,
+		active: 0,
+		errors: [],
+		requestHits: 8,
+		backendCalls: warm ? 0 : bootstrap.length + remaining.length,
+		dataHits: warm ? bootstrap.length + remaining.length : 0,
+		events: warm ? [] : events,
+	};
+}
+
+for (const scenario of ['workspace', 'history']) {
+	for (const scale of [1, 2]) {
+		test(`${scenario} scale ${scale}: accepts full inline and reordered streamed payloads`, () => {
+			const config = options(scenario, scale);
+			for (const streamed of [false, true]) {
+				assert.deepEqual(verifyOutput(fixture(config, { streamed }), config), {
+					proofCount: scenario === 'workspace' ? 264 * scale + 3 : 526 * scale + 1,
+					contentPresent: true,
+				});
+			}
+		});
+	}
+	test(`${scenario}: rejects missing, duplicate, unrelated, and wrong-valued proofs`, () => {
+		const config = options(scenario);
+		const html = fixture(config);
+		const key = `${scenario === 'workspace' ? 'tile' : 'row'}/0/profile`;
+		const value = proof(key, 'tenant-a/profile');
+		for (const corrupt of [
+			html.replace(value, ''),
+			html + value,
+			html + proof('unknown', 'extra'),
+			html.replace(value, proof(key, 'tenant-b/profile')),
+			html.replace('Synthetic entry 0:', 'Wrong entry 0:'),
+			html.replace('/preferences/theme', '/preferences/wrong-theme'),
+			html.replace(`data-proof="${key}"`, `not-data-proof="${key}"`),
+			html + '<article data-row="extra"></article>',
+		])
+			assert.throws(() => verifyOutput(corrupt, config));
+	});
+	test(`${scenario}: list order is required although sibling payload order is not`, () => {
+		const config = options(scenario);
+		assert.throws(
+			() => verifyOutput(fixture(config, { reverseItems: true }), config),
+			/item order/,
+		);
+		assert.throws(() => verifyOutput(fixture(config, { reverseList: true }), config), /item order/);
+	});
+	test(`${scenario}: accepts cold and warm request graphs`, () => {
+		for (const warm of [false, true]) {
+			const config = { ...options(scenario), warm };
+			assert.doesNotThrow(() => verifyStats(statsFixture(config, warm), config));
+		}
+	});
+}
+
+test('rejects missing/duplicate/empty shell and wrong content section', () => {
+	const config = options('workspace');
+	const html = fixture(config);
+	for (const corrupt of [
+		html.replace(shell, ''),
+		html + shell,
+		html.replace('Synthetic workspace', ''),
+		html.replace('data-content="workspace"', 'data-content="history"'),
+	])
+		assert.throws(() => verifyOutput(corrupt, config));
+});
+
+test('escaping preserves literal markup, ampersands, quotes and script-closing text', () => {
+	const config = options('workspace');
+	const html = fixture(config);
+	assert.doesNotThrow(() =>
+		verifyOutput(
+			html
+				.replaceAll('&lt;', '&#60;')
+				.replaceAll('&gt;', '&#x3e;')
+				.replaceAll('&amp;', '&#38;')
+				.replaceAll('"quoted"', '&quot;quoted&quot;'),
+			config,
+		),
+	);
+	for (const corrupt of [
+		html.replace('&lt;tag&gt;', '<tag>'),
+		html.replace('&lt;/script&gt;', '</script>'),
+	])
+		assert.throws(() => verifyOutput(corrupt, config), /Malformed proof/);
+	assert.throws(
+		() =>
+			verifyOutput(
+				shell + '<script type="application/json" data-octane-stream>{bad}</script>',
+				config,
+			),
+		/invalid Octane JSON/,
+	);
+});
+
+test('content milestone needs an actual title, not an empty section or incomplete carrier', () => {
+	assert.equal(contentPresent(shell, 'workspace'), false);
+	assert.equal(
+		contentPresent(shell + '<section data-content="workspace"></section>', 'workspace'),
+		false,
+	);
+	const partial = carrier(
+		'<section data-content="workspace">' + proof('tile/0/title', 'first tile', 'h2') + '</section>',
+	);
+	assert.equal(contentPresent(shell + partial.slice(0, -9), 'workspace'), false);
+	assert.equal(contentPresent(shell + partial, 'workspace'), true);
+	assert.equal(contentPresent(shell + partial, 'history'), false);
+	const title = proof('tile/0/title', 'tenant-a/tiles/item-0', 'h2');
+	assert.equal(
+		contentPresent('<section data-content="workspace"></section>' + title, 'workspace'),
+		false,
+	);
+	assert.equal(contentPresent('<section data-content="workspace">' + title, 'workspace'), true);
+	const config = options('workspace');
+	assert.throws(
+		() => verifyOutput(fixture(config).replace(title, '') + title, config),
+		/outside its section/,
+	);
+});
+
+test('shell gate tolerates split framing and rejects any resolved data before release', () => {
+	const config = { scenario: 'workspace', gate: 'shell' };
+	assert.equal(verifyGatePrefix('<h1 data-shell="app">Synthetic', config), false);
+	assert.equal(verifyGatePrefix(shell, config), true);
+	assert.throws(
+		() =>
+			verifyGatePrefix(shell + carrier(proof('access', 'tenant-a/access:tenant-a-detail')), config),
+		/bypassed shell gate/,
+	);
+});
+
+test('tail gate rejects buffered sibling and nested payloads before release', () => {
+	for (const scenario of ['workspace', 'history']) {
+		const config = { scenario, gate: 'tail' };
+		const prefix = scenario === 'workspace' ? 'tile' : 'row';
+		const primary =
+			shell +
+			carrier(
+				`<section data-content="${scenario}">` +
+					proof(`${prefix}/0/title`, 'first item', 'h2') +
+					'</section>',
+			);
+		assert.equal(verifyGatePrefix(shell, config), false);
+		assert.equal(verifyGatePrefix(primary, config), true);
+		const keys = scenario === 'workspace' ? ['summary'] : ['related/0', 'row/0/author'];
+		for (const key of keys)
+			assert.throws(
+				() => verifyGatePrefix(primary + carrier(proof(key, 'too early')), config),
+				/before gate release/,
+			);
+		assert.throws(
+			() => verifyGatePrefix(fixture(options(scenario), { streamed: true }), config),
+			/before gate release/,
+		);
+	}
+});
+
+test('stats reject errors, unfinished work, duplicate/missing resources and cache mistakes', () => {
+	const config = { ...options('workspace'), warm: false };
+	for (const mutate of [
+		(s) => {
+			s.errors.push('backend failed');
+		},
+		(s) => {
+			s.done = false;
+		},
+		(s) => {
+			s.active = 1;
+		},
+		(s) => {
+			s.requestHits = 0;
+		},
+		(s) => {
+			s.backendCalls++;
+		},
+		(s) => {
+			s.events.push(s.events[0]);
+		},
+		(s) => {
+			s.events.pop();
+		},
+		(s) => {
+			s.events[0].resource = 'wrong-tenant';
+		},
+		(s) => {
+			s.events[0].kind = 'unknown';
+		},
+	]) {
+		const stats = statsFixture(config);
+		mutate(stats);
+		assert.throws(() => verifyStats(stats, config));
+	}
+	const warmConfig = { ...config, warm: true };
+	const warm = statsFixture(config, true);
+	assert.throws(() => verifyStats({ ...warm, backendCalls: 1 }, warmConfig));
+	assert.throws(() => verifyStats({ ...warm, dataHits: 6 }, warmConfig));
+	assert.throws(() =>
+		verifyStats({ ...warm, events: [{ kind: 'start', resource: 'profile' }] }, warmConfig),
+	);
+});
+
+test('stats reject serialized bootstrap and requests that precede real dependencies', () => {
+	for (const scenario of ['workspace', 'history']) {
+		const config = { ...options(scenario), warm: false };
+		const serial = statsFixture(config);
+		const profileEnd = serial.events.splice(3, 1)[0];
+		serial.events.splice(1, 0, profileEnd);
+		assert.throws(() => verifyStats(serial, config), /bootstrap was serialized/);
+		const dependentKeys =
+			scenario === 'workspace'
+				? ['access:tenant-a-detail']
+				: ['history:tenant-a-detail', 'author:0'];
+		for (const resource of dependentKeys) {
+			const stats = statsFixture(config);
+			const start = stats.events.splice(
+				stats.events.findIndex((event) => event.kind === 'start' && event.resource === resource),
+				1,
+			)[0];
+			stats.events.splice(3, 0, start);
+			assert.throws(() => verifyStats(stats, config), /Dependency started early/);
+		}
+	}
+});

--- a/benchmarks/ssr-workerd/app-workloads/worker.ts
+++ b/benchmarks/ssr-workerd/app-workloads/worker.ts
@@ -1,0 +1,73 @@
+import { renderToReadableStream } from 'octane/server';
+import { Page } from './Pages.tsrx';
+import { clearDataCache, createWorkload, type Backend, type Stats } from './data';
+
+const requests = new Map<string, Stats>();
+
+// Local benchmark entry point only: diagnostic routes are not deployable app
+// endpoints. The runner drains each request, then removes its stats and gates.
+export default {
+	async fetch(
+		request: Request,
+		env: { BACKEND: Backend },
+		ctx: { waitUntil(job: Promise<unknown>): void },
+	) {
+		const url = new URL(request.url);
+		if (url.pathname === '/clear-cache') {
+			clearDataCache();
+			return new Response('ok');
+		}
+		const id = url.searchParams.get('id') ?? '';
+		if (url.pathname === '/release' || url.pathname === '/reset') {
+			return env.BACKEND.fetch(`https://backend.local${url.pathname}?id=${encodeURIComponent(id)}`);
+		}
+		if (url.pathname === '/stats') {
+			const stats = requests.get(id);
+			if (stats?.done) requests.delete(id);
+			return Response.json(stats ?? null);
+		}
+		let work;
+		try {
+			work = createWorkload(url, env.BACKEND);
+		} catch (error) {
+			return new Response(String(error), { status: 400 });
+		}
+		requests.set(id, work.stats);
+		const abort = new AbortController();
+		const timeout = setTimeout(() => abort.abort(new Error('Benchmark render timeout')), 5000);
+		try {
+			const stream = await renderToReadableStream(
+				Page,
+				{ work },
+				{
+					signal: abort.signal,
+					onError(error) {
+						work.stats.errors.push(String(error));
+					},
+				},
+			);
+			ctx.waitUntil(
+				(async () => {
+					try {
+						await stream.allReady;
+					} catch {
+						/* captured by onError */
+					}
+					await Promise.allSettled(work.jobs);
+					clearTimeout(timeout);
+					work.stats.done = true;
+				})(),
+			);
+			return new Response(stream, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+		} catch (error) {
+			clearTimeout(timeout);
+			work.stats.errors.push(String(error));
+			ctx.waitUntil(
+				Promise.allSettled(work.jobs).then(() => {
+					work.stats.done = true;
+				}),
+			);
+			return new Response(String(error), { status: 500 });
+		}
+	},
+};

--- a/benchmarks/ssr-workerd/package.json
+++ b/benchmarks/ssr-workerd/package.json
@@ -6,7 +6,10 @@
   "description": "Streaming SSR inside real workerd (Cloudflare Workers runtime) via miniflare: cold isolate start, warm streaming TTFB, and worker-script bytes for octane renderToReadableStream vs React Fizz edge, sharing the streaming-ssr fixtures.",
   "scripts": {
     "bench": "node run.mjs",
-    "bench:smoke": "node run.mjs 3"
+    "bench:smoke": "node run.mjs 3",
+    "bench:app-workloads": "node app-workloads/run.mjs",
+    "bench:app-workloads:smoke": "BENCH_ROUNDS=1 node app-workloads/run.mjs 1",
+    "test:app-workloads": "node --test app-workloads/verify.test.mjs"
   },
   "dependencies": {
     "miniflare": "catalog:default",


### PR DESCRIPTION
## Summary

- Add two original synthetic SSR workloads in real workerd: a provider-heavy workspace bootstrap and a structured record/history page with nested streaming boundaries.
- Measure first body byte, first primary content, stream completion, wire size, backend work and cache hits separately.
- Benchmark/test tooling only: no runtime, compiler, adapter or published-package behavior changes; no changeset required.

## Why

The existing fetch-pattern controls isolate small promise and data-loading shapes. These fixtures add larger component trees, consumed contexts, repeated data consumers, response-derived dependencies and nested boundaries so future framework changes can be evaluated against complete application-shaped output.

## Changes

- Workspace: six context providers, 48 navigation links, 18 rich tiles and seven unique data sources.
- History: six context providers, 40 structured rows, nested author boundaries, six related items and nine unique data sources.
- Four controls per workload: zero artificial delay, delayed data, bootstrap-blocked TTFB, and explicitly primed warm-data cache. Tree size is configurable independently of the number of backend resources.
- Request-local promise deduplication and a bounded, tenant/size-keyed cache of completed JSON values. A local service-binding Worker generates all payloads.
- Output/dependency oracles, deterministic shell/content release gates, concurrent tenant isolation, changed-size cache checks and 17 oracle tests. Add all-case smoke to the weekly/manual Bench workflow.
- Document repeated-run results and their noise. Raw local samples remain ignored; the committed baseline note identifies commands, environment and limitations.

## Validation

- [x] `pnpm sync` (with `pnpm_config_verify_deps_before_run=warn` to avoid automatic installation in the partially linked local environment); no generated tracked changes.
- [x] `node --test benchmarks/ssr-workerd/app-workloads/verify.test.mjs scripts/ci-workflow.test.mjs` — 78 tests passed.
- [x] `BENCH_ROUNDS=1 node benchmarks/ssr-workerd/app-workloads/run.mjs 1` — all eight cases and streaming/cache/isolation preflights passed.
- [x] Two complete same-input runs plus a scale-4 run, each with three rounds of seven samples per case — 504 measured responses passed their complete-output and request-graph checks.
- [x] Scoped benchmark `tsrx-tsc --noEmit` and Prettier checks passed. Local validation used cached TSRX checker/formatter 0.3.120 because the locked 0.3.126 validation tools were unavailable; TypeScript 5.9.3 and Prettier 3.9.6. Performance builds used the exact TSRX core 0.1.61, Vite 8.1.5, Miniflare 4.20260714.0 and workerd 1.20260714.1 with this worktree's framework source.
- [x] `git diff --check`.
- [ ] `pnpm format:check` — full-repository local command not run; scoped alternative above.
- [ ] `pnpm typecheck` — full-repository local command not run; scoped alternative above.
- [ ] `pnpm test` — full-repository local command not run; targeted tests above. Current-head remote CI will be checked after the draft-to-ready transition.

## Risk / follow-ups

- All fixture names, schemas, content, counts and schedules are invented. No proprietary application source, traces, endpoints, credentials, payloads or production measurements were used. These are synthetic workload candidates, not calibrated replicas of a private application.
- This measures Octane SSR in local workerd, not the app-core/Cloudflare-adapter wrapper, deployed-edge latency, browser adoption, hydration or paint. Wire-payload completeness is not a reconstructed final-DOM assertion.
- Same-code timing variance was too high for a 20% improvement/regression claim. No performance gain or absolute timing CI threshold is asserted; controlled paired measurements are required for future optimization claims.
- Diagnostic routes and backend gates are local harness code, not production endpoints. The weekly Bench smoke checks correctness, not timing thresholds.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790550672&installation_model_id=432790&pr_number=900&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F900&signature=df3393d90c8ecdc1c6fb0da95d7f69ffa6e00736b956a160d7598d3395a33721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to benchmarks, CI smoke, and documentation; no production packages or SSR runtime behavior are modified.
> 
> **Overview**
> Adds a **standalone** `benchmarks/ssr-workerd/app-workloads` harness that runs production-compiled Octane SSR in real workerd (Miniflare) against a local service-binding JSON backend—benchmark-only; no framework runtime or adapter changes.
> 
> Two invented **workspace** and **history** page shapes stress deep provider trees, nested `@try` streaming boundaries, request-scoped `load()` deduplication, and response-derived fetch chains. Each scenario runs four controls (`zero-delay`, delayed `io`, shell-less `io-blocked-root`, and explicitly primed `warm-data`), with optional `BENCH_SCALE` / delay tuning.
> 
> The runner records **TTFB**, first primary content, stream completion, wire size, and backend/cache stats, then enforces correctness via wire-payload oracles, shell/tail release gates, tenant isolation checks, and dependency-graph assertions (plus ~17 oracle unit tests). Docs include run instructions, a local baseline note (no CI timing thresholds), and `ssr-workerd` package scripts.
> 
> The weekly **Bench** workflow gains a step that runs the oracle tests and a one-round smoke of all eight cases; this suite stays **outside** the unified `bench.mjs --ratios` gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9eefa1aad4f5777d304cf0b29742377c2c6ef4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Current-head CI

All 26 jobs in [CI run 33219726137](https://github.com/octanejs/octane/actions/runs/33219726137) passed for `c9eefa1aad4f5777d304cf0b29742377c2c6ef4f`, including lint, typecheck, all test/parity shards, package validation, examples, browser/website integration, and CI provenance. Cursor Bugbot completed successfully with no findings or review threads. Final `pnpm sync` left the worktree clean; the head contains the live `main` base. The PR is ready for human review, not auto-approved or merged.

