### PR TITLE
perf(octane): drain hydration render updates in one pass

### DIFF
--- a/.changeset/hydration-queue-single-pass.md
+++ b/.changeset/hydration-queue-single-pass.md
@@ -1,0 +1,11 @@
+---
+'octane': patch
+---
+
+Make hydration render-phase queue draining scale linearly.
+
+Hydration now partitions the live scheduler queue in one pass instead of
+repeatedly rescanning and splicing it for every target-root update. A production
+multi-root benchmark at 1,024 rows dropped from 20.6 ms to 7.0 ms while
+preserving synchronous convergence, server-node adoption, foreign-root work,
+delegated interaction, render-loop limits, and error cleanup.

--- a/benchmarks/baselines/local/hydration-render-phase-queue.json
+++ b/benchmarks/baselines/local/hydration-render-phase-queue.json
@@ -1,0 +1,83 @@
+{
+  "suite": "hydration-render-phase-queue",
+  "iterations": 9,
+  "targets": [
+    {
+      "name": "rows-128",
+      "ops": {
+        "hydrate": {
+          "score": 0.7190335999999661,
+          "median": 0.7446669999999358,
+          "min": 0.6813329999999951,
+          "mean": 0.7854677777777902,
+          "p95": 1.0602080000003298,
+          "sd": 0.11655136683762493,
+          "rme": 11.405833972716563,
+          "scoreRme": 5.874723950508972,
+          "warmupRatio": 1.17988255347184,
+          "samples": 9
+        },
+        "hydrate_per_100_rows": {
+          "score": 0.5617449999999735,
+          "median": 0.5817710937499498,
+          "min": 0.5322914062499962,
+          "mean": 0.6136467013888987,
+          "p95": 0.8282875000002576,
+          "sd": 0.09105575534189449,
+          "rme": 11.405833972716561,
+          "scoreRme": 5.874723950508972,
+          "warmupRatio": 1.1798825534718398,
+          "samples": 9
+        }
+      },
+      "meta": {
+        "correctness": "pass",
+        "foreignRows": 128,
+        "foreignWorkPreserved": true,
+        "interactionHandled": true,
+        "serverNodesAdopted": true,
+        "targetRows": 128,
+        "unmountClean": true
+      }
+    },
+    {
+      "name": "rows-1024",
+      "ops": {
+        "hydrate": {
+          "score": 6.4314918000001855,
+          "median": 6.3586669999999685,
+          "min": 5.589166000000205,
+          "mean": 6.650648333333468,
+          "p95": 8.696584000000257,
+          "sd": 1.0225967492773071,
+          "rme": 11.818938473584518,
+          "scoreRme": 24.853008318545722,
+          "warmupRatio": 1.035142173391235,
+          "samples": 9
+        },
+        "hydrate_per_100_rows": {
+          "score": 0.6280753710937681,
+          "median": 0.6209635742187469,
+          "min": 0.54581699218752,
+          "mean": 0.6494773763020965,
+          "p95": 0.8492757812500251,
+          "sd": 0.09986296379661203,
+          "rme": 11.81893847358452,
+          "scoreRme": 24.853008318545722,
+          "warmupRatio": 1.035142173391235,
+          "samples": 9
+        }
+      },
+      "meta": {
+        "correctness": "pass",
+        "foreignRows": 1024,
+        "foreignWorkPreserved": true,
+        "interactionHandled": true,
+        "serverNodesAdopted": true,
+        "targetRows": 1024,
+        "unmountClean": true
+      }
+    }
+  ],
+  "harnessExit": 0
+}

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -3727,5 +3727,13 @@
     "reference": "wrappers-64",
     "maxRatio": 1.5,
     "note": "Production SSR hydration of 8x more coextensive component wrappers must retain near-linear normalized range-adoption cost. The introduction runs measured 0.99x-1.05x on 2026-08-29; the harness separately gates server-node adoption, delegated interaction, logical marker multiplicity, physical compaction, and clean unmount."
+  },
+  {
+    "suite": "hydration-render-phase-queue",
+    "op": "hydrate_per_100_rows",
+    "target": "rows-1024",
+    "reference": "rows-128",
+    "maxRatio": 1.5,
+    "note": "Production multi-root hydration with an equal-width foreign update wave already queued must retain near-linear normalized cost per row. Exact origin/main measured 2.43x per row before the single-pass drain; the harness separately gates synchronous convergence, adoption of every server node, cross-root isolation and later completion, delegated interaction, and clean unmount."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -423,6 +423,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Production multi-root hydration with a same-width foreign update wave
+		// already queued, normalized per row to catch repeated queue prefix scans.
+		name: 'hydration-render-phase-queue',
+		cwd: 'hydration-render-phase-queue',
+		servers: [],
+		iter: { normal: 9, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Headless-Chromium production scaling for late behavior events whose
 		// distinct asynchronous adoptions settle one at a time.
 		name: 'behavior-root-events',

--- a/benchmarks/hydration-render-phase-queue/README.md
+++ b/benchmarks/hydration-render-phase-queue/README.md
@@ -1,0 +1,17 @@
+# Hydration render-phase queue draining
+
+This Node/jsdom suite production-builds a server renderer and a client runtime,
+then times only `hydrateRoot` for a root whose rows each converge through two
+guarded render-phase updates. An equal-width mounted root already has one update
+per row queued ahead of the hydrating root. The 128- and 1,024-row cases share
+one process and alternate measurement order.
+
+Every sample verifies that hydration keeps every server-created button,
+publishes the converged target state synchronously, leaves the other root stale
+until the ordinary scheduler flush, commits that queued foreign work afterward,
+handles a delegated click, and unmounts both roots cleanly.
+
+```bash
+node benchmarks/hydration-render-phase-queue/run.mjs
+node benchmarks/bench.mjs --quick hydration-render-phase-queue
+```

--- a/benchmarks/hydration-render-phase-queue/run.mjs
+++ b/benchmarks/hydration-render-phase-queue/run.mjs
@@ -1,0 +1,168 @@
+process.env.NODE_ENV = 'production';
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import { octane } from '../../packages/octane/src/compiler/vite.js';
+
+const HERE = import.meta.dirname;
+const REPO = path.resolve(HERE, '../..');
+const benchmarkRequire = createRequire(path.join(REPO, 'benchmarks/news/package.json'));
+const rawIterations = process.argv[2] ?? '9';
+const iterations = Number(rawIterations);
+const COUNTS = [128, 1_024];
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new TypeError(`iterations must be a positive safe integer, received ${rawIterations}.`);
+}
+
+async function buildEntry(entry, output, ssr) {
+	const { build } = await import(pathToFileURL(benchmarkRequire.resolve('vite')).href);
+	const octaneSource = path.join(REPO, 'packages/octane/src');
+	await build({
+		root: REPO,
+		configFile: false,
+		logLevel: 'warn',
+		resolve: {
+			alias: [
+				{
+					find: /^octane\/internal\/client$/,
+					replacement: path.join(octaneSource, 'internal/client.ts'),
+				},
+				{
+					find: /^octane\/internal\/server$/,
+					replacement: path.join(octaneSource, 'internal/server.ts'),
+				},
+				{ find: /^octane\/server$/, replacement: path.join(octaneSource, 'server/index.ts') },
+				{ find: /^octane$/, replacement: path.join(octaneSource, 'index.ts') },
+			],
+		},
+		plugins: [octane({ ssr })],
+		define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+		build: {
+			lib: { entry, formats: ['es'], fileName: () => path.basename(output) },
+			outDir: path.dirname(output),
+			emptyOutDir: true,
+			minify: true,
+			target: 'node22',
+		},
+	});
+}
+
+async function setupDom() {
+	const { JSDOM } = await import('jsdom');
+	const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+		pretendToBeVisual: true,
+		url: 'http://localhost/',
+	});
+	for (const key of [
+		'window',
+		'document',
+		'navigator',
+		'EventTarget',
+		'Event',
+		'MouseEvent',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'HTMLButtonElement',
+		'HTMLOutputElement',
+		'Text',
+		'Comment',
+		'DocumentFragment',
+		'MutationObserver',
+	]) {
+		const value = key === 'window' ? dom.window : dom.window[key];
+		if (value === undefined) continue;
+		Object.defineProperty(globalThis, key, { value, configurable: true, writable: true });
+	}
+	return dom;
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-hydration-render-queue-'));
+const clientFile = path.join(tempDir, 'client', 'entry.js');
+const serverFile = path.join(tempDir, 'server', 'entry.js');
+let failure;
+const targets = [];
+
+try {
+	await buildEntry(path.join(HERE, 'src/client.ts'), clientFile, false);
+	await buildEntry(path.join(HERE, 'src/server.ts'), serverFile, true);
+	const server = await import(pathToFileURL(serverFile).href);
+	const serverHtml = new Map(COUNTS.map((count) => [count, server.renderCase(count)]));
+	const dom = await setupDom();
+	const client = await import(pathToFileURL(clientFile).href);
+	const samples = new Map(COUNTS.map((count) => [count, []]));
+	const controls = new Map();
+
+	const runCase = (count) => {
+		const foreignContainer = document.createElement('main');
+		const targetContainer = document.createElement('main');
+		targetContainer.innerHTML = serverHtml.get(count);
+		document.body.append(foreignContainer, targetContainer);
+		const result = client.runHydrationQueueCase(foreignContainer, targetContainer, count);
+		foreignContainer.remove();
+		targetContainer.remove();
+		controls.set(count, result);
+		return result.durationMs;
+	};
+
+	for (const count of COUNTS) runCase(count);
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		const order = iteration % 2 === 0 ? COUNTS : [...COUNTS].reverse();
+		for (const count of order) samples.get(count).push(runCase(count));
+	}
+
+	for (const count of COUNTS) {
+		const raw = samples.get(count);
+		const control = controls.get(count);
+		targets.push({
+			name: `rows-${count}`,
+			ops: {
+				hydrate: timingStatForJson(summarizeSamples(raw)),
+				hydrate_per_100_rows: timingStatForJson(
+					summarizeSamples(raw.map((elapsed) => (elapsed * 100) / count)),
+				),
+			},
+			meta: {
+				correctness: 'pass',
+				foreignRows: control.foreignRows,
+				foreignWorkPreserved: control.foreignWorkPreserved,
+				interactionHandled: control.interactionHandled,
+				serverNodesAdopted: control.serverNodesAdopted,
+				targetRows: control.targetRows,
+				unmountClean: control.unmountClean,
+			},
+		});
+	}
+
+	for (const target of targets) {
+		console.log(
+			`PASS hydration-render-phase-queue/${target.name}: ` +
+				`${target.ops.hydrate.score.toFixed(3)}ms ` +
+				`(${target.ops.hydrate_per_100_rows.score.toFixed(3)}ms/100 rows)`,
+		);
+	}
+	dom.window.close();
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL hydration-render-phase-queue/${failure}`);
+} finally {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+const payload = {
+	suite: 'hydration-render-phase-queue',
+	iterations,
+	targets,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+if (failure) process.exitCode = 1;

--- a/benchmarks/hydration-render-phase-queue/src/client.ts
+++ b/benchmarks/hydration-render-phase-queue/src/client.ts
@@ -1,0 +1,91 @@
+import { createRoot, flushSync, hydrateRoot } from 'octane';
+import { ForeignRows, queueForeignUpdates, TargetRows } from './fixture.tsrx';
+
+export interface HydrationQueueCase {
+	durationMs: number;
+	foreignRows: number;
+	foreignWorkPreserved: boolean;
+	interactionHandled: boolean;
+	serverNodesAdopted: boolean;
+	targetRows: number;
+	unmountClean: boolean;
+}
+
+function rows(container: HTMLElement, selector: string): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>(selector));
+}
+
+function everyRowHasText(elements: HTMLElement[], expected: string): boolean {
+	for (let index = 0; index < elements.length; index++) {
+		if (elements[index].textContent !== expected) return false;
+	}
+	return true;
+}
+
+export function runHydrationQueueCase(
+	foreignContainer: HTMLElement,
+	targetContainer: HTMLElement,
+	count: number,
+): HydrationQueueCase {
+	const foreignRoot = createRoot(foreignContainer);
+	foreignRoot.render(ForeignRows, { count });
+	const foreign = rows(foreignContainer, '[data-hydration-queue-foreign-row]');
+	const serverTargets = rows(targetContainer, '[data-hydration-queue-target-row]');
+	if (
+		foreign.length !== count ||
+		serverTargets.length !== count ||
+		!everyRowHasText(foreign, 'foreign:0') ||
+		!everyRowHasText(serverTargets, 'target:2')
+	) {
+		foreignRoot.unmount();
+		throw new Error(`The ${count}-row setup did not produce the expected public DOM.`);
+	}
+
+	queueForeignUpdates(count);
+	const started = performance.now();
+	const targetRoot = hydrateRoot(targetContainer, TargetRows, { count, settle: true });
+	const durationMs = performance.now() - started;
+
+	const hydratedTargets = rows(targetContainer, '[data-hydration-queue-target-row]');
+	const serverNodesAdopted =
+		hydratedTargets.length === count &&
+		hydratedTargets.every((node, index) => node === serverTargets[index]);
+	const targetConverged = everyRowHasText(hydratedTargets, 'target:2');
+	const foreignStayedPending = everyRowHasText(foreign, 'foreign:0');
+	if (!serverNodesAdopted || !targetConverged || !foreignStayedPending) {
+		targetRoot.unmount();
+		foreignRoot.unmount();
+		throw new Error(
+			`The ${count}-row hydration did not converge, adopt, or isolate its queued roots.`,
+		);
+	}
+
+	flushSync(() => {});
+	const foreignWorkPreserved = everyRowHasText(foreign, 'foreign:1');
+	const firstTarget = hydratedTargets[0] as HTMLButtonElement | undefined;
+	if (!foreignWorkPreserved || firstTarget === undefined) {
+		targetRoot.unmount();
+		foreignRoot.unmount();
+		throw new Error(`The ${count}-row ordinary scheduler flush lost queued foreign work.`);
+	}
+	flushSync(() => firstTarget.click());
+	const interactionHandled = firstTarget.textContent === 'target:3';
+
+	targetRoot.unmount();
+	foreignRoot.unmount();
+	const unmountClean =
+		targetContainer.childNodes.length === 0 && foreignContainer.childNodes.length === 0;
+	if (!interactionHandled || !unmountClean) {
+		throw new Error(`The ${count}-row interaction or cleanup control failed.`);
+	}
+
+	return {
+		durationMs,
+		foreignRows: foreign.length,
+		foreignWorkPreserved,
+		interactionHandled,
+		serverNodesAdopted,
+		targetRows: hydratedTargets.length,
+		unmountClean,
+	};
+}

--- a/benchmarks/hydration-render-phase-queue/src/fixture.tsrx
+++ b/benchmarks/hydration-render-phase-queue/src/fixture.tsrx
@@ -1,0 +1,52 @@
+import { useState } from 'octane';
+
+interface RowsProps {
+	count: number;
+}
+
+const foreignUpdates: Array<() => void> = [];
+
+function ForeignRow(props: { index: number }) {
+	const [value, setValue] = useState(0);
+	foreignUpdates[props.index] = () => setValue(1);
+	return <output data-hydration-queue-foreign-row={String(props.index)}>
+		{'foreign:' + value}
+	</output>;
+}
+
+function TargetRow(props: { index: number; settle: boolean }) {
+	const [value, setValue] = useState(props.settle ? 0 : 2);
+	if (props.settle && value < 2) setValue(value + 1);
+	return <button
+		data-hydration-queue-target-row={String(props.index)}
+		onClick={() => setValue(value + 1)}
+	>
+		{'target:' + value}
+	</button>;
+}
+
+export function ForeignRows(props: RowsProps) @{
+	const rows = Array.from({ length: props.count }, (_, index) => index);
+	foreignUpdates.length = 0;
+	<section data-hydration-queue-foreign="">
+		@for (const index of rows; key index) {
+			<ForeignRow index={index} />
+		}
+	</section>
+}
+
+export function TargetRows(props: RowsProps & { settle: boolean }) @{
+	const rows = Array.from({ length: props.count }, (_, index) => index);
+	<section data-hydration-queue-target="">
+		@for (const index of rows; key index) {
+			<TargetRow index={index} settle={props.settle} />
+		}
+	</section>
+}
+
+export function queueForeignUpdates(count: number): void {
+	if (foreignUpdates.length !== count) {
+		throw new Error(`Expected ${count} mounted foreign rows, received ${foreignUpdates.length}.`);
+	}
+	for (let index = 0; index < count; index++) foreignUpdates[index]();
+}

--- a/benchmarks/hydration-render-phase-queue/src/server.ts
+++ b/benchmarks/hydration-render-phase-queue/src/server.ts
@@ -1,0 +1,6 @@
+import { renderToString } from 'octane/server';
+import { TargetRows } from './fixture.tsrx';
+
+export function renderCase(count: number): string {
+	return renderToString(TargetRows, { count, settle: false }).html;
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -72,6 +72,7 @@ export const BENCHMARK_SUITES = [
 	'dev-form-diagnostics',
 	'scheduler-depth',
 	'hydration-range-compaction',
+	'hydration-render-phase-queue',
 	'behavior-root-events',
 	'radix-collection-order',
 	'router-dispatch',

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1203,6 +1203,9 @@ function runEffectCleanupCallback(callback: Cleanup): void {
 // ---------------------------------------------------------------------------
 
 const QUEUE: Block[] = [];
+// Destructive drains compact or clear QUEUE while user render code may re-enter
+// another drain. Readers use this epoch to discard cursors into the old layout.
+let QUEUE_REINDEX_EPOCH = 0;
 let scheduled = false;
 let syncFlush = false; // flushSync sets this to drain the queue synchronously
 // True while a flush (drainQueue/commitEffects) is on the stack. A flushSync
@@ -3921,28 +3924,48 @@ function belongsToBlockTree(block: Block, root: Block): boolean {
  */
 function drainHydrationRenderPhaseUpdates(root: Block): void {
 	let renders: Map<Block, number> | null = null;
-	for (;;) {
-		let index = -1;
-		for (let i = 0; i < QUEUE.length; i++) {
-			if (belongsToBlockTree(QUEUE[i], root)) {
-				index = i;
-				break;
+	let read = 0;
+	let write = 0;
+	let reindexEpoch = QUEUE_REINDEX_EPOCH;
+	try {
+		// Partition in place while reading the live length: target renders can
+		// append more target (or foreign) work, which belongs to this same pass.
+		while (read < QUEUE.length) {
+			const block = QUEUE[read++];
+			if (!belongsToBlockTree(block, root)) {
+				QUEUE[write++] = block;
+				continue;
+			}
+			if (!block.pending || block.disposed) continue;
+
+			const seen = (renders ??= new Map()).get(block) ?? 0;
+			if (seen >= RENDER_PHASE_UPDATE_LIMIT) {
+				throw new Error(formatClientError(9));
+			}
+			renders.set(block, seen + 1);
+			block.crossRenderUpdate = false;
+			try {
+				renderBlock(block);
+			} catch (error) {
+				handleRenderError(block, error);
+			}
+			// User render code can synchronously enter another hydration or flushSync.
+			// Its dense queue layout supersedes every cursor from this traversal.
+			if (reindexEpoch !== QUEUE_REINDEX_EPOCH) {
+				reindexEpoch = QUEUE_REINDEX_EPOCH;
+				read = 0;
+				write = 0;
 			}
 		}
-		if (index === -1) return;
-		const block = QUEUE.splice(index, 1)[0];
-		if (!block.pending || block.disposed) continue;
-
-		const seen = (renders ??= new Map()).get(block) ?? 0;
-		if (seen >= RENDER_PHASE_UPDATE_LIMIT) {
-			throw new Error(formatClientError(9));
-		}
-		renders.set(block, seen + 1);
-		block.crossRenderUpdate = false;
-		try {
-			renderBlock(block);
-		} catch (error) {
-			handleRenderError(block, error);
+	} finally {
+		if (reindexEpoch === QUEUE_REINDEX_EPOCH) {
+			// If rendering aborts, keep the unread suffix after the foreign entries
+			// already retained. Both groups preserve their original relative order.
+			while (read < QUEUE.length) {
+				QUEUE[write++] = QUEUE[read++];
+			}
+			QUEUE.length = write;
+			QUEUE_REINDEX_EPOCH++;
 		}
 	}
 }
@@ -4157,6 +4180,7 @@ function drainQueue(): { err: any } | null {
 		}
 	}
 	QUEUE.length = 0;
+	QUEUE_REINDEX_EPOCH++;
 	// Several sibling setters can share one hidden range. Re-scan it once after
 	// the complete render wave, before refs or layout effects can observe it.
 	// No Activity update means no collection/allocation on the ordinary path.

--- a/packages/octane/tests/hydration/_fixtures/render-phase-queue.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/render-phase-queue.tsrx
@@ -1,0 +1,75 @@
+import { flushSync, useState } from 'octane';
+
+interface RowsProps {
+	count: number;
+}
+
+interface ForeignRowsProps extends RowsProps {
+	onRender(index: number, value: number): void;
+}
+
+const foreignUpdates: Array<() => void> = [];
+
+function ForeignRow(props: { index: number; onRender(index: number, value: number): void }) {
+	const [value, setValue] = useState(0);
+	props.onRender(props.index, value);
+	foreignUpdates[props.index] = () => setValue(1);
+	return <output data-foreign-row={String(props.index)}>{'foreign:' + value}</output>;
+}
+
+function SettlingRow(props: { index: number; settle: boolean }) {
+	const [value, setValue] = useState(props.settle ? 0 : 2);
+	if (props.settle && value < 2) setValue(value + 1);
+	return <button data-settling-row={String(props.index)} onClick={() => setValue(value + 1)}>
+		{'target:' + value}
+	</button>;
+}
+
+export function ForeignRows(props: ForeignRowsProps) @{
+	const rows = Array.from({ length: props.count }, (_, index) => index);
+	foreignUpdates.length = 0;
+	<section>
+		@for (const index of rows; key index) {
+			<ForeignRow index={index} onRender={props.onRender} />
+		}
+	</section>
+}
+
+export function SettlingRows(props: RowsProps & { settle: boolean }) @{
+	const rows = Array.from({ length: props.count }, (_, index) => index);
+	<section>
+		@for (const index of rows; key index) {
+			<SettlingRow index={index} settle={props.settle} />
+		}
+	</section>
+}
+
+export function Runaway(props: { runaway: boolean }) {
+	const [value, setValue] = useState(props.runaway ? 0 : 25);
+	if (props.runaway) setValue(value + 1);
+	return <output data-runaway="">{'runaway:' + value}</output>;
+}
+
+export function Aborting(props: { abort: boolean; queueForeign(): void }) {
+	const [value, setValue] = useState(props.abort ? 0 : 1);
+	if (props.abort && value === 0) {
+		setValue(1);
+		props.queueForeign();
+	}
+	if (props.abort && value === 1) throw new Error('hydration queue abort');
+	return <output data-aborting="">{'aborting:' + value}</output>;
+}
+
+export function NestedFlush(props: { flush: boolean }) {
+	const [value, setValue] = useState(props.flush ? 0 : 1);
+	if (props.flush && value === 0) setValue(1);
+	if (props.flush && value === 1) flushSync(() => {});
+	return <output data-nested-flush="">{'nested-flush:' + value}</output>;
+}
+
+export function queueForeignUpdates(count: number): void {
+	if (foreignUpdates.length !== count) {
+		throw new Error(`Expected ${count} foreign rows, received ${foreignUpdates.length}.`);
+	}
+	for (let index = 0; index < count; index++) foreignUpdates[index]();
+}

--- a/packages/octane/tests/hydration/render-phase-queue.test.ts
+++ b/packages/octane/tests/hydration/render-phase-queue.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, flushSync, hydrateRoot } from '../../src/index.js';
+import { renderToString } from 'octane/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import {
+	Aborting,
+	ForeignRows,
+	NestedFlush,
+	queueForeignUpdates,
+	Runaway,
+	SettlingRows,
+} from './_fixtures/render-phase-queue.tsrx';
+
+const FIXTURE = 'packages/octane/tests/hydration/_fixtures/render-phase-queue.tsrx';
+const server = loadServerFixture<typeof import('./_fixtures/render-phase-queue.tsrx')>(FIXTURE);
+
+let foreign: HTMLDivElement;
+let target: HTMLDivElement;
+
+function rowText(container: HTMLElement, selector: string): Array<string | null> {
+	return Array.from(container.querySelectorAll(selector), (node) => node.textContent);
+}
+
+function mountForeign(count: number, renders: number[]) {
+	const root = createRoot(foreign);
+	root.render(ForeignRows, {
+		count,
+		onRender(index: number, value: number) {
+			if (value === 1) renders.push(index);
+		},
+	});
+	return root;
+}
+
+beforeEach(() => {
+	foreign = document.createElement('div');
+	target = document.createElement('div');
+	document.body.append(foreign, target);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	foreign.remove();
+	target.remove();
+});
+
+describe('hydrateRoot — render-phase queue isolation', () => {
+	it('drains re-entrant target updates while preserving queued foreign work', () => {
+		const renders: number[] = [];
+		const foreignRoot = mountForeign(4, renders);
+		target.innerHTML = renderToString(server.SettlingRows, { count: 4, settle: false }).html;
+		const serverRows = Array.from(target.querySelectorAll('[data-settling-row]'));
+
+		queueForeignUpdates(4);
+		const targetRoot = hydrateRoot(target, SettlingRows, { count: 4, settle: true });
+
+		expect(Array.from(target.querySelectorAll('[data-settling-row]'))).toEqual(serverRows);
+		expect(rowText(target, '[data-settling-row]')).toEqual(Array(4).fill('target:2'));
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(4).fill('foreign:0'));
+		expect(renders).toEqual([]);
+
+		flushSync(() => {});
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(4).fill('foreign:1'));
+		expect(renders).toEqual([0, 1, 2, 3]);
+
+		const first = target.querySelector('[data-settling-row]') as HTMLButtonElement;
+		flushSync(() => first.click());
+		expect(first.textContent).toBe('target:3');
+
+		targetRoot.unmount();
+		foreignRoot.unmount();
+	});
+
+	it('preserves queued foreign work when hydration exceeds the render limit', () => {
+		const renders: number[] = [];
+		const foreignRoot = mountForeign(3, renders);
+		target.innerHTML = renderToString(server.Runaway, { runaway: false }).html;
+		queueForeignUpdates(3);
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() => hydrateRoot(target, Runaway, { runaway: true })).toThrow(
+			/Too many re-renders|error #9/,
+		);
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(3).fill('foreign:0'));
+		expect(renders).toEqual([]);
+
+		flushSync(() => {});
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(3).fill('foreign:1'));
+		expect(renders).toEqual([0, 1, 2]);
+
+		foreignRoot.unmount();
+	});
+
+	it('preserves an unread foreign suffix when target rendering aborts', () => {
+		const renders: number[] = [];
+		const foreignRoot = mountForeign(3, renders);
+		target.innerHTML = renderToString(server.Aborting, {
+			abort: false,
+			queueForeign() {},
+		}).html;
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() =>
+			hydrateRoot(target, Aborting, {
+				abort: true,
+				queueForeign() {
+					queueForeignUpdates(3);
+				},
+			}),
+		).toThrow('hydration queue abort');
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(3).fill('foreign:0'));
+		expect(renders).toEqual([]);
+
+		flushSync(() => {});
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(3).fill('foreign:1'));
+		expect(renders).toEqual([0, 1, 2]);
+
+		foreignRoot.unmount();
+	});
+
+	it('survives flushSync nested in a hydration replay', () => {
+		const renders: number[] = [];
+		const foreignRoot = mountForeign(3, renders);
+		target.innerHTML = renderToString(server.NestedFlush, { flush: false }).html;
+		const serverNode = target.querySelector('[data-nested-flush]');
+		queueForeignUpdates(3);
+		let targetRoot!: ReturnType<typeof hydrateRoot>;
+
+		expect(() => {
+			targetRoot = hydrateRoot(target, NestedFlush, { flush: true });
+			flushSync(() => {});
+		}).not.toThrow();
+		expect(target.querySelector('[data-nested-flush]')).toBe(serverNode);
+		expect(serverNode?.textContent).toBe('nested-flush:1');
+		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(3).fill('foreign:1'));
+		expect(renders).toEqual([0, 1, 2]);
+
+		targetRoot.unmount();
+		foreignRoot.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

Hydration now drains render-phase updates in one pass, so work for one root stays near-linear even when another root already occupies the scheduler queue.

## Why

The previous drain searched the global queue from the front and spliced one matching block at a time. A target root with repeated render-phase updates behind a large foreign prefix therefore paid repeated scans and array shifts.

## Changes

- Partition the live queue in place while preserving foreign work and processing target updates appended during the same hydration transaction.
- Rebase traversal cursors when nested `flushSync` or hydration drains destructively reindex the queue.
- Preserve queued work through render errors and loop-limit failures, with public dev and production regressions for each boundary.
- Add a production multi-root benchmark and a normalized scaling guard.

## Benchmark

Same production-build harness, nine measured samples after warmup:

| Case | Untouched `origin/main` | This PR | Change |
| --- | ---: | ---: | ---: |
| 128 rows | 1.06 ms | 0.70 ms | -33.5% |
| 1,024 rows | 20.56 ms | 6.98 ms | -66.1% |
| Normalized cost growth for 8x rows | 2.43x | 1.24x | below the 1.5x guard |

Each sample also verifies synchronous convergence, adoption of every server node, foreign-root isolation and later completion, delegated interaction, and clean unmount.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — package prechecks passed, but the local 321-project Vitest run exhausted Node's 4 GB heap after about 30 minutes. Its branch-owned benchmark-inventory failure was fixed; every other surfaced project passed an isolated rerun or was confirmed as the host's missing `--localstorage-file` behavior.
- [x] targeted tests: hydration regression in dev and production (8), adjacent hydration coverage (269), timed-out compiler coverage (40), MCP inventory (15), and isolated Monaco browser coverage (5)
- [x] `node benchmarks/bench.mjs --ratios hydration-render-phase-queue`
- [x] `pnpm sync`
- [x] `node scripts/check-changesets.js`

## Risk / follow-ups

The queue compaction path now tracks destructive nested drains with an epoch. Regressions cover nested `flushSync`, appended target work, stable foreign ordering, render aborts, and the render-loop limit. Required CI remains the authoritative full-matrix gate for the current head.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scheduler queue compaction and hydration re-entrancy; behavior is heavily tested but mistakes could mis-order or drop queued cross-root work.
> 
> **Overview**
> **Hydration render-phase queue draining** no longer rescans and splices the global scheduler queue for each target-root update. `drainHydrationRenderPhaseUpdates` now **partitions the live `QUEUE` in one pass**, rendering matching blocks while compacting foreign work in place, with a **`QUEUE_REINDEX_EPOCH`** so nested `flushSync` or other destructive drains restart traversal safely.
> 
> The ordinary queue flush also bumps the epoch when it clears the queue, keeping hydration cursors consistent with re-entrant scheduling.
> 
> **Regression coverage** adds a production multi-root benchmark (`hydration-render-phase-queue`), scaling ratio guard, Vitest cases for foreign-work isolation, render limits, render aborts, and nested `flushSync`, plus an octane patch changeset noting large-row benchmark wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 779c073bbdb434e2987112f55504764ddcf56e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790699207&installation_model_id=432790&pr_number=914&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F914&signature=0e9c4b7ae326073a7028588ca37ba1075429e963b957a49f41848920acec643f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->