### PR TITLE
perf(octane): streamline hydrate module slicing

### DIFF
--- a/.changeset/calm-hydrate-slices.md
+++ b/.changeset/calm-hydrate-slices.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Speed up hydrate module slicing in files with many split boundaries and private declarations.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -281,6 +281,7 @@ internally, get their own baseline and guard namespace.
 | `template-call-memo` | template-call-memo | none (Node-only) | production Strong/compatibility receiver-call counts, immutable keyed rows, real dependency changes, current event captures, and survivor identity |
 | `compiler-throughput` | compiler-throughput | none (Node-only) | seven real production compiler pipelines, cold/warm/incremental transformations, 10/100/1,000 components, and heap diagnostics |
 | `tsrx-component-graph` | tsrx-component-graph | none (Node-only) | 2,400-component live-import propagation with dependent-first vs dependency-first declarations |
+| `tsrx-hydrate-module-slicing` | tsrx-hydrate-module-slicing | none (Node-only) | hydrate module-slicing selection at 150/2,400 sibling boundaries, with queried-child/server checks and retained-declaration controls |
 | `tsrx-renderer-validation-ranges` | tsrx-renderer-validation-ranges | none (Node-only) | authored renderer-validation range membership at 32/3,200 ranges plus matched 100/1,600-component whole-pipeline compiles with and without validation |
 | `tsrx-jsx-return-branches` | tsrx-jsx-return-branches | none (Node-only) | client/server compile and bundler classification for 120/480 conditional-return components, with lowering/export controls and a same-sized ineligible parse/print control |
 | `tsrx-nesting-diagnostics` | tsrx-nesting-diagnostics | none (Node-only) | development TSRX compilation at 500 and 2,000 invalid HTML sites, with parsed diagnostic count/order controls and a per-diagnostic scaling guard |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -464,6 +464,14 @@
     "note": "Same-process development TSRX compilation with every emitted nesting validation parsed and checked. The original repeated serialization and whole-array scan measured 1.59x per invalid site at 2,000 versus 500 sites, while plan-local Set membership measured 1.07x. The 1.3x ceiling leaves timing headroom while catching the quadratic path."
   },
   {
+    "suite": "tsrx-hydrate-module-slicing",
+    "op": "compile_per_1000_boundaries",
+    "target": "focused-movable-high",
+    "reference": "focused-movable-low",
+    "maxRatio": 1.5,
+    "note": "Same-process hydrate preparation normalizes 2,400 and 150 sibling split boundaries by boundary count. Exact pinned main measured about 3.3x more CPU per boundary at the large size, while the indexed/direct-selection path measured about 1.1x; the 1.5x ceiling catches restoration of module-wide Set copies, synthetic child modules, or boundary/declaration cross-products."
+  },
+  {
     "suite": "tsrx-renderer-validation-ranges",
     "op": "compile_per_1000_ranges",
     "target": "focused-high",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -913,6 +913,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Hydrate module-slicing selection at 150 and 2,400 sibling boundaries,
+		// with retained declarations and whole-compiler targets as controls.
+		name: 'tsrx-hydrate-module-slicing',
+		cwd: 'tsrx-hydrate-module-slicing',
+		servers: [],
+		iter: { normal: 7, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Authored renderer-validation range membership at two scales plus matched
 		// whole-pipeline compiles with and without validation in the same process.
 		name: 'tsrx-renderer-validation-ranges',

--- a/benchmarks/tsrx-hydrate-module-slicing/README.md
+++ b/benchmarks/tsrx-hydrate-module-slicing/README.md
@@ -1,0 +1,19 @@
+# TSRX hydrate module slicing
+
+Measure the production hydrate-boundary compiler when one module contains many sibling split points and same-module declarations:
+
+- `focused-movable-*` calls hydrate preparation with an already parsed AST. This isolates boundary/declaration selection at 150 and 2,400 sibling boundaries.
+- `focused-retained-high` keeps declarations public while exercising the same preparation layer, providing a path-local control that bypasses module slicing.
+- `pipeline-movable-*` compiles the same sources through the production client compiler.
+- `pipeline-retained-high` keeps the 2,400 declarations as public exports. It preserves parsing, boundary discovery, and split-module generation without moving declarations into child modules, so candidate-only parser or printer drift cannot masquerade as a slicing win.
+
+Before timing, the runner compiles the public root, representative queried children, and server output. It verifies diagnostics, every dynamic request, declaration placement, server completeness, and stable output checksums. Timed target order reverses on alternating iterations. The primary metric is process CPU milliseconds, which measures compiler work without charging a target for unrelated scheduler contention; wall time remains in the JSON as a diagnostic.
+
+```bash
+node benchmarks/tsrx-hydrate-module-slicing/run.mjs 7
+node benchmarks/tsrx-hydrate-module-slicing/compare.mjs \
+  /path/to/baseline /path/to/candidate 7
+node benchmarks/bench.mjs --quick --ratios tsrx-hydrate-module-slicing
+```
+
+The cross-checkout comparator uses conservative 95% timing bounds. It requires at least a 1.5x and 200 ms focused improvement with no focused retained-control regression above 5%. Whole-pipeline timings remain visible as a fixed-cost diagnostic rather than diluting the slicing phase behind parsing and code generation. The comparator also requires byte-identical client and server output metadata and rejects identical compiler sources.

--- a/benchmarks/tsrx-hydrate-module-slicing/compare.mjs
+++ b/benchmarks/tsrx-hydrate-module-slicing/compare.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RUNNER = path.join(HERE, 'run.mjs');
+
+function targetStat(payload, name) {
+	const stat = target(payload, name).ops?.compile;
+	assert.ok(stat && Number.isFinite(stat.score), `${name} has no finite compile score`);
+	return stat;
+}
+
+function target(payload, name) {
+	const entry = payload.targets?.find((candidate) => candidate.name === name);
+	assert.equal(entry?.meta?.correctness, 'pass', `${name} did not pass semantics`);
+	return entry;
+}
+
+function assertEquivalentOutput(baseline, candidate, name) {
+	const before = target(baseline, name).meta;
+	const after = target(candidate, name).meta;
+	for (const field of [
+		'boundaryRequests',
+		'rootChecksum',
+		'rootOutputBytes',
+		'serverChecksum',
+		'serverOutputBytes',
+	]) {
+		assert.equal(after[field], before[field], `${name} changed ${field}`);
+	}
+}
+
+function bounds(stat) {
+	const central = Number.isFinite(stat.mean) ? stat.mean : stat.score;
+	const margin = central * ((Number.isFinite(stat.rme) ? stat.rme : 0) / 100);
+	return { central, lower: central - margin, upper: central + margin };
+}
+
+function conservativeImprovement(baseline, candidate) {
+	const before = bounds(baseline);
+	const after = bounds(candidate);
+	return {
+		absoluteMs: before.lower - after.upper,
+		ratio: before.lower / after.upper,
+	};
+}
+
+export function evaluateComparison(baseline, candidate) {
+	for (const name of ['focused-movable-low', 'focused-movable-high', 'focused-retained-high']) {
+		assertEquivalentOutput(baseline, candidate, name);
+	}
+	const focused = conservativeImprovement(
+		targetStat(baseline, 'focused-movable-high'),
+		targetStat(candidate, 'focused-movable-high'),
+	);
+	const pipeline = conservativeImprovement(
+		targetStat(baseline, 'pipeline-movable-high'),
+		targetStat(candidate, 'pipeline-movable-high'),
+	);
+	const baselineControl = bounds(targetStat(baseline, 'focused-retained-high'));
+	const candidateControl = bounds(targetStat(candidate, 'focused-retained-high'));
+	const controlRatio = candidateControl.central / baselineControl.central;
+	const controlRegressed =
+		candidateControl.lower > baselineControl.upper * 1.05 || controlRatio > 1.05;
+	const low = conservativeImprovement(
+		targetStat(baseline, 'pipeline-movable-low'),
+		targetStat(candidate, 'pipeline-movable-low'),
+	);
+	const gates = {
+		control: !controlRegressed,
+		focusedAbsolute: focused.absoluteMs >= 200,
+		focusedRatio: focused.ratio >= 1.5,
+	};
+	return {
+		controlRatio,
+		focused,
+		gates,
+		low,
+		pass: Object.values(gates).every(Boolean),
+		pipeline,
+	};
+}
+
+function compilerDigest(root) {
+	const source = fs.readFileSync(
+		path.join(root, 'packages/octane/src/compiler/hydrate-boundaries.js'),
+	);
+	return createHash('sha256').update(source).digest('hex');
+}
+
+function runCheckout(root, iterations) {
+	const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-hydrate-slicing-'));
+	const output = path.join(temporary, 'result.json');
+	try {
+		const run = spawnSync(process.execPath, [RUNNER, String(iterations), '--raw-samples'], {
+			cwd: HERE,
+			encoding: 'utf8',
+			env: { ...process.env, BENCH_JSON: output, OCTANE_HYDRATE_SLICING_ROOT: root },
+			maxBuffer: 10 * 1024 * 1024,
+			stdio: ['ignore', 'pipe', 'inherit'],
+		});
+		if (run.error) throw run.error;
+		if (run.status !== 0) {
+			throw new Error(`benchmark failed for ${root}: ${(run.stderr || run.stdout).trim()}`);
+		}
+		const payload = JSON.parse(fs.readFileSync(output, 'utf8'));
+		if (payload.failed) throw new Error(`benchmark failed for ${root}: ${payload.failed}`);
+		return payload;
+	} finally {
+		fs.rmSync(temporary, { force: true, recursive: true });
+	}
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+	const baselineRoot = process.argv[2];
+	const candidateRoot = process.argv[3];
+	const iterations = Number.parseInt(process.argv[4] ?? '7', 10);
+	if (!baselineRoot || !candidateRoot || !Number.isSafeInteger(iterations) || iterations < 1) {
+		throw new Error('usage: node compare.mjs <baseline-root> <candidate-root> [iterations]');
+	}
+	const baseline = path.resolve(baselineRoot);
+	const candidate = path.resolve(candidateRoot);
+	assert.notEqual(baseline, candidate, 'baseline and candidate roots must differ');
+	assert.notEqual(
+		compilerDigest(baseline),
+		compilerDigest(candidate),
+		'baseline and candidate compiler sources are identical',
+	);
+	const comparison = evaluateComparison(
+		runCheckout(baseline, iterations),
+		runCheckout(candidate, iterations),
+	);
+	console.log(JSON.stringify(comparison, null, '\t'));
+	if (!comparison.pass) process.exitCode = 1;
+}

--- a/benchmarks/tsrx-hydrate-module-slicing/run.mjs
+++ b/benchmarks/tsrx-hydrate-module-slicing/run.mjs
@@ -1,0 +1,363 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_ROOT = process.env.OCTANE_HYDRATE_SLICING_ROOT
+	? path.resolve(process.env.OCTANE_HYDRATE_SLICING_ROOT)
+	: path.resolve(HERE, '../..');
+const { createOctaneCompiler } = await import(
+	pathToFileURL(path.join(SOURCE_ROOT, 'packages/octane/src/compiler/bundler.js')).href
+);
+const { prepareHydrateBoundaries } = await import(
+	pathToFileURL(path.join(SOURCE_ROOT, 'packages/octane/src/compiler/hydrate-boundaries.js')).href
+);
+const sourceRequire = createRequire(path.join(SOURCE_ROOT, 'packages/octane/package.json'));
+const { parseModule } = await import(pathToFileURL(sourceRequire.resolve('@tsrx/core')).href);
+
+const FILE = '/project/src/App.tsrx';
+const HIGH_BOUNDARIES = 2_400;
+const LOW_BOUNDARIES = 150;
+const GROUP_SIZE = 40;
+const runnerArgs = process.argv.slice(2);
+const positionalArgs = runnerArgs.filter((argument) => !argument.startsWith('--'));
+const flags = new Set(runnerArgs.filter((argument) => argument.startsWith('--')));
+const iterations = Number.parseInt(positionalArgs[0] ?? '7', 10);
+const includeRawSamples = flags.has('--raw-samples');
+
+if (
+	positionalArgs.length > 1 ||
+	[...flags].some((flag) => flag !== '--raw-samples') ||
+	!Number.isSafeInteger(iterations) ||
+	iterations < 1 ||
+	(positionalArgs[0] !== undefined && String(iterations) !== positionalArgs[0])
+) {
+	throw new Error('usage: node run.mjs [positive-iterations] [--raw-samples]');
+}
+
+function fixtureSource(boundaries, movable) {
+	const declarations = Array.from(
+		{ length: boundaries },
+		(_, index) =>
+			`${movable ? '' : 'export '}function Item${index}() @{ <span data-slice="${index}">${index}</span> }`,
+	).join('\n');
+	const groupCount = Math.ceil(boundaries / GROUP_SIZE);
+	const groups = Array.from({ length: groupCount }, (_, group) => {
+		const start = group * GROUP_SIZE;
+		const children = Array.from(
+			{ length: Math.min(GROUP_SIZE, boundaries - start) },
+			(_, offset) => {
+				const index = start + offset;
+				return `<Hydrate when={true}><Item${index} /></Hydrate>`;
+			},
+		).join('');
+		return `function Group${group}() @{ <>${children}</> }`;
+	}).join('\n');
+	const groupChildren = Array.from({ length: groupCount }, (_, group) => `<Group${group} />`).join(
+		'',
+	);
+	return `import { Hydrate } from 'octane';
+${declarations}
+${groups}
+export function App() @{ <>${groupChildren}</> }`;
+}
+
+function compiler() {
+	return createOctaneCompiler({ root: '/project', hmr: false, dev: false });
+}
+
+function checksumString(value) {
+	let checksum = 2_166_136_261;
+	for (let index = 0; index < value.length; index++) {
+		checksum = Math.imul(checksum ^ value.charCodeAt(index), 16_777_619) >>> 0;
+	}
+	return checksum;
+}
+
+function walkAst(root, visit) {
+	const seen = new WeakSet();
+	const walk = (node) => {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		visit(node);
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'loc' || key === 'metadata' || key === 'parent') continue;
+			walk(value);
+		}
+	};
+	walk(root);
+}
+
+function dynamicImportRequests(code) {
+	const requests = new Set();
+	walkAst(parseModule(code, 'compiled.js'), (node) => {
+		if (node.type === 'ImportExpression' && typeof node.source?.value === 'string') {
+			requests.add(node.source.value);
+		}
+	});
+	return requests;
+}
+
+function compileRoot(source, environment = 'client') {
+	const result = compiler().transform(source, FILE, { environment });
+	assert.ok(result, `${environment} compiler returned no result`);
+	assert.deepEqual(result.diagnostics, [], `${environment} compiler emitted diagnostics`);
+	return result;
+}
+
+function compileChild(source, boundaryPath) {
+	const result = compiler().transform(source, `${FILE}?octane-hydrate=${boundaryPath}`, {
+		environment: 'client',
+	});
+	assert.ok(result, `child ${boundaryPath} compiler returned no result`);
+	assert.deepEqual(result.diagnostics, [], `child ${boundaryPath} compiler emitted diagnostics`);
+	return result;
+}
+
+function validateFixture(fixture) {
+	const root = compileRoot(fixture.source);
+	const requests = dynamicImportRequests(root.code);
+	assert.equal(requests.size, fixture.boundaries, `${fixture.name} changed dynamic import count`);
+	for (const index of [0, Math.floor(fixture.boundaries / 2), fixture.boundaries - 1]) {
+		const request = `./App.tsrx?octane-hydrate=${index}`;
+		assert.ok(requests.has(request), `${fixture.name} omitted ${request}`);
+		const child = compileChild(fixture.source, String(index));
+		const marker = `data-slice=\\"${index}\\"`;
+		if (fixture.movable) {
+			assert.ok(child.code.includes(marker), `${fixture.name} child ${index} lost its declaration`);
+			assert.ok(
+				!root.code.includes(marker),
+				`${fixture.name} root retained moved declaration ${index}`,
+			);
+		} else {
+			assert.ok(
+				root.code.includes(marker),
+				`${fixture.name} root lost retained declaration ${index}`,
+			);
+			assert.ok(
+				!child.code.includes(marker),
+				`${fixture.name} child copied retained declaration ${index}`,
+			);
+		}
+	}
+	const server = compileRoot(fixture.source, 'server');
+	assert.equal(
+		dynamicImportRequests(server.code).size,
+		0,
+		`${fixture.name} server output gained dynamic imports`,
+	);
+	assert.ok(
+		server.code.includes('data-slice="0"'),
+		`${fixture.name} server lost first declaration`,
+	);
+	assert.ok(
+		server.code.includes(`data-slice="${fixture.boundaries - 1}"`),
+		`${fixture.name} server lost last declaration`,
+	);
+	fixture.meta = {
+		...fixture.meta,
+		boundaryRequests: requests.size,
+		rootChecksum: checksumString(root.code),
+		rootOutputBytes: Buffer.byteLength(root.code),
+		serverChecksum: checksumString(server.code),
+		serverOutputBytes: Buffer.byteLength(server.code),
+	};
+}
+
+function measureFocused(fixture) {
+	const startedCpu = process.cpuUsage();
+	const startedWall = performance.now();
+	const prepared = prepareHydrateBoundaries(fixture.source, FILE, null, fixture.ast);
+	const elapsedWall = performance.now() - startedWall;
+	const elapsedCpu = process.cpuUsage(startedCpu);
+	assert.ok(prepared, `${fixture.name} produced no hydrate preparation`);
+	return {
+		checksum: prepared.ast.body.length,
+		elapsed: (elapsedCpu.user + elapsedCpu.system) / 1_000,
+		elapsedWall,
+	};
+}
+
+function measurePipeline(fixture) {
+	const startedCpu = process.cpuUsage();
+	const startedWall = performance.now();
+	const result = compiler().transform(fixture.source, FILE, { environment: 'client' });
+	const elapsedWall = performance.now() - startedWall;
+	const elapsedCpu = process.cpuUsage(startedCpu);
+	assert.ok(result, `${fixture.name} compiler returned no result`);
+	assert.deepEqual(result.diagnostics, [], `${fixture.name} compiler emitted diagnostics`);
+	return {
+		checksum: checksumString(result.code),
+		elapsed: (elapsedCpu.user + elapsedCpu.system) / 1_000,
+		elapsedWall,
+	};
+}
+
+const movableLow = {
+	name: 'movable-low',
+	boundaries: LOW_BOUNDARIES,
+	movable: true,
+	source: fixtureSource(LOW_BOUNDARIES, true),
+	meta: { boundaries: LOW_BOUNDARIES, declarations: LOW_BOUNDARIES, movable: true },
+};
+const movableHigh = {
+	name: 'movable-high',
+	boundaries: HIGH_BOUNDARIES,
+	movable: true,
+	source: fixtureSource(HIGH_BOUNDARIES, true),
+	meta: { boundaries: HIGH_BOUNDARIES, declarations: HIGH_BOUNDARIES, movable: true },
+};
+const retainedHigh = {
+	name: 'retained-high',
+	boundaries: HIGH_BOUNDARIES,
+	movable: false,
+	source: fixtureSource(HIGH_BOUNDARIES, false),
+	meta: { boundaries: HIGH_BOUNDARIES, declarations: HIGH_BOUNDARIES, movable: false },
+};
+for (const fixture of [movableLow, movableHigh, retainedHigh]) {
+	fixture.ast = parseModule(fixture.source, FILE);
+	fixture.meta.sourceBytes = Buffer.byteLength(fixture.source);
+}
+
+const targets = [
+	{
+		name: 'focused-movable-low',
+		fixture: movableLow,
+		measure: () => measureFocused(movableLow),
+		normalizeBy: LOW_BOUNDARIES,
+		samples: [],
+		wallSamples: [],
+	},
+	{
+		name: 'focused-movable-high',
+		fixture: movableHigh,
+		measure: () => measureFocused(movableHigh),
+		normalizeBy: HIGH_BOUNDARIES,
+		samples: [],
+		wallSamples: [],
+	},
+	{
+		name: 'focused-retained-high',
+		fixture: retainedHigh,
+		measure: () => measureFocused(retainedHigh),
+		normalizeBy: HIGH_BOUNDARIES,
+		samples: [],
+		wallSamples: [],
+	},
+	{
+		name: 'pipeline-movable-low',
+		fixture: movableLow,
+		measure: () => measurePipeline(movableLow),
+		normalizeBy: LOW_BOUNDARIES,
+		samples: [],
+		wallSamples: [],
+	},
+	{
+		name: 'pipeline-movable-high',
+		fixture: movableHigh,
+		measure: () => measurePipeline(movableHigh),
+		normalizeBy: HIGH_BOUNDARIES,
+		samples: [],
+		wallSamples: [],
+	},
+	{
+		name: 'pipeline-retained-high',
+		fixture: retainedHigh,
+		measure: () => measurePipeline(retainedHigh),
+		normalizeBy: HIGH_BOUNDARIES,
+		samples: [],
+		wallSamples: [],
+	},
+];
+
+let failure;
+try {
+	for (const fixture of [movableLow, movableHigh, retainedHigh]) validateFixture(fixture);
+	const expectedChecksums = new Map();
+	for (const target of targets) {
+		expectedChecksums.set(target.name, target.measure().checksum);
+	}
+	for (let warmup = 0; warmup < 2; warmup++) {
+		for (const target of warmup % 2 === 0 ? targets : targets.toReversed()) {
+			const sample = target.measure();
+			assert.equal(
+				sample.checksum,
+				expectedChecksums.get(target.name),
+				`${target.name} warmup checksum changed`,
+			);
+		}
+	}
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		for (const target of iteration % 2 === 0 ? targets : targets.toReversed()) {
+			const sample = target.measure();
+			assert.equal(
+				sample.checksum,
+				expectedChecksums.get(target.name),
+				`${target.name} checksum changed`,
+			);
+			target.samples.push(sample.elapsed);
+			target.wallSamples.push(sample.elapsedWall);
+		}
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL tsrx-hydrate-module-slicing/${failure}`);
+}
+
+const rows = targets.map((target) => {
+	const ops =
+		target.samples.length === 0
+			? {}
+			: {
+					compile: timingStatForJson(summarizeSamples(target.samples), { p99: true }),
+					compile_wall: timingStatForJson(summarizeSamples(target.wallSamples), { p99: true }),
+					compile_per_1000_boundaries: timingStatForJson(
+						summarizeSamples(
+							target.samples.map((elapsed) => (elapsed * 1_000) / target.normalizeBy),
+						),
+						{ p99: true },
+					),
+				};
+	return {
+		name: target.name,
+		ops,
+		meta: {
+			...target.fixture.meta,
+			correctness: failure ? 'fail' : 'pass',
+			focused: target.name.startsWith('focused-'),
+		},
+		...(includeRawSamples ? { rawSamples: { compile: target.samples } } : {}),
+	};
+});
+
+if (!failure) {
+	for (const target of rows) {
+		console.log(
+			`PASS tsrx-hydrate-module-slicing/${target.name}: ` +
+				`${target.ops.compile.score.toFixed(3)}ms CPU, ` +
+				`${target.ops.compile_wall.score.toFixed(3)}ms wall`,
+		);
+	}
+}
+
+const payload = {
+	suite: 'tsrx-hydrate-module-slicing',
+	iterations,
+	meta: { sourceRoot: SOURCE_ROOT, timing: 'process-cpu-ms' },
+	targets: rows,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+
+if (failure) process.exitCode = 1;

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -112,6 +112,7 @@ export const BENCHMARK_SUITES = [
 	'template-call-memo',
 	'compiler-throughput',
 	'tsrx-component-graph',
+	'tsrx-hydrate-module-slicing',
 	'tsrx-renderer-validation-ranges',
 	'tsrx-jsx-return-branches',
 	'text-type-roots',

--- a/packages/octane-mcp-server/src/index.test.js
+++ b/packages/octane-mcp-server/src/index.test.js
@@ -76,6 +76,7 @@ describe('@octanejs/mcp-server helpers', () => {
 			.split('\n')
 			.map((line) => line.trim())
 			.filter((line) => line && line !== 'Available suites:');
+		expect(suites).toContain('tsrx-hydrate-module-slicing');
 		expect(suites).toContain('tsrx-renderer-validation-ranges');
 		expect(suites).toEqual(BENCHMARK_SUITES);
 

--- a/packages/octane/src/compiler/hydrate-boundaries.js
+++ b/packages/octane/src/compiler/hydrate-boundaries.js
@@ -693,17 +693,38 @@ function visitJsxTag(name, visitIdentifier) {
 }
 
 /** Collect names whose values must cross from the parent module into a queried child. */
-function collectCaptures(nodes, importBindings, shadowedImports = new Set()) {
+function collectCaptures(
+	nodes,
+	importBindings,
+	shadowedImports = new Set(),
+	additionalBindings = null,
+) {
 	const captures = new Set();
 	const scopes = [];
 	const seen = new WeakSet();
-	const isBound = (name) => {
-		if (importBindings.has(name) && !shadowedImports.has(name)) return true;
-		for (let index = scopes.length - 1; index >= 0; index--) {
-			if (scopes[index].has(name)) return true;
-		}
-		return false;
-	};
+	// Module slicing can consult a second binding set without materializing its
+	// union for every boundary. Preserve the single-set path for all other walks.
+	const isBound =
+		additionalBindings === null
+			? (name) => {
+					if (importBindings.has(name) && !shadowedImports.has(name)) return true;
+					for (let index = scopes.length - 1; index >= 0; index--) {
+						if (scopes[index].has(name)) return true;
+					}
+					return false;
+				}
+			: (name) => {
+					if (
+						(importBindings.has(name) || additionalBindings.has(name)) &&
+						!shadowedImports.has(name)
+					) {
+						return true;
+					}
+					for (let index = scopes.length - 1; index >= 0; index--) {
+						if (scopes[index].has(name)) return true;
+					}
+					return false;
+				};
 	const reference = (node) => {
 		if (node?.name && !isBound(node.name)) captures.add(node.name);
 	};
@@ -976,8 +997,31 @@ function privateModuleDeclarationGraph(ast, importBindings) {
 	return { byBinding, records };
 }
 
+function sortedBoundaryRanges(boundaries) {
+	return boundaries
+		.map((boundary) => ({ end: boundary.node.end, start: boundary.node.start }))
+		.sort((left, right) => left.start - right.start || left.end - right.end);
+}
+
+function declarationContainsBoundary(node, boundaryRanges) {
+	let low = 0;
+	let high = boundaryRanges.length;
+	while (low < high) {
+		const middle = (low + high) >>> 1;
+		if (boundaryRanges[middle].start < node.start) low = middle + 1;
+		else high = middle;
+	}
+	for (let index = low; index < boundaryRanges.length; index++) {
+		const boundary = boundaryRanges[index];
+		if (boundary.start > node.end) break;
+		if (boundary.end <= node.end) return true;
+	}
+	return false;
+}
+
 function movableModuleDeclarations(analysis) {
 	const records = [];
+	let boundaryRanges = null;
 	const moduleBindings = topLevelBindingNames(analysis.ast);
 	const exportedBindings = localExportBindings(analysis.ast);
 	for (const node of analysis.ast.body ?? []) {
@@ -994,11 +1038,8 @@ function movableModuleDeclarations(analysis) {
 		// A declaration containing its own Hydrate site needs another extraction
 		// pass after it moves. Keep that uncommon declaration in the parent until
 		// recursive declaration slicing has an explicit protocol of its own.
-		if (
-			analysis.boundaries.some(
-				(boundary) => boundary.node.start >= node.start && boundary.node.end <= node.end,
-			)
-		) {
+		boundaryRanges ??= sortedBoundaryRanges(analysis.boundaries);
+		if (declarationContainsBoundary(node, boundaryRanges)) {
 			continue;
 		}
 		const bindings = declarationBindingSet(node);
@@ -1007,6 +1048,7 @@ function movableModuleDeclarations(analysis) {
 		records.push({
 			bindings,
 			dependencies: new Set(),
+			order: records.length,
 			retainedDependencies: new Set(),
 			node,
 		});
@@ -1123,8 +1165,12 @@ function hydrateBoundaryElement(
 	if (boundary.disabled) return node;
 	assertDirectChildren(boundary, boundary.filename);
 	validateBoundary(boundary, boundary.filename, boundary.hookNames);
-	const availableBindings = new Set([...importBindings, ...additionalModuleBindings]);
-	const captures = collectCaptures(node.children, availableBindings, boundary.shadowedImports);
+	const captures = collectCaptures(
+		node.children,
+		importBindings,
+		boundary.shadowedImports,
+		additionalModuleBindings.size === 0 ? null : additionalModuleBindings,
+	);
 	const attributes = [
 		...(opening.attributes ?? []),
 		jsxExpressionAttribute('__load', hydrateLoaderExpression(boundary, request), opening),
@@ -1222,8 +1268,9 @@ function extractedModuleAst(
 	const moduleBindings = moduleBindingsByPath.get(boundary.path) ?? new Set();
 	const captures = collectCaptures(
 		boundary.node.children,
-		new Set([...analysis.imports.importBindings, ...moduleBindings]),
+		analysis.imports.importBindings,
 		boundary.shadowedImports,
+		moduleBindings.size === 0 ? null : moduleBindings,
 	);
 	const pathName = boundary.path.replace(/[^A-Za-z0-9_$]/g, '_');
 	const componentName = uniqueGeneratedName(source, `__OctaneHydrateBoundary_${pathName}`);
@@ -1276,7 +1323,31 @@ function extractedModuleAst(
 	return pruneUnusedImportsAst(program, false);
 }
 
-function createModuleMovePlanAst(source, analysis, request) {
+function moduleReferencesForBoundary(analysis, boundary, request, moduleBindingsByPath) {
+	assertDirectChildren(boundary, boundary.filename);
+	validateBoundary(boundary, boundary.filename, analysis.imports.hookNames);
+	if (boundary.children.length === 0) {
+		return collectCaptures(boundary.node.children, analysis.imports.importBindings);
+	}
+	const nestedAnalysis = {
+		...analysis,
+		roots: boundary.children,
+	};
+	const fragment = transformHydrateAst(
+		{
+			type: 'Program',
+			sourceType: 'module',
+			body: boundary.node.children,
+			metadata: { path: [] },
+		},
+		nestedAnalysis,
+		request,
+		moduleBindingsByPath,
+	);
+	return collectCaptures(fragment.body, analysis.imports.importBindings);
+}
+
+function createModuleMovePlanAst(analysis, request) {
 	const candidates = movableModuleDeclarations(analysis);
 	if (candidates.records.length === 0) {
 		return {
@@ -1340,13 +1411,9 @@ function createModuleMovePlanAst(source, analysis, request) {
 	const referencesByPath = new Map();
 	for (const boundary of analysis.boundaries) {
 		if (boundary.disabled || hasPermanentStaticAncestor(boundary)) continue;
-		const childAst = extractedModuleAst(source, analysis, boundary, request, allBindingsByPath);
 		referencesByPath.set(
 			boundary.path,
-			collectCaptures(
-				(childAst.body ?? []).filter((node) => node.type !== 'ImportDeclaration'),
-				analysis.imports.importBindings,
-			),
+			moduleReferencesForBoundary(analysis, boundary, request, allBindingsByPath),
 		);
 	}
 	const recordsForReferences = (childReferences) => {
@@ -1371,8 +1438,11 @@ function createModuleMovePlanAst(source, analysis, request) {
 		return records;
 	};
 	const preliminaryCounts = new Map();
-	for (const references of referencesByPath.values()) {
-		for (const record of recordsForReferences(references)) {
+	const preliminaryRecordsByPath = new Map();
+	for (const [path, references] of referencesByPath) {
+		const records = recordsForReferences(references);
+		preliminaryRecordsByPath.set(path, records);
+		for (const record of records) {
 			preliminaryCounts.set(record, (preliminaryCounts.get(record) ?? 0) + 1);
 		}
 	}
@@ -1383,9 +1453,12 @@ function createModuleMovePlanAst(source, analysis, request) {
 	const movedRecords = new Set();
 	for (const boundary of analysis.boundaries) {
 		if (boundary.disabled || hasPermanentStaticAncestor(boundary)) continue;
-		const records = recordsForReferences(referencesByPath.get(boundary.path) ?? []);
-		if (records.size === 0) continue;
-		const ordered = candidates.records.filter((record) => records.has(record));
+		const records = preliminaryRecordsByPath.get(boundary.path);
+		if (records === undefined) continue;
+		const ordered = [...records]
+			.filter((record) => !eagerRecords.has(record))
+			.sort((left, right) => left.order - right.order);
+		if (ordered.length === 0) continue;
 		bindingsByPath.set(boundary.path, new Set(ordered.flatMap((record) => [...record.bindings])));
 		declarationsByPath.set(boundary.path, ordered);
 		for (const record of ordered) movedRecords.add(record);
@@ -1532,7 +1605,7 @@ export function prepareHydrateBoundaries(source, filename, boundaryPath = null, 
 		boundary.hookNames = analysis.imports.hookNames;
 	}
 	const request = sameSourceRequest(filename);
-	const moduleMovePlan = createModuleMovePlanAst(source, analysis, request);
+	const moduleMovePlan = createModuleMovePlanAst(analysis, request);
 	const permanentStaticRemoved =
 		boundaryPath === null
 			? createPermanentStaticRemovalPlanAst(analysis, request, moduleMovePlan)

--- a/packages/octane/src/compiler/hydrate-boundaries.js
+++ b/packages/octane/src/compiler/hydrate-boundaries.js
@@ -1326,8 +1326,12 @@ function extractedModuleAst(
 function moduleReferencesForBoundary(analysis, boundary, request, moduleBindingsByPath) {
 	assertDirectChildren(boundary, boundary.filename);
 	validateBoundary(boundary, boundary.filename, analysis.imports.hookNames);
+	const collectModuleReferences = (nodes) =>
+		collectCaptures(nodes, analysis.imports.importBindings).filter(
+			(name) => !boundary.shadowedImports.has(name),
+		);
 	if (boundary.children.length === 0) {
-		return collectCaptures(boundary.node.children, analysis.imports.importBindings);
+		return collectModuleReferences(boundary.node.children);
 	}
 	const nestedAnalysis = {
 		...analysis,
@@ -1344,7 +1348,7 @@ function moduleReferencesForBoundary(analysis, boundary, request, moduleBindings
 		request,
 		moduleBindingsByPath,
 	);
-	return collectCaptures(fragment.body, analysis.imports.importBindings);
+	return collectModuleReferences(fragment.body);
 }
 
 function createModuleMovePlanAst(analysis, request) {

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -92,6 +92,18 @@ function runtimeExports(code: string): Set<string> {
 	return names;
 }
 
+function topLevelRuntimeBindings(code: string): string[] {
+	const names: string[] = [];
+	for (const node of parseModule(code, 'compiled.js').body as any[]) {
+		const declaration = node.type === 'ExportNamedDeclaration' ? node.declaration : node;
+		if (declaration?.id?.name) names.push(declaration.id.name);
+		for (const item of declaration?.declarations ?? []) {
+			if (item.id?.type === 'Identifier') names.push(item.id.name);
+		}
+	}
+	return names;
+}
+
 function hasReExport(code: string, request: string): boolean {
 	return (parseModule(code, 'compiled.js').body as any[]).some(
 		(node) => node.type === 'ExportNamedDeclaration' && node.source?.value === request,
@@ -350,6 +362,52 @@ export function App(props) @{
 		})!;
 		expect(staticImportLocals(child.code, './review-data.js')).toEqual(['reviewPrefix']);
 		expect(child.code).toContain('reviewPrefix + label');
+	});
+
+	it('keeps sibling split declarations isolated and dependency-ordered', () => {
+		const source = `
+import { Hydrate } from 'octane';
+const firstPrefix = 'first:';
+const firstLabel = firstPrefix + 'item';
+function First() @{ <span>{firstLabel}</span> }
+const secondPrefix = 'second:';
+const secondLabel = secondPrefix + 'item';
+function Second() @{ <span>{secondLabel}</span> }
+export function App() @{
+  <>
+    <Hydrate when={gate}><First /></Hydrate>
+    <Hydrate when={gate}><Second /></Hydrate>
+  </>
+}
+`;
+		const instance = compiler();
+		const root = instance.transform(source, FILE, { environment: 'client' })!;
+		expect(root.code).not.toContain("'first:'");
+		expect(root.code).not.toContain("'second:'");
+
+		const first = instance.transform(source, `${FILE}?octane-hydrate=0`, {
+			environment: 'client',
+		})!;
+		expect(first.code).toContain("'first:'");
+		expect(first.code).not.toContain("'second:'");
+		const firstBindings = topLevelRuntimeBindings(first.code);
+		expect(firstBindings.indexOf('firstPrefix')).toBeLessThan(firstBindings.indexOf('firstLabel'));
+		expect(firstBindings.indexOf('firstLabel')).toBeLessThan(firstBindings.indexOf('First'));
+
+		const second = instance.transform(source, `${FILE}?octane-hydrate=1`, {
+			environment: 'client',
+		})!;
+		expect(second.code).toContain("'second:'");
+		expect(second.code).not.toContain("'first:'");
+		const secondBindings = topLevelRuntimeBindings(second.code);
+		expect(secondBindings.indexOf('secondPrefix')).toBeLessThan(
+			secondBindings.indexOf('secondLabel'),
+		);
+		expect(secondBindings.indexOf('secondLabel')).toBeLessThan(secondBindings.indexOf('Second'));
+
+		const server = instance.transform(source, FILE, { environment: 'server' })!;
+		expect(server.code).toContain("'first:'");
+		expect(server.code).toContain("'second:'");
 	});
 
 	it('keeps a same-module child eager when retained output also references it', () => {

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -410,6 +410,24 @@ export function App() @{
 		expect(server.code).toContain("'second:'");
 	});
 
+	it('keeps a module declaration eager when an ancestor binding shadows it', () => {
+		const source = `
+import { Hydrate } from 'octane';
+const label = setupLabel();
+export function App(label) @{
+  <Hydrate when={true}><span>{label}</span></Hydrate>
+}
+`;
+		const instance = compiler();
+		const root = instance.transform(source, FILE, { environment: 'client' })!;
+		expect(root.code).toContain('setupLabel()');
+
+		const child = instance.transform(source, `${FILE}?octane-hydrate=0`, {
+			environment: 'client',
+		})!;
+		expect(child.code).not.toContain('setupLabel()');
+	});
+
 	it('keeps a same-module child eager when retained output also references it', () => {
 		const source = `
 import { Hydrate } from 'octane';


### PR DESCRIPTION
## Summary

- avoid rebuilding, pruning, and rescanning a synthetic child module for every sibling Hydrate boundary
- index declaration ranges and reuse per-boundary dependency selections instead of repeating boundary/declaration cross-products
- keep ancestor-shadowed captures eager so private module initialization stays in the parent
- add semantic regression coverage and a production-path scaling benchmark with retained-declaration controls

## Validation

- [x] `pnpm sync`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — attempted locally; the first run reached V8's 4 GB heap limit under an older Node, and the required-Node rerun exhausted the host volume while Vite created caches. Focused suites pass and CI is the authoritative broad run.
- [x] targeted tests: hydrate compiler (47), MCP benchmark catalog (15), Node register hooks (6)
- [x] `node benchmarks/bench.mjs --quick --ratios tsrx-hydrate-module-slicing`
- [x] 7-sample balanced comparison against exact `origin/main`

The balanced comparison passed byte-identical client/server output checks and all performance gates:

| Metric | Result | Gate |
| --- | ---: | ---: |
| focused high conservative speedup | 4.78× | ≥ 1.50× |
| focused high conservative saving | 357.4 ms CPU | ≥ 200 ms |
| retained-control ratio | 0.981× | ≤ 1.05× |

## Risk / follow-ups

The change is internal to hydrate-boundary module planning. The benchmark validates root, representative queried-child, and server output metadata against the exact base revision. The full repository suite remains for CI because the local host ran out of disk during the supported-Node rerun.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790725931&installation_model_id=432790&pr_number=918&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F918&signature=8578162f66a1547f0352a2af21544999be920beb97e3dd09cdc8217b1e47ecc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hydrate-boundary module move planning and capture analysis; incorrect slicing could misplace declarations or split outputs, though new benchmarks and compiler tests target semantic parity.
> 
> **Overview**
> **Speeds up hydrate module slicing** when one file has many sibling `<Hydrate>` splits and private top-level declarations, without changing emitted client/server output.
> 
> The hydrate-boundary compiler **stops building a full synthetic child module per boundary** during move planning. **`moduleReferencesForBoundary`** derives each slice’s module references from a lighter nested transform, and **reuses per-path declaration selections** instead of repeating boundary×declaration work. **Indexed, sorted boundary ranges** replace linear scans when deciding whether a declaration contains its own split site, and **`collectCaptures`** can consult extra module bindings without allocating a merged `Set` on every walk.
> 
> Adds **`tsrx-hydrate-module-slicing`** benchmarks (150 vs 2,400 boundaries, focused vs full pipeline, retained-declaration controls), ratio guards, MCP/bench wiring, and hydrate-compiler tests for **sibling slice isolation**, **dependency order**, and **shadowed bindings staying eager**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffd10d48cc2c577787f4a57c191a6d4a986b376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
