### PR TITLE
perf(octane): batch universal object teardown detaches

### DIFF
--- a/.changeset/faster-universal-object-teardown.md
+++ b/.changeset/faster-universal-object-teardown.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Speed up large universal object-driver teardown batches by compacting detached
+sibling arrays once per transaction instead of shifting them for every host.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -82,6 +82,7 @@ Some suites need no preview servers: **news**, **hydration-interactivity**, and
 the three runtime-stress suites vite-build and time each target themselves (the
 runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
+**universal-object-teardown**,
 **universal-template-events**, **universal-external-store**,
 **lynx-render**, **lynx-bundle-size**, and **tsrx-renderer-validation-ranges**
 are Node-only,
@@ -270,6 +271,7 @@ internally, get their own baseline and guard namespace.
 | `async-composition` | async-composition | octane-tsrx, react, inferno | dashboard composition: adjacent async panels, nested children, imported custom hook, and one true dependency |
 | `lynx-list` | lynx-list | none (Node-only) | deterministic 1,000-row native-list physical allocation, reuse, and teardown through a fake Element PAPI |
 | `universal-leaf-update` | universal-leaf-update | none (Node-only) | universal update locality beside 0–4,000 unrelated component siblings through the compiler and native object driver: plain leaf `setState`, keyed `@for` item state, a leaf under an idle `@try`, a structural (insert/remove) update, and compact-row list selection |
+| `universal-object-teardown` | universal-object-teardown | none (Node-only) | transactional object-driver unmount scaling at 2, 4,096, and 16,384 flat siblings, with exact remove/destroy and empty-driver controls |
 | `universal-template-events` | universal-template-events | none (Node-only) | shape-stable handler updates across 128 and 1,024 retained native event sites through the fallback collapsed-template host capability, with host identity, latest-handler dispatch, and redundant-command controls |
 | `universal-external-store` | universal-external-store | none (Node-only) | 128 native universal store subscribers, getter/subscribe identity controls, notification bursts, and deterministic subscription-lifetime and state-projection guards |
 | `lynx-render` | lynx-render | none (Node-only) | dual-thread Lynx render CPU: empty startup, create 1,000 and 10,000 keyed rows through the real background root, transport, and main receiver over a cheap fake Element PAPI, plus a gate that a native tap reaches its background handler via the engine `publishEvent` receiver |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -384,6 +384,14 @@
     "note": "Compact leaf rows driven by their list component's selection state replay only that component (its 100 rows), so unrelated siblings must not change the cost. Rejects the compact-range bail that forced list selection through a whole-root replay."
   },
   {
+    "suite": "universal-object-teardown",
+    "op": "unmount_ms",
+    "target": "siblings-16384",
+    "reference": "siblings-4096",
+    "maxRatio": 8,
+    "note": "Four times as many flat object-driver siblings should stay within twice linear growth. Transaction-local detach sets measure about 4-5x; per-child indexOf/splice during both simulation and apply grows about 19x."
+  },
+  {
     "suite": "universal-template-events",
     "op": "event_update_ms",
     "target": "events-1024",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -796,6 +796,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Universal object-driver teardown (Node-only): wide sibling unmounts through
+		// transactional simulation and apply, with exact remove/destroy controls.
+		name: 'universal-object-teardown',
+		cwd: 'universal-object-teardown',
+		servers: [],
+		iter: { normal: 7, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Universal fallback collapsed-template events (Node-only): handler-only
 		// updates across 128 and 1,024 retained native event sites.
 		name: 'universal-template-events',

--- a/benchmarks/universal-object-teardown/README.md
+++ b/benchmarks/universal-object-teardown/README.md
@@ -1,0 +1,17 @@
+# Universal object-driver teardown
+
+This Node-only benchmark measures root unmount through the public universal
+runtime and object driver. Each sample mounts a flat keyed list, then times the
+transactional teardown that simulates and applies every remove/destroy command.
+
+Every scale point verifies the mounted host count and type, the exact remove and
+destroy command counts, and the empty container/driver state after unmount. The
+16,384 / 4,096 ratio is the regression signal: four times as many siblings should
+remain close to linear. The former per-child `indexOf` + `splice` path shifted
+the shrinking sibling array during both transaction simulation and apply, so it
+scaled quadratically.
+
+```bash
+node benchmarks/universal-object-teardown/run.mjs 7
+node benchmarks/bench.mjs --quick universal-object-teardown
+```

--- a/benchmarks/universal-object-teardown/run.mjs
+++ b/benchmarks/universal-object-teardown/run.mjs
@@ -1,0 +1,126 @@
+// Universal object-driver teardown benchmark. A public object root mounts a
+// flat keyed host list, then unmounts it through the transactional driver.
+process.env.NODE_ENV = 'production';
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const ROOT = import.meta.dirname;
+const REPO = path.resolve(ROOT, '../..');
+const rawIterations = process.argv[2] ?? '7';
+const iterations = Number(rawIterations);
+
+if (!Number.isSafeInteger(iterations) || iterations <= 0) {
+	throw new TypeError(`iterations must be a positive safe integer, received ${rawIterations}.`);
+}
+
+const build = spawnSync('pnpm', ['--filter', 'octane', 'build'], {
+	cwd: REPO,
+	stdio: 'inherit',
+});
+if ((build.status ?? 1) !== 0) throw new Error('The octane package build failed.');
+
+const runtimeUrl = pathToFileURL(path.join(REPO, 'packages/octane/dist/universal-native.js')).href;
+const {
+	createObjectContainer,
+	createObjectDriver,
+	createUniversalRoot,
+	defineUniversalComponent,
+	universalFor,
+	universalPlan,
+	universalValue,
+} = await import(runtimeUrl);
+
+const plan = universalPlan('object', { kind: 'host', type: 'row' });
+const rowsBySize = new Map();
+const rows = (size) => {
+	let value = rowsBySize.get(size);
+	if (value === undefined) {
+		value = Array.from({ length: size }, (_, index) => index);
+		rowsBySize.set(size, value);
+	}
+	return value;
+};
+const Scene = defineUniversalComponent('object', ({ size }) =>
+	universalFor(
+		rows(size),
+		(index) => index,
+		() => universalValue(plan, []),
+	),
+);
+
+const WARMUPS = 3;
+const SIZES = [2, 4_096, 16_384];
+const targets = [];
+const failures = [];
+
+for (const size of SIZES) {
+	const samples = [];
+	let removeCommands = 0;
+	let destroyCommands = 0;
+	for (let sample = 0; sample < WARMUPS + iterations; sample++) {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		root.render(Scene, { size });
+		const mounted = [...container.children];
+		if (
+			mounted.length !== size ||
+			container.instanceCount !== size ||
+			mounted.some((instance) => instance.type !== 'row')
+		) {
+			failures.push(`size ${size}: mounted object-host shape did not match the input list`);
+		}
+
+		const start = performance.now();
+		root.unmount();
+		const duration = performance.now() - start;
+		if (sample >= WARMUPS) samples.push(duration);
+
+		const teardown = container.commits.at(-1);
+		removeCommands = teardown?.commands.filter((command) => command.op === 'remove').length ?? -1;
+		destroyCommands = teardown?.commands.filter((command) => command.op === 'destroy').length ?? -1;
+		if (
+			container.children.length !== 0 ||
+			container.instanceCount !== 0 ||
+			removeCommands !== size ||
+			destroyCommands !== size
+		) {
+			failures.push(`size ${size}: teardown did not remove and destroy every mounted host`);
+		}
+	}
+
+	const stats = summarizeSamples(samples);
+	targets.push({
+		name: `siblings-${size}`,
+		ops: { unmount_ms: timingStatForJson(stats) },
+		meta: {
+			siblings: size,
+			removeCommands,
+			destroyCommands,
+			remainingInstances: 0,
+		},
+	});
+}
+
+const payload = {
+	suite: 'universal-object-teardown',
+	iterations,
+	targets,
+	...(failures.length > 0 ? { failed: failures.join('; ') } : null),
+};
+
+console.table(
+	targets.map((target) => ({
+		target: target.name,
+		unmount_ms: target.ops.unmount_ms.score.toFixed(3),
+		rme: target.ops.unmount_ms.rme.toFixed(2) + '%',
+	})),
+);
+if (process.env.BENCH_JSON)
+	fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, 2));
+if (failures.length > 0) throw new Error(failures.join('\n'));

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -101,6 +101,7 @@ export const BENCHMARK_SUITES = [
 	'async-composition',
 	'lynx-list',
 	'universal-leaf-update',
+	'universal-object-teardown',
 	'universal-template-events',
 	'universal-external-store',
 	'lynx-render',

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -12592,6 +12592,10 @@ export function createObjectDriver(
 				);
 			}
 			const state = container[OBJECT_DRIVER_STATE];
+			// Below this size V8's direct indexOf/splice path is cheaper than building
+			// detach sets. Large teardown batches cross over decisively and compact each
+			// touched sibling array once instead of shifting it for every command.
+			const useBatchedDetaches = batch.commands.length >= 4_096;
 			type SimulatedInstance = {
 				type: string;
 				props: Readonly<Record<string, unknown>>;
@@ -12635,26 +12639,65 @@ export function createObjectDriver(
 			type SimulatedParent = number | null | typeof DETACHED;
 			const parentChanges = new Map<number, SimulatedParent>();
 			let rootChildren: number[] | null = null;
+			let pendingDetaches: Map<number | null, Set<number>> | null = null;
 			const readParent = (id: number): SimulatedParent => {
 				if (parentChanges.has(id)) return parentChanges.get(id)!;
 				return state.parents.has(id) ? state.parents.get(id)! : DETACHED;
 			};
-			const simulatedChildren = (parent: number | null) => {
-				if (parent === null) {
-					return (rootChildren ??= container.children.map((child) => child.id));
+			const flushPendingDetaches = (parent: number | null, children: number[]): void => {
+				const detached = pendingDetaches?.get(parent);
+				if (detached === undefined) return;
+				let write = 0;
+				for (let read = 0; read < children.length; read++) {
+					const child = children[read];
+					if (!detached.delete(child)) children[write++] = child;
 				}
-				const value = readSimulated(parent);
-				if (value === undefined) throw new Error(`Object driver: unknown parent ${parent}.`);
-				return value.children;
+				if (detached.size !== 0) {
+					const missing = detached.values().next().value!;
+					throw new Error(`Object driver: child ${missing} is not attached.`);
+				}
+				children.length = write;
+				pendingDetaches!.delete(parent);
+				if (pendingDetaches!.size === 0) pendingDetaches = null;
+			};
+			const simulatedChildren = (parent: number | null): number[] => {
+				let children: number[];
+				if (parent === null) {
+					children = rootChildren ??= container.children.map((child) => child.id);
+				} else {
+					const value = readSimulated(parent);
+					if (value === undefined) throw new Error(`Object driver: unknown parent ${parent}.`);
+					children = value.children;
+				}
+				flushPendingDetaches(parent, children);
+				return children;
 			};
 			const detachSimulated = (id: number): void => {
 				const parent = readParent(id);
 				if (parent === DETACHED) return;
-				const children = simulatedChildren(parent);
-				const index = children.indexOf(id);
-				if (index === -1) throw new Error(`Object driver: child ${id} is not attached.`);
-				children.splice(index, 1);
+				if (useBatchedDetaches) {
+					const detaches = (pendingDetaches ??= new Map());
+					const detached = detaches.get(parent);
+					if (detached === undefined) detaches.set(parent, new Set([id]));
+					else detached.add(id);
+				} else {
+					const children = simulatedChildren(parent);
+					const index = children.indexOf(id);
+					if (index === -1) throw new Error(`Object driver: child ${id} is not attached.`);
+					children.splice(index, 1);
+				}
 				parentChanges.set(id, DETACHED);
+			};
+			const forgetPendingDetachParent = (parent: number): void => {
+				if (pendingDetaches === null) return;
+				pendingDetaches.delete(parent);
+				if (pendingDetaches.size === 0) pendingDetaches = null;
+			};
+			const flushAllPendingDetaches = (): void => {
+				while (pendingDetaches !== null) {
+					const parent = pendingDetaches.keys().next().value!;
+					simulatedChildren(parent);
+				}
 			};
 			for (const command of batch.commands) {
 				if (command.op === 'create') {
@@ -12755,11 +12798,10 @@ export function createObjectDriver(
 					if (command.parent !== null && typeof command.parent !== 'number') {
 						throw new Error('Object driver does not support portal target parents.');
 					}
-					const children = simulatedChildren(command.parent);
-					const index = children.indexOf(command.id);
-					if (index === -1) throw new Error(`Object driver: child ${command.id} is not attached.`);
-					children.splice(index, 1);
-					parentChanges.set(command.id, DETACHED);
+					if (readParent(command.id) !== command.parent) {
+						throw new Error(`Object driver: child ${command.id} is not attached.`);
+					}
+					detachSimulated(command.id);
 					for (const type of readSimulated(command.id)!.localCallbacks.keys()) {
 						cleanupKeys.add(keyFor(command.id, type));
 					}
@@ -12770,9 +12812,11 @@ export function createObjectDriver(
 					detachSimulated(command.id);
 					for (const child of instance.children) parentChanges.set(child, DETACHED);
 					instance.children.length = 0;
+					forgetPendingDetachParent(command.id);
 					destroyed.add(command.id);
 				}
 			}
+			flushAllPendingDetaches();
 			for (const [id, instance] of stagedInstances) {
 				const staged = readSimulated(id);
 				if (staged === undefined) continue;
@@ -12787,16 +12831,47 @@ export function createObjectDriver(
 			}
 			let status: 'prepared' | 'applied' | 'aborted' = 'prepared';
 			let acceptedCallbacksRan = false;
-			const liveChildren = (parent: number | null): ObjectHostInstance[] =>
-				objectChildren(container, parent, state.instances);
+			let pendingLiveDetaches: Map<number | null, Set<number>> | null = null;
+			const liveChildren = (parent: number | null): ObjectHostInstance[] => {
+				const children = objectChildren(container, parent, state.instances);
+				const detached = pendingLiveDetaches?.get(parent);
+				if (detached === undefined) return children;
+				let write = 0;
+				for (let read = 0; read < children.length; read++) {
+					const child = children[read];
+					if (!detached.has(child.id)) children[write++] = child;
+				}
+				children.length = write;
+				pendingLiveDetaches!.delete(parent);
+				if (pendingLiveDetaches!.size === 0) pendingLiveDetaches = null;
+				return children;
+			};
 			const detachLive = (id: number): void => {
 				if (!state.parents.has(id)) return;
 				const parent = state.parents.get(id)!;
 				const instance = state.instances.get(id)!;
-				const children = liveChildren(parent);
-				const index = children.indexOf(instance);
-				if (index !== -1) children.splice(index, 1);
+				if (useBatchedDetaches) {
+					const detaches = (pendingLiveDetaches ??= new Map());
+					const detached = detaches.get(parent);
+					if (detached === undefined) detaches.set(parent, new Set([id]));
+					else detached.add(id);
+				} else {
+					const children = liveChildren(parent);
+					const index = children.indexOf(instance);
+					if (index !== -1) children.splice(index, 1);
+				}
 				state.parents.delete(id);
+			};
+			const forgetPendingLiveParent = (parent: number): void => {
+				if (pendingLiveDetaches === null) return;
+				pendingLiveDetaches.delete(parent);
+				if (pendingLiveDetaches.size === 0) pendingLiveDetaches = null;
+			};
+			const flushAllPendingLiveDetaches = (): void => {
+				while (pendingLiveDetaches !== null) {
+					const parent = pendingLiveDetaches.keys().next().value!;
+					liveChildren(parent);
+				}
 			};
 			return {
 				apply() {
@@ -12866,14 +12941,13 @@ export function createObjectDriver(
 								if (command.parent !== null && typeof command.parent !== 'number') {
 									throw new Error('Object driver does not support portal target parents.');
 								}
-								const children = liveChildren(command.parent);
-								children.splice(children.indexOf(state.instances.get(command.id)!), 1);
-								state.parents.delete(command.id);
+								detachLive(command.id);
 							} else if (command.op === 'destroy') {
 								const instance = state.instances.get(command.id)!;
 								detachLive(command.id);
 								for (const child of instance.children) state.parents.delete(child.id);
 								instance.children.length = 0;
+								forgetPendingLiveParent(command.id);
 								state.instances.delete(command.id);
 								state.parents.delete(command.id);
 								state.events.delete(command.id);
@@ -12882,6 +12956,7 @@ export function createObjectDriver(
 								state.localCleanups.delete(command.id);
 							}
 						}
+						flushAllPendingLiveDetaches();
 						container.commits.push(batch);
 					});
 					runCommitTasks(tasks);

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -12672,10 +12672,10 @@ export function createObjectDriver(
 				flushPendingDetaches(parent, children);
 				return children;
 			};
-			const detachSimulated = (id: number): void => {
+			const detachSimulated = (id: number, defer: boolean): void => {
 				const parent = readParent(id);
 				if (parent === DETACHED) return;
-				if (useBatchedDetaches) {
+				if (useBatchedDetaches && defer) {
 					const detaches = (pendingDetaches ??= new Map());
 					const detached = detaches.get(parent);
 					if (detached === undefined) detaches.set(parent, new Set([id]));
@@ -12780,7 +12780,7 @@ export function createObjectDriver(
 					}
 					if (!hasSimulated(command.id))
 						throw new Error(`Object driver: unknown child ${command.id}.`);
-					detachSimulated(command.id);
+					detachSimulated(command.id, false);
 					const children = simulatedChildren(command.parent);
 					const before =
 						command.before === null ? children.length : children.indexOf(command.before);
@@ -12801,7 +12801,7 @@ export function createObjectDriver(
 					if (readParent(command.id) !== command.parent) {
 						throw new Error(`Object driver: child ${command.id} is not attached.`);
 					}
-					detachSimulated(command.id);
+					detachSimulated(command.id, true);
 					for (const type of readSimulated(command.id)!.localCallbacks.keys()) {
 						cleanupKeys.add(keyFor(command.id, type));
 					}
@@ -12809,7 +12809,7 @@ export function createObjectDriver(
 					const instance = readSimulated(command.id);
 					if (instance === undefined)
 						throw new Error(`Object driver: unknown destroy ${command.id}.`);
-					detachSimulated(command.id);
+					detachSimulated(command.id, true);
 					for (const child of instance.children) parentChanges.set(child, DETACHED);
 					instance.children.length = 0;
 					forgetPendingDetachParent(command.id);
@@ -12846,11 +12846,11 @@ export function createObjectDriver(
 				if (pendingLiveDetaches!.size === 0) pendingLiveDetaches = null;
 				return children;
 			};
-			const detachLive = (id: number): void => {
+			const detachLive = (id: number, defer: boolean): void => {
 				if (!state.parents.has(id)) return;
 				const parent = state.parents.get(id)!;
 				const instance = state.instances.get(id)!;
-				if (useBatchedDetaches) {
+				if (useBatchedDetaches && defer) {
 					const detaches = (pendingLiveDetaches ??= new Map());
 					const detached = detaches.get(parent);
 					if (detached === undefined) detaches.set(parent, new Set([id]));
@@ -12929,7 +12929,7 @@ export function createObjectDriver(
 									throw new Error('Object driver does not support portal target parents.');
 								}
 								const instance = state.instances.get(command.id)!;
-								detachLive(command.id);
+								detachLive(command.id, false);
 								const children = liveChildren(command.parent);
 								const before =
 									command.before === null
@@ -12941,10 +12941,10 @@ export function createObjectDriver(
 								if (command.parent !== null && typeof command.parent !== 'number') {
 									throw new Error('Object driver does not support portal target parents.');
 								}
-								detachLive(command.id);
+								detachLive(command.id, true);
 							} else if (command.op === 'destroy') {
 								const instance = state.instances.get(command.id)!;
-								detachLive(command.id);
+								detachLive(command.id, true);
 								for (const child of instance.children) state.parents.delete(child.id);
 								instance.children.length = 0;
 								forgetPendingLiveParent(command.id);

--- a/packages/octane/tests/universal-semantics-regressions.test.ts
+++ b/packages/octane/tests/universal-semantics-regressions.test.ts
@@ -171,6 +171,32 @@ describe('universal runtime semantic regressions', () => {
 		expect(container.instanceCount).toBe(0);
 	});
 
+	it('preserves wide object-driver order when batched removals precede moves', () => {
+		const { container, root } = objectRoot();
+		const items = Array.from({ length: 4_096 }, (_, index) => `item-${index}`);
+		root.render(ObjectDriverSiblingScene, { groups: [{ id: 'wide', items }] });
+		const group = container.children[0];
+		const survivorLabels = [items.at(-1)!, items[2_048]!, items[0]!];
+		const survivors = new Map(
+			group.children
+				.filter((child) => survivorLabels.includes(child.props.label as string))
+				.map((child) => [child.props.label, child]),
+		);
+
+		root.render(ObjectDriverSiblingScene, {
+			groups: [{ id: 'wide', items: survivorLabels }],
+		});
+
+		expect(container.children).toEqual([group]);
+		expect(group.children.map((child) => child.props.label)).toEqual(survivorLabels);
+		for (const child of group.children) expect(child).toBe(survivors.get(child.props.label));
+		expect(container.instanceCount).toBe(survivorLabels.length + 1);
+
+		root.unmount();
+		expect(container.children).toEqual([]);
+		expect(container.instanceCount).toBe(0);
+	});
+
 	it('preserves object-driver sibling order and empties every detached parent', () => {
 		const { container, root } = objectRoot();
 		root.render(ObjectDriverSiblingScene, {

--- a/packages/octane/tests/universal-semantics-regressions.test.ts
+++ b/packages/octane/tests/universal-semantics-regressions.test.ts
@@ -6,6 +6,7 @@ import {
 	createUniversalRoot,
 	defineUniversalComponent,
 	rendererRegion,
+	universalFor,
 	universalKey,
 	universalPlan,
 	universalValue,
@@ -125,7 +126,94 @@ const DuplicateKeyFailureDraftScene = defineUniversalComponent(
 	},
 );
 
+const objectDriverLeafPlan = universalPlan('object', {
+	kind: 'host',
+	type: 'object-driver-leaf',
+	bindings: [['label', 0]],
+});
+const objectDriverGroupPlan = universalPlan('object', {
+	kind: 'host',
+	type: 'object-driver-group',
+	bindings: [['label', 0]],
+	children: [{ kind: 'slot', slot: 1 }],
+});
+const ObjectDriverSiblingScene = defineUniversalComponent<{
+	groups: Array<{ id: string; items: string[] }>;
+}>('object', ({ groups }) =>
+	universalFor(
+		groups,
+		(group) => group.id,
+		(group) =>
+			universalValue(objectDriverGroupPlan, [
+				group.id,
+				universalFor(
+					group.items,
+					(item) => item,
+					(item) => universalValue(objectDriverLeafPlan, [item]),
+				),
+			]),
+	),
+);
+
 describe('universal runtime semantic regressions', () => {
+	it('empties a wide object-driver parent and its root in one teardown batch', () => {
+		const { container, root } = objectRoot();
+		const items = Array.from({ length: 4_096 }, (_, index) => `item-${index}`);
+		root.render(ObjectDriverSiblingScene, { groups: [{ id: 'wide', items }] });
+		const group = container.children[0];
+		expect(group.children).toHaveLength(items.length);
+		expect(container.instanceCount).toBe(items.length + 1);
+
+		root.unmount();
+
+		expect(group.children).toEqual([]);
+		expect(container.children).toEqual([]);
+		expect(container.instanceCount).toBe(0);
+	});
+
+	it('preserves object-driver sibling order and empties every detached parent', () => {
+		const { container, root } = objectRoot();
+		root.render(ObjectDriverSiblingScene, {
+			groups: [
+				{ id: 'a', items: ['a1', 'a2', 'a3', 'a4'] },
+				{ id: 'b', items: ['b1', 'b2', 'b3'] },
+				{ id: 'removed', items: ['r1', 'r2'] },
+			],
+		});
+		const groupA = container.children[0];
+		const groupB = container.children[1];
+		const removedGroup = container.children[2];
+		const retained = new Map(
+			[...groupA.children, ...groupB.children].map((child) => [child.props.label, child]),
+		);
+
+		root.render(ObjectDriverSiblingScene, {
+			groups: [
+				{ id: 'b', items: ['b3', 'b1', 'b4'] },
+				{ id: 'a', items: ['a4', 'a2'] },
+				{ id: 'new', items: ['n1', 'n2'] },
+			],
+		});
+
+		expect(container.children.map((group) => group.props.label)).toEqual(['b', 'a', 'new']);
+		expect(container.children[0]).toBe(groupB);
+		expect(container.children[1]).toBe(groupA);
+		expect(groupB.children.map((child) => child.props.label)).toEqual(['b3', 'b1', 'b4']);
+		expect(groupA.children.map((child) => child.props.label)).toEqual(['a4', 'a2']);
+		for (const label of ['b3', 'b1', 'a4', 'a2']) {
+			expect(allInstances(container).find((child) => child.props.label === label)).toBe(
+				retained.get(label),
+			);
+		}
+		expect(removedGroup.children).toEqual([]);
+
+		const mountedGroups = [...container.children];
+		root.unmount();
+		expect(container.children).toEqual([]);
+		expect(container.instanceCount).toBe(0);
+		for (const group of mountedGroups) expect(group.children).toEqual([]);
+	});
+
 	it('retains fresh compiler-memoized promises through every initial suspension stratum', async () => {
 		const { container, root } = objectRoot();
 		const first = deferred<string>();


### PR DESCRIPTION
## Summary

- compact deferred object-driver sibling removals once per large teardown transaction
- keep insert and move commands on the direct detach path so wide keyed reorders do not regress
- add public-path behavior and performance coverage, a ratio guard, benchmark discovery, and an `octane` patch changeset

## Why

The object driver simulated and applied every wide unmount by running `indexOf` plus `splice` for each sibling. Both transaction phases repeatedly shifted the same shrinking array, so teardown cost grew quadratically for bookkeeping that can be batched.

On the latest `origin/main` baseline, 16,384 siblings took a 157.889 ms median to unmount. The final candidate takes 36.004 ms, with the retained 16,384 / 4,096 ratio guard passing at 4.78x. Review also caught a large-reorder regression in the first representation: an 8,192-sibling reverse improved from 1,241.285 ms to 101.536 ms after restricting deferred compaction to destructive commands.

## Changes

- preserve the existing direct path below 4,096 commands
- queue destructive detaches by parent in large batches and compact each affected sibling array once before order is observed or the transaction completes
- preserve validation, sequential insert/move semantics, retained host identity, nested-parent cleanup, and abort behavior
- add wide teardown, wide remove-plus-reorder, and cross-parent order/identity regression tests
- register `universal-object-teardown` in the benchmark runner and MCP benchmark inventory

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck` (full workspace before the final two-file review fix; current-head Octane `tsgo`, package build, and declarations also pass)
- [ ] `pnpm test` (the all-project process later exceeded Node's 4 GB heap after about 15 minutes; its sole earlier Volar failure passed immediately in isolation)
- [x] targeted tests: 35 universal dev/prod files, 758 tests; final regression file in dev/prod, 36 tests; MCP inventory, 15 tests; isolated Volar, 24 tests
- [x] `node benchmarks/bench.mjs --ratios universal-object-teardown` (7 samples; ratio guard passed)
- [x] `pnpm changeset:check status`
- [x] `pnpm sync` left the worktree clean

## Risk / follow-ups

- The optimization is internal to the universal object driver; no binding package or public type signature changes.
- CI should complete the clean all-project matrix that exhausted the local long-lived Vitest process.
- Structured review findings were applied in `fix(review): preserve wide reorder performance`; no review residuals remain.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790736475&installation_model_id=432790&pr_number=919&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F919&signature=d0f4808c0c59fd3f509f80c2b8d04302af3a30cf463d6cca27f8141678df85e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transactional object-driver simulation and apply paths for large batches; behavior is guarded by new semantics tests and a scaling benchmark, but insert/move vs deferred-remove interactions are subtle.
> 
> **Overview**
> Large universal **object-driver** teardown batches no longer pay quadratic cost from repeating `indexOf` + `splice` on the same sibling list during transaction simulation and apply.
> 
> When a batch has **≥4,096 commands**, `remove`/`destroy` detaches are **deferred per parent** and each affected sibling array is **compacted once** (simulation and live apply both use the same pattern). **Insert/move** still detach immediately so wide keyed reorders do not regress.
> 
> Adds **`universal-object-teardown`** (Node benchmark at 2 / 4,096 / 16,384 flat siblings), a **16,384÷4,096 `unmount_ms` ratio guard** (max 8×), wide teardown / remove-plus-reorder / cross-parent **semantic regression tests**, runner + MCP inventory wiring, and an **`octane` patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e216d9ba671e7f13d396330997a82006500a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->