### PR TITLE
perf(octane): reduce deferred hydration setup allocations

### DIFF
--- a/.changeset/lazy-deferred-hydration-waiters.md
+++ b/.changeset/lazy-deferred-hydration-waiters.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Allocate deferred-hydration procedural prefetch waiter sets only when `waitFor()` is used.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -237,6 +237,7 @@ internally, get their own baseline and guard namespace.
 | `dev-form-diagnostics` | dev-form-diagnostics | none (Node/jsdom) | development-only controlled-form diagnostic commit scaling at 4,000 and 32,000 hosts |
 | `scheduler-depth` | scheduler-depth | none (Node/jsdom) | production client scheduler ordering across 500 and 2,000 deeply nested queued components |
 | `hydration-range-compaction` | hydration-range-compaction | none (Node/jsdom) | production SSR hydration range compaction across 64 and 512 coextensive wrappers, with adoption, interaction, marker-depth, and unmount gates |
+| `deferred-hydration-boundaries` | deferred-hydration-boundaries | none (Node/jsdom) | production deferred hydration at 1 and 2,048 server-preserved boundaries, with a deterministic per-boundary setup-allocation guard and plain-mount control |
 | `external-store-fanout` | external-store-fanout | none (builds) | 512 subscribers, narrow and broad writes, rapid-write tearing checks, deterministic 100-notification work guards, and balanced subscription removal |
 | `external-store-integrations` | external-store-integrations | none (builds) | real Zustand stores, Jotai atoms, and TanStack Query caches with selector fan-out, query invalidation, and seven-framework cleanup gates |
 | `store-selector-fanout` | store-selector-fanout | none (builds) | 512 subscribers reading one store through a `with-selector`-shaped selector, 20 unrelated parent re-renders with the store untouched, and deterministic selector-invocation counts beside render and snapshot counts |

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -423,6 +423,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Production deferred-boundary adoption at 1 and 2,048 boundaries, with a
+		// deterministic per-boundary Set-allocation slope and plain-mount control.
+		name: 'deferred-hydration-boundaries',
+		cwd: 'deferred-hydration-boundaries',
+		servers: [],
+		iter: { normal: 9, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Production multi-root hydration with a same-width foreign update wave
 		// already queued, normalized per row to catch repeated queue prefix scans.
 		name: 'hydration-render-phase-queue',

--- a/benchmarks/deferred-hydration-boundaries/README.md
+++ b/benchmarks/deferred-hydration-boundaries/README.md
@@ -1,0 +1,51 @@
+# Deferred hydration boundary setup
+
+This Node/jsdom suite production-builds Octane's server renderer and client
+runtime, then measures `hydrateRoot` for one and 2,048 server-preserved
+`<Hydrate when={load()}>` boundaries. Every boundary adopts one server-created
+cell. A same-sized plain client mount is the counter-workload for machine-wide
+timing drift.
+
+The timed interval contains only `hydrateRoot`. HTML parsing, DOM identity
+capture, correctness checks, instrumentation, and unmount are outside it. The
+two hydration sizes share one process, receive an untimed warmup, and alternate
+measurement order across nine normal samples.
+
+## Allocation guard
+
+An additional untimed pass replaces the JavaScript `Set` constructor with a
+semantics-preserving counting subclass while each hydration case runs. The
+single-boundary count removes fixed root/runtime setup from the 2,048-boundary
+count. The suite fails above 3.05 `Set` allocations per added boundary.
+
+Before lazy waiter allocation, the slope was exactly 4.000 and the 2,048-case
+created 8,204 sets. The optimized path is exactly 3.000 and creates 6,156: one
+fewer retained empty set per boundary, or 25% fewer setup-set allocations in
+this workload. A procedural prefetch that actually calls `waitFor()` still
+allocates its waiter set on demand; behavior coverage exercises multiple
+concurrent subscribers and the hydrate, prefetch, and abort outcomes.
+
+## Timing evidence
+
+Three independent nine-sample runs on Node 22.22.2 produced these scores in
+milliseconds:
+
+| run | eager waiters: 2,048 hydrate | lazy waiters: 2,048 hydrate | eager plain control | lazy plain control |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 64.775 | 53.694 | 100.584 | 93.734 |
+| 2 | 66.883 | 68.255 | 103.354 | 112.215 |
+| 3 | 68.233 | 58.868 | 102.837 | 95.449 |
+
+Normalized against the plain-mount control, the hydration ratio is lower in
+every run; absolute hydration time is lower in two runs and nearly flat in the
+run where the control also slowed. The allocation slope is the durable claim
+and regression gate because the control movement shows why absolute timing
+alone is not a reliable CI threshold.
+
+Every sample also proves the boundary count, cell count, server-node identity,
+protocol-sidecar cleanup, and complete unmount.
+
+```bash
+node benchmarks/deferred-hydration-boundaries/run.mjs
+node benchmarks/bench.mjs --quick deferred-hydration-boundaries
+```

--- a/benchmarks/deferred-hydration-boundaries/run.mjs
+++ b/benchmarks/deferred-hydration-boundaries/run.mjs
@@ -1,0 +1,285 @@
+process.env.NODE_ENV = 'production';
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import { octane } from '../../packages/octane/src/compiler/vite.js';
+
+const HERE = import.meta.dirname;
+const REPO = path.resolve(HERE, '../..');
+const benchmarkRequire = createRequire(path.join(REPO, 'benchmarks/news/package.json'));
+const rawIterations = process.argv[2] ?? '9';
+const iterations = Number(rawIterations);
+const CASES = [
+	{ name: 'boundary-1', boundaryCount: 1, childCount: 1 },
+	{ name: 'boundaries-2048', boundaryCount: 2_048, childCount: 1 },
+];
+const PLAIN_CONTROL = {
+	name: 'plain-2048',
+	boundaryCount: 2_048,
+	childCount: 1,
+};
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new TypeError(`iterations must be a positive safe integer, received ${rawIterations}.`);
+}
+
+async function buildEntry(entry, output, ssr) {
+	const { build } = await import(pathToFileURL(benchmarkRequire.resolve('vite')).href);
+	const octaneSource = path.join(REPO, 'packages/octane/src');
+	await build({
+		root: REPO,
+		configFile: false,
+		logLevel: 'warn',
+		resolve: {
+			alias: [
+				{
+					find: /^octane\/internal\/client$/,
+					replacement: path.join(octaneSource, 'internal/client.ts'),
+				},
+				{
+					find: /^octane\/internal\/server$/,
+					replacement: path.join(octaneSource, 'internal/server.ts'),
+				},
+				{
+					find: /^octane\/hydration$/,
+					replacement: path.join(octaneSource, 'hydration/index.ts'),
+				},
+				{ find: /^octane\/server$/, replacement: path.join(octaneSource, 'server/index.ts') },
+				{ find: /^octane$/, replacement: path.join(octaneSource, 'index.ts') },
+			],
+		},
+		plugins: [octane({ ssr })],
+		define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+		build: {
+			lib: { entry, formats: ['es'], fileName: () => path.basename(output) },
+			outDir: path.dirname(output),
+			emptyOutDir: true,
+			minify: true,
+			target: 'node22',
+		},
+	});
+}
+
+async function setupDom() {
+	const { JSDOM } = await import('jsdom');
+	const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+		pretendToBeVisual: true,
+		url: 'http://localhost/',
+	});
+	for (const key of [
+		'window',
+		'document',
+		'navigator',
+		'EventTarget',
+		'Event',
+		'MouseEvent',
+		'Node',
+		'NodeFilter',
+		'Element',
+		'HTMLElement',
+		'HTMLButtonElement',
+		'Text',
+		'Comment',
+		'DocumentFragment',
+		'MutationObserver',
+		'AbortController',
+		'AbortSignal',
+	]) {
+		const value = key === 'window' ? dom.window : dom.window[key];
+		if (value === undefined) continue;
+		Object.defineProperty(globalThis, key, { value, configurable: true, writable: true });
+	}
+	return dom;
+}
+
+function countSetAllocations(run) {
+	const NativeSet = globalThis.Set;
+	let setAllocations = 0;
+	class CountingSet extends NativeSet {
+		constructor(values) {
+			super(values);
+			setAllocations++;
+		}
+	}
+	Object.defineProperty(globalThis, 'Set', {
+		value: CountingSet,
+		configurable: true,
+		writable: true,
+	});
+	try {
+		const result = run();
+		return { result, setAllocations };
+	} finally {
+		Object.defineProperty(globalThis, 'Set', {
+			value: NativeSet,
+			configurable: true,
+			writable: true,
+		});
+	}
+}
+
+function assertHydrationResult(testCase, result) {
+	const expectedCells = testCase.boundaryCount * testCase.childCount;
+	if (
+		result.boundaryCount !== testCase.boundaryCount ||
+		result.cellCount !== expectedCells ||
+		!result.serverNodesAdopted ||
+		!result.sidecarsRemoved ||
+		!result.unmountClean
+	) {
+		throw new Error(`${testCase.name} failed its semantic controls: ${JSON.stringify(result)}`);
+	}
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-deferred-boundaries-'));
+const clientFile = path.join(tempDir, 'client', 'entry.js');
+const serverFile = path.join(tempDir, 'server', 'entry.js');
+let failure;
+let dom;
+const targets = [];
+
+try {
+	await buildEntry(path.join(HERE, 'src/client.ts'), clientFile, false);
+	await buildEntry(path.join(HERE, 'src/server.ts'), serverFile, true);
+	const server = await import(pathToFileURL(serverFile).href);
+	const serverHtml = new Map(
+		CASES.map((testCase) => [
+			testCase.name,
+			server.renderCase(testCase.boundaryCount, testCase.childCount),
+		]),
+	);
+	dom = await setupDom();
+	const client = await import(pathToFileURL(clientFile).href);
+	const samples = new Map([...CASES, PLAIN_CONTROL].map((testCase) => [testCase.name, []]));
+	const controls = new Map();
+	const setupSetAllocations = new Map();
+
+	const runHydration = (testCase) => {
+		const container = document.createElement('main');
+		document.body.appendChild(container);
+		container.innerHTML = serverHtml.get(testCase.name);
+		const result = client.hydrateCase(container, testCase.boundaryCount, testCase.childCount);
+		assertHydrationResult(testCase, result);
+		container.remove();
+		controls.set(testCase.name, result);
+		return result.durationMs;
+	};
+	const runPlainControl = () => {
+		const container = document.createElement('main');
+		document.body.appendChild(container);
+		const result = client.mountPlainCase(
+			container,
+			PLAIN_CONTROL.boundaryCount,
+			PLAIN_CONTROL.childCount,
+		);
+		if (
+			result.cellCount !== PLAIN_CONTROL.boundaryCount * PLAIN_CONTROL.childCount ||
+			!result.unmountClean
+		) {
+			throw new Error(`plain control failed its semantic controls: ${JSON.stringify(result)}`);
+		}
+		container.remove();
+		controls.set(PLAIN_CONTROL.name, result);
+		return result.durationMs;
+	};
+
+	for (const testCase of CASES) runHydration(testCase);
+	runPlainControl();
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		const orderedCases = iteration % 2 === 0 ? CASES : [...CASES].reverse();
+		for (const testCase of orderedCases) {
+			samples.get(testCase.name).push(runHydration(testCase));
+		}
+		samples.get(PLAIN_CONTROL.name).push(runPlainControl());
+	}
+
+	for (const testCase of CASES) {
+		const container = document.createElement('main');
+		document.body.appendChild(container);
+		container.innerHTML = serverHtml.get(testCase.name);
+		const instrumented = countSetAllocations(() =>
+			client.hydrateCase(container, testCase.boundaryCount, testCase.childCount),
+		);
+		assertHydrationResult(testCase, instrumented.result);
+		container.remove();
+		setupSetAllocations.set(testCase.name, instrumented.setAllocations);
+		const control = controls.get(testCase.name);
+		targets.push({
+			name: testCase.name,
+			ops: { hydrate: timingStatForJson(summarizeSamples(samples.get(testCase.name))) },
+			meta: {
+				correctness: 'pass',
+				boundaries: testCase.boundaryCount,
+				cells: control.cellCount,
+				hydrateSetupSetAllocations: instrumented.setAllocations,
+				serverNodesAdopted: control.serverNodesAdopted,
+				sidecarsRemoved: control.sidecarsRemoved,
+				unmountClean: control.unmountClean,
+			},
+		});
+	}
+	const plainControl = controls.get(PLAIN_CONTROL.name);
+	targets.push({
+		name: PLAIN_CONTROL.name,
+		ops: { mount: timingStatForJson(summarizeSamples(samples.get(PLAIN_CONTROL.name))) },
+		meta: {
+			correctness: 'pass',
+			boundaries: PLAIN_CONTROL.boundaryCount,
+			cells: plainControl.cellCount,
+			unmountClean: plainControl.unmountClean,
+		},
+	});
+	const smallSetAllocations = setupSetAllocations.get(CASES[0].name);
+	const largeSetAllocations = setupSetAllocations.get(CASES[1].name);
+	const largeTarget = targets.find((target) => target.name === CASES[1].name);
+	if (
+		typeof smallSetAllocations !== 'number' ||
+		typeof largeSetAllocations !== 'number' ||
+		largeTarget === undefined
+	) {
+		throw new Error('deferred boundary setup allocation controls are incomplete');
+	}
+	const addedBoundaryCount = CASES[1].boundaryCount - CASES[0].boundaryCount;
+	const setAllocationsPerAddedBoundary =
+		(largeSetAllocations - smallSetAllocations) / addedBoundaryCount;
+	largeTarget.meta.setAllocationsPerAddedBoundary = setAllocationsPerAddedBoundary;
+	if (setAllocationsPerAddedBoundary > 3.05) {
+		throw new Error(
+			`deferred boundary setup allocated ${setAllocationsPerAddedBoundary.toFixed(3)} Sets per added boundary`,
+		);
+	}
+
+	for (const target of targets) {
+		const operation = target.ops.hydrate ?? target.ops.mount;
+		console.log(
+			`PASS deferred-hydration-boundaries/${target.name}: ${operation.score.toFixed(3)}ms`,
+		);
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	console.error(`FAIL deferred-hydration-boundaries/${failure}`);
+} finally {
+	dom?.window.close();
+	fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+const payload = {
+	suite: 'deferred-hydration-boundaries',
+	iterations,
+	targets,
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+if (failure) process.exitCode = 1;
+// Deferred hydration initializes the runtime's post-paint MessageChannel. Every
+// root has been unmounted and every result has been written, so do not leave the
+// benchmark process alive solely for that reusable scheduler handle.
+process.exit(failure ? 1 : 0);

--- a/benchmarks/deferred-hydration-boundaries/src/client.ts
+++ b/benchmarks/deferred-hydration-boundaries/src/client.ts
@@ -1,0 +1,77 @@
+import { createRoot, hydrateRoot } from 'octane';
+import { load } from 'octane/hydration';
+import { DeferredBoundaryGrid, PlainBoundaryGrid } from './fixture.tsrx';
+
+export interface BoundaryCaseResult {
+	boundaryCount: number;
+	cellCount: number;
+	durationMs: number;
+	serverNodesAdopted: boolean;
+	sidecarsRemoved: boolean;
+	unmountClean: boolean;
+}
+
+function ids(count: number): number[] {
+	return Array.from({ length: count }, (_, index) => index);
+}
+
+export function hydrateCase(
+	container: HTMLElement,
+	boundaryCount: number,
+	childCount: number,
+): BoundaryCaseResult {
+	const cells = Array.from(container.querySelectorAll<HTMLElement>('[data-deferred-cell]'));
+	const props = {
+		boundaryIds: ids(boundaryCount),
+		childIds: ids(childCount),
+		when: load(),
+	};
+
+	const started = performance.now();
+	const root = hydrateRoot(container, DeferredBoundaryGrid, props);
+	const durationMs = performance.now() - started;
+
+	const hydratedCells = container.querySelectorAll<HTMLElement>('[data-deferred-cell]');
+	const serverNodesAdopted =
+		hydratedCells.length === cells.length &&
+		cells.every((cell, index) => hydratedCells[index] === cell);
+	const sidecarsRemoved =
+		container.querySelector(
+			'script[data-octane-hydrate-seed],script[data-octane-native-signals]',
+		) === null;
+	const adoptedBoundaryCount = container.querySelectorAll('[data-octane-hydrate-id]').length;
+	root.unmount();
+	return {
+		boundaryCount: adoptedBoundaryCount,
+		cellCount: cells.length,
+		durationMs,
+		serverNodesAdopted,
+		sidecarsRemoved,
+		unmountClean: container.childNodes.length === 0,
+	};
+}
+
+export function mountPlainCase(
+	container: HTMLElement,
+	boundaryCount: number,
+	childCount: number,
+): BoundaryCaseResult {
+	const props = {
+		boundaryIds: ids(boundaryCount),
+		childIds: ids(childCount),
+	};
+	const root = createRoot(container);
+	const started = performance.now();
+	root.render(PlainBoundaryGrid, props);
+	const durationMs = performance.now() - started;
+	const cells = container.querySelectorAll('[data-plain-cell]');
+	root.unmount();
+	return {
+		boundaryCount,
+		cellCount: cells.length,
+		durationMs,
+		serverNodesAdopted: true,
+		sidecarsRemoved: true,
+		unmountClean: container.childNodes.length === 0,
+	};
+}

--- a/benchmarks/deferred-hydration-boundaries/src/fixture.tsrx
+++ b/benchmarks/deferred-hydration-boundaries/src/fixture.tsrx
@@ -1,0 +1,36 @@
+import { Hydrate } from 'octane';
+import type { HydrationStrategy } from 'octane/hydration';
+
+interface BoundaryGridProps {
+	boundaryIds: readonly number[];
+	childIds: readonly number[];
+	when: HydrationStrategy;
+}
+
+export function DeferredBoundaryGrid(props: BoundaryGridProps) @{
+	<main data-deferred-boundary-grid="">
+		@for (const boundaryId of props.boundaryIds; key boundaryId) {
+			<Hydrate when={props.when} split={false}>
+				@for (const childId of props.childIds; key childId) {
+					<span data-deferred-cell={boundaryId + ':' + childId}>
+						{'cell:' + boundaryId + ':' + childId}
+					</span>
+				}
+			</Hydrate>
+		}
+	</main>
+}
+
+export function PlainBoundaryGrid(props: Omit<BoundaryGridProps, 'when'>) @{
+	<main data-plain-boundary-grid="">
+		@for (const boundaryId of props.boundaryIds; key boundaryId) {
+			<div data-plain-boundary={String(boundaryId)}>
+				@for (const childId of props.childIds; key childId) {
+					<span data-plain-cell={boundaryId + ':' + childId}>
+						{'cell:' + boundaryId + ':' + childId}
+					</span>
+				}
+			</div>
+		}
+	</main>
+}

--- a/benchmarks/deferred-hydration-boundaries/src/server.ts
+++ b/benchmarks/deferred-hydration-boundaries/src/server.ts
@@ -1,0 +1,11 @@
+import { load } from 'octane/hydration';
+import { renderToString } from 'octane/server';
+import { DeferredBoundaryGrid } from './fixture.tsrx';
+
+export function renderCase(boundaryCount: number, childCount: number): string {
+	return renderToString(DeferredBoundaryGrid, {
+		boundaryIds: Array.from({ length: boundaryCount }, (_, index) => index),
+		childIds: Array.from({ length: childCount }, (_, index) => index),
+		when: load(),
+	}).html;
+}

--- a/benchmarks/deferred-hydration-boundaries/tsconfig.json
+++ b/benchmarks/deferred-hydration-boundaries/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["src/**/*.ts", "src/**/*.tsrx"],
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2024"],
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "target": "ES2024",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "paths": {
+      "octane": ["../../packages/octane/src/index.ts"],
+      "octane/*": ["../../packages/octane/src/*"]
+    },
+    "plugins": [{ "name": "@tsrx/typescript-plugin" }]
+  }
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -72,6 +72,7 @@ export const BENCHMARK_SUITES = [
 	'dev-form-diagnostics',
 	'scheduler-depth',
 	'hydration-range-compaction',
+	'deferred-hydration-boundaries',
 	'hydration-render-phase-queue',
 	'behavior-root-events',
 	'radix-collection-order',

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -9010,7 +9010,8 @@ interface HydrateSlot {
 	prefetchPromise: Promise<void> | null;
 	preloadPromise: Promise<void> | null;
 	loadedBody: ComponentBody | null;
-	hydrationWaiters: Set<(reason: HydrationPrefetchWaitReason) => void>;
+	/** Allocated only when procedural prefetch subscribes through waitFor(). */
+	hydrationWaiters: Set<(reason: HydrationPrefetchWaitReason) => void> | null;
 	/** Invalidates async completions from an earlier hydration request. */
 	activationGeneration: number;
 	activationRequested: boolean;
@@ -9281,10 +9282,10 @@ function beginHydratePreload(state: HydrateSlot): Promise<void> | null {
 }
 
 function resolveHydrateWaiters(state: HydrateSlot, reason: HydrationPrefetchWaitReason): void {
-	if (state.hydrationWaiters.size === 0) return;
-	const waiters = [...state.hydrationWaiters];
-	state.hydrationWaiters.clear();
-	for (let i = 0; i < waiters.length; i++) waiters[i](reason);
+	const waiters = state.hydrationWaiters;
+	if (waiters === null) return;
+	state.hydrationWaiters = null;
+	for (const waiter of waiters) waiter(reason);
 }
 
 function waitForHydratePrefetchStrategy(
@@ -9306,13 +9307,13 @@ function waitForHydratePrefetchStrategy(
 			if (settled) return;
 			settled = true;
 			cleanup?.();
-			state.hydrationWaiters.delete(onHydrate);
+			state.hydrationWaiters?.delete(onHydrate);
 			signal.removeEventListener('abort', onAbort);
 			resolve(reason);
 		};
 		const onHydrate = () => finish('hydrate');
 		const onAbort = () => finish('abort');
-		state.hydrationWaiters.add(onHydrate);
+		(state.hydrationWaiters ??= new Set()).add(onHydrate);
 		signal.addEventListener('abort', onAbort, { once: true });
 		cleanup = strategy._s?.({
 			element: state.wrapper,
@@ -9824,7 +9825,7 @@ function createHydrateSlot(
 		prefetchPromise: null,
 		preloadPromise: null,
 		loadedBody: null,
-		hydrationWaiters: new Set(),
+		hydrationWaiters: null,
 		activationGeneration: 0,
 		activationRequested: !serverPreserved,
 		activationReady: !serverPreserved,

--- a/packages/octane/tests/hydration/deferred-hydration-contract.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-contract.test.ts
@@ -714,6 +714,35 @@ describe('deferred hydration contract edges', () => {
 		expect(onHydrated).toHaveBeenCalledOnce();
 	});
 
+	it('resolves every concurrent procedural waitFor subscriber when hydration starts', async () => {
+		let reasons: string[] | undefined;
+		const onHydrated = vi.fn();
+		const prefetch = vi.fn(async ({ waitFor }: HydrationPrefetchContext) => {
+			reasons = await Promise.all([
+				waitFor(idle({ timeout: 100_000 })),
+				waitFor(idle({ timeout: 100_000 })),
+			]);
+		});
+		const props = { when: condition(false), prefetch, onHydrated };
+		container.innerHTML = renderToString(server.ProceduralPrefetchHydration, props).html;
+
+		root = hydrateRoot(container, client.ProceduralPrefetchHydration, props);
+		flushSync(() => {});
+		flushEffects();
+		expect(prefetch).toHaveBeenCalledOnce();
+		expect(reasons).toBeUndefined();
+
+		await act(() =>
+			root!.render(client.ProceduralPrefetchHydration, {
+				...props,
+				when: load(),
+			}),
+		);
+
+		expect(reasons).toEqual(['hydrate', 'hydrate']);
+		expect(onHydrated).toHaveBeenCalledOnce();
+	});
+
 	it('blocks load hydration on awaited procedural work but not fire-and-forget work', async () => {
 		const required = deferred<void>();
 		const onRequiredHydrated = vi.fn();


### PR DESCRIPTION
## Summary

Deferred hydration boundaries no longer allocate an empty procedural-waiter `Set` unless prefetch work calls `waitFor()`. This removes 25% of setup `Set` allocations in the 2,048-boundary server-adoption workload without changing SSR node identity, hydration outcomes, aborts, or cleanup.

## Performance

The deterministic allocation slope is the durable regression signal. The same production build and 2,048-boundary workload produced:

| metric | eager waiters | lazy waiters | delta |
| --- | ---: | ---: | ---: |
| `Set` allocations per added boundary | 4.000 | 3.000 | -25% |
| `Set` allocations at 2,048 boundaries | 8,204 | 6,156 | -2,048 |

Wall-clock timings use a same-sized plain-mount control because absolute timings move with the host. The hydration-to-control ratio improved in all three nine-sample runs; absolute hydration time improved in two runs and was nearly flat in the run where the control also slowed.

| run | eager hydrate | lazy hydrate | eager control | lazy control |
| --- | ---: | ---: | ---: | ---: |
| 1 | 64.775 ms | 53.694 ms | 100.584 ms | 93.734 ms |
| 2 | 66.883 ms | 68.255 ms | 103.354 ms | 112.215 ms |
| 3 | 68.233 ms | 58.868 ms | 102.837 ms | 95.449 ms |

The benchmark also verifies boundary and cell counts, server-node identity, protocol-sidecar removal, and clean unmounts. A deliberately restored eager allocation breached the guard at exactly 4.000 `Set` allocations per boundary.

## Validation

- `pnpm sync`
- `pnpm format:check`
- `pnpm typecheck`
- Scoped `tsgo` runtime typecheck and `tsrx-tsc` benchmark typecheck
- 165 focused hydration and MCP manifest tests in development and production projects
- `node benchmarks/bench.mjs --quick --ratios deferred-hydration-boundaries`
- Full suite under an 8 GiB heap: 2,496 files and 27,553 tests passed. One compiler Volar case timed out only under aggregate load, and 13 Vitest workers timed out while starting; the Volar suite passed 24/24 in isolation, and no runtime or hydration test failed. CI is the clean-runner check for this host-load residual.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790789345&installation_model_id=432790&pr_number=920&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F920&signature=a3a5f963d3b6129760e86abb04e80810351e4f962d65f1c33f5ae103e80d1e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core deferred-hydration runtime paths (`waitFor`, waiter resolution, slot init); behavior is guarded by existing hydration contract tests plus the new allocation benchmark, but prefetch/hydrate races are subtle.
> 
> **Overview**
> **Deferred hydration boundaries no longer create an empty procedural-prefetch waiter `Set` at setup.** In `HydrateSlot`, `hydrationWaiters` starts as `null` and is created only when procedural prefetch calls `waitFor()`; resolution and cleanup use null-safe paths so boundaries that never subscribe avoid one `Set` per boundary (~25% fewer setup `Set` allocations in the 2,048-boundary `load()` workload).
> 
> A new **`deferred-hydration-boundaries`** Node/jsdom benchmark times production `hydrateRoot` at 1 and 2,048 server-preserved `<Hydrate when={load()}>` boundaries, enforces a deterministic allocation slope (fail above 3.05 `Set`s per added boundary), and includes a plain-mount control. The suite is wired into `bench.mjs`, benchmark docs, and the MCP benchmark list.
> 
> **Contract coverage** adds a test that multiple concurrent `waitFor()` subscribers all resolve with `'hydrate'` when activation starts. Changeset records an `octane` patch for the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17488eee3924c2e94637b41e9174184987d2abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->