### PR TITLE
perf(rspack): scan CSS graph once per phase

### DIFF
--- a/.changeset/rspack-css-graph-index.md
+++ b/.changeset/rspack-css-graph-index.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/rspack-plugin': patch
+---
+
+Resolve multiple CSS-module constant-folding proofs by scanning the current Rspack module graph once per compilation phase instead of once per CSS request.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -246,6 +246,7 @@ internally, get their own baseline and guard namespace.
 | `scaling-curves` | scaling-curves | none (builds) | independently correctness-gated controlled updates at 8, 32, 96, 256, and 512 components |
 | `radix-collection-order` | radix-collection-order | none (Node-only) | production Radix collection ordering versus the prior comparator at 16, 64, 256, and 4,096 items, with missing-ref and stable-order controls |
 | `router-dispatch` | router-dispatch | none (Node-only) | app-core static, wrong-method, and dynamic matching across 1,000-route tables |
+| `rspack-css-graph` | rspack-css-graph | none (Node-only) | CSS-module proof collection and verification across zero, one, and sixteen requests, with deterministic module-graph traversal and connection-visit guards |
 | `floating-tree-navigation` | floating-tree-navigation | none (Node-only) | Floating UI deepest-open-node lookup on deep chains, equal-depth forks, and a root-only control, with exact previous-behavior and deterministic node-read gates |
 | `ink-cursor-update` | ink-cursor-update | none (Node-only) | Ink standard/incremental cursor-only updates over equal 20,000-line frames, with exact previous branches, byte/split gates, stable-frame stress scaling, and initial/changed-render controls |
 | `manifest-cache-invalidation` | manifest-cache-invalidation | none (Node-only) | shared-compiler source invalidation across 129 and 5,001 cached nearest-manifest decisions, plus a required manifest-scan control |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -544,6 +544,14 @@
     "note": "Same-process lowercase method misses through 1,000 server routes, normalized per candidate. Re-normalizing the request method for every route measured at 0.31x the dynamic control; one dispatch-level normalization measured at 0.07x. The 0.2 ceiling leaves timing headroom while catching repeated method normalization."
   },
   {
+    "suite": "rspack-css-graph",
+    "op": "graph_traversals",
+    "target": "sixteen-requests",
+    "reference": "one-request",
+    "maxRatio": 1,
+    "note": "Deterministic public module-graph traversals through collection, post-rebuild verification, and seal. The repeated resolver performed 48 traversals for sixteen requests versus 3 for one request; the phase-local batch performs 3 for both, so the exact 1x ceiling catches restoration of request-by-connection graph scans."
+  },
+  {
     "suite": "floating-tree-navigation",
     "op": "node_reads",
     "target": "indexed-deep-chain",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -441,6 +441,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Node-only Rspack CSS-module proof collection and verification with
+		// deterministic graph traversal and yielded-connection counts.
+		name: 'rspack-css-graph',
+		cwd: 'rspack-css-graph',
+		servers: [],
+		iter: { normal: 8, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Floating UI's virtual nested-menu routing: exact previous behavior versus
 		// production on deep and branching trees, with deterministic node-read counts.
 		name: 'floating-tree-navigation',

--- a/benchmarks/rspack-css-graph/README.md
+++ b/benchmarks/rspack-css-graph/README.md
@@ -1,0 +1,20 @@
+# Rspack CSS-module graph benchmark
+
+This Node-only suite runs the production CSS-module constants controller through
+its public compiler hooks with zero, one, and sixteen exact ESM requests. It
+counts public `moduleGraph.getOutgoingConnections()` traversals and yielded
+connections while semantic gates require every safe target to reach the provider
+and every proof request to be consumed.
+
+The sixteen-request fixture previously performed 48 graph traversals and 768
+connection visits through collection, post-rebuild verification, and seal. The
+batched resolver performs three traversals and 48 visits. A same-run ratio guard
+compares its traversal count with the one-request control, while exact assertions
+also protect the zero-request path and early termination after all requested
+targets become invalid.
+
+Run the suite through the unified harness:
+
+```bash
+node benchmarks/bench.mjs --quick --ratios rspack-css-graph
+```

--- a/benchmarks/rspack-css-graph/run.mjs
+++ b/benchmarks/rspack-css-graph/run.mjs
@@ -1,0 +1,231 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { installCssModuleConstants } from '../../packages/rspack-plugin-octane/src/css-module-constants.js';
+import {
+	CSS_MODULE_BUILD_INFO_KEY,
+	CSS_MODULE_CONTEXT_KEY,
+	cssModuleSourceHash,
+} from '../../packages/rspack-plugin-octane/src/css-module-data.js';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+
+const iterations = Number.parseInt(process.argv[2] ?? '8', 10);
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Rspack CSS graph iterations must be a positive integer');
+}
+
+const EXPORTS = `var root = 'mapped_root'; var label = 'mapped_label'; export { root, label };`;
+
+function hook() {
+	const taps = [];
+	const add = (options, run) => {
+		taps.push({ stage: typeof options === 'string' ? 0 : (options.stage ?? 0), run });
+	};
+	const ordered = () => [...taps].sort((left, right) => left.stage - right.stage);
+	return {
+		tap: add,
+		tapPromise: add,
+		call(...args) {
+			for (const tap of ordered()) tap.run(...args);
+		},
+		async promise(...args) {
+			for (const tap of ordered()) await tap.run(...args);
+		},
+	};
+}
+
+function module(id, source, resource = '/project/styles.module.css') {
+	return {
+		id,
+		type: 'javascript/auto',
+		resource,
+		source,
+		buildInfo: {},
+		identifier() {
+			return this.id;
+		},
+		originalSource() {
+			return { source: () => this.source };
+		},
+	};
+}
+
+function importer(id, requests) {
+	const result = module(id, 'export {};', `/project/${id}.tsrx`);
+	result.buildInfo[CSS_MODULE_BUILD_INFO_KEY] = {
+		sourceHash: cssModuleSourceHash(`authored:${id}`),
+		requests,
+		consumed: [],
+	};
+	return result;
+}
+
+function edge(request, target, attributes) {
+	return {
+		dependency: { request, category: 'esm', attributes },
+		module: target,
+	};
+}
+
+function compiler(provider) {
+	const result = {
+		options: { mode: 'production', watch: false },
+		watchMode: false,
+		hooks: { thisCompilation: hook(), finishMake: hook() },
+		webpack: {
+			NormalModule: { getCompilationHooks: (compilation) => compilation.loaderHooks },
+			Compilation: { PROCESS_ASSETS_STAGE_REPORT: 5000 },
+		},
+	};
+	installCssModuleConstants(result, { option: provider, environment: 'client' });
+	return result;
+}
+
+function countedGraph(edges, activity) {
+	return {
+		getOutgoingConnections(current) {
+			activity.traversals++;
+			const connections = edges.get(current.id) ?? [];
+			return (function* () {
+				for (const connection of connections) {
+					activity.visits++;
+					yield connection;
+				}
+			})();
+		},
+	};
+}
+
+async function runSafeScenario(requestCount) {
+	const requests = Array.from(
+		{ length: requestCount },
+		(_, index) => `./styles-${index}.module.css`,
+	);
+	const app = importer(`requests-${requestCount}`, requests);
+	const styles = requests.map((request, index) =>
+		module(
+			`styles-${index}`,
+			EXPORTS.replaceAll('mapped_', `mapped_${index}_`),
+			`/project/${request.slice(2)}`,
+		),
+	);
+	const unrelated = module('unrelated', EXPORTS);
+	const edges = new Map([
+		[
+			app.id,
+			requestCount === 0
+				? [edge('./unrelated.module.css', unrelated)]
+				: requests.map((request, index) => edge(request, styles[index])),
+		],
+	]);
+	const activity = { traversals: 0, visits: 0 };
+	const supplied = [];
+	const proofRequests = [];
+	const currentCompiler = compiler((input) => {
+		supplied.push(input.id);
+	});
+	const compilation = {
+		modules: new Set([app, ...styles, unrelated]),
+		loaderHooks: { loader: hook() },
+		hooks: { seal: hook(), processAssets: hook() },
+		moduleGraph: countedGraph(edges, activity),
+	};
+	const contextFor = (current) => {
+		const context = {};
+		compilation.loaderHooks.loader.call(context, current);
+		return context[CSS_MODULE_CONTEXT_KEY];
+	};
+	compilation.rebuildModule = (current, done) => {
+		queueMicrotask(() => {
+			try {
+				const proof = structuredClone(contextFor(current)).proof;
+				assert.ok(proof, 'Expected the benchmark importer to receive a proof');
+				const consumed = proof.imports.map((entry) => entry.request);
+				proofRequests.push(...consumed);
+				current.buildInfo[CSS_MODULE_BUILD_INFO_KEY] = {
+					...current.buildInfo[CSS_MODULE_BUILD_INFO_KEY],
+					consumed,
+				};
+				done(null, current);
+			} catch (error) {
+				done(error);
+			}
+		});
+	};
+	currentCompiler.hooks.thisCompilation.call(compilation);
+	await currentCompiler.hooks.finishMake.promise(compilation);
+	compilation.hooks.seal.call();
+	compilation.hooks.processAssets.call({});
+
+	assert.deepEqual([...new Set(supplied)].sort(), styles.map((style) => style.id).sort());
+	assert.deepEqual([...new Set(proofRequests)].sort(), requests.toSorted());
+	return activity;
+}
+
+async function runTerminalInvalidScenario() {
+	const requests = ['./invalid-a.module.css', './invalid-b.module.css'];
+	const app = importer('terminal-invalidity', requests);
+	const invalidA = module('invalid-a', EXPORTS);
+	const invalidB = module('invalid-b', EXPORTS);
+	const trailing = Array.from({ length: 16 }, (_, index) => module(`trailing-${index}`, EXPORTS));
+	const edges = new Map([
+		[
+			app.id,
+			[
+				edge(requests[0], invalidA, { type: 'css' }),
+				edge(requests[1], invalidB, { type: 'css' }),
+				...trailing.map((target, index) => edge(`./trailing-${index}.module.css`, target)),
+			],
+		],
+	]);
+	const activity = { traversals: 0, visits: 0 };
+	const currentCompiler = compiler(true);
+	const compilation = {
+		modules: new Set([app, invalidA, invalidB, ...trailing]),
+		loaderHooks: { loader: hook() },
+		hooks: { seal: hook(), processAssets: hook() },
+		moduleGraph: countedGraph(edges, activity),
+		rebuildModule() {
+			throw new Error('Terminally invalid requests must not schedule a rebuild');
+		},
+	};
+	currentCompiler.hooks.thisCompilation.call(compilation);
+	await currentCompiler.hooks.finishMake.promise(compilation);
+	compilation.hooks.seal.call();
+	compilation.hooks.processAssets.call({});
+	return activity;
+}
+
+const scenarios = [
+	{ name: 'zero-requests', requests: 0, activity: await runSafeScenario(0) },
+	{ name: 'one-request', requests: 1, activity: await runSafeScenario(1) },
+	{ name: 'sixteen-requests', requests: 16, activity: await runSafeScenario(16) },
+	{ name: 'terminal-invalid', requests: 2, activity: await runTerminalInvalidScenario() },
+];
+
+assert.deepEqual(scenarios[0].activity, { traversals: 0, visits: 0 });
+assert.deepEqual(scenarios[1].activity, { traversals: 3, visits: 3 });
+assert.deepEqual(scenarios[2].activity, { traversals: 3, visits: 48 });
+assert.deepEqual(scenarios[3].activity, { traversals: 1, visits: 2 });
+
+const targets = scenarios.map((scenario) => {
+	console.log(
+		`PASS rspack-css-graph/${scenario.name}: ${scenario.activity.traversals} traversals, ` +
+			`${scenario.activity.visits} connection visits`,
+	);
+	return {
+		name: scenario.name,
+		ops: {
+			graph_traversals: deterministicStatForJson(deterministicCount(scenario.activity.traversals)),
+			connection_visits: deterministicStatForJson(deterministicCount(scenario.activity.visits)),
+		},
+		meta: {
+			requests: scenario.requests,
+			correctness: 'pass',
+		},
+	};
+});
+
+const payload = { suite: 'rspack-css-graph', iterations, targets };
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -74,6 +74,7 @@ export const BENCHMARK_SUITES = [
 	'behavior-root-events',
 	'radix-collection-order',
 	'router-dispatch',
+	'rspack-css-graph',
 	'floating-tree-navigation',
 	'ink-cursor-update',
 	'manifest-cache-invalidation',

--- a/packages/rspack-plugin-octane/src/css-module-constants.js
+++ b/packages/rspack-plugin-octane/src/css-module-constants.js
@@ -229,24 +229,18 @@ function verifyGraph(compilation, state) {
 	for (const [id, receipt] of state.receipts) {
 		const importer = modules.get(id);
 		const info = candidateInfo(importer);
+		const requests = receipt.imports.map((entry) => entry.request);
 		if (
 			info === null ||
 			info.sourceHash !== receipt.sourceHash ||
-			!sameStrings(
-				info.consumed,
-				receipt.imports.map((entry) => entry.request),
-			)
+			!sameStrings(info.consumed, requests)
 		) {
 			changed(id, undefined, 'the authored importer or committed-use receipt differs');
 		}
 		if (receipt.imports.length === 1) {
 			verifyTarget(compilation, importer, receipt.imports[0]);
 		} else {
-			const targets = targetsForRequests(
-				compilation,
-				importer,
-				receipt.imports.map((entry) => entry.request),
-			);
+			const targets = targetsForRequests(compilation, importer, requests);
 			for (const entry of receipt.imports) {
 				verifyResolvedTarget(importer, entry, targets.get(entry.request));
 			}

--- a/packages/rspack-plugin-octane/src/css-module-constants.js
+++ b/packages/rspack-plugin-octane/src/css-module-constants.js
@@ -94,6 +94,39 @@ function targetForRequest(compilation, importer, request) {
 	return targets.size === 1 ? targets.values().next().value : null;
 }
 
+/** Resolve several exact requests with one fresh walk of the current graph. */
+function targetsForRequests(compilation, importer, requests) {
+	const states = new Map();
+	for (const request of requests) {
+		states.set(request, { id: null, target: null, invalid: false });
+	}
+	let invalid = 0;
+	for (const connection of compilation.moduleGraph.getOutgoingConnections(importer)) {
+		const dependency = connection.dependency;
+		if (dependency?.category !== 'esm') continue;
+		const state = states.get(dependency.request);
+		if (state === undefined || state.invalid) continue;
+		const target = connection.module;
+		const id =
+			dependency.attributes != null && Object.keys(dependency.attributes).length > 0
+				? null
+				: identifier(target);
+		if (id === null || (state.id !== null && state.id !== id)) {
+			state.invalid = true;
+			state.target = null;
+			invalid++;
+			if (invalid === states.size) break;
+			continue;
+		}
+		state.id = id;
+		state.target = target;
+	}
+	for (const [request, state] of states) {
+		states.set(request, state.invalid ? null : state.target);
+	}
+	return states;
+}
+
 function sortedStrings(values) {
 	return [...new Set([...iterable(values)].filter((value) => typeof value === 'string'))].sort();
 }
@@ -175,8 +208,7 @@ function sameStrings(left, right) {
 	return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
-function verifyTarget(compilation, importer, entry) {
-	const target = targetForRequest(compilation, importer, entry.request);
+function verifyResolvedTarget(importer, entry, target) {
 	if (identifier(target) !== entry.id)
 		changed(identifier(importer), entry.request, 'the effective module identity differs');
 	if (!JAVASCRIPT_TYPES.has(target.type))
@@ -185,6 +217,10 @@ function verifyTarget(compilation, importer, entry) {
 	if (source === null || cssModuleSourceHash(source) !== entry.fingerprint) {
 		changed(identifier(importer), entry.request, 'the final provider source differs');
 	}
+}
+
+function verifyTarget(compilation, importer, entry) {
+	verifyResolvedTarget(importer, entry, targetForRequest(compilation, importer, entry.request));
 }
 
 function verifyGraph(compilation, state) {
@@ -203,7 +239,18 @@ function verifyGraph(compilation, state) {
 		) {
 			changed(id, undefined, 'the authored importer or committed-use receipt differs');
 		}
-		for (const entry of receipt.imports) verifyTarget(compilation, importer, entry);
+		if (receipt.imports.length === 1) {
+			verifyTarget(compilation, importer, receipt.imports[0]);
+		} else {
+			const targets = targetsForRequests(
+				compilation,
+				importer,
+				receipt.imports.map((entry) => entry.request),
+			);
+			for (const entry of receipt.imports) {
+				verifyResolvedTarget(importer, entry, targets.get(entry.request));
+			}
+		}
 	}
 }
 
@@ -251,8 +298,14 @@ async function collectAndRebuild(compilation, state, option, environment) {
 			const importer = modules.get(id);
 			const info = candidateInfo(importer);
 			const imports = [];
-			for (const request of [...new Set(info.requests)].sort()) {
-				const target = targetForRequest(compilation, importer, request);
+			const requests = [...new Set(info.requests)].sort();
+			const targets =
+				requests.length === 1 ? null : targetsForRequests(compilation, importer, requests);
+			for (const request of requests) {
+				const target =
+					targets === null
+						? targetForRequest(compilation, importer, request)
+						: targets.get(request);
 				if (target === null) continue;
 				const proof = readTargetProof(target, option, environment, cache);
 				if (proof !== null) imports.push({ request, ...proof });

--- a/packages/rspack-plugin-octane/tests/css-module-graph.test.ts
+++ b/packages/rspack-plugin-octane/tests/css-module-graph.test.ts
@@ -271,7 +271,7 @@ describe('Rspack CSS-module graph proofs', () => {
 				edge(safeRequest, safe),
 			];
 			const consumed = vi.fn(() => [safeRequest]);
-			const provider = vi.fn(() => undefined);
+			const provider = vi.fn((_input: { id: string }) => undefined);
 			const graph = harness({ option: provider }).createCompilation(
 				[app, invalid, otherwiseValid, safe],
 				new Map([[app.id, connections]]),
@@ -295,7 +295,7 @@ describe('Rspack CSS-module graph proofs', () => {
 		const styles = module('stable-styles', EXPORTS);
 		const duplicate = module(styles.id, EXPORTS);
 		const decoy = module('commonjs-decoy', EXPORTS.replaceAll('mapped_', 'wrong_'));
-		const provider = vi.fn(() => undefined);
+		const provider = vi.fn((_input: { id: string }) => undefined);
 		const graph = harness({ option: provider }).createCompilation(
 			[app, styles, duplicate, decoy],
 			new Map([

--- a/packages/rspack-plugin-octane/tests/css-module-graph.test.ts
+++ b/packages/rspack-plugin-octane/tests/css-module-graph.test.ts
@@ -93,6 +93,10 @@ type TestEdge = ReturnType<typeof edge>;
 type ContextData = {
 	proof: null | { imports: { request: string }[] };
 };
+type GraphActivity = {
+	traversals: number;
+	visits: number;
+};
 
 // Real production builds cover rendered classes and stylesheet ownership. This
 // harness supplies adversarial public Rspack graph states that cannot be timed
@@ -121,12 +125,22 @@ function harness({
 			afterRebuild?: (module: TestModule, compilation: any) => void;
 		} = {},
 	) => {
+		const graphActivity: GraphActivity = { traversals: 0, visits: 0 };
 		const compilation: any = {
 			modules: new Set(modules),
 			loaderHooks: { loader: hook() },
 			hooks: { seal: hook(), processAssets: hook() },
 			moduleGraph: {
-				getOutgoingConnections: (module: TestModule) => edges.get(module.id) ?? [],
+				getOutgoingConnections(module: TestModule) {
+					graphActivity.traversals++;
+					const connections = edges.get(module.id) ?? [];
+					return (function* () {
+						for (const connection of connections) {
+							graphActivity.visits++;
+							yield connection;
+						}
+					})();
+				},
 			},
 		};
 		const contextFor = (module: TestModule) => {
@@ -165,6 +179,7 @@ function harness({
 		compiler.hooks.thisCompilation.call(compilation);
 		return {
 			compilation,
+			graphActivity,
 			finish: () => compiler.hooks.finishMake.promise(compilation),
 			seal: () => compilation.hooks.seal.call(),
 			emit: () => compilation.hooks.processAssets.call({}),
@@ -177,6 +192,176 @@ const EXPORTS = `var root = 'mapped_root'; var label = 'mapped_label'; export { 
 const CHANGED = /@octanejs\/rspack-plugin: CSS-module proof changed/;
 
 describe('Rspack CSS-module graph proofs', () => {
+	it('scales graph reads with CSS requests across proof phases', async () => {
+		const requests = Array.from({ length: 16 }, (_, index) => `./styles-${index}.module.css`);
+		const app = importer('many-imports', requests);
+		const styles = requests.map((request, index) =>
+			module(`styles-${index}`, EXPORTS.replaceAll('mapped_', `mapped_${index}_`), {
+				resource: `/project/${request.slice(2)}`,
+			}),
+		);
+		const graph = harness().createCompilation(
+			[app, ...styles],
+			new Map([[app.id, requests.map((request, index) => edge(request, styles[index]))]]),
+		);
+
+		await graph.finish();
+		expect(graph.graphActivity).toEqual({ traversals: 2, visits: 32 });
+		graph.seal();
+		expect(graph.graphActivity).toEqual({ traversals: 3, visits: 48 });
+		graph.emit();
+		expect(graph.graphActivity).toEqual({ traversals: 3, visits: 48 });
+	});
+
+	it.each([
+		{ requests: [] as string[], afterFinish: 0, afterSeal: 0 },
+		{ requests: ['./styles.module.css'], afterFinish: 2, afterSeal: 3 },
+	])('avoids unrelated graph reads for $requests.length CSS requests', async (scenario) => {
+		const app = importer('request-count', scenario.requests);
+		const styles = module('request-count-styles', EXPORTS);
+		const graph = harness().createCompilation(
+			[app, styles],
+			new Map([[app.id, [edge('./styles.module.css', styles)]]]),
+		);
+
+		await graph.finish();
+		expect(graph.graphActivity).toEqual({
+			traversals: scenario.afterFinish,
+			visits: scenario.afterFinish,
+		});
+		graph.seal();
+		expect(graph.graphActivity).toEqual({
+			traversals: scenario.afterSeal,
+			visits: scenario.afterSeal,
+		});
+		graph.emit();
+		expect(graph.graphActivity).toEqual({
+			traversals: scenario.afterSeal,
+			visits: scenario.afterSeal,
+		});
+	});
+
+	it.each([
+		{ invalidKind: 'attributes', invalidFirst: true },
+		{ invalidKind: 'attributes', invalidFirst: false },
+		{ invalidKind: 'unidentifiable', invalidFirst: true },
+		{ invalidKind: 'unidentifiable', invalidFirst: false },
+	] as const)(
+		'declines $invalidKind targets without poisoning safe peers when invalidFirst=$invalidFirst',
+		async ({ invalidKind, invalidFirst }) => {
+			const invalidRequest = './invalid.module.css';
+			const safeRequest = './safe.module.css';
+			const app = importer('request-local-invalidity', [invalidRequest, safeRequest]);
+			const invalid = module('invalid', EXPORTS, {
+				resource: '/project/invalid.module.css',
+			});
+			if (invalidKind === 'unidentifiable') invalid.identifier = undefined as any;
+			const otherwiseValid = module('otherwise-valid', EXPORTS, {
+				resource: '/project/invalid.module.css',
+			});
+			const safe = module('safe', EXPORTS, { resource: '/project/safe.module.css' });
+			const invalidEdge = edge(
+				invalidRequest,
+				invalid,
+				invalidKind === 'attributes' ? { attributes: { type: 'css' } } : {},
+			);
+			const validEdge = edge(invalidRequest, otherwiseValid);
+			const connections = [
+				...(invalidFirst ? [invalidEdge, validEdge] : [validEdge, invalidEdge]),
+				edge(safeRequest, safe),
+			];
+			const consumed = vi.fn(() => [safeRequest]);
+			const provider = vi.fn(() => undefined);
+			const graph = harness({ option: provider }).createCompilation(
+				[app, invalid, otherwiseValid, safe],
+				new Map([[app.id, connections]]),
+				{ consume: consumed },
+			);
+
+			await expect(graph.finish()).resolves.toBeUndefined();
+			expect(consumed).toHaveBeenCalledWith(
+				app,
+				expect.objectContaining({ imports: [expect.objectContaining({ request: safeRequest })] }),
+			);
+			expect(provider.mock.calls.map(([input]) => input.id)).toEqual([safe.id]);
+			expect(() => graph.seal()).not.toThrow();
+			expect(() => graph.emit()).not.toThrow();
+		},
+	);
+
+	it('accepts duplicate effective identities and ignores non-ESM decoys', async () => {
+		const request = './styles.module.css';
+		const app = importer('duplicate-identity', [request]);
+		const styles = module('stable-styles', EXPORTS);
+		const duplicate = module(styles.id, EXPORTS);
+		const decoy = module('commonjs-decoy', EXPORTS.replaceAll('mapped_', 'wrong_'));
+		const provider = vi.fn(() => undefined);
+		const graph = harness({ option: provider }).createCompilation(
+			[app, styles, duplicate, decoy],
+			new Map([
+				[
+					app.id,
+					[
+						edge(request, decoy, { category: 'commonjs' }),
+						edge(request, styles),
+						edge(request, duplicate),
+					],
+				],
+			]),
+		);
+
+		await expect(graph.finish()).resolves.toBeUndefined();
+		expect(provider.mock.calls.map(([input]) => input.id)).toEqual([styles.id]);
+		expect(() => graph.seal()).not.toThrow();
+	});
+
+	it('reacquires graph and module identities for final verification', async () => {
+		const request = './styles.module.css';
+		const app = importer('fresh-identities', [request]);
+		const styles = module('fresh-styles', EXPORTS);
+		const edges = new Map([[app.id, [edge(request, styles)]]]);
+		const graph = harness().createCompilation([app, styles], edges);
+
+		await graph.finish();
+		const nextApp = importer(app.id, [request]);
+		nextApp.buildInfo[CSS_MODULE_BUILD_INFO_KEY] = structuredClone(
+			app.buildInfo[CSS_MODULE_BUILD_INFO_KEY],
+		);
+		const nextStyles = module(styles.id, styles.source);
+		graph.compilation.modules = new Set([nextApp, nextStyles]);
+		edges.set(nextApp.id, [edge(request, nextStyles)]);
+
+		expect(() => graph.seal()).not.toThrow();
+		expect(() => graph.emit()).not.toThrow();
+	});
+
+	it('stops reading after all requested targets are terminally invalid', async () => {
+		const requests = ['./invalid-a.module.css', './invalid-b.module.css'];
+		const app = importer('terminal-invalidity', requests);
+		const invalidA = module('invalid-a', EXPORTS);
+		const invalidB = module('invalid-b', EXPORTS);
+		const trailing = Array.from({ length: 16 }, (_, index) => module(`trailing-${index}`, EXPORTS));
+		const graph = harness().createCompilation(
+			[app, invalidA, invalidB, ...trailing],
+			new Map([
+				[
+					app.id,
+					[
+						edge(requests[0], invalidA, { attributes: { type: 'css' } }),
+						edge(requests[1], invalidB, { attributes: { type: 'css' } }),
+						...trailing.map((target, index) => edge(`./trailing-${index}.module.css`, target)),
+					],
+				],
+			]),
+		);
+
+		await graph.finish();
+		expect(graph.graphActivity).toEqual({ traversals: 1, visits: 2 });
+		graph.seal();
+		graph.emit();
+		expect(graph.graphActivity).toEqual({ traversals: 1, visits: 2 });
+	});
+
 	it('provides exact effective-module identities and read-only metadata', async () => {
 		const a = importer('app-alpha', ['./styles.module.css?theme=one']);
 		const b = importer('app-beta', ['./styles.module.css?theme=two']);

--- a/packages/rspack-plugin-octane/tests/css-module-graph.test.ts
+++ b/packages/rspack-plugin-octane/tests/css-module-graph.test.ts
@@ -93,10 +93,6 @@ type TestEdge = ReturnType<typeof edge>;
 type ContextData = {
 	proof: null | { imports: { request: string }[] };
 };
-type GraphActivity = {
-	traversals: number;
-	visits: number;
-};
 
 // Real production builds cover rendered classes and stylesheet ownership. This
 // harness supplies adversarial public Rspack graph states that cannot be timed
@@ -125,22 +121,12 @@ function harness({
 			afterRebuild?: (module: TestModule, compilation: any) => void;
 		} = {},
 	) => {
-		const graphActivity: GraphActivity = { traversals: 0, visits: 0 };
 		const compilation: any = {
 			modules: new Set(modules),
 			loaderHooks: { loader: hook() },
 			hooks: { seal: hook(), processAssets: hook() },
 			moduleGraph: {
-				getOutgoingConnections(module: TestModule) {
-					graphActivity.traversals++;
-					const connections = edges.get(module.id) ?? [];
-					return (function* () {
-						for (const connection of connections) {
-							graphActivity.visits++;
-							yield connection;
-						}
-					})();
-				},
+				getOutgoingConnections: (module: TestModule) => edges.get(module.id) ?? [],
 			},
 		};
 		const contextFor = (module: TestModule) => {
@@ -179,7 +165,6 @@ function harness({
 		compiler.hooks.thisCompilation.call(compilation);
 		return {
 			compilation,
-			graphActivity,
 			finish: () => compiler.hooks.finishMake.promise(compilation),
 			seal: () => compilation.hooks.seal.call(),
 			emit: () => compilation.hooks.processAssets.call({}),
@@ -192,55 +177,6 @@ const EXPORTS = `var root = 'mapped_root'; var label = 'mapped_label'; export { 
 const CHANGED = /@octanejs\/rspack-plugin: CSS-module proof changed/;
 
 describe('Rspack CSS-module graph proofs', () => {
-	it('scales graph reads with CSS requests across proof phases', async () => {
-		const requests = Array.from({ length: 16 }, (_, index) => `./styles-${index}.module.css`);
-		const app = importer('many-imports', requests);
-		const styles = requests.map((request, index) =>
-			module(`styles-${index}`, EXPORTS.replaceAll('mapped_', `mapped_${index}_`), {
-				resource: `/project/${request.slice(2)}`,
-			}),
-		);
-		const graph = harness().createCompilation(
-			[app, ...styles],
-			new Map([[app.id, requests.map((request, index) => edge(request, styles[index]))]]),
-		);
-
-		await graph.finish();
-		expect(graph.graphActivity).toEqual({ traversals: 2, visits: 32 });
-		graph.seal();
-		expect(graph.graphActivity).toEqual({ traversals: 3, visits: 48 });
-		graph.emit();
-		expect(graph.graphActivity).toEqual({ traversals: 3, visits: 48 });
-	});
-
-	it.each([
-		{ requests: [] as string[], afterFinish: 0, afterSeal: 0 },
-		{ requests: ['./styles.module.css'], afterFinish: 2, afterSeal: 3 },
-	])('avoids unrelated graph reads for $requests.length CSS requests', async (scenario) => {
-		const app = importer('request-count', scenario.requests);
-		const styles = module('request-count-styles', EXPORTS);
-		const graph = harness().createCompilation(
-			[app, styles],
-			new Map([[app.id, [edge('./styles.module.css', styles)]]]),
-		);
-
-		await graph.finish();
-		expect(graph.graphActivity).toEqual({
-			traversals: scenario.afterFinish,
-			visits: scenario.afterFinish,
-		});
-		graph.seal();
-		expect(graph.graphActivity).toEqual({
-			traversals: scenario.afterSeal,
-			visits: scenario.afterSeal,
-		});
-		graph.emit();
-		expect(graph.graphActivity).toEqual({
-			traversals: scenario.afterSeal,
-			visits: scenario.afterSeal,
-		});
-	});
-
 	it.each([
 		{ invalidKind: 'attributes', invalidFirst: true },
 		{ invalidKind: 'attributes', invalidFirst: false },
@@ -289,15 +225,19 @@ describe('Rspack CSS-module graph proofs', () => {
 		},
 	);
 
-	it('accepts duplicate effective identities and ignores non-ESM decoys', async () => {
+	it('accepts duplicate effective identities and ignores non-ESM decoys in a batch', async () => {
 		const request = './styles.module.css';
-		const app = importer('duplicate-identity', [request]);
+		const safeRequest = './safe.module.css';
+		const app = importer('duplicate-identity', [request, safeRequest]);
 		const styles = module('stable-styles', EXPORTS);
 		const duplicate = module(styles.id, EXPORTS);
 		const decoy = module('commonjs-decoy', EXPORTS.replaceAll('mapped_', 'wrong_'));
+		const safe = module('safe-styles', EXPORTS.replaceAll('mapped_', 'safe_'), {
+			resource: '/project/safe.module.css',
+		});
 		const provider = vi.fn((_input: { id: string }) => undefined);
 		const graph = harness({ option: provider }).createCompilation(
-			[app, styles, duplicate, decoy],
+			[app, styles, duplicate, decoy, safe],
 			new Map([
 				[
 					app.id,
@@ -305,61 +245,70 @@ describe('Rspack CSS-module graph proofs', () => {
 						edge(request, decoy, { category: 'commonjs' }),
 						edge(request, styles),
 						edge(request, duplicate),
+						edge(safeRequest, safe),
 					],
 				],
 			]),
 		);
 
 		await expect(graph.finish()).resolves.toBeUndefined();
-		expect(provider.mock.calls.map(([input]) => input.id)).toEqual([styles.id]);
+		expect(provider.mock.calls.map(([input]) => input.id).sort()).toEqual(
+			[safe.id, styles.id].sort(),
+		);
 		expect(() => graph.seal()).not.toThrow();
 	});
 
-	it('reacquires graph and module identities for final verification', async () => {
-		const request = './styles.module.css';
-		const app = importer('fresh-identities', [request]);
+	it('reacquires equivalent graph and module identities for batch verification', async () => {
+		const requests = ['./styles.module.css', './safe.module.css'];
+		const app = importer('fresh-identities', requests);
 		const styles = module('fresh-styles', EXPORTS);
-		const edges = new Map([[app.id, [edge(request, styles)]]]);
-		const graph = harness().createCompilation([app, styles], edges);
+		const safe = module('fresh-safe', EXPORTS.replaceAll('mapped_', 'safe_'), {
+			resource: '/project/safe.module.css',
+		});
+		const graph = harness().createCompilation(
+			[app, styles, safe],
+			new Map([[app.id, [edge(requests[0], styles), edge(requests[1], safe)]]]),
+		);
 
 		await graph.finish();
-		const nextApp = importer(app.id, [request]);
+		const nextApp = importer(app.id, requests);
 		nextApp.buildInfo[CSS_MODULE_BUILD_INFO_KEY] = structuredClone(
 			app.buildInfo[CSS_MODULE_BUILD_INFO_KEY],
 		);
 		const nextStyles = module(styles.id, styles.source);
-		graph.compilation.modules = new Set([nextApp, nextStyles]);
-		edges.set(nextApp.id, [edge(request, nextStyles)]);
+		const nextSafe = module(safe.id, safe.source, { resource: safe.resource });
+		graph.compilation.modules = new Set([nextApp, nextStyles, nextSafe]);
+		graph.compilation.moduleGraph = {
+			getOutgoingConnections: (module: TestModule) =>
+				module.id === nextApp.id
+					? [edge(requests[0], nextStyles), edge(requests[1], nextSafe)]
+					: [],
+		};
 
 		expect(() => graph.seal()).not.toThrow();
 		expect(() => graph.emit()).not.toThrow();
 	});
 
-	it('stops reading after all requested targets are terminally invalid', async () => {
-		const requests = ['./invalid-a.module.css', './invalid-b.module.css'];
-		const app = importer('terminal-invalidity', requests);
-		const invalidA = module('invalid-a', EXPORTS);
-		const invalidB = module('invalid-b', EXPORTS);
-		const trailing = Array.from({ length: 16 }, (_, index) => module(`trailing-${index}`, EXPORTS));
+	it('rejects target changes from the current graph during batch verification', async () => {
+		const requests = ['./styles.module.css', './safe.module.css'];
+		const app = importer('changed-batch-target', requests);
+		const styles = module('changed-batch-styles', EXPORTS);
+		const safe = module('changed-batch-safe', EXPORTS.replaceAll('mapped_', 'safe_'), {
+			resource: '/project/safe.module.css',
+		});
+		const replacement = module('replacement-safe', safe.source, { resource: safe.resource });
 		const graph = harness().createCompilation(
-			[app, invalidA, invalidB, ...trailing],
-			new Map([
-				[
-					app.id,
-					[
-						edge(requests[0], invalidA, { attributes: { type: 'css' } }),
-						edge(requests[1], invalidB, { attributes: { type: 'css' } }),
-						...trailing.map((target, index) => edge(`./trailing-${index}.module.css`, target)),
-					],
-				],
-			]),
+			[app, styles, safe, replacement],
+			new Map([[app.id, [edge(requests[0], styles), edge(requests[1], safe)]]]),
 		);
 
 		await graph.finish();
-		expect(graph.graphActivity).toEqual({ traversals: 1, visits: 2 });
-		graph.seal();
-		graph.emit();
-		expect(graph.graphActivity).toEqual({ traversals: 1, visits: 2 });
+		graph.compilation.moduleGraph = {
+			getOutgoingConnections: (module: TestModule) =>
+				module.id === app.id ? [edge(requests[0], styles), edge(requests[1], replacement)] : [],
+		};
+
+		expect(() => graph.seal()).toThrow(CHANGED);
 	});
 
 	it('provides exact effective-module identities and read-only metadata', async () => {


### PR DESCRIPTION
## Summary

Multi-request CSS-module constant proofs now scan the current Rspack module graph once per compilation phase instead of once per request. The direct one-request path and request-local proof safety remain unchanged.

## Why

Each CSS request previously rescanned every outgoing connection during collection, post-rebuild verification, and seal. That made proof work grow with requests multiplied by graph edges, even though all requests consulted the same connection set.

The deterministic fixture uses one importer with 16 safe requests and 16 outgoing connections. Counts are cumulative through each phase.

| Work | Before | After |
| --- | ---: | ---: |
| Graph traversals after `finish()` | 32 | 2 |
| Connection visits after `finish()` | 512 | 32 |
| Graph traversals after `seal()` | 48 | 3 |
| Connection visits after `seal()` | 768 | 48 |

## Changes

- Resolve multiple exact ESM requests from one fresh graph traversal in each proof phase.
- Preserve the allocation-free direct resolver for one request and discard every batch result before the graph can mutate.
- Register a deterministic benchmark and same-run ratio guard for zero, one, sixteen, and terminally invalid request shapes.
- Add a patch changeset for `@octanejs/rspack-plugin`.

The registered benchmark compares the 16-request traversal count with the one-request control. Semantic gates also cover request-local invalidity, duplicate identities, non-ESM decoys, graph replacement, and early terminal invalidation.

## Validation

- [ ] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` - the repository run reached unrelated Docusaurus, Jotai, and compiler-environment failures, then exhausted local disk while Vite created browser caches; current-head CI is the clean full-suite gate.
- [x] targeted tests:
  - `pnpm --filter @octanejs/rspack-plugin test -- css-module-graph.test.ts` - 10 files, 153 tests passed
  - `node benchmarks/bench.mjs --quick --ratios rspack-css-graph` - 1 ratio guard passed
  - `pnpm typecheck:files packages/rspack-plugin-octane/src/css-module-constants.js packages/rspack-plugin-octane/tests/css-module-graph.test.ts`
  - scoped `pnpm format:files:check`, `pnpm changeset:check`, and `pnpm sync`

## Risk / follow-ups

- Each multi-request resolution is phase-local. No graph or module object is retained across rebuild or seal boundaries.
- Browser testing is not applicable because the change only affects build-time Rspack graph proof resolution.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790564639&installation_model_id=432790&pr_number=902&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F902&signature=e80b8663e07d22047813fad9dd27fd1d0c2784213604e8095cfc24de820a5694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time proof resolution for multi-request CSS modules changes hot compilation paths; regressions could break constant folding or miss graph identity drift, though single-request behavior and extensive new tests/benchmarks mitigate this.
> 
> **Overview**
> **Rspack CSS-module constant folding** no longer walks `moduleGraph.getOutgoingConnections` once per CSS import when an importer has multiple requests. A new **`targetsForRequests`** batch resolver matches all pending ESM edges in a single traversal during proof collection and during seal-time graph verification; the existing **`targetForRequest`** path is unchanged for a single request.
> 
> Verification is split so batch checks reuse pre-resolved targets via **`verifyResolvedTarget`**, with the same invalidity rules (attributes, ambiguous identities, early exit when every request is invalid).
> 
> A new **Node-only `rspack-css-graph` benchmark** (harness entry, ratio guard, MCP suite list) asserts that sixteen-request work stays at **3 graph traversals** like the one-request control, plus correctness scenarios for zero requests, terminal invalidity, and mixed safe/invalid peers. **`css-module-graph.test.ts`** adds coverage for batch resolution and verification edge cases. Patch **changeset** for `@octanejs/rspack-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216fb7366afe977ae504998a3e2870deb9edbb51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->