### PR TITLE
fix: keep continuous events responsive during async Actions

### DIFF
--- a/.changeset/continuous-events-pending-actions.md
+++ b/.changeset/continuous-events-pending-actions.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep ordinary delegated continuous-event updates responsive while an unrelated async transition Action is pending. Continuous events retain microtask batching, and updates explicitly wrapped in a transition still wait for the Action.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -845,6 +845,12 @@ setPage(next); // If it suspends, show the pending fallback.
 startTransition(() => setPage(next)); // Keep the previous content while pending.
 ```
 
+Delegated discrete events such as `click` flush at the outermost dispatch boundary.
+Continuous events such as `mousemove`, `pointermove`, and `scroll` retain microtask
+batching; Octane does not give them a separate interruptible priority lane. Ordinary
+delegated event updates do not join an unrelated pending async Action, while an
+explicit `startTransition` inside the handler still opts into transition work.
+
 Already-visible Suspense content stays visible without a timeout during a
 transition, matching React's
 [shell-retention contract](https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-reconciler/src/ReactFiberWorkLoop.js#L1356-L1369).

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1231,10 +1231,11 @@ let TRANSITION_DEPTH = 0;
  * callback; for an `async` action it is already 0 by the time the continuation
  * after the first `await` runs, so post-await setters would otherwise schedule
  * at urgent priority. Keeping this count elevated across the in-flight window
- * makes those setters transition-priority (React 19 Actions). Caveat: it's a
- * process-global window, so an unrelated urgent update fired while an async
- * action is pending is also tagged transition — perfect per-action scoping
- * would need AsyncContext, which isn't available in the browser target.
+ * preserves Octane's automatic post-await transition priority. Caveat: it's a
+ * process-global window, so an unrelated update outside a delegated event or
+ * flushSync while an async action is pending is also tagged transition —
+ * perfect per-action scoping would need AsyncContext, which isn't available
+ * in the browser target.
  */
 let ASYNC_TRANSITION_COUNT = 0;
 
@@ -1318,8 +1319,6 @@ interface TransitionActionBatch {
 let ACTIVE_TRANSITION_ACTION_BATCH: TransitionActionBatch | null = null;
 /** The entangled batch shared by explicit transitions while an Action is awaiting. */
 let IN_FLIGHT_TRANSITION_ACTION_BATCH: TransitionActionBatch | null = null;
-/** Direct updates from discrete handlers stay urgent even while an Action is awaiting. */
-let ACTIVE_DISCRETE_EVENT_DEPTH = 0;
 
 function createTransitionActionBatch(): TransitionActionBatch {
 	return { updates: new Map(), pendingActions: 0, closed: false, flushed: false };
@@ -1328,9 +1327,11 @@ function createTransitionActionBatch(): TransitionActionBatch {
 function transitionActionBatchForUpdate(): TransitionActionBatch | null {
 	if (ACTIVE_TRANSITION_ACTION_BATCH !== null) return ACTIVE_TRANSITION_ACTION_BATCH;
 	// AsyncContext is not available in the browser target, so post-await Action
-	// continuations share the one entangled in-flight batch. Explicit urgent
-	// surfaces opt out: their updates must commit immediately.
-	if (syncFlush || ACTIVE_DISCRETE_EVENT_DEPTH > 0) return null;
+	// continuations share the one entangled in-flight batch. Delegated handlers
+	// (including continuous events) and flushSync opt out of that fallback.
+	// This only selects the batch: continuous events still flush in a microtask,
+	// and an explicit transition inside a handler wins above.
+	if (syncFlush || _dispatchDepth > 0) return null;
 	return IN_FLIGHT_TRANSITION_ACTION_BATCH;
 }
 
@@ -3863,7 +3864,7 @@ function scheduleRender(block: Block): void {
 	const mode: 'urgent' | 'transition' =
 		TRANSITION_DEPTH > 0 ||
 		(renderPhaseSelf && block.currentRenderMode === 'transition') ||
-		(!syncFlush && ACTIVE_DISCRETE_EVENT_DEPTH === 0 && ASYNC_TRANSITION_COUNT > 0)
+		(!syncFlush && _dispatchDepth === 0 && ASYNC_TRANSITION_COUNT > 0)
 			? 'transition'
 			: 'urgent';
 	const deferred = DEFERRED_SPAWN || (renderPhaseSelf && block.currentRenderDeferred);
@@ -16491,17 +16492,14 @@ function unregisterDelegationTarget(target: Node): void {
 }
 
 /**
- * Event types React tags as DiscreteEventPriority. Updates triggered from
- * these handlers MUST commit synchronously before the handler returns to
- * the browser — otherwise:
- *   - fast double-clicks see pre-flush state and double-submit
- *   - autofocus after reveal misses (focus runs before the microtask)
- *   - `e.preventDefault(); setX(...); read(measure)` reads stale layout
- *   - controlled inputs drop keystrokes (value lags one task)
+ * Event types that use Octane's outermost delegated-dispatch sync flush, so
+ * subsequent interactions observe committed state and controlled values.
+ * Updates still batch inside a handler: setState followed by a DOM read does
+ * not observe the update without an explicit flushSync.
  *
- * Source: facebook/react packages/react-dom-bindings/src/events/
- * ReactDOMEventListener.js — getEventPriority's DiscreteEventPriority arm.
- * Kept verbatim so future React additions can be picked up by diff.
+ * Based on facebook/react packages/react-dom-bindings/src/events/
+ * ReactDOMEventListener.js — getEventPriority. React's priority classification
+ * is separate from its sync-lane microtask flush boundary.
  */
 const DISCRETE_EVENTS = new Set<string>([
 	'auxclick',
@@ -16563,6 +16561,8 @@ const DISCRETE_EVENTS = new Set<string>([
  * — nested handlers (e.g. a click handler that synthetically dispatches another
  * event on the same target chain) inherit the outer flush instead of producing
  * intermediate commits that React wouldn't.
+ * It also scopes ordinary delegated updates outside an unrelated pending Action,
+ * independently of whether this event type flushes synchronously.
  */
 let _dispatchDepth = 0;
 
@@ -16671,12 +16671,10 @@ function reportListenerError(err: unknown): void {
 	console.error(err);
 }
 
-// React parity: discrete events (click, keydown, input, …) must commit before the
-// browser regains control — otherwise fast double-clicks, focus-after-reveal,
-// e.preventDefault+setState+measure patterns and controlled-input value reads all see
-// stale state. Only the OUTERMOST dispatch flushes — nested synthetic dispatches
-// inherit the outer commit window. Non-discrete events keep microtask-batched
-// semantics so they don't thrash the scheduler.
+// Only the OUTERMOST discrete dispatch flushes: nested programmatic dispatches
+// inherit the outer commit window. Non-discrete events keep microtask batching;
+// they must not be staged with an unrelated async Action merely because they do
+// not flush synchronously here.
 function maybeFlushDiscrete(type: string): void {
 	if (_dispatchDepth === 0 && DISCRETE_EVENTS.has(type)) {
 		// Commit handler-scheduled work first, so the controlled restore below
@@ -16756,8 +16754,6 @@ function dispatchDelegated(event: Event): void {
 				}
 			: null;
 	if (submitRec !== null) ACTIVE_SUBMIT_DISPATCH = submitRec;
-	const discrete = DISCRETE_EVENTS.has(event.type);
-	if (discrete) ACTIVE_DISCRETE_EVENT_DEPTH++;
 	const nativeBatch = beginNativeEventBatch(event);
 	try {
 		// CAPTURE_DELEGATED types have BOTH dispatchers attached as capture-phase
@@ -16807,7 +16803,6 @@ function dispatchDelegated(event: Event): void {
 		} catch (error) {
 			reportListenerError(error);
 		}
-		if (discrete) ACTIVE_DISCRETE_EVENT_DEPTH--;
 		_dispatchDepth--;
 		maybeFlushDiscrete(event.type);
 	}
@@ -16832,8 +16827,6 @@ function dispatchDelegatedCapture(event: Event): void {
 		node = node.$$portalParent ? node.$$portalParent : node.parentNode;
 	}
 	_dispatchDepth++;
-	const discrete = DISCRETE_EVENTS.has(event.type);
-	if (discrete) ACTIVE_DISCRETE_EVENT_DEPTH++;
 	const nativeBatch = beginNativeEventBatch(event);
 	try {
 		for (let i = CAPTURE_PATH.length - 1; i >= pathBase; i--) {
@@ -16862,7 +16855,6 @@ function dispatchDelegatedCapture(event: Event): void {
 		} catch (error) {
 			reportListenerError(error);
 		}
-		if (discrete) ACTIVE_DISCRETE_EVENT_DEPTH--;
 		_dispatchDepth--;
 		finishCaptureDispatch(event);
 	}

--- a/packages/octane/tests/_fixtures/continuous-actions.tsrx
+++ b/packages/octane/tests/_fixtures/continuous-actions.tsrx
@@ -1,0 +1,65 @@
+import { startTransition, useState, useTransition } from 'octane';
+
+export type EventPhase = 'capture' | 'bubble';
+export type ActionProbeOptions = {
+	phase: EventPhase;
+	transition?: boolean;
+	postAwait?: boolean;
+};
+
+export type ActionProbeProps =
+	ActionProbeOptions & {
+		gate: Promise<void>;
+		record(label: string, event: Event): void;
+	};
+
+export function ContinuousActionProbe(props: ActionProbeProps) @{
+	const [moves, setMoves] = useState(0);
+	const [saved, setSaved] = useState('initial');
+	const [pending, start] = useTransition();
+	const move = (event: MouseEvent) => {
+		props.record('before', event);
+		if (props.transition) startTransition(() => setMoves((value) => value + 1));
+		else setMoves((value) => value + 1);
+		props.record('after', event);
+	};
+	const handlers =
+		props.phase === 'capture' ? { onMouseMoveCapture: move } : { onMouseMove: move };
+	<section>
+		<button
+			data-start
+			onClick={() => start(async () => {
+				setSaved('started');
+				await props.gate;
+				setSaved('finished');
+			})}
+		>Start action</button>
+		<div data-move {...handlers}>Move here</div>
+		<output data-moves>{String(moves)}</output>
+		<output data-saved>{saved as string}</output>
+		<output data-pending>
+			{pending ? 'pending' : 'idle'}
+		</output>
+	</section>
+}
+
+export function PostAwaitActionProbe(props: ActionProbeProps) @{
+	const [saved, setSaved] = useState('initial');
+	const [pending, start] = useTransition();
+	const begin = (event: MouseEvent) => start(async () => {
+		await Promise.resolve();
+		setSaved('intermediate');
+		props.record('continuation', event);
+		await props.gate;
+		setSaved('finished');
+	});
+	const handlers =
+		props.phase === 'capture' ? { onClickCapture: begin } : { onClick: begin };
+	<section>
+		<button data-start {...handlers}>Start action</button>
+		<output data-saved>{saved as string}</output>
+		<output data-pending>
+			{pending ? 'pending' : 'idle'}
+		</output>
+	</section>
+}

--- a/packages/octane/tests/browser/continuous-actions/continuous-actions.test.ts
+++ b/packages/octane/tests/browser/continuous-actions/continuous-actions.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+import { launchBrowser } from '../../../../../test-utils/playwright-browser.js';
+import { createServer, type Plugin, type ViteDevServer } from 'vite';
+import { compile as compileToReact } from '@tsrx/react';
+import { transformSync } from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { octane } from 'octane/compiler/vite';
+import type { ActionProbeOptions } from '../../_fixtures/continuous-actions.tsrx';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(HERE, '../../_fixtures/continuous-actions.tsrx');
+const REACT_FIXTURE_ID = '\0continuous-actions-react-fixture';
+let server: ViteDevServer;
+let browser: Browser;
+let baseUrl: string;
+let page: Page | undefined;
+let pageFailures: string[] = [];
+
+function reactFixturePlugin(): Plugin {
+	return {
+		name: 'continuous-actions-react-fixture',
+		enforce: 'pre',
+		async resolveId(id, importer) {
+			if (id === 'virtual:continuous-actions-react-fixture') return REACT_FIXTURE_ID;
+			if (id === 'octane' && importer === REACT_FIXTURE_ID) {
+				return this.resolve('react', FIXTURE, { skipSelf: true });
+			}
+		},
+		load(id) {
+			if (id !== REACT_FIXTURE_ID) return;
+			const result = compileToReact(readFileSync(FIXTURE, 'utf8'), FIXTURE);
+			if (result.errors?.length)
+				throw new Error(result.errors.map((error: Error) => error.message).join('\n'));
+			return transformSync(result.code, {
+				loader: 'tsx',
+				jsx: 'automatic',
+				jsxImportSource: 'react',
+				target: 'esnext',
+				format: 'esm',
+				sourcefile: FIXTURE,
+			}).code;
+		},
+	};
+}
+
+beforeAll(async () => {
+	server = await createServer({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		cacheDir: resolve(HERE, '../../../../../node_modules/.vite/octane-continuous-actions'),
+		plugins: [reactFixturePlugin(), octane()],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	await server.listen();
+	const address = server.httpServer!.address();
+	if (!address || typeof address === 'string') throw new Error('No Vite TCP port');
+	baseUrl = `http://127.0.0.1:${address.port}`;
+	browser = await launchBrowser({ headless: true });
+});
+
+afterEach(async () => {
+	const failures = pageFailures;
+	await page?.close();
+	page = undefined;
+	pageFailures = [];
+	expect(failures).toEqual([]);
+});
+
+afterAll(async () => {
+	await browser?.close();
+	await server?.close();
+});
+
+async function openCase(options: ActionProbeOptions): Promise<Page> {
+	page = await browser.newPage();
+	page.on('pageerror', (error) => pageFailures.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'warning' || message.type() === 'error')
+			pageFailures.push(message.text());
+	});
+	await page.goto(baseUrl);
+	await page.waitForFunction(() => Boolean(window.__continuousActions));
+	await page.evaluate((options) => window.__continuousActions.mount(options), options);
+	await page.waitForSelector('#octane-root [data-start]');
+	await page.waitForSelector('#react-root [data-start]');
+	return page;
+}
+
+async function startActions(page: Page): Promise<void> {
+	await page.locator('#octane-root [data-start]').click();
+	await page.locator('#react-root [data-start]').click();
+	await page.waitForFunction(() =>
+		['octane', 'react'].every(
+			(runtime) =>
+				window.__continuousActions.state(runtime as 'octane' | 'react').pending === 'pending',
+		),
+	);
+}
+
+async function readBoth(page: Page) {
+	return page.evaluate(() => ({
+		octane: window.__continuousActions.state('octane'),
+		react: window.__continuousActions.state('react'),
+	}));
+}
+
+async function taskBoundary(page: Page): Promise<void> {
+	await page.evaluate(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+}
+
+async function releaseActions(page: Page): Promise<void> {
+	await page.evaluate(() => window.__continuousActions.release());
+	await page.waitForFunction(() =>
+		['octane', 'react'].every(
+			(runtime) =>
+				window.__continuousActions.state(runtime as 'octane' | 'react').pending === 'idle',
+		),
+	);
+}
+
+describe.sequential('continuous input during async Actions', () => {
+	// React 19.2.7 classifies mousemove as continuous input rather than a transition:
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom-bindings/src/events/ReactDOMEventListener.js#L372-L391
+	for (const phase of ['capture', 'bubble'] as const) {
+		for (const interaction of ['trusted', 'programmatic'] as const) {
+			it(`${phase}: accepts ${interaction} input before the pending Action settles without synchronous DOM writes`, async () => {
+				const page = await openCase({ phase });
+				await startActions(page);
+				for (const runtime of ['octane', 'react'] as const) {
+					if (interaction === 'trusted') {
+						const box = await page.locator(`#${runtime}-root [data-move]`).boundingBox();
+						if (!box) throw new Error('Missing input surface');
+						await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+					} else {
+						const immediate = await page.evaluate((runtime) => {
+							document
+								.querySelector(`#${runtime}-root [data-move]`)!
+								.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+							return window.__continuousActions.state(runtime);
+						}, runtime);
+						expect(immediate).toEqual({ moves: 0, saved: 'initial', pending: 'pending' });
+					}
+				}
+				await page.waitForFunction(() => window.__continuousActions.state('react').moves === 1);
+				const logs = await page.evaluate(() => window.__continuousActions.logs);
+				for (const runtime of ['octane', 'react'] as const) {
+					expect(logs[runtime]).toEqual([
+						{
+							label: 'before',
+							trusted: interaction === 'trusted',
+							moves: 0,
+							saved: 'initial',
+							pending: 'pending',
+						},
+						{
+							label: 'after',
+							trusted: interaction === 'trusted',
+							moves: 0,
+							saved: 'initial',
+							pending: 'pending',
+						},
+					]);
+				}
+				const pending = await readBoth(page);
+				expect(pending.react).toEqual({ moves: 1, saved: 'initial', pending: 'pending' });
+				expect(pending.octane).toEqual(pending.react);
+				await releaseActions(page);
+				const settled = await readBoth(page);
+				expect(settled.react).toEqual({ moves: 1, saved: 'finished', pending: 'idle' });
+				expect(settled.octane).toEqual(settled.react);
+			});
+		}
+
+		it(`${phase}: keeps explicitly transitioned input inside the pending Action`, async () => {
+			const page = await openCase({ phase, transition: true });
+			await startActions(page);
+			await page.evaluate(() => {
+				for (const runtime of ['octane', 'react'] as const) {
+					document
+						.querySelector(`#${runtime}-root [data-move]`)!
+						.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+				}
+			});
+			await taskBoundary(page);
+			const pending = await readBoth(page);
+			expect(pending.react).toEqual({ moves: 0, saved: 'initial', pending: 'pending' });
+			expect(pending.octane).toEqual(pending.react);
+			await releaseActions(page);
+			const settled = await readBoth(page);
+			expect(settled.react).toEqual({ moves: 1, saved: 'finished', pending: 'idle' });
+			expect(settled.octane).toEqual(settled.react);
+		});
+
+		it(`${phase}: retains the Action's post-await write after a trusted click`, async () => {
+			const page = await openCase({ phase, postAwait: true });
+			await page.locator('#octane-root [data-start]').click();
+			await page.waitForFunction(() =>
+				window.__continuousActions.logs.octane.some(({ label }) => label === 'continuation'),
+			);
+			await taskBoundary(page);
+			// OCTANE DIVERGENCE: an Action retains its unwrapped post-await writes.
+			// A trusted event's callback microtasks still expose window.event, but
+			// the Action continuation must not be mistaken for new user input.
+			expect(await page.evaluate(() => window.__continuousActions.state('octane'))).toEqual({
+				moves: 0,
+				saved: 'initial',
+				pending: 'pending',
+			});
+			await releaseActions(page);
+			expect(await page.evaluate(() => window.__continuousActions.state('octane'))).toEqual({
+				moves: 0,
+				saved: 'finished',
+				pending: 'idle',
+			});
+		});
+	}
+});

--- a/packages/octane/tests/browser/continuous-actions/index.html
+++ b/packages/octane/tests/browser/continuous-actions/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Continuous input during async Actions</title>
+		<style>
+			section {
+				padding: 20px;
+			}
+			[data-move] {
+				width: 240px;
+				height: 64px;
+				margin-top: 20px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="octane-root"></div>
+		<div id="react-root"></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/continuous-actions/main.ts
+++ b/packages/octane/tests/browser/continuous-actions/main.ts
@@ -1,0 +1,65 @@
+/// <reference path="./react-fixture.d.ts" />
+
+import { createRoot as createOctaneRoot } from '../../../src/index.js';
+import { createRoot as createReactRoot } from 'react-dom/client';
+import { createElement } from 'react';
+import * as OctaneFixture from '../../_fixtures/continuous-actions.tsrx';
+import * as ReactFixture from 'virtual:continuous-actions-react-fixture';
+import type { ActionProbeOptions } from '../../_fixtures/continuous-actions.tsrx';
+
+type RuntimeName = 'octane' | 'react';
+type ProbeState = { moves: number; saved: string; pending: string };
+type HandlerRecord = ProbeState & { label: string; trusted: boolean };
+const runtimes: RuntimeName[] = ['octane', 'react'];
+const containers = {
+	octane: document.querySelector<HTMLElement>('#octane-root')!,
+	react: document.querySelector<HTMLElement>('#react-root')!,
+};
+const logs: Record<RuntimeName, HandlerRecord[]> = { octane: [], react: [] };
+const releases: Array<() => void> = [];
+
+function state(runtime: RuntimeName): ProbeState {
+	const container = containers[runtime];
+	return {
+		moves: Number(container.querySelector('[data-moves]')?.textContent ?? '0'),
+		saved: container.querySelector('[data-saved]')?.textContent ?? '',
+		pending: container.querySelector('[data-pending]')?.textContent ?? '',
+	};
+}
+
+function mount(options: ActionProbeOptions): void {
+	for (const runtime of runtimes) {
+		const props = {
+			...options,
+			gate: new Promise<void>((resolve) => releases.push(resolve)),
+			record(label: string, event: Event) {
+				const native = (event as Event & { nativeEvent?: Event }).nativeEvent ?? event;
+				logs[runtime].push({ ...state(runtime), label, trusted: native.isTrusted });
+			},
+		};
+		const name = options.postAwait ? 'PostAwaitActionProbe' : 'ContinuousActionProbe';
+		if (runtime === 'octane') {
+			createOctaneRoot(containers[runtime]).render(OctaneFixture[name], props);
+		} else {
+			createReactRoot(containers[runtime]).render(createElement(ReactFixture[name], props));
+		}
+	}
+}
+
+window.__continuousActions = {
+	mount,
+	logs,
+	state,
+	release: () => releases.forEach((resolve) => resolve()),
+};
+
+declare global {
+	interface Window {
+		__continuousActions: {
+			mount(options: ActionProbeOptions): void;
+			logs: Record<RuntimeName, HandlerRecord[]>;
+			state(runtime: RuntimeName): ProbeState;
+			release(): void;
+		};
+	}
+}

--- a/packages/octane/tests/browser/continuous-actions/react-fixture.d.ts
+++ b/packages/octane/tests/browser/continuous-actions/react-fixture.d.ts
@@ -1,0 +1,8 @@
+declare module 'virtual:continuous-actions-react-fixture' {
+	export const ContinuousActionProbe: import('react').ComponentType<
+		import('../../_fixtures/continuous-actions.tsrx').ActionProbeProps
+	>;
+	export const PostAwaitActionProbe: import('react').ComponentType<
+		import('../../_fixtures/continuous-actions.tsrx').ActionProbeProps
+	>;
+}

--- a/packages/octane/tests/conformance/_fixtures/async-actions.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/async-actions.tsrx
@@ -1,8 +1,55 @@
 import { useState, useTransition, useOptimistic } from 'octane';
 
+export function AsyncActionEvents(props: {
+	gate: Promise<void>;
+	transition: boolean;
+	resume?: Promise<void>;
+	onResume?: () => void;
+	stopPropagation?: boolean;
+}) @{
+	const [saved, setSaved] = useState('initial');
+	const [count, setCount] = useState(0);
+	const [pending, start] = useTransition();
+	const increment = (event: Event) => {
+		if (props.stopPropagation) event.stopPropagation();
+		if (props.transition) start(() => setCount((value) => value + 1));
+		else setCount((value) => value + 1);
+	};
+	<div>
+		<button
+			id="event-action"
+			type="button"
+			onClick={() => start(async () => {
+				setSaved('started');
+				await props.resume;
+				setSaved('awaited');
+				props.onResume?.();
+				await props.gate;
+				setSaved('finished');
+			})}
+		>Start action</button>
+		<button id="event-pointermove" type="button" onPointerMove={increment}>Pointer move</button>
+		<button id="event-mousemove" type="button" onMouseMoveCapture={increment}>Mouse move</button>
+		<button id="event-wheel" type="button" onWheel={increment}>Wheel</button>
+		<div id="event-scroll" onScroll={increment}>Scroll</div>
+		<button id="event-pointerdown" type="button" onPointerDown={increment}>Pointer down</button>
+		<button id="event-click" type="button" onClickCapture={increment}>Click</button>
+		<output id="event-count">{String(count)}</output>
+		<output id="event-saved">{saved as string}</output>
+		<output id="event-pending">
+			{pending ? 'pending' : 'idle'}
+		</output>
+	</div>
+}
+
 // useOptimistic rebases the pending optimistic update on top of a passthrough that
 // changes mid-action, using a CUSTOM reducer. Per ReactAsyncActions-test.js:685 / :887.
-export function OptimisticRebase(props) @{
+interface OptimisticRebaseProps {
+	gate: Promise<void>;
+	bind: (api: { add: () => void; bumpSaved: () => void }) => void;
+}
+
+export function OptimisticRebase(props: OptimisticRebaseProps) @{
 	const [saved, setSaved] = useState(1);
 	const [isPending, start] = useTransition();
 	const [optimistic, addOptimistic] = useOptimistic(saved, (n: number, delta: number) => n + delta);
@@ -18,14 +65,19 @@ export function OptimisticRebase(props) @{
 		<span id="pending">
 			{isPending ? '1' : '0'}
 		</span>
-		<span id="opt">{optimistic as string}</span>
-		<span id="saved">{saved as string}</span>
+		<span id="opt">{String(optimistic)}</span>
+		<span id="saved">{String(saved)}</span>
 	</div>
 }
 
 // Several addOptimistic calls in ONE async action all fold onto the passthrough.
 // Per ReactAsyncActions-test.js:1141 "useOptimistic can update repeatedly in the same async action".
-export function OptimisticRepeated(props) @{
+interface OptimisticRepeatedProps {
+	gate: Promise<void>;
+	bind: (run: () => void) => void;
+}
+
+export function OptimisticRepeated(props: OptimisticRepeatedProps) @{
 	const [saved, setSaved] = useState(0);
 	const [isPending, start] = useTransition();
 	const [optimistic, addOptimistic] = useOptimistic(saved, (n: number, delta: number) => n + delta);
@@ -42,7 +94,7 @@ export function OptimisticRepeated(props) @{
 		<span id="pending">
 			{isPending ? '1' : '0'}
 		</span>
-		<span id="opt">{optimistic as string}</span>
-		<span id="saved">{saved as string}</span>
+		<span id="opt">{String(optimistic)}</span>
+		<span id="saved">{String(saved)}</span>
 	</div>
 }

--- a/packages/octane/tests/conformance/async-actions.test.ts
+++ b/packages/octane/tests/conformance/async-actions.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { mount, flushEffects } from '../_helpers';
 import { flushSync } from '../../src/index.js';
-import { OptimisticRebase, OptimisticRepeated } from './_fixtures/async-actions.tsrx';
+import {
+	AsyncActionEvents,
+	OptimisticRebase,
+	OptimisticRepeated,
+} from './_fixtures/async-actions.tsrx';
 
 function deferred<T = void>() {
 	let resolve!: (v: T) => void;
@@ -20,6 +24,126 @@ async function settle() {
 	flushEffects();
 }
 
+async function microtasks() {
+	for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe('conformance: delegated events during async actions', () => {
+	// Per ReactDOMNativeEventHeuristic-test.js:53/:285 (event update priority) and
+	// ReactAsyncActions-test.js:352 (unrelated urgent updates during an async Action).
+	// Their event-scheduling × pending-Action cross-product is an additional regression.
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js#L53
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js#L352-L430
+	it.each([
+		{
+			type: 'pointermove',
+			discrete: false,
+			transition: false,
+			name: 'bubble pointermove stays responsive',
+		},
+		{
+			type: 'mousemove',
+			discrete: false,
+			transition: false,
+			name: 'capture mousemove stays responsive',
+		},
+		{ type: 'wheel', discrete: false, transition: false, name: 'wheel stays responsive' },
+		{
+			type: 'scroll',
+			discrete: false,
+			transition: false,
+			name: 'non-bubbling scroll stays responsive',
+		},
+		{
+			type: 'pointerdown',
+			discrete: true,
+			transition: false,
+			name: 'bubble pointerdown still commits synchronously',
+		},
+		{
+			type: 'click',
+			discrete: true,
+			transition: false,
+			name: 'capture click still commits synchronously',
+		},
+		{
+			type: 'pointermove',
+			discrete: false,
+			transition: true,
+			name: 'explicit pointermove transition remains held',
+		},
+	])('$name while an action is pending', async ({ type, discrete, transition }) => {
+		const gate = deferred();
+		const r = mount(AsyncActionEvents, { gate: gate.promise, transition });
+		try {
+			// No act or flushSync: these updates must retain their own event priority.
+			(r.find('#event-action') as HTMLButtonElement).click();
+			await microtasks();
+			expect(r.find('#event-pending').textContent).toBe('pending');
+			// Both the Action's initial setter and its post-await setter remain held.
+			expect(r.find('#event-saved').textContent).toBe('initial');
+
+			r.find(`#event-${type}`).dispatchEvent(new Event(type, { bubbles: type !== 'scroll' }));
+			// Continuous interactions retain microtask batching rather than flushing inline.
+			expect(r.find('#event-count').textContent).toBe(discrete ? '1' : '0');
+			await microtasks();
+			expect(r.find('#event-count').textContent).toBe(transition ? '0' : '1');
+			expect(r.find('#event-pending').textContent).toBe('pending');
+			expect(r.find('#event-saved').textContent).toBe('initial');
+
+			gate.resolve();
+			await microtasks();
+			expect(r.find('#event-count').textContent).toBe('1');
+			expect(r.find('#event-pending').textContent).toBe('idle');
+			expect(r.find('#event-saved').textContent).toBe('finished');
+		} finally {
+			gate.resolve();
+			await microtasks();
+			r.unmount();
+		}
+	});
+
+	// Per ReactAsyncActions-test.js:352; also preserves Octane's automatic post-await staging.
+	it('keeps a resumed action held after a stopped continuous event', async () => {
+		const resume = deferred();
+		const finish = deferred();
+		let resumed = false;
+		const r = mount(AsyncActionEvents, {
+			gate: finish.promise,
+			resume: resume.promise,
+			onResume: () => {
+				resumed = true;
+			},
+			transition: false,
+			stopPropagation: true,
+		});
+		try {
+			(r.find('#event-action') as HTMLButtonElement).click();
+			await microtasks();
+			r.find('#event-pointermove').dispatchEvent(new Event('pointermove', { bubbles: true }));
+			await microtasks();
+			expect(r.find('#event-count').textContent).toBe('1');
+
+			resume.resolve();
+			await microtasks();
+			expect(resumed).toBe(true);
+			expect(r.find('#event-saved').textContent).toBe('initial');
+			expect(r.find('#event-pending').textContent).toBe('pending');
+			expect(r.find('#event-count').textContent).toBe('1');
+
+			finish.resolve();
+			await microtasks();
+			expect(r.find('#event-saved').textContent).toBe('finished');
+			expect(r.find('#event-pending').textContent).toBe('idle');
+		} finally {
+			resume.resolve();
+			finish.resolve();
+			await microtasks();
+			r.unmount();
+		}
+	});
+});
+
 // Ports of ReactAsyncActions-test.js useOptimistic cases. octane folds the optimistic
 // queue onto the CURRENT passthrough each render, so a passthrough change mid-action
 // rebases the pending update — matching React.
@@ -27,7 +151,7 @@ describe('conformance: useOptimistic rebasing (async actions)', () => {
 	it('rebases the pending optimistic update on top of a passthrough that changes mid-action', async () => {
 		const gate = deferred();
 		let api!: { add: () => void; bumpSaved: () => void };
-		const r = mount(OptimisticRebase as any, { gate: gate.promise, bind: (a: any) => (api = a) });
+		const r = mount(OptimisticRebase, { gate: gate.promise, bind: (a) => (api = a) });
 		flushSync(() => {});
 		expect(r.find('#opt').textContent).toBe('1');
 		expect(r.find('#saved').textContent).toBe('1');
@@ -56,7 +180,7 @@ describe('conformance: useOptimistic rebasing (async actions)', () => {
 	it('folds several addOptimistic calls in one action onto the passthrough', async () => {
 		const gate = deferred();
 		let run!: () => void;
-		const r = mount(OptimisticRepeated as any, { gate: gate.promise, bind: (f: any) => (run = f) });
+		const r = mount(OptimisticRepeated, { gate: gate.promise, bind: (f) => (run = f) });
 		flushSync(() => {});
 		expect(r.find('#opt').textContent).toBe('0');
 


### PR DESCRIPTION
## Summary

- Keep ordinary delegated continuous-event updates responsive while an unrelated async transition Action is pending.
- Preserve discrete-event sync flushing, continuous-event microtask batching, and explicitly requested transitions.

## Why

Only discrete handlers were excluded from the process-global pending-Action fallback. A `mousemove`, `pointermove`, `wheel`, or `scroll` update could therefore be staged with an unrelated Action and remain invisible after the event's normal microtask flush, until that Action resolved.

The new browser regression holds an Action open, dispatches capture/bubble mouse moves, and compares the same fixture against React. Four browser cases failed before the fix and pass afterward. The conformance suite separately covers additional event types, propagation cancellation, and Action continuation cleanup.

## Changes

- Reuse the existing delegated dispatch depth to exclude ordinary handlers from the fallback in both update staging and render scheduling; remove the redundant discrete-only counter.
- Keep explicit transition context authoritative. Do not change the discrete-event set, flush boundary, native event batching, or controlled-value restoration.
- Add real Chromium React/Octane comparisons for trusted and programmatic movement, plus controls for explicit transitions and post-await Action retention.
- Document the scheduling contract and add an `octane` patch changeset.

## Validation

- [x] `pnpm sync`; generated files are current and the worktree is clean.
- [x] Scoped typecheck: all 7 changed program files passed `tsrx-tsc` through `scripts/typecheck-files.mjs`.
- [x] Scoped Prettier: all 10 changed files passed `scripts/format-files.mjs --check`.
- [x] Targeted development/production tests: **256 passed** across async Actions, transitions, event listeners, browser event emission, controlled restoration/checkables, form Actions, view transitions, scheduler priority, and discrete-flush reentrancy.
- [x] Real Chromium: **20 passed**, including the new 8-test continuous-Action suite and the existing 12-test native-change suite.
- [x] `git diff --check`.
- [ ] Full `pnpm format:check`, `pnpm typecheck`, and `pnpm test` were not run locally; repository CI supplies the broad checks.

All final local checks were rerun after rebasing onto `456ac4b2e` and installing its updated TSRX versions. The local install covers the selected validation/benchmark dependency graph rather than every workspace package. Scoped checks were invoked through their unchanged Node scripts because pnpm's default pre-run behavior attempts a full-workspace reinstall; the final sync used `pnpm_config_verify_deps_before_run=warn` to report that partial workspace without reinstalling it. Registry and supply-chain policies were not changed.

### Performance

Paired production Chromium runs used the same dependencies and machine (macOS arm64, Node 26.4.0), comparing base `456ac4b2e` with this patch. Commands: `node benchmarks/event-delegation/work.mjs` and `node benchmarks/event-delegation/run.mjs octane-tsrx 10` for each candidate, with the harness's normal warmup.

| Measure | Base | Patched |
| --- | ---: | ---: |
| Mean event burst | 5.38 ms | 5.11 ms |
| p95 | 7.60 ms | 6.70 ms |
| Relative margin of error | 19.87% | 20.61% |
| Built fixture JS, raw | 197,855 B | 197,772 B |
| Built fixture JS, gzip | 64,100 B | 64,074 B |

Timing differences are within noise; no speedup is claimed. Both candidates pass identical deterministic gates: 512 hosts; 128 events, captures, bubbles, updated fields and outputs; no invalid `currentTarget`; 256 definitions sharing one descriptor/getter and one capture path. The runtime change introduces no new allocation, listener, or scheduling hop. Bundle totals describe this fixture, not application startup cost.

## Risk / follow-ups

- This fixes independently reproduced continuous-event starvation. It does **not** establish or claim to fix the separately reported intermittent missing-submit issue.
- Arbitrary native `addEventListener` callbacks outside Octane's delegated dispatcher remain outside this fix. The global fallback's inability to distinguish other unrelated async work from post-await Action updates also remains.
- Continuous events do not gain React's separate interruptible priority lane; their existing microtask batching is preserved. No compiler, SSR, or hydration behavior is intentionally changed; those broader modes were not separately benchmarked locally.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core update scheduling and async Action entanglement in `runtime.ts`; behavior is heavily regression-tested but unrelated updates outside delegated dispatch can still inherit transition priority while an Action is pending.
> 
> **Overview**
> Fixes **continuous delegated input** (`mousemove`, `pointermove`, `wheel`, `scroll`, etc.) being staged with an unrelated in-flight async Action so updates never appeared after their normal microtask flush.
> 
> **Runtime:** Drops `ACTIVE_DISCRETE_EVENT_DEPTH` and treats **any** outer delegated dispatch (`_dispatchDepth > 0`) as opting out of the global `IN_FLIGHT_TRANSITION_ACTION_BATCH` fallback for both batch selection and urgent vs transition scheduling. **Discrete** events still sync-flush at the outermost boundary; continuous events still batch in microtasks. **`startTransition` inside a handler** still defers those updates with the Action.
> 
> **Docs/tests:** Documents the contract in `differences-from-react.md`, adds a patch changeset, conformance cases for multiple event types, and Chromium Octane vs React browser regression for movement during a held Action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ee3942650893bae1c0ffd3a91ec11f9b80540a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790888689&installation_model_id=432790&pr_number=925&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F925&signature=2baae748c0344904dddeb057d5ab676f95d6622e8beab64460f2bd7855e07320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->