### PR TITLE
perf(hydration): compact exact ranges linearly

### DIFF
--- a/.changeset/hydration-range-compaction-linear.md
+++ b/.changeset/hydration-range-compaction-linear.md
@@ -1,0 +1,12 @@
+---
+'octane': patch
+---
+
+Make hydration of deeply nested, coextensive component wrappers scale linearly.
+
+Hydration now remembers matching nested marker pairs for the lifetime of the
+adoption pass, resolves compacted range owners through a deferred parent chain,
+and removes contiguous redundant marker runs in one DOM mutation. A production
+SSR benchmark at 512 wrappers dropped from 39.2 ms to 4.9 ms while preserving
+server-node adoption, delegated interaction, logical marker multiplicity, and
+clean unmount behavior.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -234,6 +234,7 @@ internally, get their own baseline and guard namespace.
 | `controlled-form` | controlled-form | none (builds) | 512 controlled fields, real typing, DOM identity, focus and caret, validation cancellation, complete submit/reset, and native select/checkbox/radio correctness |
 | `dev-form-diagnostics` | dev-form-diagnostics | none (Node/jsdom) | development-only controlled-form diagnostic commit scaling at 4,000 and 32,000 hosts |
 | `scheduler-depth` | scheduler-depth | none (Node/jsdom) | production client scheduler ordering across 500 and 2,000 deeply nested queued components |
+| `hydration-range-compaction` | hydration-range-compaction | none (Node/jsdom) | production SSR hydration range compaction across 64 and 512 coextensive wrappers, with adoption, interaction, marker-depth, and unmount gates |
 | `external-store-fanout` | external-store-fanout | none (builds) | 512 subscribers, narrow and broad writes, rapid-write tearing checks, deterministic 100-notification work guards, and balanced subscription removal |
 | `external-store-integrations` | external-store-integrations | none (builds) | real Zustand stores, Jotai atoms, and TanStack Query caches with selector fan-out, query invalidation, and seven-framework cleanup gates |
 | `store-selector-fanout` | store-selector-fanout | none (builds) | 512 subscribers reading one store through a `with-selector`-shaped selector, 20 unrelated parent re-renders with the store untouched, and deterministic selector-invocation counts beside render and snapshot counts |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -3679,5 +3679,13 @@
     "reference": "work-model",
     "maxRatio": 1,
     "note": "Each of 32 changes cycling through all five use() factory dependencies must refresh the resource once and display the new value. This guards generic automatic caching without pinning private compiler helper names."
+  },
+  {
+    "suite": "hydration-range-compaction",
+    "op": "hydrate_per_100_wrappers",
+    "target": "wrappers-512",
+    "reference": "wrappers-64",
+    "maxRatio": 1.5,
+    "note": "Production SSR hydration of 8x more coextensive component wrappers must retain near-linear normalized range-adoption cost. The introduction runs measured 0.99x-1.05x on 2026-08-29; the harness separately gates server-node adoption, delegated interaction, logical marker multiplicity, physical compaction, and clean unmount."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -414,6 +414,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Production SSR hydration of coextensive wrapper chains, normalized per
+		// wrapper to catch repeated post-adoption range bookkeeping.
+		name: 'hydration-range-compaction',
+		cwd: 'hydration-range-compaction',
+		servers: [],
+		iter: { normal: 9, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Headless-Chromium production scaling for late behavior events whose
 		// distinct asynchronous adoptions settle one at a time.
 		name: 'behavior-root-events',

--- a/benchmarks/hydration-range-compaction/README.md
+++ b/benchmarks/hydration-range-compaction/README.md
@@ -1,0 +1,17 @@
+# Hydration range compaction
+
+This Node/jsdom suite renders and hydrates a production-built Octane component
+chain whose wrappers all adopt the same interactive leaf. The 64- and
+512-wrapper cases share one process and alternate measurement order. The
+reported `hydrate_per_100_wrappers` metric exposes repeated post-hydration range
+bookkeeping without mixing server rendering, HTML parsing, interaction, or
+unmount into the timed interval.
+
+Every sample verifies that hydration keeps the server-created button, preserves
+the logical hydration-marker multiplicity while compacting physical pairs,
+handles a real delegated click, and removes the complete tree on unmount.
+
+```bash
+node benchmarks/hydration-range-compaction/run.mjs
+node benchmarks/bench.mjs --quick hydration-range-compaction
+```

--- a/benchmarks/hydration-range-compaction/run.mjs
+++ b/benchmarks/hydration-range-compaction/run.mjs
@@ -1,0 +1,205 @@
+process.env.NODE_ENV = 'production';
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import { octane } from '../../packages/octane/src/compiler/vite.js';
+
+if (process.env.OCTANE_HYDRATION_RANGE_STACK !== '1') {
+	const { spawnSync } = await import('node:child_process');
+	const child = spawnSync(
+		process.execPath,
+		['--stack-size=16384', import.meta.filename, ...process.argv.slice(2)],
+		{
+			env: { ...process.env, OCTANE_HYDRATION_RANGE_STACK: '1' },
+			stdio: 'inherit',
+		},
+	);
+	process.exit(child.status ?? 1);
+}
+
+const HERE = import.meta.dirname;
+const REPO = path.resolve(HERE, '../..');
+const benchmarkRequire = createRequire(path.join(REPO, 'benchmarks/news/package.json'));
+const rawIterations = process.argv[2] ?? '9';
+const iterations = Number(rawIterations);
+const DEPTHS = [64, 512];
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new TypeError(`iterations must be a positive safe integer, received ${rawIterations}.`);
+}
+
+async function buildEntry(entry, output, ssr) {
+	const { build } = await import(pathToFileURL(benchmarkRequire.resolve('vite')).href);
+	const octaneSource = path.join(REPO, 'packages/octane/src');
+	await build({
+		root: REPO,
+		configFile: false,
+		logLevel: 'warn',
+		resolve: {
+			alias: [
+				{ find: /^octane\/server$/, replacement: path.join(octaneSource, 'server/index.ts') },
+				{ find: /^octane$/, replacement: path.join(octaneSource, 'index.ts') },
+			],
+		},
+		plugins: [octane({ ssr })],
+		define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+		build: {
+			lib: { entry, formats: ['es'], fileName: () => path.basename(output) },
+			outDir: path.dirname(output),
+			emptyOutDir: true,
+			minify: true,
+			target: 'node22',
+		},
+	});
+}
+
+async function setupDom() {
+	const { JSDOM } = await import('jsdom');
+	const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+		pretendToBeVisual: true,
+		url: 'http://localhost/',
+	});
+	for (const key of [
+		'window',
+		'document',
+		'navigator',
+		'EventTarget',
+		'Event',
+		'MouseEvent',
+		'Node',
+		'NodeFilter',
+		'Element',
+		'HTMLElement',
+		'HTMLButtonElement',
+		'Text',
+		'Comment',
+		'DocumentFragment',
+		'MutationObserver',
+	]) {
+		const value = key === 'window' ? dom.window : dom.window[key];
+		if (value === undefined) continue;
+		Object.defineProperty(globalThis, key, { value, configurable: true, writable: true });
+	}
+	return dom;
+}
+
+function hydrationMarkers(container) {
+	const iterator = document.createNodeIterator(container, NodeFilter.SHOW_COMMENT);
+	let opens = 0;
+	let closes = 0;
+	let logicalDepth = 0;
+	for (let node = iterator.nextNode(); node !== null; node = iterator.nextNode()) {
+		const open = /^\[(\d*)$/.exec(node.data);
+		if (open !== null) {
+			opens++;
+			logicalDepth += open[1] === '' ? 1 : Number(open[1]);
+			continue;
+		}
+		const close = /^\](\d*)$/.exec(node.data);
+		if (close !== null) closes++;
+	}
+	return { opens, closes, logicalDepth };
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-hydration-range-'));
+const clientFile = path.join(tempDir, 'client', 'entry.js');
+const serverFile = path.join(tempDir, 'server', 'entry.js');
+let failure;
+const targets = [];
+
+try {
+	await buildEntry(path.join(HERE, 'src/client.ts'), clientFile, false);
+	await buildEntry(path.join(HERE, 'src/server.ts'), serverFile, true);
+	const server = await import(pathToFileURL(serverFile).href);
+	const serverHtml = new Map(DEPTHS.map((depth) => [depth, server.renderCase(depth)]));
+	const dom = await setupDom();
+	const client = await import(pathToFileURL(clientFile).href);
+	const samples = new Map(DEPTHS.map((depth) => [depth, []]));
+	const controls = new Map();
+
+	const runCase = (depth) => {
+		const container = document.createElement('main');
+		document.body.appendChild(container);
+		container.innerHTML = serverHtml.get(depth);
+		const before = hydrationMarkers(container);
+		const result = client.hydrateCase(container, depth);
+		const after = hydrationMarkers(container);
+		if (before.opens !== before.closes || after.opens !== after.closes) {
+			throw new Error(`${depth}-wrapper hydration left unbalanced marker pairs.`);
+		}
+		if (before.logicalDepth !== after.logicalDepth || after.opens >= before.opens) {
+			throw new Error(
+				`${depth}-wrapper hydration did not preserve and compact its logical ranges: ` +
+					JSON.stringify({ before, after }),
+			);
+		}
+		result.root.unmount();
+		if (container.childNodes.length !== 0 || result.leaf.isConnected) {
+			throw new Error(`${depth}-wrapper unmount left hydrated content connected.`);
+		}
+		container.remove();
+		controls.set(depth, { before, after });
+		return result.durationMs;
+	};
+
+	for (const depth of DEPTHS) runCase(depth);
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		const order = iteration % 2 === 0 ? DEPTHS : [...DEPTHS].reverse();
+		for (const depth of order) samples.get(depth).push(runCase(depth));
+	}
+
+	for (const depth of DEPTHS) {
+		const raw = samples.get(depth);
+		const control = controls.get(depth);
+		targets.push({
+			name: `wrappers-${depth}`,
+			ops: {
+				hydrate: timingStatForJson(summarizeSamples(raw)),
+				hydrate_per_100_wrappers: timingStatForJson(
+					summarizeSamples(raw.map((elapsed) => (elapsed * 100) / depth)),
+				),
+			},
+			meta: {
+				correctness: 'pass',
+				logicalRanges: control.after.logicalDepth,
+				physicalPairsBefore: control.before.opens,
+				physicalPairsAfter: control.after.opens,
+				serverLeafAdopted: true,
+				interactionHandled: true,
+				unmountClean: true,
+				wrappers: depth,
+			},
+		});
+	}
+
+	for (const target of targets) {
+		console.log(
+			`PASS hydration-range-compaction/${target.name}: ` +
+				`${target.ops.hydrate.score.toFixed(3)}ms ` +
+				`(${target.ops.hydrate_per_100_wrappers.score.toFixed(3)}ms/100 wrappers)`,
+		);
+	}
+	dom.window.close();
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL hydration-range-compaction/${failure}`);
+} finally {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+const payload = {
+	suite: 'hydration-range-compaction',
+	iterations,
+	targets,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+if (failure) process.exitCode = 1;

--- a/benchmarks/hydration-range-compaction/run.mjs
+++ b/benchmarks/hydration-range-compaction/run.mjs
@@ -88,22 +88,41 @@ async function setupDom() {
 	return dom;
 }
 
+function hydrationMarker(data) {
+	if (data === '[' || data === '[f0' || data === '[f1') {
+		return { kind: 'open', multiplicity: 1 };
+	}
+	if (data === ']') return { kind: 'close', multiplicity: 1 };
+	const match = /^(\[|\])([1-9]\d*)$/.exec(data);
+	if (match === null) return null;
+	const multiplicity = Number(match[2]);
+	if (!Number.isSafeInteger(multiplicity) || multiplicity < 2) return null;
+	return { kind: match[1] === '[' ? 'open' : 'close', multiplicity };
+}
+
 function hydrationMarkers(container) {
 	const iterator = document.createNodeIterator(container, NodeFilter.SHOW_COMMENT);
-	let opens = 0;
-	let closes = 0;
-	let logicalDepth = 0;
+	const stack = [];
+	let logicalPairs = 0;
+	let physicalPairs = 0;
 	for (let node = iterator.nextNode(); node !== null; node = iterator.nextNode()) {
-		const open = /^\[(\d*)$/.exec(node.data);
-		if (open !== null) {
-			opens++;
-			logicalDepth += open[1] === '' ? 1 : Number(open[1]);
+		const marker = hydrationMarker(node.data);
+		if (marker === null) continue;
+		if (marker.kind === 'open') {
+			stack.push(marker.multiplicity);
+			logicalPairs += marker.multiplicity;
+			physicalPairs++;
 			continue;
 		}
-		const close = /^\](\d*)$/.exec(node.data);
-		if (close !== null) closes++;
+		const openMultiplicity = stack.pop();
+		if (openMultiplicity !== marker.multiplicity) {
+			throw new Error(
+				`Unbalanced hydration close marker ${node.data}; matching open multiplicity was ${String(openMultiplicity)}.`,
+			);
+		}
 	}
-	return { opens, closes, logicalDepth };
+	if (stack.length !== 0) throw new Error('Hydration left unclosed marker pairs.');
+	return { logicalPairs, physicalPairs };
 }
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-hydration-range-'));
@@ -129,10 +148,13 @@ try {
 		const before = hydrationMarkers(container);
 		const result = client.hydrateCase(container, depth);
 		const after = hydrationMarkers(container);
-		if (before.opens !== before.closes || after.opens !== after.closes) {
-			throw new Error(`${depth}-wrapper hydration left unbalanced marker pairs.`);
-		}
-		if (before.logicalDepth !== after.logicalDepth || after.opens >= before.opens) {
+		const expectedPairs = depth + 2;
+		if (
+			before.logicalPairs !== expectedPairs ||
+			before.physicalPairs !== expectedPairs ||
+			after.logicalPairs !== expectedPairs ||
+			after.physicalPairs !== 1
+		) {
 			throw new Error(
 				`${depth}-wrapper hydration did not preserve and compact its logical ranges: ` +
 					JSON.stringify({ before, after }),
@@ -166,9 +188,9 @@ try {
 			},
 			meta: {
 				correctness: 'pass',
-				logicalRanges: control.after.logicalDepth,
-				physicalPairsBefore: control.before.opens,
-				physicalPairsAfter: control.after.opens,
+				logicalRanges: control.after.logicalPairs,
+				physicalPairsBefore: control.before.physicalPairs,
+				physicalPairsAfter: control.after.physicalPairs,
 				serverLeafAdopted: true,
 				interactionHandled: true,
 				unmountClean: true,

--- a/benchmarks/hydration-range-compaction/src/client.ts
+++ b/benchmarks/hydration-range-compaction/src/client.ts
@@ -1,0 +1,28 @@
+import { flushSync, hydrateRoot, type Root } from 'octane';
+import { DeepWrapperChain } from './fixture.tsrx';
+
+export interface HydratedCase {
+	durationMs: number;
+	leaf: HTMLButtonElement;
+	root: Root;
+}
+
+export function hydrateCase(container: HTMLElement, depth: number): HydratedCase {
+	const leaf = container.querySelector<HTMLButtonElement>('[data-hydration-range-leaf]');
+	if (leaf === null) throw new Error(`The ${depth}-wrapper server leaf is missing.`);
+
+	const started = performance.now();
+	const root = hydrateRoot(container, DeepWrapperChain, { depth });
+	const durationMs = performance.now() - started;
+
+	if (container.querySelector('[data-hydration-range-leaf]') !== leaf) {
+		root.unmount();
+		throw new Error(`Hydration replaced the ${depth}-wrapper server leaf.`);
+	}
+	flushSync(() => leaf.click());
+	if (leaf.textContent !== 'count:1') {
+		root.unmount();
+		throw new Error(`The ${depth}-wrapper leaf did not handle its delegated click.`);
+	}
+	return { durationMs, leaf, root };
+}

--- a/benchmarks/hydration-range-compaction/src/fixture.tsrx
+++ b/benchmarks/hydration-range-compaction/src/fixture.tsrx
@@ -1,0 +1,21 @@
+import { useState } from 'octane';
+
+interface WrapperProps {
+	remaining: number;
+}
+
+function InteractiveLeaf() {
+	const [count, setCount] = useState(0);
+	return <button data-hydration-range-leaf="" onClick={() => setCount(count + 1)}>
+		{'count:' + count}
+	</button>;
+}
+
+function Wrapper(props: WrapperProps) {
+	if (props.remaining === 0) return <InteractiveLeaf />;
+	return <Wrapper remaining={props.remaining - 1} />;
+}
+
+export function DeepWrapperChain(props: { depth: number }) {
+	return <Wrapper remaining={props.depth} />;
+}

--- a/benchmarks/hydration-range-compaction/src/server.ts
+++ b/benchmarks/hydration-range-compaction/src/server.ts
@@ -1,0 +1,6 @@
+import { renderToString } from 'octane/server';
+import { DeepWrapperChain } from './fixture.tsrx';
+
+export function renderCase(depth: number): string {
+	return renderToString(DeepWrapperChain, { depth }).html;
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -71,6 +71,7 @@ export const BENCHMARK_SUITES = [
 	'scaling-curves',
 	'dev-form-diagnostics',
 	'scheduler-depth',
+	'hydration-range-compaction',
 	'behavior-root-events',
 	'radix-collection-order',
 	'router-dispatch',

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12393,6 +12393,8 @@ class HydrationCapability {
 	private abandoned = false;
 	private readonly freshNodes = new WeakSet<Node>();
 	private readonly unframedRootRanges = new WeakMap<Node, Node>();
+	/** Pairs discovered while matching an outer range; released with this hydration pass. */
+	private matchingCloses: WeakMap<Node, Comment> | null = null;
 	/** First unclaimed root sibling after a compiled root clone; undefined until known. */
 	private rootRemainder: Node | null | undefined;
 	private rootCleanupBoundary: Node | null = null;
@@ -12441,7 +12443,9 @@ class HydrationCapability {
 	}
 
 	close(open: Node): Comment {
-		const found = findMatchingClose(open);
+		const known = this.matchingCloses?.get(open);
+		const found =
+			known ?? findMatchingClose(open, (this.matchingCloses ??= new WeakMap<Node, Comment>()));
 		if (
 			!this.hasAdjacentRangePair &&
 			isBlockOpen(open.previousSibling) &&
@@ -13387,8 +13391,8 @@ function isTextSeparator(node: Node | null): node is Comment {
  * genuine fresh client mount, e.g. the server rendered the slot empty).
  */
 /** From a block-open `<!--[-->`, the matching `<!--]-->` (depth-tracked). */
-function findMatchingClose(open: Node): Comment {
-	let depth = 0;
+function findMatchingClose(open: Node, matches: WeakMap<Node, Comment>): Comment {
+	let nested: Comment[] | null = null;
 	let node: Node = getNextSibling(open) as Node;
 	for (;;) {
 		if (node.nodeType === 8) {
@@ -13404,12 +13408,14 @@ function findMatchingClose(open: Node): Comment {
 				}
 			}
 			if (close) {
-				if (depth === 0) {
-					return node as Comment;
+				const found = node as Comment;
+				if (nested === null || nested.length === 0) {
+					matches.set(open, found);
+					return found;
 				}
-				depth -= 1;
+				matches.set(nested.pop()!, found);
 			} else if (nestedOpen) {
-				depth += 1;
+				(nested ??= []).push(node as Comment);
 			}
 		}
 		node = getNextSibling(node) as Node;
@@ -31522,6 +31528,8 @@ interface HydrationRangeGroup {
 	end: Comment;
 	/** Number of logical hydration ranges represented by this physical pair. */
 	depth: number;
+	/** Surviving exact-range group; null while this pair remains canonical. */
+	parent: HydrationRangeGroup | null;
 	blocks: Block[];
 	liteScopes: Scope[];
 	owners: CoalescedRangeOwner[];
@@ -31553,8 +31561,22 @@ function coalesceHydratedRanges(
 	const blockGroups = new WeakMap<Block, HydrationRangeGroup>();
 	const scopeGroups = new WeakMap<Scope, HydrationRangeGroup>();
 	const ownerGroups = new WeakMap<object, HydrationRangeGroup>();
+	const groups: HydrationRangeGroup[] = [];
 	const seenBlocks = new WeakSet<Block>();
 	const seenScopes = new WeakSet<Scope>();
+	let redundantMarkers: Set<Comment> | null = null;
+	let removalRange: Range | null = null;
+
+	function canonicalGroup(group: HydrationRangeGroup): HydrationRangeGroup {
+		let canonical = group;
+		while (canonical.parent !== null) canonical = canonical.parent;
+		while (group.parent !== null && group.parent !== canonical) {
+			const parent = group.parent;
+			group.parent = canonical;
+			group = parent;
+		}
+		return canonical;
+	}
 
 	function makeGroup(
 		startNode: Node | null,
@@ -31572,26 +31594,16 @@ function coalesceHydratedRanges(
 			start: startNode,
 			end: endNode,
 			depth: openDepth,
+			parent: null,
 			blocks: block === undefined ? [] : [block],
 			liteScopes: liteScope === undefined ? [] : [liteScope],
 			owners: owner === undefined ? [] : [owner],
 		};
+		groups.push(group);
 		if (block !== undefined) blockGroups.set(block, group);
 		if (liteScope !== undefined) scopeGroups.set(liteScope, group);
 		if (owner !== undefined) ownerGroups.set(owner, group);
 		return group;
-	}
-
-	function appendUnique<T>(target: T[], source: T[]): void {
-		for (let i = 0; i < source.length; i++) {
-			if (target.indexOf(source[i]) === -1) target.push(source[i]);
-		}
-	}
-
-	function remapGroup(from: HydrationRangeGroup, to: HydrationRangeGroup): void {
-		for (let i = 0; i < from.blocks.length; i++) blockGroups.set(from.blocks[i], to);
-		for (let i = 0; i < from.liteScopes.length; i++) scopeGroups.set(from.liteScopes[i], to);
-		for (let i = 0; i < from.owners.length; i++) ownerGroups.set(from.owners[i], to);
 	}
 
 	function writeMultiplicity(group: HydrationRangeGroup): void {
@@ -31599,17 +31611,38 @@ function coalesceHydratedRanges(
 		group.end.data = group.depth === 1 ? HYDRATION_END : HYDRATION_END + String(group.depth);
 	}
 
+	function removeRedundantMarkerRun(anchor: Comment, after: boolean): void {
+		if (redundantMarkers === null) return;
+		const adjacent = after ? anchor.nextSibling : anchor.previousSibling;
+		if (
+			adjacent === null ||
+			adjacent.nodeType !== 8 ||
+			!redundantMarkers.has(adjacent as Comment)
+		) {
+			return;
+		}
+		let edge = adjacent;
+		for (;;) {
+			const next = after ? edge.nextSibling : edge.previousSibling;
+			if (next === null || next.nodeType !== 8 || !redundantMarkers.has(next as Comment)) break;
+			edge = next;
+		}
+		const range = (removalRange ??= anchor.ownerDocument!.createRange());
+		range.setStartBefore(after ? adjacent : edge);
+		range.setEndAfter(after ? edge : adjacent);
+		range.deleteContents();
+	}
+
 	/** Merge bookkeeping for two runtime owners that already share one pair. */
 	function unifySharedPair(
 		outer: HydrationRangeGroup,
 		inner: HydrationRangeGroup,
 	): HydrationRangeGroup {
+		outer = canonicalGroup(outer);
+		inner = canonicalGroup(inner);
 		if (outer === inner) return outer;
 		outer.depth = Math.max(outer.depth, inner.depth);
-		appendUnique(outer.blocks, inner.blocks);
-		appendUnique(outer.liteScopes, inner.liteScopes);
-		appendUnique(outer.owners, inner.owners);
-		remapGroup(inner, outer);
+		inner.parent = outer;
 		writeMultiplicity(outer);
 		return outer;
 	}
@@ -31625,8 +31658,8 @@ function coalesceHydratedRanges(
 		);
 	}
 
-	/** Redirect every inner runtime owner before removing its redundant pair. */
-	function borrowInnerRange(outer: HydrationRangeGroup, inner: HydrationRangeGroup): void {
+	/** Redirect one group's direct runtime owners after all exact pairs are known. */
+	function borrowGroupMembers(outer: HydrationRangeGroup, inner: HydrationRangeGroup): void {
 		for (let i = 0; i < inner.blocks.length; i++) {
 			const block = inner.blocks[i];
 			block.startMarker = outer.start;
@@ -31658,6 +31691,8 @@ function coalesceHydratedRanges(
 		outer: HydrationRangeGroup,
 		inner: HydrationRangeGroup,
 	): HydrationRangeGroup {
+		outer = canonicalGroup(outer);
+		inner = canonicalGroup(inner);
 		if (outer === inner) return outer;
 		if (outer.start === inner.start && outer.end === inner.end) {
 			return unifySharedPair(outer, inner);
@@ -31667,20 +31702,16 @@ function coalesceHydratedRanges(
 		// Both inputs were decoded as safe integers, but their sum may not be. Keep
 		// both physical pairs rather than minting metadata the protocol cannot parse.
 		if (!Number.isSafeInteger(mergedDepth)) return outer;
-		borrowInnerRange(outer, inner);
-		inner.start.remove();
-		inner.end.remove();
+		(redundantMarkers ??= new Set<Comment>()).add(inner.start).add(inner.end);
 		outer.depth = mergedDepth;
-		appendUnique(outer.blocks, inner.blocks);
-		appendUnique(outer.liteScopes, inner.liteScopes);
-		appendUnique(outer.owners, inner.owners);
-		remapGroup(inner, outer);
+		inner.parent = outer;
 		writeMultiplicity(outer);
 		return outer;
 	}
 
 	function attachOwner(group: HydrationRangeGroup | null, owner: CoalescedRangeOwner): void {
 		if (group === null) return;
+		group = canonicalGroup(group);
 		if (group.owners.indexOf(owner) === -1) group.owners.push(owner);
 		ownerGroups.set(owner, group);
 	}
@@ -31720,7 +31751,8 @@ function coalesceHydratedRanges(
 
 	function mappedGroup(value: any): HydrationRangeGroup | undefined {
 		if (value === null || typeof value !== 'object') return undefined;
-		return ownerGroups.get(value) ?? scopeGroups.get(value as Scope);
+		const group = ownerGroups.get(value) ?? scopeGroups.get(value as Scope);
+		return group === undefined ? undefined : canonicalGroup(group);
 	}
 
 	/**
@@ -31752,7 +31784,8 @@ function coalesceHydratedRanges(
 			(registered[0] as ChildSlot).compactable &&
 			mayBorrowCandidate(registered[0])
 		) {
-			return ownerGroups.get(registered[0]) ?? null;
+			const group = ownerGroups.get(registered[0]);
+			return group === undefined ? null : canonicalGroup(group);
 		}
 		return null;
 	}
@@ -31846,6 +31879,27 @@ function coalesceHydratedRanges(
 	}
 
 	visitBlock(rootBlock);
+	// Weak lookup tables make traversal cheap but cannot drive finalization. The
+	// ordered group list visits each directly registered member once, after path
+	// compression resolves any chain of removed marker pairs to its survivor.
+	for (let i = 0; i < groups.length; i++) {
+		const group = groups[i];
+		const canonical = canonicalGroup(group);
+		if (group.start !== canonical.start || group.end !== canonical.end) {
+			borrowGroupMembers(canonical, group);
+		}
+	}
+	// Exact nesting leaves the redundant opens and closes in two contiguous
+	// runs. Delete each run as one DOM mutation instead of repeatedly repairing
+	// sibling links and live collections for every wrapper layer.
+	if (redundantMarkers !== null) {
+		for (let i = 0; i < groups.length; i++) {
+			const group = groups[i];
+			if (group.parent !== null) continue;
+			removeRedundantMarkerRun(group.start, true);
+			removeRedundantMarkerRun(group.end, false);
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/octane/tests/hydration/_fixtures/wrapper-adoption.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/wrapper-adoption.tsrx
@@ -32,6 +32,23 @@ export function WrapperChain() @{
 	</section>
 }
 
+function RecursiveWrapper(props: { remaining: number }) {
+	if (props.remaining === 0) return <DeepStructuralLeaf />;
+	return <RecursiveWrapper remaining={props.remaining - 1} />;
+}
+
+function DeepStructuralLeaf() {
+	const [active, setActive] = useState(true);
+	if (!active) return <strong class="deep-wrapper-replacement">replaced</strong>;
+	return <button class="deep-wrapper-button" onClick={() => setActive(false)}>replace</button>;
+}
+
+export function DeepWrapperChain(props: { depth: number }) @{
+	<section class="deep-wrapper-chain">
+		<RecursiveWrapper remaining={props.depth} />
+	</section>
+}
+
 function KeyedReturnMiddle(props: { itemKey?: string }) {
 	return <InteractiveLeaf key={props.itemKey} label="keyed" className="keyed-return-button" />;
 }

--- a/packages/octane/tests/hydration/wrapper-adoption.test.ts
+++ b/packages/octane/tests/hydration/wrapper-adoption.test.ts
@@ -5,6 +5,7 @@ import { compile } from 'octane/compiler';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import {
+	DeepWrapperChain,
 	KeyedReturnWrapper,
 	KeyedWrapperList,
 	ReturnedSuspenseChildSlot,
@@ -56,6 +57,21 @@ describe('hydrateRoot — nested wrapper and boundary adoption', () => {
 		expect(section.querySelector('.wrapper-button')).toBe(serverButton);
 		expect(serverButton.textContent).toBe('wrapped:1');
 		root.unmount();
+	});
+
+	it('keeps a deeply wrapped server node interactive through hydration and cleanup', () => {
+		container.innerHTML = renderServer('DeepWrapperChain', { depth: 32 });
+		const serverButton = container.querySelector('.deep-wrapper-button') as HTMLButtonElement;
+
+		const root = hydrateRoot(container, DeepWrapperChain, { depth: 32 });
+		expect(container.querySelector('.deep-wrapper-button')).toBe(serverButton);
+
+		flushSync(() => serverButton.click());
+		expect(container.querySelector('.deep-wrapper-button')).toBeNull();
+		expect(container.querySelector('.deep-wrapper-replacement')?.textContent).toBe('replaced');
+		expect(serverButton.isConnected).toBe(false);
+		root.unmount();
+		expect(container.childNodes).toHaveLength(0);
 	});
 
 	it('preserves component state when a hydrated branch swaps away and back', () => {


### PR DESCRIPTION
## Summary

Deep server-rendered wrapper chains now hydrate in approximately linear time. Exact-range compaction no longer repeatedly moves every accumulated owner or removes markers one pair at a time; it links range groups to a canonical survivor, rebinds each direct owner once, and deletes the two redundant marker runs in batches.

The focused production SSR/hydration benchmark reproduced the old superlinear behavior before the runtime changed. It measures only hydration and also verifies server-node adoption, counted marker multiplicity, delegated interaction, updates, and clean unmount.

| Wrapper depth | Before median | After median | Change |
| ---: | ---: | ---: | ---: |
| 64 | 0.880 ms | 0.608 ms | -30.9% |
| 512 | 39.233 ms | 4.885 ms | -87.5% |

An 8x depth increase changed from 44.6x raw hydration time to 8.0x. Normalized time per 100 wrappers is flat, and a 1.5x ratio guard leaves room for CI noise while rejecting renewed superlinear growth.

Session-settled decisions carried from planning: keep the work in Octane core, avoid overlap with Jon Wheeler's recent performance pull requests, and require a reproducible benchmark before retaining a runtime edit (all user-directed).

## Validation

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests:
  - `./node_modules/.bin/prettier --check <changed files>`
  - `./node_modules/.bin/tsrx-tsc --noEmit -p packages/octane/tsconfig.json`
  - hydration dev/prod projects: 88 files, 776 tests passed
  - core browser hydration projects: 3 files, 22 tests passed
  - `node benchmarks/hydration-range-compaction/run.mjs 3`
  - `node benchmarks/bench.mjs --quick --ratios hydration-range-compaction`
  - `node scripts/check-changesets.js`
  - `pnpm sync`

The full `pnpm test` run was attempted outside the sandbox. It reached unrelated Doom, Jotai/localStorage, resizable-panels, and Rspack failures, then exhausted Node's 4 GB heap after about 18 minutes. No affected Octane hydration project failed; current-head CI is the full-suite gate.

## Risk / follow-ups

- Marker parsing, safe-integer guards, ownership flags, barriers, server-node identity, post-hydration updates, and unmount behavior retain focused regression coverage.
- The `ce-test-browser` route runner could not start because `agent-browser` is not installed. The repository's existing Chromium-backed core hydration tests passed instead.
- No binding package is changed, and the target does not overlap the recent compiler, scheduler, SSR replay, manifest, host-prop, or renderer performance work.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SSR hydration marker matching and post-hydration range compaction in `runtime.ts`, but behavior is heavily regression-gated by benchmarks and focused hydration tests.
> 
> **Overview**
> **Deep SSR wrapper chains** no longer pay superlinear cost during post-hydration exact-range compaction. Adoption **caches** open→close marker matches for the pass, compaction **links** nested groups to a canonical survivor via a deferred `parent` chain (with path compression on lookup), **rebinds** each group's direct owners once at the end, and **strips** redundant marker comments in two batched `Range` deletes instead of per-pair DOM removal and eager owner remapping.
> 
> A new **`hydration-range-compaction`** Node/jsdom benchmark (64 vs 512 coextensive wrappers) times hydration only and gates server-node adoption, logical vs physical marker multiplicity, delegated clicks, and clean unmount; **`baselines/ratios.json`** adds a ~1.5× scaling guard on normalized `hydrate_per_100_wrappers`. Hydration tests add a **32-deep recursive wrapper** fixture exercising adoption, interaction, and teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2299a72dc333af9f866fa92216f1868154b0abab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790637278&installation_model_id=432790&pr_number=907&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F907&signature=c94cdd2e20ca19cb88da4dbe7d7acc9a97b9a09f9257c128d21cd3092a311d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->