### PR TITLE
fix(lynx): keep readiness requests alive

### DIFF
--- a/.changeset/lynx-readiness-signal.md
+++ b/.changeset/lynx-readiness-signal.md
@@ -1,0 +1,9 @@
+---
+'@octanejs/lynx': patch
+---
+
+Keep the background transport's correlated readiness request alive until the
+main thread answers or the transport closes. Lynx initializes its main and
+background scripts independently, so the initial request and main's unsolicited
+announcement can both precede their peer listener; repeating the same id makes
+that listener-installation race recoverable without changing the wire shape.

--- a/packages/lynx/src/core/transport.ts
+++ b/packages/lynx/src/core/transport.ts
@@ -185,6 +185,7 @@ interface RunningBackgroundCall {
 }
 
 let NEXT_READY_REQUEST = 1;
+const READINESS_SIGNAL_DELAY_MS = 16;
 const MAX_DISPOSE_ATTEMPTS = 3;
 const MAX_QUEUED_THREAD_CALLS = 128;
 
@@ -286,7 +287,7 @@ export function createLynxBackgroundTransport(
 	let lazyPublicInstances = false;
 	let postFirstTreeLazyPublicInstances = false;
 	let deferredFirstTreeCapabilities: LynxMainThreadCapabilities | undefined;
-	let readinessRetrySent = false;
+	let readinessSignal: ReturnType<typeof setTimeout> | null = null;
 	let disposeDeferred: Deferred<void> | null = null;
 	let disposeIdentity: UniversalTransportIdentity | null = null;
 	let disposeAttempts = 0;
@@ -598,12 +599,19 @@ export function createLynxBackgroundTransport(
 		runningBackgroundCalls.clear();
 	};
 
+	const stopReadinessSignal = (): void => {
+		if (readinessSignal === null) return;
+		globalThis.clearTimeout(readinessSignal);
+		readinessSignal = null;
+	};
+
 	const closeClientState = (
 		error: Error,
 		preserveDisposeResolution: boolean,
 		notifyMain = true,
 	): boolean => {
 		if (closedError !== null) return false;
+		stopReadinessSignal();
 		closeThreadCalls(error, notifyMain);
 		// Nothing will acknowledge a held native event once the transport closes.
 		dropDeferredNativeEvents();
@@ -622,6 +630,34 @@ export function createLynxBackgroundTransport(
 	const closeInternal = (error: Error, preserveDisposeResolution: boolean) => {
 		if (!closeClientState(error, preserveDisposeResolution)) return;
 		detachReceiver();
+	};
+
+	const sendReadinessSignal = (): void => {
+		readinessSignal = null;
+		if (closedError !== null || readyReceived || readyDeferred.settled) {
+			return;
+		}
+		try {
+			dispatch(readinessRequest);
+		} catch (error) {
+			closeInternal(report(error, 'Octane Lynx failed to signal main readiness.'), false);
+			return;
+		}
+		if (closedError === null && !readyReceived && !readyDeferred.settled) {
+			readinessSignal = globalThis.setTimeout(sendReadinessSignal, READINESS_SIGNAL_DELAY_MS);
+		}
+	};
+
+	const startReadinessSignal = (): void => {
+		if (
+			closedError !== null ||
+			readyReceived ||
+			readyDeferred.settled ||
+			readinessSignal !== null
+		) {
+			return;
+		}
+		sendReadinessSignal();
 	};
 
 	const queuePageDestroyHandler = (): void => {
@@ -749,15 +785,11 @@ export function createLynxBackgroundTransport(
 
 	const handleReady = (message: LynxMainReadyReply) => {
 		if (message.request === LYNX_READY_ANNOUNCEMENT_REQUEST) {
-			if (readyReceived || readyDeferred.settled || readinessRetrySent) return;
+			if (readyReceived || readyDeferred.settled) return;
 			// Request 0 is only an availability hint. Re-send this transport's
 			// correlation ID so main can order queued page data before the reply.
-			readinessRetrySent = true;
-			try {
-				dispatch(readinessRequest);
-			} catch (error) {
-				closeInternal(report(error, 'Octane Lynx failed to retry main readiness.'), false);
-			}
+			stopReadinessSignal();
+			startReadinessSignal();
 			return;
 		}
 		if (message.request !== readyRequest) {
@@ -782,6 +814,7 @@ export function createLynxBackgroundTransport(
 		lazyPublicInstances = capabilities?.lazyPublicInstances === 1;
 		setLynxClientCapabilities(container, capabilities);
 		readyReceived = true;
+		stopReadinessSignal();
 		readyDeferred.resolve(undefined);
 	};
 
@@ -1440,12 +1473,8 @@ export function createLynxBackgroundTransport(
 	}
 	if (pageDestroyedBeforeReady) {
 		handlePageDestroy();
-	} else if (closedError === null && !readyReceived && !readinessRetrySent) {
-		try {
-			dispatch(readinessRequest);
-		} catch (error) {
-			closeInternal(report(error, 'Octane Lynx failed to request main readiness.'), false);
-		}
+	} else {
+		startReadinessSignal();
 	}
 
 	const transport: LynxBackgroundTransport = {

--- a/packages/lynx/src/core/transport.ts
+++ b/packages/lynx/src/core/transport.ts
@@ -601,7 +601,7 @@ export function createLynxBackgroundTransport(
 
 	const stopReadinessSignal = (): void => {
 		if (readinessSignal === null) return;
-		globalThis.clearTimeout(readinessSignal);
+		clearTimeout(readinessSignal);
 		readinessSignal = null;
 	};
 
@@ -644,7 +644,7 @@ export function createLynxBackgroundTransport(
 			return;
 		}
 		if (closedError === null && !readyReceived && !readyDeferred.settled) {
-			readinessSignal = globalThis.setTimeout(sendReadinessSignal, READINESS_SIGNAL_DELAY_MS);
+			readinessSignal = setTimeout(sendReadinessSignal, READINESS_SIGNAL_DELAY_MS);
 		}
 	};
 

--- a/packages/lynx/tests/protocol.test.ts
+++ b/packages/lynx/tests/protocol.test.ts
@@ -2167,6 +2167,73 @@ describe('@octanejs/lynx transported protocol', () => {
 		).toContainEqual([LYNX_BACKGROUND_TO_MAIN_EVENT, 'terminal-dispose']);
 	});
 
+	it('repeats one correlated readiness request until a late main listener answers', async () => {
+		vi.useFakeTimers();
+		try {
+			const context = new FakeContextProxy();
+			const transport = createLynxBackgroundTransport(context, createLynxClientContainer());
+			const requests = () =>
+				context.events
+					.filter((event) => event.type === LYNX_BACKGROUND_TO_MAIN_EVENT)
+					.map((event) => unwire(event.data))
+					.filter(
+						(message): message is LynxMainReadyRequest =>
+							message !== null &&
+							typeof message === 'object' &&
+							(message as { readonly type?: unknown }).type === 'main-ready-request',
+					);
+			const initial = requests();
+			expect(initial).toHaveLength(1);
+
+			let ready = false;
+			void transport.ready.then(() => {
+				ready = true;
+			});
+			await flushMicrotasks();
+			expect(ready).toBe(false);
+
+			installMainHarness(context);
+			await vi.advanceTimersToNextTimerAsync();
+			expect(ready).toBe(true);
+			const recovered = requests();
+			expect(recovered).toHaveLength(2);
+			expect(recovered.map(({ request }) => request)).toEqual([
+				initial[0]!.request,
+				initial[0]!.request,
+			]);
+
+			await vi.advanceTimersByTimeAsync(160);
+			expect(requests()).toHaveLength(recovered.length);
+			transport.close();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('stops readiness requests when a waiting transport closes', async () => {
+		vi.useFakeTimers();
+		try {
+			const context = new FakeContextProxy();
+			const transport = createLynxBackgroundTransport(context, createLynxClientContainer());
+			const requestCount = () =>
+				context.events.filter(
+					(event) =>
+						event.type === LYNX_BACKGROUND_TO_MAIN_EVENT &&
+						(unwire(event.data) as { readonly type?: unknown }).type === 'main-ready-request',
+				).length;
+			const beforeClose = requestCount();
+			const reason = new Error('closed before main listener installation');
+			const ready = transport.ready.catch((error: unknown) => error);
+
+			transport.close(reason);
+			expect(await ready).toBe(reason);
+			await vi.advanceTimersByTimeAsync(160);
+			expect(requestCount()).toBe(beforeClose);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('waits for named-event readiness, publishes handles at ACK, and preserves update identity', async () => {
 		const context = new FakeContextProxy();
 		const main = installMainHarness(context);


### PR DESCRIPTION
## Summary

### Reproduction

Lynx starts its main-thread and background scripts independently. The background transport can install its receiver and send its first correlated `main-ready-request` before main installs its receiver. Main's unsolicited request-0 announcement can likewise be emitted before the background receiver exists, so the current one-shot announcement retry does not guarantee that either side observes the other.

The regression test creates the background transport before installing the main harness. Before this change the initial request is lost and `transport.ready` remains pending. With this change the next readiness pulse reaches main, and the reply resolves the same transport without changing its correlation id.

### Accident history

The transport previously depended on startup scheduling making either the initial request or the single announcement-triggered retry cross the listener boundary. That was an accidental liveness guarantee: both messages can be delivered too early on Native even though listener installation is correctly ordered within each script.

#885 fixed the separate transport-materialization failure class; it did not make readiness durable. The same-id readiness/presence semantics were already exercised on Native in [Huxpro/octane#233](https://github.com/Huxpro/octane/pull/233). This patch uses that verified semantic contract while rewriting the implementation around upstream's current transport lifecycle, close path, and completed-request tombstones.

### Remove the failure class

- Keep one recursive 16 ms readiness timer, using Lynx's documented bare global timer API, while the background transport is waiting.
- Re-send the same frozen request, including the same correlation id, so main's existing tombstone handling keeps late duplicates idempotent.
- Stop the timer on the correlated reply and on every transport-close path.
- Treat request 0 as an availability hint that expedites the next same-id pulse.

This changes no protocol keys, capability rungs, first-tree behavior, main-thread implementation, D2 performance-entry code, or program/adoption surface.

### `getOwnPropertyNames` site audit

This PR adds, removes, or changes no `Object.getOwnPropertyNames` call. Each current Lynx site remains deliberate after #885's transport boundary:

- `packages/lynx/src/core/protocol.ts:599` — retained. It enforces dense arrays and data-property descriptors on already decoded protocol values.
- `packages/lynx/src/core/worklets.ts:152` — retained. It enforces exact enumerable data-property shapes for decoded worklet payloads and rejects accessors/symbol fields.
- `packages/lynx/src/core/lifecycle-data.ts:109` — retained. It validates lifecycle clone inputs above the decoded transport boundary, including array length handling and accessor rejection.
- `packages/lynx/src/core/transport-codec.ts:13` — documentation only, not an executable call site; retained because it records the native bridge accident that #885 removed.

The upstream-state correction and validation caveats were reported before this PR in [Huxpro/octane#232](https://github.com/Huxpro/octane/issues/232#issuecomment-5468602046).

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the unsharded local run exhausted the shared host's `/tmp` and file-descriptor limits (`ENOSPC`/`EMFILE`), causing 1,314 unrelated suites not to collect; the official CI shards and dedicated heavy/browser/parity jobs are the full-suite gate.
- [x] [official upstream CI run 33311512894](https://github.com/octanejs/octane/actions/runs/33311512894) — all four Node 24 test shards, all four React parity shards, heavy package/Astro, heavy Chromium, website, example shards, publishable packages, Three/Lynx compatibility, lint, typecheck, and provenance passed
- [x] targeted tests:
  - red-before / green-after late-listener regression in `packages/lynx/tests/protocol.test.ts`
  - `pnpm exec vitest run --project lynx` — 27 files, 395 tests passed
  - `pnpm exec tsgo --noEmit -p packages/lynx/tsconfig.json`
  - `pnpm exec tsgo --noEmit -p packages/lynx/tsconfig.testing.json`
  - `pnpm exec tsgo --noEmit -p packages/lynx/typetests/tsconfig.json`
  - `pnpm typecheck:files packages/lynx/src/core/transport.ts`
  - `pnpm sync`
  - `pnpm changeset:check`
  - `git diff --check`
  - disposable `main + #909@9994674bba + #886@7378d00477` Native build/load — the corrected bundle exposes the expected 1000-row semantic snapshot with no application error; the leased Explorer identifies as SDK `0.0.1` and lacks both bare and `globalThis` timer APIs, so readiness-pulse and ACK/two-frame acceptance are deliberately not claimed on that image ([evidence](https://github.com/Huxpro/octane/issues/232#issuecomment-5468658476))

## Risk / follow-ups

The only repeated work is one small same-id transport message every 16 ms before readiness. It stops as soon as readiness resolves or the transport closes. No D2 code is included here; #886's device acceptance will be tested as a disposable stack on top of this PR while #886 itself remains unchanged.

## Provenance

- [x] An agent produced this diff (`agent-authored`)
