### PR TITLE
fix: respect root boundaries and native event cancellation

### DIFF
--- a/.changeset/root-bounded-event-propagation.md
+++ b/.changeset/root-bounded-event-propagation.md
@@ -1,0 +1,7 @@
+---
+"octane": patch
+---
+
+Scope delegated events to native root boundaries, preserve shadow/slot event paths and logical portal ancestry, and separate framework propagation cancellation from external native stop flags. Native `stopImmediatePropagation()` no longer truncates an already-running delegated handler queue; use `stopPropagation()` as well to stop logical ancestors.
+
+Expose native dialog lifecycle event handlers on logical ancestors in JSX typings.

--- a/.changeset/root-bounded-event-propagation.md
+++ b/.changeset/root-bounded-event-propagation.md
@@ -2,6 +2,6 @@
 "octane": patch
 ---
 
-Scope delegated events to native root boundaries, preserve shadow/slot event paths and logical portal ancestry, and separate framework propagation cancellation from external native stop flags. Native `stopImmediatePropagation()` no longer truncates an already-running delegated handler queue; use `stopPropagation()` as well to stop logical ancestors.
+Scope delegated events to native root boundaries, preserve shadow/slot event paths and logical portal ancestry, and separate framework propagation cancellation from external native stop flags. Native `stopImmediatePropagation()` no longer truncates an already-running delegated handler queue; use `stopPropagation()` as well to stop the remaining handlers in that logical phase.
 
 Expose native dialog lifecycle event handlers on logical ancestors in JSX typings.

--- a/benchmarks/event-delegation/README.md
+++ b/benchmarks/event-delegation/README.md
@@ -21,6 +21,14 @@ It also requires the 128 capture traversals to reuse one path array. Native
 capture and bubbling, framework capture, event targets, all 128 controlled
 inputs, and their corresponding output text must remain correct.
 
+Before those inputs, a separate work-only fixture mounts and unmounts two compiled
+JSX portals sharing `document.body` three times. Portal capture, target and bubble
+handlers and ref cleanup must all run; detached buttons must stop receiving
+delegated clicks, while the second owner stays live after the first unmounts.
+The subsequent ordinary input events must perform no sibling
+walks or DOM-order comparisons left over from portal ownership. These observers
+run only in this deterministic gate, not in the timing application.
+
 The work gate builds its own production fixture, starts a temporary preview, and
 closes it before exiting. The unified benchmark runner also invokes the gate
 after its existing per-framework timing runs:
@@ -30,4 +38,5 @@ node benchmarks/event-delegation/work.mjs
 node benchmarks/bench.mjs --quick event-delegation
 ```
 
-Set `EVENT_URL` to reuse an existing production preview instead of building one.
+Set `EVENT_URL` to an existing production `event-work.html` preview instead of
+building one.

--- a/benchmarks/event-delegation/work.mjs
+++ b/benchmarks/event-delegation/work.mjs
@@ -12,6 +12,7 @@ const { chromium } = requireFromNews('playwright');
 const appDirectory = fileURLToPath(new URL('../news/octane-tsrx/', import.meta.url));
 const EVENTS = 128;
 const FIELDS = 512;
+const PORTAL_CYCLES = 3;
 const failures = [];
 
 let browser;
@@ -29,7 +30,7 @@ try {
 				emptyOutDir: true,
 				minify: 'esbuild',
 				rollupOptions: {
-					input: path.join(appDirectory, 'runtime-stress.html'),
+					input: path.join(appDirectory, 'event-work.html'),
 					output: {
 						chunkFileNames: 'assets/[name]-[hash].js',
 						entryFileNames: 'assets/[name]-[hash].js',
@@ -47,7 +48,7 @@ try {
 		if (address === null || typeof address === 'string') {
 			throw new Error('The production event fixture did not expose a TCP port');
 		}
-		target = `http://127.0.0.1:${address.port}/runtime-stress.html`;
+		target = `http://127.0.0.1:${address.port}/event-work.html`;
 	}
 
 	browser = await chromium.launch({
@@ -56,19 +57,33 @@ try {
 	});
 	const page = await browser.newPage();
 	await page.goto(target, { waitUntil: 'load' });
-	await page.waitForFunction(() => globalThis.__runtimeStress?.ready === true, null, {
-		timeout: 10_000,
-	});
+	await page.waitForFunction(
+		() =>
+			globalThis.__runtimeStress?.ready === true &&
+			typeof globalThis.__eventWorkPortalLifecycle === 'function',
+		null,
+		{
+			timeout: 10_000,
+		},
+	);
 	observed = await page.evaluate(
-		({ events, fields }) => {
+		({ events, fields, portalCycles }) => {
 			const form = document.querySelector('#stress-form');
 			if (form === null) throw new Error('Missing controlled benchmark form');
 			if (document.querySelectorAll('input[data-field-index]').length !== fields) {
 				throw new Error('The application did not mount its complete controlled form');
 			}
+			// Mount through compiled JSX child position, not a createElement value
+			// portal. After its owner unmounts, ordinary input work must be portal-free.
+			const portalLifecycle = globalThis.__eventWorkPortalLifecycle(portalCycles);
 
 			const originalDefineProperty = Object.defineProperty;
 			const originalPush = Array.prototype.push;
+			const originalPreviousSibling = Object.getOwnPropertyDescriptor(
+				Node.prototype,
+				'previousSibling',
+			);
+			const originalComparePosition = Node.prototype.compareDocumentPosition;
 			const setInputValue = Object.getOwnPropertyDescriptor(
 				HTMLInputElement.prototype,
 				'value',
@@ -83,6 +98,8 @@ try {
 			let nativeBubbles = 0;
 			let frameworkCaptures = 0;
 			let invalidCurrentTargets = 0;
+			let previousSiblingReads = 0;
+			let documentPositionComparisons = 0;
 			const capture = () => nativeCaptures++;
 			const bubble = () => nativeBubbles++;
 
@@ -112,6 +129,17 @@ try {
 				}
 				return originalPush.apply(this, values);
 			};
+			Object.defineProperty(Node.prototype, 'previousSibling', {
+				...originalPreviousSibling,
+				get() {
+					previousSiblingReads++;
+					return originalPreviousSibling.get.call(this);
+				},
+			});
+			Node.prototype.compareDocumentPosition = function (node) {
+				documentPositionComparisons++;
+				return originalComparePosition.call(this, node);
+			};
 
 			try {
 				for (let index = 0; index < events; index++) {
@@ -126,6 +154,8 @@ try {
 				currentInput = null;
 				Object.defineProperty = originalDefineProperty;
 				Array.prototype.push = originalPush;
+				Object.defineProperty(Node.prototype, 'previousSibling', originalPreviousSibling);
+				Node.prototype.compareDocumentPosition = originalComparePosition;
 				document.removeEventListener('input', capture, true);
 				document.removeEventListener('input', bubble);
 				delete globalThis.__octaneDelegatedInputCapture;
@@ -143,6 +173,7 @@ try {
 				}
 			}
 			return {
+				...portalLifecycle,
 				eventHosts: document.querySelectorAll('input[data-field-index]').length,
 				events,
 				nativeCaptures,
@@ -155,9 +186,11 @@ try {
 				descriptors: descriptors.size,
 				getters: getters.size,
 				capturePaths: capturePaths.size,
+				previousSiblingReads,
+				documentPositionComparisons,
 			};
 		},
-		{ events: EVENTS, fields: FIELDS },
+		{ events: EVENTS, fields: FIELDS, portalCycles: PORTAL_CYCLES },
 	);
 } finally {
 	try {
@@ -186,6 +219,25 @@ if (observed.definitions !== EVENTS * 2) {
 }
 for (const key of ['descriptors', 'getters', 'capturePaths']) {
 	if (observed[key] > 1) failures.push(`${key}: ${observed[key]} exceeds 1`);
+}
+if (observed.portalCycles !== PORTAL_CYCLES)
+	failures.push(`portalCycles: ${observed.portalCycles} is not ${PORTAL_CYCLES}`);
+for (const key of ['portalCaptures', 'portalClicks', 'portalBubbles']) {
+	if (observed[key] !== PORTAL_CYCLES * 3)
+		failures.push(`${key}: ${observed[key]} is not ${PORTAL_CYCLES * 3}`);
+}
+for (const key of ['portalRefsMounted', 'portalRefsCleared']) {
+	if (observed[key] !== PORTAL_CYCLES * 2)
+		failures.push(`${key}: ${observed[key]} is not ${PORTAL_CYCLES * 2}`);
+}
+for (const key of [
+	'portalDetachedClicks',
+	'portalNodesAfterUnmount',
+	'previousSiblingReads',
+	'documentPositionComparisons',
+]) {
+	if (observed[key] !== 0)
+		failures.push(`${key}: ${observed[key]} is not zero after portal cleanup`);
 }
 
 console.log('Production delegated-event work:');
@@ -217,5 +269,5 @@ if (failures.length > 0) {
 	for (const failure of failures) console.error(`✗ ${failure}`);
 	process.exitCode = 1;
 } else {
-	console.log('All deterministic delegated-event allocation gates passed.');
+	console.log('All deterministic delegated-event work and lifecycle gates passed.');
 }

--- a/benchmarks/news/octane-tsrx/event-work.html
+++ b/benchmarks/news/octane-tsrx/event-work.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Octane delegated-event work</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/runtime-stress/entry.ts"></script>
+		<script type="module" src="/src/runtime-stress/event-work.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/octane-tsrx/src/runtime-stress/EventWorkPortal.tsrx
+++ b/benchmarks/news/octane-tsrx/src/runtime-stress/EventWorkPortal.tsrx
@@ -1,0 +1,22 @@
+import { createPortal } from 'octane';
+
+export function EventWorkPortal(props: {
+	target: Element;
+	id: number;
+	onCapture: () => void;
+	onClick: () => void;
+	onBubble: () => void;
+	onRef: (node: HTMLButtonElement | null) => void;
+}) @{
+	<section onClickCapture={props.onCapture} onClick={props.onBubble}>{createPortal(
+		<button
+			type="button"
+			data-event-work-portal={String(props.id)}
+			ref={props.onRef}
+			onClick={props.onClick}
+		>
+			Portal event
+		</button>,
+		props.target,
+	)}</section>
+}

--- a/benchmarks/news/octane-tsrx/src/runtime-stress/event-work.ts
+++ b/benchmarks/news/octane-tsrx/src/runtime-stress/event-work.ts
@@ -1,0 +1,65 @@
+import { createRoot, flushSync } from 'octane';
+import { EventWorkPortal } from './EventWorkPortal.tsrx';
+
+export function runPortalLifecycle(cycles: number) {
+	const result = {
+		portalCycles: cycles,
+		portalCaptures: 0,
+		portalClicks: 0,
+		portalBubbles: 0,
+		portalRefsMounted: 0,
+		portalRefsCleared: 0,
+		portalDetachedClicks: 0,
+		portalNodesAfterUnmount: 0,
+	};
+	for (let cycle = 0; cycle < cycles; cycle++) {
+		const owners = Array.from({ length: 2 }, (_, index) => {
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			return { container, root: createRoot(container), id: cycle * 2 + index };
+		});
+		try {
+			const buttons = owners.map(({ root, id }) => {
+				flushSync(() =>
+					root.render(EventWorkPortal, {
+						target: document.body,
+						id,
+						onCapture: () => result.portalCaptures++,
+						onClick: () => result.portalClicks++,
+						onBubble: () => result.portalBubbles++,
+						onRef: (node: HTMLButtonElement | null) => {
+							if (node === null) result.portalRefsCleared++;
+							else result.portalRefsMounted++;
+						},
+					}),
+				);
+				const button = document.querySelector<HTMLButtonElement>(
+					`[data-event-work-portal="${id}"]`,
+				);
+				if (button?.parentNode !== document.body) throw new Error('Portal did not mount into body');
+				button.click();
+				return button;
+			});
+			for (let index = 0; index < owners.length; index++) {
+				owners[index].root.unmount();
+				const before = result.portalClicks;
+				buttons[index].click();
+				result.portalDetachedClicks += result.portalClicks - before;
+				if (buttons[index].isConnected) throw new Error('Unmounted portal is still connected');
+				// A shared target stays live until its last owner unmounts.
+				if (index === 0) buttons[1].click();
+			}
+		} finally {
+			for (const { root, container } of owners) {
+				root.unmount();
+				container.remove();
+			}
+		}
+		result.portalNodesAfterUnmount += document.querySelectorAll('[data-event-work-portal]').length;
+	}
+	return result;
+}
+
+(
+	globalThis as typeof globalThis & { __eventWorkPortalLifecycle: typeof runPortalLifecycle }
+).__eventWorkPortalLifecycle = runPortalLifecycle;

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -556,10 +556,39 @@ JavaScript evaluation semantics.
 
 ## Native event objects, no synthetic event layer
 
-Event propagation itself matches React and is **not a divergence**. Ordinary
-bubbling and capture, `stopPropagation`, logical propagation through portals,
-and native non-bubbling families (`toggle`, dialog `close`/`cancel`, media,
-`load`/`error`) all reach the same logical ancestors React does.
+Delegated capture and bubbling are scoped to each root's portion of the event
+path. Native listeners between nested roots run before the next root's handlers,
+and can prevent the event from reaching that root. Shadow roots and distributed
+slots use the browser's composed path without replacing its retargeted `target`
+or `relatedTarget`. Portals still propagate through their logical ancestors.
+A portal rendered into a closed shadow root physically inside its own outer
+root is a known interop limit: the outer listener cannot see the hidden portal
+boundary, so shared outer ancestors can receive both deliveries. React also
+exhibits duplicate delivery in this topology.
+Native non-bubbling families (`toggle`, dialog `close`/`cancel`, media,
+`load`/`error`) emulate logical bubbling from a root capture listener; their
+interleaving with direct native listeners is not identical to React's event
+plugins.
+
+Within a delegated phase, propagation cancellation follows React's separation
+between its framework queue and native dispatch, while keeping a native event:
+
+- `event.stopPropagation()` in an Octane handler stops the remaining handlers
+  in that logical phase and calls the browser's native method.
+- An earlier external listener on the same root calling native
+  `stopPropagation()` does not truncate Octane's handler queue. An external
+  listener below the root can still prevent that queue from receiving the event.
+- `event.stopImmediatePropagation()` stops later native listeners on the same
+  node, but does not truncate the logical phase already running. This corresponds
+  to React's `event.nativeEvent.stopImmediatePropagation()`. Call both stop
+  methods to stop both queues. Neither method cancels the default action; use
+  `preventDefault()` for that.
+
+The native `cancelBubble` flag remains visible; it is not cleared to continue a
+logical queue. Calling a native prototype method directly or setting that flag
+operates on native propagation, not the separate framework queue. An immutable,
+non-configurable own stop method also remains native-only: Octane does not
+replace it or change the identity of the event.
 
 What differs is the event API and synthesis layer:
 

--- a/packages/octane/src/jsx-runtime.d.ts
+++ b/packages/octane/src/jsx-runtime.d.ts
@@ -62,15 +62,14 @@ export type ClassValue =
 	| readonly ClassValue[]
 	| { readonly [name: string]: unknown };
 
-/**
- * React's synthetic handler props (all of `DOMAttributes` except children and
- * dangerouslySetInnerHTML). The NAMES are octane's public event surface; only
- * the parameter types change (native instead of synthetic).
- */
-type ReactSyntheticProps = Exclude<
-	keyof React.DOMAttributes<Element>,
-	'children' | 'dangerouslySetInnerHTML'
->;
+// React's types restrict dialog lifecycle handlers to <dialog>, but Octane
+// delegates these events through logical ancestors in both phases.
+type DialogLifecycleProps = 'onCancel' | 'onCancelCapture' | 'onClose' | 'onCloseCapture';
+
+/** Handler names whose parameters are native rather than React synthetic events. */
+type ReactSyntheticProps =
+	| Exclude<keyof React.DOMAttributes<Element>, 'children' | 'dangerouslySetInnerHTML'>
+	| DialogLifecycleProps;
 
 /**
  * Convert one React synthetic handler type to its native form: the parameter
@@ -86,6 +85,8 @@ type NativeHandler<H, T> =
 
 type NativeEventHandlers<P, T> = {
 	[K in Extract<keyof P, ReactSyntheticProps>]?: NativeHandler<P[K], T>;
+} & {
+	[K in DialogLifecycleProps]?: (event: Event & { currentTarget: T }) => void;
 };
 
 /** Props whose lowercase spelling is not a native attribute with equivalent behavior. */

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -7080,6 +7080,7 @@ function unmountSlot(val: any, detachDom: boolean): void {
 		const childDetach = k === 'portalSlotSlot' ? true : detachDom;
 		if (val.block) unmountBlock(val.block, childDetach);
 		if (k === 'portalSlotSlot' && val.target) {
+			unregisterPortalEventRange(val.target, val);
 			unregisterDelegationTarget(val.target);
 		}
 	}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -16297,11 +16297,64 @@ const _delegated = new Set<string>();
 // portals are currently rendering into it so we detach only when the last
 // one unmounts. createRoot containers have refcount 1 for their lifetime.
 const _delegationTargets = new Map<Node, number>();
+// Public roots end a logical event branch; portal targets do not. Keep this
+// production ownership separate from the development-only duplicate-root guard.
+interface EventRootMembership {
+	count: number;
+	since: number;
+	previous: EventRootMembership | undefined;
+}
+const _eventRoots = new WeakMap<Node, EventRootMembership>();
+let eventRootEpoch = 0;
+const EVENT_ROOT_EPOCH = /* @__PURE__ */ Symbol('octane.rootEpoch');
 
-// Event names with capture-phase handlers (`onXxxCapture`). These get a SEPARATE
-// capture-phase listener (`dispatchDelegatedCapture`) on every delegation target,
-// independent of the bubble-phase `_delegated` set — an event type can have both
-// (`onClick` + `onClickCapture`).
+function changeEventRootMembership(target: Node, delta: number): void {
+	const previous = _eventRoots.get(target);
+	_eventRoots.set(target, {
+		count: (previous?.count || 0) + delta,
+		since: ++eventRootEpoch,
+		previous,
+	});
+	if (previous !== undefined) {
+		// A native event keeps its original route even if a handler unmounts or
+		// remounts a root. Retain membership history through this native delivery,
+		// then release it. Only root lifecycle changes allocate/schedule here;
+		// events retain a number, never a snapshot holding root DOM nodes alive.
+		setTimeout(() => {
+			const current = _eventRoots.get(target);
+			if (current !== undefined) current.previous = undefined;
+		}, 0);
+	}
+}
+
+function isEventRoot(node: Node, epoch: number): boolean {
+	let membership = _eventRoots.get(node);
+	while (membership !== undefined && membership.since > epoch) membership = membership.previous;
+	return membership !== undefined && membership.count > 0;
+}
+
+function prepareDelegatedEvent(event: Event, listener: Node): EventTarget[] {
+	const path = event.composedPath();
+	// Every delegated type has a root capture observer, even without an authored
+	// capture handler. The outermost observer starts a fresh native delivery, so
+	// synchronously redispatching the same Event never inherits an old root epoch.
+	if (_delegationTargets.size === 1) {
+		(event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
+		return path;
+	}
+	for (let i = path.length - 1; i >= 0; i--) {
+		if (_delegationTargets.has(path[i] as Node)) {
+			if (path[i] === listener) (event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
+			break;
+		}
+	}
+	return path;
+}
+
+// Event names with authored capture-phase handlers (`onXxxCapture`). Ordinary
+// bubbling types always have a capture observer to snapshot root membership;
+// only these names also run a logical capture queue. Non-bubbling families share
+// one native capture callback for their capture and emulated bubble queues.
 const _delegatedCapture = new Set<string>();
 
 // Non-bubbling events must be delegated in the CAPTURE phase so the single root
@@ -16412,11 +16465,19 @@ export function delegateEvents(eventNames: string[]): void {
 		// back-attach the listener to every active target so handlers stamped on
 		// their DOM via `el.$$click = …` still receive events.
 		for (const target of _delegationTargets.keys()) {
+			if (delegatedCapture(name) && _delegatedCapture.has(name)) continue;
 			target.addEventListener(
 				name,
 				dispatchDelegated,
 				delegatedListenerOptions(name, delegatedCapture(name)),
 			);
+			if (!delegatedCapture(name)) {
+				target.addEventListener(
+					name,
+					dispatchDelegatedCapture,
+					delegatedListenerOptions(name, true),
+				);
+			}
 		}
 	}
 }
@@ -16436,7 +16497,12 @@ export function delegateCaptureEvents(eventNames: string[]): void {
 		// `$$capture:<type>` along the built path).
 		if (canSeed) seedExpando(Element.prototype, CAPTURE_PREFIX + name);
 		for (const target of _delegationTargets.keys()) {
-			target.addEventListener(name, dispatchDelegatedCapture, delegatedListenerOptions(name, true));
+			if (_delegated.has(name)) continue;
+			target.addEventListener(
+				name,
+				delegatedCapture(name) ? dispatchDelegated : dispatchDelegatedCapture,
+				delegatedListenerOptions(name, true),
+			);
 		}
 	}
 }
@@ -16447,8 +16513,9 @@ export function delegateCaptureEvents(eventNames: string[]): void {
  * attaches all known delegated event listeners, subsequent registrations
  * just bump the refcount.
  */
-function registerDelegationTarget(target: Node): void {
+function registerDelegationTarget(target: Node, root = false): void {
 	initDomOperations();
+	if (root) changeEventRootMembership(target, 1);
 	const prev = _delegationTargets.get(target) || 0;
 	_delegationTargets.set(target, prev + 1);
 	if (prev === 0) {
@@ -16465,9 +16532,21 @@ function registerDelegationTarget(target: Node): void {
 				dispatchDelegated,
 				delegatedListenerOptions(name, delegatedCapture(name)),
 			);
+			if (!delegatedCapture(name)) {
+				target.addEventListener(
+					name,
+					dispatchDelegatedCapture,
+					delegatedListenerOptions(name, true),
+				);
+			}
 		}
 		for (const name of _delegatedCapture) {
-			target.addEventListener(name, dispatchDelegatedCapture, delegatedListenerOptions(name, true));
+			if (_delegated.has(name)) continue;
+			target.addEventListener(
+				name,
+				delegatedCapture(name) ? dispatchDelegated : dispatchDelegatedCapture,
+				delegatedListenerOptions(name, true),
+			);
 		}
 	}
 }
@@ -16475,16 +16554,22 @@ function registerDelegationTarget(target: Node): void {
 /**
  * Inverse of `registerDelegationTarget`. Last referent detaches all listeners.
  */
-function unregisterDelegationTarget(target: Node): void {
+function unregisterDelegationTarget(target: Node, root = false): void {
+	if (root) changeEventRootMembership(target, -1);
 	const prev = _delegationTargets.get(target);
 	if (!prev) return;
 	if (prev === 1) {
 		_delegationTargets.delete(target);
 		for (const name of _delegated) {
 			target.removeEventListener(name, dispatchDelegated, delegatedCapture(name));
+			if (!delegatedCapture(name)) target.removeEventListener(name, dispatchDelegatedCapture, true);
 		}
 		for (const name of _delegatedCapture) {
-			target.removeEventListener(name, dispatchDelegatedCapture, true);
+			target.removeEventListener(
+				name,
+				delegatedCapture(name) ? dispatchDelegated : dispatchDelegatedCapture,
+				true,
+			);
 		}
 	} else {
 		_delegationTargets.set(target, prev - 1);
@@ -16566,21 +16651,96 @@ const DISCRETE_EVENTS = new Set<string>([
  */
 let _dispatchDepth = 0;
 
-// Capture and bubble delegation use separate native root listeners, but a
-// bubbling event is one discrete update window. When the capture listener can
-// hand off to a registered bubble listener, that listener owns controlled
-// restoration and the synchronous flush. A task fallback handles a descendant
-// native listener stopping propagation before the event returns to the root.
-const CAPTURE_FLUSH_FALLBACK = /* @__PURE__ */ Symbol('octane.capture.flushFallback');
+// A bubble version closes capture-only flush fallbacks without retaining a DOM
+// path or a dispatch-completed flag on the Event. The same Event may be dispatched
+// again synchronously; every native delivery must start a fresh logical walk.
+const DELEGATED_BUBBLE_VERSION = /* @__PURE__ */ Symbol('octane.bubbleVersion');
 
-// Stamps marking a native event whose delegated walk has already run, per phase. A
-// single native event can reach more than one delegation listener when targets nest —
-// a portal target inside a root, nested roots, or overlapping portal targets. Each
-// listener walks the full logical tree, so without this guard the shared portion of
-// the chain would fire its handlers once per nested listener. Capture and bubble are
-// independent phases, so each carries its own stamp.
-const DELEGATED_DISPATCHED = /* @__PURE__ */ Symbol('octane.dispatched');
-const CAPTURE_DISPATCHED = /* @__PURE__ */ Symbol('octane.dispatched.capture');
+// Keep framework propagation distinct from the browser's native stop flags.
+// An earlier listener on this same root may already have set cancelBubble, and
+// native stopImmediatePropagation must not abort an already-running logical queue.
+// These temporary methods still operate on the original browser Event, and the
+// exact prior own descriptors are restored before control returns to native code.
+const PROPAGATION_FLAGS = /* @__PURE__ */ Symbol('octane.propagationFlags');
+const NATIVE_STOP_PROPAGATION = /* @__PURE__ */ Symbol('octane.stopPropagation');
+const NATIVE_STOP_IMMEDIATE = /* @__PURE__ */ Symbol('octane.stopImmediatePropagation');
+function stopDelegatedPropagation(this: Event): void {
+	if ((this as any)[PROPAGATION_FLAGS] !== undefined) (this as any)[PROPAGATION_FLAGS] |= 1;
+	const stop = (this as any)[NATIVE_STOP_PROPAGATION] || this.stopPropagation;
+	// A consumer may retain the method and call it after native dispatch. The
+	// temporary dispatch state is gone then, but the restored native method lives on.
+	(stop === stopDelegatedPropagation ? Event.prototype.stopPropagation : stop).call(this);
+}
+function stopImmediateNativePropagation(this: Event): void {
+	if ((this as any)[PROPAGATION_FLAGS] !== undefined) (this as any)[PROPAGATION_FLAGS] |= 2;
+	const stop = (this as any)[NATIVE_STOP_IMMEDIATE] || this.stopImmediatePropagation;
+	(stop === stopImmediateNativePropagation ? Event.prototype.stopImmediatePropagation : stop).call(
+		this,
+	);
+}
+const STOP_PROPAGATION_DESCRIPTOR: PropertyDescriptor = {
+	configurable: true,
+	writable: true,
+	value: stopDelegatedPropagation,
+};
+const STOP_IMMEDIATE_DESCRIPTOR: PropertyDescriptor = {
+	configurable: true,
+	writable: true,
+	value: stopImmediateNativePropagation,
+};
+
+function installPropagationMethod(
+	event: Event,
+	name: 'stopPropagation' | 'stopImmediatePropagation',
+	previous: PropertyDescriptor | undefined,
+	descriptor: PropertyDescriptor,
+): void {
+	if (previous?.configurable === false) {
+		// An immutable own method cannot be interposed while preserving the native
+		// Event. Leave it native-only, like calling Event.prototype's method directly.
+		if (previous.writable) Object.defineProperty(event, name, { value: descriptor.value });
+	} else {
+		Object.defineProperty(event, name, descriptor);
+	}
+}
+
+function beginDelegatedPropagation(
+	event: Event,
+	stop: PropertyDescriptor | undefined,
+	immediate: PropertyDescriptor | undefined | null,
+): void {
+	(event as any)[PROPAGATION_FLAGS] = 0;
+	(event as any)[NATIVE_STOP_PROPAGATION] = event.stopPropagation;
+	installPropagationMethod(event, 'stopPropagation', stop, STOP_PROPAGATION_DESCRIPTOR);
+	// Only emulated bubbling needs to distinguish a native immediate stop before
+	// starting another logical phase. Ordinary browser phases leave it untouched.
+	if (immediate !== null) {
+		(event as any)[NATIVE_STOP_IMMEDIATE] = event.stopImmediatePropagation;
+		installPropagationMethod(
+			event,
+			'stopImmediatePropagation',
+			immediate,
+			STOP_IMMEDIATE_DESCRIPTOR,
+		);
+	}
+}
+
+function endDelegatedPropagation(
+	event: Event,
+	stop: PropertyDescriptor | undefined,
+	immediate: PropertyDescriptor | undefined | null,
+): void {
+	if (stop === undefined) delete (event as any).stopPropagation;
+	else Object.defineProperty(event, 'stopPropagation', stop);
+	if (immediate !== null) {
+		if (immediate === undefined) delete (event as any).stopImmediatePropagation;
+		else Object.defineProperty(event, 'stopImmediatePropagation', immediate);
+		delete (event as any)[NATIVE_STOP_IMMEDIATE];
+	}
+	delete (event as any)[PROPAGATION_FLAGS];
+	delete (event as any)[NATIVE_STOP_PROPAGATION];
+}
+
 // A receiver-specific target lets one accessor survive nested native dispatch.
 const CURRENT_TARGET_NODE = /* @__PURE__ */ Symbol('octane.currentTarget');
 const CURRENT_TARGET_DESCRIPTOR: PropertyDescriptor = {
@@ -16589,8 +16749,131 @@ const CURRENT_TARGET_DESCRIPTOR: PropertyDescriptor = {
 		return (this as any)[CURRENT_TARGET_NODE] as EventTarget | null;
 	},
 };
-// Synchronous nested capture walks borrow disjoint frames from this one stack.
+// Synchronous nested delegated walks borrow disjoint frames from this one stack.
 const CAPTURE_PATH: any[] = [];
+
+type DelegatedNode = Node & {
+	$$portalParent?: Node;
+	$$portalContainer?: Node;
+};
+
+function eventPathNode(target: EventTarget | null | undefined): DelegatedNode | null {
+	return target != null && typeof (target as Node).nodeType === 'number'
+		? (target as DelegatedNode)
+		: null;
+}
+
+/**
+ * Append the listener's logical target-to-root branch, excluding its owning
+ * public root container. Returns the appended count; zero also means no route.
+ *
+ * Root containers themselves belong to the enclosing root when rebasing across
+ * a foreign public root. Portal containers are routing boundaries, not ordinary
+ * root boundaries: merely registering a portal target does not truncate children
+ * that are not in a portal-owned range.
+ */
+function buildDelegatedPath(event: Event, listener: Node, path = event.composedPath()): number {
+	const output = CAPTURE_PATH;
+	const base = output.length;
+	const epoch = (event as any)[EVENT_ROOT_EPOCH] ?? eventRootEpoch;
+	const listenerIndex = path.indexOf(listener);
+	if (listenerIndex < 0) return 0;
+	// The usual application has one unchanged public root and no portals. It
+	// needs neither foreign-boundary rebasing nor per-ancestor ownership lookups.
+	// A lifecycle change since capture disables this path for the current event.
+	if (_delegationTargets.size === 1 && epoch === eventRootEpoch && isEventRoot(listener, epoch)) {
+		let i = 0;
+		for (; i < listenerIndex; i++) {
+			const node = eventPathNode(path[i]);
+			if (node === null || node.$$portalParent != null) break;
+			output.push(node);
+		}
+		if (i === listenerIndex) return output.length - base;
+		output.length = base;
+	}
+	let start = eventPathNode(path[0]);
+	if (start === null) return 0;
+	let startIndex = 0;
+	let rebaseRootAtStart = false;
+
+	for (;;) {
+		output.length = base;
+		let node: DelegatedNode | null = start;
+		let index = startIndex;
+		let firstBoundary: Node | null = null;
+		let ownsBranch = false;
+		let supersededByNearerPortal = false;
+
+		while (node !== null) {
+			// A fresh inner root owns the descendants, not the container's outer
+			// handler. On rebasing, include that container in the next outer tree.
+			if (isEventRoot(node, epoch) && !(node === start && rebaseRootAtStart)) {
+				firstBoundary ??= node;
+				if (node === listener) {
+					if (firstBoundary === node) ownsBranch = true;
+					else supersededByNearerPortal = true;
+				}
+				break;
+			}
+
+			output.push(node);
+			const logicalParent = node.$$portalParent;
+			if (logicalParent != null) {
+				// Use the actual portal container, NOT composedPath's next item:
+				// a direct portal child can be slotted, making that next item a
+				// <slot> rather than its real portal container. The cold stamp
+				// also survives a handler moving the node during this dispatch.
+				const container = node.$$portalContainer;
+				if (container == null) {
+					// Missing ownership is not permission to walk unrelated DOM.
+					output.length = base;
+					return 0;
+				}
+				firstBoundary ??= container;
+				if (container === listener) {
+					if (firstBoundary === container) ownsBranch = true;
+					else supersededByNearerPortal = true;
+				}
+				// Keep walking after a matched portal: it owns the whole logical
+				// branch up to the public root, not just its physical child range.
+				node = logicalParent as DelegatedNode;
+				index = path.indexOf(logicalParent);
+			} else if (index >= 0) {
+				node = eventPathNode(path[++index]);
+			} else {
+				// The logical portal host may not be on this native event's path.
+				// Do not force a hidden shadow-root -> host crossing here.
+				node = node.parentNode as DelegatedNode | null;
+			}
+		}
+
+		if (supersededByNearerPortal) {
+			output.length = base;
+			return 0;
+		}
+		if (ownsBranch) return output.length - base;
+		if (firstBoundary === null) {
+			output.length = base;
+			return 0;
+		}
+
+		// A foreign root/portal lies between the event target and this listener.
+		// Switch to its host container in the enclosing tree. This is also how
+		// a portal mounted inside another root reaches that other root's slots.
+		const boundaryIndex = path.indexOf(firstBoundary);
+		if (
+			boundaryIndex < startIndex ||
+			boundaryIndex >= listenerIndex ||
+			(boundaryIndex === startIndex && rebaseRootAtStart)
+		) {
+			output.length = base;
+			return 0;
+		}
+		start = firstBoundary as DelegatedNode;
+		startIndex = boundaryIndex;
+		rebaseRootAtStart = true;
+	}
+}
 
 // Invoke one event slot — a bare handler `fn(event)` or a nominal `{ fn, args }` bundle
 // (the compiler's zero-argument-arrow optimisation) as `fn(...args)`. A bundled
@@ -16701,18 +16984,16 @@ function maybeFlushDiscrete(type: string): void {
 function finishCaptureDispatch(event: Event): void {
 	const type = event.type;
 	if (!event.bubbles || event.cancelBubble || !_delegated.has(type)) {
-		if (event.bubbles && _delegated.has(type) && (event as any)[DELEGATED_DISPATCHED] !== true)
-			maybeEnqueueRestore(event);
+		if (event.bubbles && _delegated.has(type)) maybeEnqueueRestore(event);
 		maybeFlushDiscrete(type);
 		return;
 	}
-	if (!DISCRETE_EVENTS.has(type) || (event as any)[CAPTURE_FLUSH_FALLBACK] === true) return;
-	(event as any)[CAPTURE_FLUSH_FALLBACK] = true;
+	if (!DISCRETE_EVENTS.has(type)) return;
+	const bubbleVersion = (event as any)[DELEGATED_BUBBLE_VERSION];
 	const fallback = () => {
-		// The ordinary bubble listener stamped the event and already flushed. If
-		// propagation was stopped below the root, it never ran: enqueue the edit
-		// restore now and close the capture-only discrete window.
-		if ((event as any)[DELEGATED_DISPATCHED] !== true) {
+		// Any delivered bubble segment flushes all capture-scheduled work. When a
+		// native listener stops the event below its root, close that window here.
+		if ((event as any)[DELEGATED_BUBBLE_VERSION] === bubbleVersion) {
 			maybeEnqueueRestore(event);
 			maybeFlushDiscrete(type);
 		}
@@ -16729,16 +17010,14 @@ function finishCaptureDispatch(event: Event): void {
 	else queueMicrotask(fallback);
 }
 
-function dispatchDelegated(event: Event): void {
-	// Only the first delegation listener to receive this event walks it (its walk
-	// already covers every logical ancestor across roots/portals); the rest no-op.
-	if ((event as any)[DELEGATED_DISPATCHED] === true) return;
-	(event as any)[DELEGATED_DISPATCHED] = true;
+function dispatchDelegated(this: Node, event: Event): void {
+	if (delegatedCapture(event.type)) prepareDelegatedEvent(event, this);
+	(event as any)[DELEGATED_BUBBLE_VERSION] = ((event as any)[DELEGATED_BUBBLE_VERSION] || 0) + 1;
 	maybeEnqueueRestore(event);
 	const key = '$$' + event.type;
 	const targetOnly = TARGET_ONLY_DELEGATED.has(event.type);
 	_dispatchDepth++;
-	let node = event.target as any;
+	const node = event.target as any;
 	// A submit dispatch targeting a form opens the manual-action useFormStatus
 	// window (see publishManualFormPending): handlers' startTransition calls
 	// register on the record; the walk's end decides whether to publish.
@@ -16755,42 +17034,39 @@ function dispatchDelegated(event: Event): void {
 			: null;
 	if (submitRec !== null) ACTIVE_SUBMIT_DISPATCH = submitRec;
 	const nativeBatch = beginNativeEventBatch(event);
+	const pathBase = CAPTURE_PATH.length;
+	let stop: PropertyDescriptor | undefined;
+	let propagationStarted = false;
 	try {
-		// CAPTURE_DELEGATED types have BOTH dispatchers attached as capture-phase
-		// listeners on the same root, so same-node registration ORDER — not phase —
-		// would decide whether the capture pass or this walk runs first. Run the
-		// capture pass explicitly first (it self-stamps, so the natively-queued
-		// capture listener no-ops), and honor a capture-phase stopPropagation
-		// before walking — native cross-phase semantics. Nested inside our
-		// _dispatchDepth++ so the capture pass can't flush discrete work mid-event.
+		// Non-bubbling families share one native capture callback. Run the logical
+		// capture queue first, independent of module registration order, and honor
+		// a stop within that phase before starting the emulated bubble queue.
 		if (
 			delegatedCapture(event.type) &&
-			(event as any)[CAPTURE_DISPATCHED] !== true &&
-			_delegatedCapture.has(event.type)
-		) {
-			dispatchDelegatedCapture(event);
-			if (event.cancelBubble) return;
-		}
-		while (node !== null && node !== undefined) {
-			const slot = node[key] as EventSlot;
+			_delegatedCapture.has(event.type) &&
+			dispatchDelegatedCapture.call(this, event)
+		)
+			return;
+		if (!_delegated.has(event.type)) return;
+		buildDelegatedPath(event, this);
+		stop = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
+		propagationStarted = true;
+		beginDelegatedPropagation(event, stop, null);
+		for (let i = pathBase; i < CAPTURE_PATH.length; i++) {
+			const current = CAPTURE_PATH[i];
+			// Target-only native families never transfer a handler to a root boundary.
+			if (targetOnly && current !== event.target) break;
+			const slot = current[key] as EventSlot;
 			if (slot != null) {
-				// React parity: the handler's element is the currentTarget.
-				setCurrentTarget(event, node);
+				setCurrentTarget(event, current);
 				fireEventSlot(slot, event);
-				if (event.cancelBubble) return;
+				if (((event as any)[PROPAGATION_FLAGS] & 1) !== 0) break;
 			}
-			// Enter/leave and scroll events fire on the target only (see
-			// TARGET_ONLY_DELEGATED). Other capture-delegated non-bubbling events
-			// emulate React propagation and continue through logical ancestors.
-			if (targetOnly) return;
-			// Portal-aware ascent: when crossing a portal root, jump to the rendering Block's DOM parent.
-			if (node.$$portalParent) {
-				node = node.$$portalParent;
-			} else {
-				node = node.parentNode;
-			}
+			if (targetOnly) break;
 		}
 	} finally {
+		CAPTURE_PATH.length = pathBase;
+		if (propagationStarted) endDelegatedPropagation(event, stop, null);
 		if (submitRec !== null) {
 			ACTIVE_SUBMIT_DISPATCH = prevSubmitRec;
 			// Before the depth drop + discrete flush, so a published pending status
@@ -16808,48 +17084,44 @@ function dispatchDelegated(event: Event): void {
 	}
 }
 
-// Capture-phase counterpart of dispatchDelegated for `onXxxCapture` handlers. Builds
-// the logical target→root path (with portal jumps), then fires the `$$capture:<type>`
-// slots ROOT→TARGET — React's capture order. Cross-phase `stopPropagation` is handled
-// by the browser (this listener and the bubble listener are separate native
-// listeners, so a stopped event never reaches the bubble phase).
-function dispatchDelegatedCapture(event: Event): void {
-	if ((event as any)[CAPTURE_DISPATCHED] === true) return;
-	(event as any)[CAPTURE_DISPATCHED] = true;
-	// A registered bubble listener owns final restoration after bubble handlers.
-	// Enqueuing here would let the capture fallback restore a checkable before
-	// its native onChange handler can observe the activated value.
+// Capture runs only this native listener's segment, in reverse path order.
+// Returning whether this queue stopped native propagation lets the shared
+// non-bubbling listener decide whether it may start its emulated bubble queue.
+function dispatchDelegatedCapture(this: Node, event: Event): boolean {
+	const path = prepareDelegatedEvent(event, this);
+	if (!_delegatedCapture.has(event.type)) return false;
 	if (!event.bubbles || !_delegated.has(event.type)) maybeEnqueueRestore(event);
 	const key = CAPTURE_PREFIX + event.type;
 	const pathBase = CAPTURE_PATH.length;
-	for (let node = event.target as any; node !== null && node !== undefined;) {
-		CAPTURE_PATH.push(node);
-		node = node.$$portalParent ? node.$$portalParent : node.parentNode;
-	}
+	buildDelegatedPath(event, this, path);
+	const stop = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
+	const immediate = delegatedCapture(event.type)
+		? Object.getOwnPropertyDescriptor(event, 'stopImmediatePropagation')
+		: null;
+	const wasCancelled = event.cancelBubble;
+	let stopped = false;
 	_dispatchDepth++;
 	const nativeBatch = beginNativeEventBatch(event);
 	try {
+		beginDelegatedPropagation(event, stop, immediate);
 		for (let i = CAPTURE_PATH.length - 1; i >= pathBase; i--) {
 			const slot = CAPTURE_PATH[i][key] as EventSlot;
 			if (slot != null) {
-				// React parity: the handler's element is the currentTarget.
 				setCurrentTarget(event, CAPTURE_PATH[i]);
 				fireEventSlot(slot, event);
-				if (event.cancelBubble) return;
+				if (((event as any)[PROPAGATION_FLAGS] & 1) !== 0) break;
 			}
 		}
 	} finally {
-		// Nested dispatch appends its own frame and restores the outer traversal.
+		stopped = (event as any)[PROPAGATION_FLAGS] !== 0 || (!wasCancelled && event.cancelBubble);
 		CAPTURE_PATH.length = pathBase;
+		endDelegatedPropagation(event, stop, immediate);
 		clearCurrentTarget(event);
 		try {
 			endNativeEventBatch(
 				event,
 				nativeBatch,
-				event.bubbles &&
-					!event.cancelBubble &&
-					_delegated.has(event.type) &&
-					(event as any)[DELEGATED_DISPATCHED] !== true,
+				event.bubbles && !event.cancelBubble && _delegated.has(event.type),
 				reportListenerError,
 			);
 		} catch (error) {
@@ -16858,6 +17130,7 @@ function dispatchDelegatedCapture(event: Event): void {
 		_dispatchDepth--;
 		finishCaptureDispatch(event);
 	}
+	return stopped;
 }
 
 function noop(): void {}
@@ -18813,6 +19086,7 @@ function renderPortalState(
 	if (state.interleavedFragment === undefined) {
 		while (n !== null && n !== state.end) {
 			(n as any).$$portalParent = host;
+			(n as any).$$portalContainer = target;
 			n = n.nextSibling;
 		}
 	} else {
@@ -18823,6 +19097,7 @@ function renderPortalState(
 				continue;
 			}
 			(n as any).$$portalParent = host;
+			(n as any).$$portalContainer = target;
 			n = n.nextSibling;
 		}
 	}
@@ -32788,7 +33063,7 @@ function makeRoot(
 				renderOwner.adopt = undefined;
 				renderOwner.retryKey = null;
 				renderOwner.transaction = null;
-				unregisterDelegationTarget(container);
+				unregisterDelegationTarget(container, true);
 				releaseRootContainer(container, ownerToken);
 			}
 		},
@@ -32818,7 +33093,7 @@ function createRootWithOutputHandler(
 	// Register the container as an event-delegation target up front. Listeners
 	// for all currently-known delegated events attach now; any new event types
 	// registered later (via `delegateEvents`) will back-attach automatically.
-	registerDelegationTarget(container);
+	registerDelegationTarget(container, true);
 	// Lazy root: the block is created on the first `.render()` call.
 	return makeRoot(
 		container,
@@ -32911,7 +33186,7 @@ export function hydrateRoot(
 		nativeSidecar === null ? undefined : parseNativeSignalManifest(nativeSidecar.textContent || '');
 	nativeSidecar?.remove();
 	const ownerToken = claimRootContainer(container);
-	registerDelegationTarget(container);
+	registerDelegationTarget(container, true);
 	let rootBlock = createBlock(
 		'root',
 		null,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -16297,6 +16297,12 @@ const _delegated = new Set<string>();
 // portals are currently rendering into it so we detach only when the last
 // one unmounts. createRoot containers have refcount 1 for their lifetime.
 const _delegationTargets = new Map<Node, number>();
+// Portal descendants can add their first host during a later local update,
+// without rerendering the portal itself. Resolve those hosts from the portal's
+// live owned range, paying this bookkeeping only for applications using portals.
+const _portalEventRanges = new WeakMap<Node, Set<PortalSlot>>();
+let portalEventTargetCount = 0;
+const PORTAL_EVENT_PATH_LENGTH = /* @__PURE__ */ Symbol('octane.portalPathLength');
 // Public roots end a logical event branch; portal targets do not. Keep this
 // production ownership separate from the development-only duplicate-root guard.
 interface EventRootMembership {
@@ -16340,11 +16346,29 @@ function prepareDelegatedEvent(event: Event, listener: Node): EventTarget[] {
 	// synchronously redispatching the same Event never inherits an old root epoch.
 	if (_delegationTargets.size === 1) {
 		(event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
+		if (portalEventTargetCount !== 0) {
+			preparePortalEventOwners(path, eventRootEpoch);
+			(event as any)[PORTAL_EVENT_PATH_LENGTH] = path.length;
+		}
 		return path;
 	}
 	for (let i = path.length - 1; i >= 0; i--) {
 		if (_delegationTargets.has(path[i] as Node)) {
-			if (path[i] === listener) (event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
+			if (path[i] === listener) {
+				(event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
+				if (portalEventTargetCount !== 0) {
+					preparePortalEventOwners(path, eventRootEpoch);
+					(event as any)[PORTAL_EVENT_PATH_LENGTH] = path.length;
+				}
+			} else if (
+				portalEventTargetCount !== 0 &&
+				path.length > ((event as any)[PORTAL_EVENT_PATH_LENGTH] || 0)
+			) {
+				// A closed shadow root reveals additional nodes only to its inner
+				// listener. Keep just a length on the Event, never a retained DOM path.
+				preparePortalEventOwners(path, (event as any)[EVENT_ROOT_EPOCH] ?? eventRootEpoch);
+				(event as any)[PORTAL_EVENT_PATH_LENGTH] = path.length;
+			}
 			break;
 		}
 	}
@@ -16756,6 +16780,83 @@ type DelegatedNode = Node & {
 	$$portalParent?: Node;
 	$$portalContainer?: Node;
 };
+
+type PortalEventBoundary = Node & {
+	$$portalEventRange?: PortalSlot;
+	$$portalEventStart?: PortalEventBoundary;
+};
+
+function resolvePortalEventOwner(node: DelegatedNode): void {
+	if (node.$$portalParent != null || node.parentNode === null) return;
+	// assignedSlot/composedPath can put a <slot> next, but a portal range belongs
+	// to the direct child's actual DOM container, not the slot it projects into.
+	const target = node.parentNode;
+	const ranges = _portalEventRanges.get(target);
+	if (ranges === undefined) return;
+	let owner: PortalSlot | undefined;
+	let previous = node.previousSibling as PortalEventBoundary | null;
+	let remainingSkips = ranges.size;
+	while (previous !== null) {
+		const closedStart = previous.$$portalEventStart;
+		const closedRange = closedStart?.$$portalEventRange;
+		if (
+			remainingSkips !== 0 &&
+			closedStart !== undefined &&
+			closedRange !== undefined &&
+			ranges.has(closedRange) &&
+			closedRange.start === closedStart &&
+			closedRange.end === previous &&
+			closedStart.parentNode === target
+		) {
+			// Skip a completed foreign range, including all its content. A valid
+			// backward walk skips each active range at most once. Bounding jumps
+			// also prevents cycles if external DOM code reverses a marker pair;
+			// after that bound, ordinary previousSibling steps always make progress.
+			remainingSkips--;
+			previous = closedStart.previousSibling as PortalEventBoundary | null;
+			continue;
+		}
+		const range = previous.$$portalEventRange;
+		const end = range?.end;
+		if (
+			range !== undefined &&
+			ranges.has(range) &&
+			range.start === previous &&
+			end != null &&
+			end.parentNode === target &&
+			(previous.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 &&
+			(node.compareDocumentPosition(end) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+		) {
+			// The first enclosing start encountered backwards is the innermost
+			// active owner, including foreign ranges interleaved in a Fragment.
+			owner = range;
+			break;
+		}
+		previous = previous.previousSibling as PortalEventBoundary | null;
+	}
+	if (owner === undefined) return;
+	if (ROOT_RENDER_TRANSACTION !== null) {
+		journalRootProperty(node, '$$portalParent');
+		journalRootProperty(node, '$$portalContainer');
+	}
+	node.$$portalParent = owner.host;
+	node.$$portalContainer = target;
+}
+
+function preparePortalEventOwners(path: EventTarget[], epoch: number): void {
+	for (let i = 0; i < path.length; i++) {
+		const node = eventPathNode(path[i]);
+		if (node === null) continue;
+		resolvePortalEventOwner(node);
+		// A nested portal's logical host need not occur on the native path.
+		// Resolve that branch too, before native target listeners can move nodes.
+		let logical = node.$$portalParent as DelegatedNode | undefined;
+		while (logical != null && !isEventRoot(logical, epoch) && path.indexOf(logical) < 0) {
+			resolvePortalEventOwner(logical);
+			logical = (logical.$$portalParent || logical.parentNode) as DelegatedNode | undefined;
+		}
+	}
+}
 
 function eventPathNode(target: EventTarget | null | undefined): DelegatedNode | null {
 	return target != null && typeof (target as Node).nodeType === 'number'
@@ -18751,12 +18852,39 @@ interface PortalSlot {
 	__kind: 'portalSlotSlot';
 	block: Block | null;
 	target: Element | null;
+	host: Node;
 	start: Comment | null;
 	end: Comment | null;
 	fragmentOwners?: FragmentInstance | readonly FragmentInstance[];
 	fragmentAnchor?: Node;
 	sourceAnchor?: Node;
 	interleavedFragment?: FragmentInstance;
+}
+
+function registerPortalEventRange(target: Node, portal: PortalSlot): void {
+	let ranges = _portalEventRanges.get(target);
+	if (ranges === undefined) {
+		ranges = new Set();
+		_portalEventRanges.set(target, ranges);
+		portalEventTargetCount++;
+	}
+	ranges.add(portal);
+	(portal.start as PortalEventBoundary).$$portalEventRange = portal;
+	(portal.end as PortalEventBoundary).$$portalEventStart = portal.start as PortalEventBoundary;
+}
+
+function unregisterPortalEventRange(target: Node, portal: PortalSlot): void {
+	const start = portal.start as PortalEventBoundary | null;
+	const end = portal.end as PortalEventBoundary | null;
+	if (start?.$$portalEventRange === portal) delete start.$$portalEventRange;
+	if (end?.$$portalEventStart === start) delete end.$$portalEventStart;
+	const ranges = _portalEventRanges.get(target);
+	if (ranges === undefined) return;
+	ranges.delete(portal);
+	if (ranges.size === 0) {
+		_portalEventRanges.delete(target);
+		portalEventTargetCount--;
+	}
 }
 
 /**
@@ -19056,16 +19184,25 @@ function renderPortalState(
 		if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__) {
 			__profileTrackComponent(block, profilePortalComponent(rawBody));
 		}
-		state = { __kind: 'portalSlotSlot', block, target, start, end };
+		state = { __kind: 'portalSlotSlot', block, target, host, start, end };
+		registerPortalEventRange(target, state);
 		activityPortalCreated?.(block);
 		// Portal target hosts handlers stamped via the same `el.$$click = …`
 		// mechanism as the main tree, so it needs the delegated event listeners too.
 		// Refcounted: a target hosting two portals attaches once, detaches when the
 		// last portal unmounts.
 		registerDelegationTarget(target);
-		if (ROOT_RENDER_TRANSACTION !== null) journalUndo(() => unregisterDelegationTarget(target));
+		if (ROOT_RENDER_TRANSACTION !== null) {
+			const created = state;
+			journalUndo(() => {
+				unregisterPortalEventRange(target, created);
+				unregisterDelegationTarget(target);
+			});
+		}
 		renderBlock(block);
 	} else {
+		if (state.host !== host) journalRootProperty(state, 'host');
+		state.host = host;
 		if (state.block!.body !== norm.body) journalRootProperty(state.block!, 'body');
 		if (state.block!.props !== norm.props) journalRootProperty(state.block!, 'props');
 		if (state.block!.extra !== env) journalRootProperty(state.block!, 'extra');
@@ -19125,6 +19262,7 @@ function teardownPortalState(state: PortalSlot): void {
 		state.block = null;
 	}
 	if (state.target) {
+		unregisterPortalEventRange(state.target, state);
 		unregisterDelegationTarget(state.target);
 		state.target = null;
 	}

--- a/packages/octane/tests/_fixtures/event-boundaries.tsrx
+++ b/packages/octane/tests/_fixtures/event-boundaries.tsrx
@@ -1,0 +1,88 @@
+declare module 'octane/jsx-runtime' {
+	namespace Octane {
+		namespace JSX {
+			interface IntrinsicElements {
+				'event-probe-host': IntrinsicElements['div'];
+			}
+		}
+	}
+}
+
+export type EventProbeProps = {
+	record(label: string, event: Event): void;
+};
+
+export function SameRoot(props: EventProbeProps) @{
+	<section
+		data-name="parent"
+		onClickCapture={(event) => props.record('parent:capture', event)}
+		onClick={(event) => props.record('parent:bubble', event)}
+	>
+		<button
+			data-name="target"
+			data-target
+			onClickCapture={(event) => props.record('target:capture', event)}
+			onClick={(event) => props.record('target:bubble', event)}
+		>Click</button>
+	</section>
+}
+
+export function OuterNested(props: EventProbeProps) @{
+	<section
+		data-name="outer"
+		onClickCapture={(event) => props.record('outer:capture', event)}
+		onClick={(event) => props.record('outer:bubble', event)}
+	>
+		<div data-name="middle" data-middle>
+			<div data-inner-root />
+		</div>
+	</section>
+}
+
+export function Inner(props: EventProbeProps) @{
+	<section
+		data-name="inner"
+		onClickCapture={(event) => props.record('inner:capture', event)}
+		onClick={(event) => props.record('inner:bubble', event)}
+	>
+		<button data-name="target" data-target>Click</button>
+	</section>
+}
+
+export function OuterShadow(props: EventProbeProps) @{
+	<section
+		data-name="outer"
+		onClickCapture={(event) => props.record('outer:capture', event)}
+		onClick={(event) => props.record('outer:bubble', event)}
+	>
+		<event-probe-host data-name="host" data-host />
+	</section>
+}
+
+export function OuterSlot(props: EventProbeProps) @{
+	<section
+		data-name="outer"
+		onClickCapture={(event) => props.record('outer:capture', event)}
+		onClick={(event) => props.record('outer:bubble', event)}
+	>
+		<event-probe-host data-name="host" data-host>
+			<button
+				data-name="light"
+				data-target
+				slot="content"
+				onClickCapture={(event) => props.record('light:capture', event)}
+				onClick={(event) => props.record('light:bubble', event)}
+			>Click</button>
+		</event-probe-host>
+	</section>
+}
+
+export function SlotInner(props: EventProbeProps) @{
+	<section
+		data-name="inner"
+		onClickCapture={(event) => props.record('inner:capture', event)}
+		onClick={(event) => props.record('inner:bubble', event)}
+	>
+		<slot name="content" />
+	</section>
+}

--- a/packages/octane/tests/browser/event-boundaries/event-boundaries.test.ts
+++ b/packages/octane/tests/browser/event-boundaries/event-boundaries.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+import { launchBrowser } from '../../../../../test-utils/playwright-browser.js';
+import { createServer, type Plugin, type ViteDevServer } from 'vite';
+import { compile as compileToReact } from '@tsrx/react';
+import { transformSync } from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { octane } from 'octane/compiler/vite';
+import type { ProbeOptions, RuntimeName, SameRootScenario } from './main.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(HERE, '../../_fixtures/event-boundaries.tsrx');
+const REACT_FIXTURE_ID = '\0event-boundaries-react-fixture';
+let server: ViteDevServer;
+let browser: Browser;
+let baseUrl: string;
+let page: Page | undefined;
+let pageFailures: string[] = [];
+
+function reactFixturePlugin(): Plugin {
+	return {
+		name: 'event-boundaries-react-fixture',
+		enforce: 'pre',
+		resolveId(id) {
+			if (id === 'virtual:event-boundaries-react-fixture') return REACT_FIXTURE_ID;
+		},
+		load(id) {
+			if (id !== REACT_FIXTURE_ID) return;
+			const result = compileToReact(readFileSync(FIXTURE, 'utf8'), FIXTURE);
+			if (result.errors?.length)
+				throw new Error(result.errors.map((error: Error) => error.message).join('\n'));
+			return transformSync(result.code, {
+				loader: 'tsx',
+				jsx: 'automatic',
+				jsxImportSource: 'react',
+				target: 'esnext',
+				format: 'esm',
+				sourcefile: FIXTURE,
+			}).code;
+		},
+	};
+}
+
+beforeAll(async () => {
+	server = await createServer({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		cacheDir: resolve(HERE, '../../../../../node_modules/.vite/octane-event-boundaries'),
+		plugins: [reactFixturePlugin(), octane()],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	await server.listen();
+	const address = server.httpServer!.address();
+	if (!address || typeof address === 'string') throw new Error('No Vite TCP port');
+	baseUrl = `http://127.0.0.1:${address.port}`;
+	browser = await launchBrowser({ headless: true });
+});
+
+afterEach(async () => {
+	const failures = pageFailures;
+	await page?.close();
+	page = undefined;
+	pageFailures = [];
+	expect(failures).toEqual([]);
+});
+
+afterAll(async () => {
+	await browser?.close();
+	await server?.close();
+});
+
+async function openCase(options: ProbeOptions): Promise<Page> {
+	page = await browser.newPage();
+	page.on('pageerror', (error) => pageFailures.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'warning' || message.type() === 'error')
+			pageFailures.push(message.text());
+	});
+	await page.goto(baseUrl);
+	await page.waitForFunction(() => Boolean(window.__eventBoundaries));
+	await page.evaluate((options) => window.__eventBoundaries.mount(options), options);
+	return page;
+}
+
+async function click(page: Page, runtime: RuntimeName): Promise<string[]> {
+	// Coordinates also exercise closed shadow roots with trusted browser input.
+	const point = await page.evaluate(
+		(runtime) => window.__eventBoundaries.clickPoint(runtime),
+		runtime,
+	);
+	await page.mouse.click(point.x, point.y);
+	const records = await page.evaluate((runtime) => window.__eventBoundaries.logs[runtime], runtime);
+	expect(records.every(({ trusted }) => trusted)).toBe(true);
+	return records.map(({ label }) => label);
+}
+
+describe.sequential('trusted event propagation across native listener and root boundaries', () => {
+	// React tracks logical cancellation separately from native cancelBubble:
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom-bindings/src/events/SyntheticEvent.js#L81
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js#L266
+	// Native target cancellation also has upstream coverage in
+	// testNativeStopPropagationInInnerBubblePhase:
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js#L2690
+	const captured = ['parent:capture', 'target:capture'];
+	const nativeTarget = ['native:target:first', 'native:target:second'];
+	const beforeBubble = [...captured, ...nativeTarget, 'native:root:before'];
+	const sameRootCases: Array<{ scenario: SameRootScenario; expected: string[] }> = [
+		{
+			scenario: 'baseline',
+			expected: [
+				...beforeBubble,
+				'target:bubble',
+				'parent:bubble',
+				'native:root:after',
+				'native:document',
+			],
+		},
+		{
+			scenario: 'framework-stop',
+			expected: [...beforeBubble, 'target:bubble', 'native:root:after'],
+		},
+		{
+			scenario: 'framework-native-immediate',
+			expected: [...beforeBubble, 'target:bubble', 'parent:bubble'],
+		},
+		{
+			scenario: 'framework-stop-and-immediate',
+			expected: [...beforeBubble, 'target:bubble'],
+		},
+		{
+			scenario: 'root-bubble-stop',
+			expected: [...beforeBubble, 'target:bubble', 'parent:bubble', 'native:root:after'],
+		},
+		{
+			scenario: 'root-bubble-immediate',
+			expected: beforeBubble,
+		},
+		{
+			scenario: 'root-capture-stop',
+			expected: ['native:root:before', ...captured, 'native:root:after'],
+		},
+		{
+			scenario: 'root-capture-immediate',
+			expected: ['native:root:before'],
+		},
+		{
+			scenario: 'target-stop',
+			expected: [...captured, ...nativeTarget],
+		},
+		{
+			scenario: 'target-immediate',
+			expected: [...captured, 'native:target:first'],
+		},
+	];
+
+	for (const { scenario, expected } of sameRootCases) {
+		it(`preserves native listener and logical handler cancellation for ${scenario}`, async () => {
+			const page = await openCase({ kind: 'same-root', scenario });
+			const react = await click(page, 'react');
+			expect(react).toEqual(expected);
+			expect(await click(page, 'octane')).toEqual(react);
+			if (
+				scenario === 'framework-native-immediate' ||
+				scenario === 'root-bubble-stop' ||
+				scenario === 'root-capture-stop'
+			) {
+				const label = scenario === 'root-capture-stop' ? 'target:capture' : 'parent:bubble';
+				// Continuing logical delivery must not clear the browser's native stop flag.
+				expect(
+					await page.evaluate(
+						(label) =>
+							window.__eventBoundaries.logs.octane.find((entry) => entry.label === label)
+								?.nativeStopped,
+						label,
+					),
+				).toBe(true);
+			}
+		});
+	}
+
+	for (const stop of [false, true]) {
+		it(`interleaves native listeners between nested roots${stop ? ' without crossing a native stop' : ''}`, async () => {
+			const page = await openCase({ kind: 'nested', stop });
+			const react = await click(page, 'react');
+			expect(react).toEqual([
+				'outer:capture',
+				'native:middle:capture',
+				'inner:capture',
+				'inner:bubble',
+				'native:middle:bubble',
+				...(stop ? [] : ['outer:bubble']),
+			]);
+			expect(await click(page, 'octane')).toEqual(react);
+		});
+	}
+
+	for (const mode of ['open', 'closed'] as const) {
+		it(`propagates through a custom element's ${mode} shadow root while preserving target retargeting`, async () => {
+			const page = await openCase({ kind: 'shadow', mode });
+			expect(await click(page, 'octane')).toEqual([
+				'outer:capture',
+				'inner:capture',
+				'inner:bubble',
+				'outer:bubble',
+			]);
+			const records = await page.evaluate(() => window.__eventBoundaries.logs.octane);
+			expect(records.map(({ currentTarget, target }) => [currentTarget, target])).toEqual([
+				['outer', 'host'],
+				['inner', 'target'],
+				['inner', 'target'],
+				['outer', 'host'],
+			]);
+		});
+	}
+
+	it('propagates through a native slot and its shadow ancestors in capture and bubble order', async () => {
+		const page = await openCase({ kind: 'slot' });
+		expect(await page.evaluate(() => window.__eventBoundaries.slotDistributesTarget())).toBe(true);
+		expect(await click(page, 'octane')).toEqual([
+			'outer:capture',
+			'inner:capture',
+			'light:capture',
+			'light:bubble',
+			'inner:bubble',
+			'outer:bubble',
+		]);
+		const records = await page.evaluate(() => window.__eventBoundaries.logs.octane);
+		expect(records.map(({ currentTarget, target }) => [currentTarget, target])).toEqual([
+			['outer', 'light'],
+			['inner', 'light'],
+			['light', 'light'],
+			['light', 'light'],
+			['inner', 'light'],
+			['outer', 'light'],
+		]);
+	});
+});

--- a/packages/octane/tests/browser/event-boundaries/index.html
+++ b/packages/octane/tests/browser/event-boundaries/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Event propagation across roots and web components</title>
+	</head>
+	<body>
+		<div id="octane-root"></div>
+		<div id="react-root"></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/event-boundaries/main.ts
+++ b/packages/octane/tests/browser/event-boundaries/main.ts
@@ -1,0 +1,197 @@
+/// <reference path="./react-fixture.d.ts" />
+
+import { createRoot as createOctaneRoot } from '../../../src/index.js';
+import { createRoot as createReactRoot } from 'react-dom/client';
+import { flushSync as flushReactSync } from 'react-dom';
+import { createElement } from 'react';
+import * as OctaneFixture from '../../_fixtures/event-boundaries.tsrx';
+import * as ReactFixture from 'virtual:event-boundaries-react-fixture';
+import type { EventProbeProps } from '../../_fixtures/event-boundaries.tsrx';
+
+export type RuntimeName = 'octane' | 'react';
+export type SameRootScenario =
+	| 'baseline'
+	| 'framework-stop'
+	| 'framework-native-immediate'
+	| 'framework-stop-and-immediate'
+	| 'root-bubble-stop'
+	| 'root-bubble-immediate'
+	| 'root-capture-stop'
+	| 'root-capture-immediate'
+	| 'target-stop'
+	| 'target-immediate';
+export type ProbeOptions =
+	| { kind: 'same-root'; scenario: SameRootScenario }
+	| { kind: 'nested'; stop: boolean }
+	| { kind: 'shadow'; mode: ShadowRootMode }
+	| { kind: 'slot' };
+type HandlerRecord = {
+	label: string;
+	trusted: boolean;
+	nativeStopped: boolean;
+	target: string;
+	currentTarget: string;
+};
+const containers = {
+	octane: document.querySelector<HTMLElement>('#octane-root')!,
+	react: document.querySelector<HTMLElement>('#react-root')!,
+};
+const logs: Record<RuntimeName, HandlerRecord[]> = { octane: [], react: [] };
+const targets: Partial<Record<RuntimeName, HTMLElement>> = {};
+let slot: HTMLSlotElement | undefined;
+
+customElements.define('event-probe-host', class extends HTMLElement {});
+
+function name(target: EventTarget | null): string {
+	if (target === document) return 'document';
+	if (target instanceof HTMLElement) return target.dataset.name ?? target.id;
+	return '';
+}
+
+function record(runtime: RuntimeName, label: string, event: Event): void {
+	const native = (event as Event & { nativeEvent?: Event }).nativeEvent ?? event;
+	logs[runtime].push({
+		label,
+		trusted: native.isTrusted,
+		nativeStopped: native.cancelBubble,
+		target: name(event.target),
+		currentTarget: name(event.currentTarget),
+	});
+}
+
+function render(
+	runtime: RuntimeName,
+	component: 'SameRoot' | 'OuterNested' | 'Inner',
+	container: HTMLElement,
+	props: EventProbeProps,
+): void {
+	if (runtime === 'octane') {
+		createOctaneRoot(container).render(OctaneFixture[component], props);
+	} else {
+		// Only mounting is synchronous; trusted input is never wrapped in flushSync.
+		flushReactSync(() => {
+			createReactRoot(container).render(createElement(ReactFixture[component], props));
+		});
+	}
+}
+
+function mountSameRoot(runtime: RuntimeName, scenario: SameRootScenario): void {
+	const container = containers[runtime];
+	const rootCapture = scenario.startsWith('root-capture');
+	container.addEventListener(
+		'click',
+		(event) => {
+			record(runtime, 'native:root:before', event);
+			if (scenario.startsWith('root-')) {
+				if (scenario.endsWith('immediate')) event.stopImmediatePropagation();
+				else event.stopPropagation();
+			}
+		},
+		rootCapture,
+	);
+	const props: EventProbeProps = {
+		record(label, event) {
+			record(runtime, label, event);
+			if (label !== 'target:bubble') return;
+			if (scenario === 'framework-stop' || scenario === 'framework-stop-and-immediate') {
+				event.stopPropagation();
+			}
+			if (
+				scenario === 'framework-native-immediate' ||
+				scenario === 'framework-stop-and-immediate'
+			) {
+				const native = (event as Event & { nativeEvent?: Event }).nativeEvent ?? event;
+				native.stopImmediatePropagation();
+			}
+		},
+	};
+	render(runtime, 'SameRoot', container, props);
+	const target = container.querySelector<HTMLElement>('[data-target]')!;
+	targets[runtime] = target;
+	target.addEventListener('click', (event) => {
+		record(runtime, 'native:target:first', event);
+		if (scenario === 'target-stop') event.stopPropagation();
+		if (scenario === 'target-immediate') event.stopImmediatePropagation();
+	});
+	target.addEventListener('click', (event) => record(runtime, 'native:target:second', event));
+	container.addEventListener(
+		'click',
+		(event) => record(runtime, 'native:root:after', event),
+		rootCapture,
+	);
+	document.addEventListener('click', (event) => {
+		if (container.contains(event.target as Node)) record(runtime, 'native:document', event);
+	});
+}
+
+function mountNested(runtime: RuntimeName, stop: boolean): void {
+	const container = containers[runtime];
+	const props: EventProbeProps = { record: (label, event) => record(runtime, label, event) };
+	render(runtime, 'OuterNested', container, props);
+	const middle = container.querySelector<HTMLElement>('[data-middle]')!;
+	middle.addEventListener(
+		'click',
+		(event) => record(runtime, 'native:middle:capture', event),
+		true,
+	);
+	middle.addEventListener('click', (event) => {
+		record(runtime, 'native:middle:bubble', event);
+		if (stop) event.stopPropagation();
+	});
+	render(runtime, 'Inner', container.querySelector<HTMLElement>('[data-inner-root]')!, props);
+	targets[runtime] = container.querySelector<HTMLElement>('[data-target]')!;
+}
+
+function mountShadow(options: Extract<ProbeOptions, { kind: 'shadow' | 'slot' }>): void {
+	const props: EventProbeProps = {
+		record: (label, event) => record('octane', label, event),
+	};
+	const isSlot = options.kind === 'slot';
+	createOctaneRoot(containers.octane).render(
+		isSlot ? OctaneFixture.OuterSlot : OctaneFixture.OuterShadow,
+		props,
+	);
+	const host = containers.octane.querySelector<HTMLElement>('[data-host]')!;
+	const shadow = host.attachShadow({ mode: options.kind === 'shadow' ? options.mode : 'open' });
+	const inner = document.createElement('div');
+	shadow.append(inner);
+	createOctaneRoot(inner).render(isSlot ? OctaneFixture.SlotInner : OctaneFixture.Inner, props);
+	targets.octane = (isSlot ? host : inner).querySelector<HTMLElement>('[data-target]')!;
+	if (isSlot) slot = inner.querySelector<HTMLSlotElement>('slot')!;
+}
+
+window.__eventBoundaries = {
+	logs,
+	mount(options: ProbeOptions) {
+		if (options.kind === 'shadow' || options.kind === 'slot') mountShadow(options);
+		else {
+			for (const runtime of ['octane', 'react'] as const) {
+				if (options.kind === 'same-root') mountSameRoot(runtime, options.scenario);
+				else mountNested(runtime, options.stop);
+			}
+		}
+	},
+	clickPoint(runtime: RuntimeName) {
+		const rect = targets[runtime]!.getBoundingClientRect();
+		return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+	},
+	slotDistributesTarget() {
+		return (
+			slot instanceof HTMLSlotElement &&
+			slot.assignedElements().length === 1 &&
+			slot.assignedElements()[0] === targets.octane &&
+			targets.octane?.assignedSlot === slot
+		);
+	},
+};
+
+declare global {
+	interface Window {
+		__eventBoundaries: {
+			logs: Record<RuntimeName, HandlerRecord[]>;
+			mount(options: ProbeOptions): void;
+			clickPoint(runtime: RuntimeName): { x: number; y: number };
+			slotDistributesTarget(): boolean;
+		};
+	}
+}

--- a/packages/octane/tests/browser/event-boundaries/react-fixture.d.ts
+++ b/packages/octane/tests/browser/event-boundaries/react-fixture.d.ts
@@ -1,0 +1,11 @@
+declare module 'virtual:event-boundaries-react-fixture' {
+	export const SameRoot: import('react').ComponentType<
+		import('../../_fixtures/event-boundaries.tsrx').EventProbeProps
+	>;
+	export const OuterNested: import('react').ComponentType<
+		import('../../_fixtures/event-boundaries.tsrx').EventProbeProps
+	>;
+	export const Inner: import('react').ComponentType<
+		import('../../_fixtures/event-boundaries.tsrx').EventProbeProps
+	>;
+}

--- a/packages/octane/tests/conformance/_fixtures/event-listener.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/event-listener.tsrx
@@ -8,6 +8,25 @@ export function RootDiv(props: { name: string; onOut: (e: Event) => void }) @{
 	<div class={props.name} onMouseOut={props.onOut}>{props.name}</div>
 }
 
+export function PropagationTree(props: {
+	onParent?: (event: Event) => void;
+	onParentCapture?: (event: Event) => void;
+	onTarget?: (event: Event) => void;
+	onTargetCapture?: (event: Event) => void;
+}) @{
+	<section
+		class="propagation-parent"
+		onClick={props.onParent}
+		onClickCapture={props.onParentCapture}
+	>
+		<button
+			class="propagation-target"
+			onClick={props.onTarget}
+			onClickCapture={props.onTargetCapture}
+		>Target</button>
+	</section>
+}
+
 // :106 — the clicked element is REMOVED by the update its own handler schedules.
 export function DisappearingButton() @{
 	const [clicked, setClicked] = useState(false);

--- a/packages/octane/tests/conformance/_fixtures/event-listener.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/event-listener.tsrx
@@ -1,7 +1,7 @@
 // Fixtures for conformance/event-listener.test.ts — port of
 // react-dom/src/__tests__/ReactDOMEventListener-test.js. Kept minimal: each
 // component models exactly the tree shape one React case dispatches into.
-import { useState } from 'octane';
+import { createPortal, useState } from 'octane';
 
 // Nested-root propagation (:32/:65) — one div per root, handler + name via props.
 export function RootDiv(props: { name: string; onOut: (e: Event) => void }) @{
@@ -25,6 +25,36 @@ export function PropagationTree(props: {
 			onClickCapture={props.onTargetCapture}
 		>Target</button>
 	</section>
+}
+
+interface DeferredPortalProps {
+	target: Element;
+	register: (setVisible: (visible: boolean) => void) => void;
+	log: (label: string) => void;
+}
+
+function DeferredPortalChild(props: DeferredPortalProps) @{
+	const [visible, setVisible] = useState(false);
+	props.register(setVisible);
+	<>
+		@if (visible) {
+			<button
+				class="deferred-portal-target"
+				onClickCapture={() => props.log('target capture')}
+				onClick={() => props.log('target bubble')}
+				onAuxClick={() => props.log('target bubble')}
+			>Portal target</button>
+		}
+	</>
+}
+
+export function DeferredPortalEvents(props: DeferredPortalProps) @{
+	<section
+		class="deferred-portal-parent"
+		onClickCapture={() => props.log('logical capture')}
+		onClick={() => props.log('logical bubble')}
+		onAuxClick={() => props.log('logical bubble')}
+	>{createPortal(<DeferredPortalChild {...props} />, props.target)}</section>
 }
 
 // :106 — the clicked element is REMOVED by the update its own handler schedules.

--- a/packages/octane/tests/conformance/event-listener.test.ts
+++ b/packages/octane/tests/conformance/event-listener.test.ts
@@ -12,11 +12,13 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import { mount, createLog, type EffectLog } from '../_helpers';
+import { loadServerFixture } from '../_server-fixture';
 import * as ClientRT from '../../src/index.js';
-import { flushSync, hydrateRoot } from '../../src/index.js';
+import { createRoot, flushSync, hydrateRoot } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import {
 	RootDiv,
+	PropagationTree,
 	DisappearingButton,
 	BatchChild,
 	BatchParent,
@@ -49,8 +51,7 @@ describe('ReactDOMEventListener — propagation across nested roots', () => {
 			.dispatchEvent(new Event('mouseout', { bubbles: true, cancelable: true }));
 
 		// Both handlers fire, inner-first, each seeing its OWN element as
-		// currentTarget — and exactly once each (the outer root's delegated
-		// listener must not re-walk the chain).
+		// currentTarget — and exactly once each.
 		expect(log.drain()).toEqual(['out:childdiv', 'out:parentdiv']);
 		child.unmount();
 		parent.unmount();
@@ -75,6 +76,55 @@ describe('ReactDOMEventListener — propagation across nested roots', () => {
 		grand.unmount();
 	});
 
+	// Lifecycle extension of ReactDOMEventListener's nested-root propagation:
+	// unmounting cannot replay an inner root's completed handler queue when the
+	// same native event subsequently reaches an enclosing root. Whether a removed
+	// target still reaches outer framework handlers is intentionally not pinned.
+	it.each([
+		{ at: 'handler', reattach: false },
+		{ at: 'handler', reattach: true },
+		{ at: 'native bridge', reattach: false },
+		{ at: 'native bridge', reattach: true },
+	] as const)(
+		'does not replay an unmounted root during native propagation (%j)',
+		({ at, reattach }) => {
+			const log: string[] = [];
+			const outer = mount(PropagationTree, { onParent: () => log.push('outer') });
+			const bridge = document.createElement('div');
+			outer.find('.propagation-parent').appendChild(bridge);
+			const innerContainer = document.createElement('div');
+			bridge.appendChild(innerContainer);
+			const inner = createRoot(innerContainer);
+			let target: HTMLElement | null = null;
+			const retire = () => {
+				inner.unmount();
+				if (reattach && target !== null) innerContainer.appendChild(target);
+			};
+			inner.render(PropagationTree, {
+				onTarget: () => {
+					log.push('inner target');
+					if (at === 'handler') retire();
+				},
+				onParent: () => log.push('inner parent'),
+			});
+			target = innerContainer.querySelector<HTMLElement>('.propagation-target')!;
+			bridge.addEventListener('click', () => {
+				log.push('native bridge');
+				if (at === 'native bridge') retire();
+			});
+			try {
+				target.click();
+				expect(log.filter((entry) => entry.startsWith('inner '))).toEqual([
+					'inner target',
+					'inner parent',
+				]);
+			} finally {
+				inner.unmount();
+				outer.unmount();
+			}
+		},
+	);
+
 	// Per ReactDOMEventListener-test.js:106 — should not get confused by disappearing elements
 	it('is not confused by the clicked element disappearing in its own handler update', () => {
 		const r = mount(DisappearingButton);
@@ -88,15 +138,9 @@ describe('ReactDOMEventListener — propagation across nested roots', () => {
 	// Per ReactDOMEventListener-test.js:157 — should batch between handlers from
 	// different roots (discrete).
 	//
-	// Intentional divergence (synthetic architecture): React attaches ONE listener
-	// per root, so a discrete event entering two nested roots flushes between the
-	// two listeners (their test reads '1' inside the outer root's handler — a
-	// behavior React itself documents as incidental "over-flushing"). octane's
-	// single deduped delegated walk gives ONE batch window: neither handler
-	// observes a mid-event commit. The React-shared contract that IS asserted:
-	// updates are batched while handlers run, and a discrete event's updates are
-	// committed synchronously by the time the dispatch returns.
-	it('batches between handlers from different roots (discrete): one batch window, committed by dispatch end', () => {
+	// Each root handles its own segment of the native event path. A discrete
+	// update commits after the inner root, before the event reaches the outer one.
+	it('commits a discrete update before the event enters its outer root', () => {
 		const log = createLog();
 		let childSet: (v: string) => void = () => {};
 		const childR = mount(BatchChild, {
@@ -117,9 +161,7 @@ describe('ReactDOMEventListener — propagation across nested roots', () => {
 		const span = childR.find('.child-span') as HTMLElement;
 		span.click();
 
-		// Both handlers ran; neither saw a mid-event flush (React's second read
-		// would be '1' — see divergence note above).
-		expect(log.drain()).toEqual(['read:Child', 'read:Child']);
+		expect(log.drain()).toEqual(['read:Child', 'read:1']);
 		// Discrete event: the final update is committed synchronously before the
 		// dispatch returns to the browser (React parity).
 		expect(span.textContent).toBe('2');
@@ -158,6 +200,386 @@ describe('ReactDOMEventListener — propagation across nested roots', () => {
 		expect(span.textContent).toBe('2');
 		childR.unmount();
 		parentR.unmount();
+	});
+});
+
+describe('ReactDOMEventListener — native listeners between nested roots', () => {
+	// Derived from ReactDOMEventPropagation-test.js:2552, :2620, and :2690:
+	// a native listener between roots runs between their framework dispatches.
+	it.each(['none', 'capture', 'bubble'] as const)(
+		'preserves native interleaving when propagation stops at %s',
+		(stopAt) => {
+			const log: string[] = [];
+			const outer = mount(PropagationTree, {
+				onParentCapture: () => log.push('outer capture'),
+				onParent: () => log.push('outer bubble'),
+			});
+			const inner = mount(PropagationTree, {
+				onParentCapture: () => log.push('inner capture'),
+				onTarget: () => log.push('inner target'),
+				onParent: () => log.push('inner bubble'),
+			});
+			const bridge = document.createElement('div');
+			outer.find('.propagation-parent').appendChild(bridge);
+			bridge.appendChild(inner.container);
+			bridge.addEventListener('click', (event) => {
+				log.push('native bubble');
+				if (stopAt === 'bubble') event.stopPropagation();
+			});
+			bridge.addEventListener(
+				'click',
+				(event) => {
+					log.push('native capture');
+					if (stopAt === 'capture') event.stopPropagation();
+				},
+				true,
+			);
+			try {
+				(inner.find('.propagation-target') as HTMLElement).click();
+				const expected = ['outer capture', 'native capture'];
+				if (stopAt !== 'capture') {
+					expected.push('inner capture', 'inner target', 'inner bubble', 'native bubble');
+					if (stopAt === 'none') expected.push('outer bubble');
+				}
+				expect(log).toEqual(expected);
+			} finally {
+				inner.unmount();
+				outer.unmount();
+			}
+		},
+	);
+
+	// Hydration extension of ReactDOMEventListener-test.js:32 and :1176:
+	// adopted roots retain the same native interleaving as newly mounted roots.
+	it('preserves native interleaving across hydrated roots without replacing their nodes', () => {
+		const server = loadServerFixture<{ PropagationTree: typeof PropagationTree }>(
+			join(process.cwd(), 'packages/octane/tests/conformance/_fixtures/event-listener.tsrx'),
+		);
+		const { html } = ServerRT.renderToString(server.PropagationTree, {});
+		const log: string[] = [];
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const parent = container.querySelector('.propagation-parent')!;
+		const outer = hydrateRoot(container, PropagationTree, {
+			onParentCapture: () => log.push('outer capture'),
+			onParent: () => log.push('outer bubble'),
+		});
+		flushSync(() => {});
+		const bridge = document.createElement('div');
+		const innerContainer = document.createElement('div');
+		parent.appendChild(bridge);
+		bridge.appendChild(innerContainer);
+		innerContainer.innerHTML = html;
+		const target = innerContainer.querySelector('.propagation-target')!;
+		const inner = hydrateRoot(innerContainer, PropagationTree, {
+			onParentCapture: () => log.push('inner capture'),
+			onTarget: () => log.push('target'),
+			onParent: () => log.push('inner bubble'),
+		});
+		flushSync(() => {});
+		bridge.addEventListener('click', () => log.push('native capture'), true);
+		bridge.addEventListener('click', () => log.push('native bubble'));
+		try {
+			expect(container.querySelector('.propagation-parent')).toBe(parent);
+			expect(innerContainer.querySelector('.propagation-target')).toBe(target);
+			target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(log).toEqual([
+				'outer capture',
+				'native capture',
+				'inner capture',
+				'target',
+				'inner bubble',
+				'native bubble',
+				'outer bubble',
+			]);
+		} finally {
+			inner.unmount();
+			outer.unmount();
+			container.remove();
+		}
+	});
+});
+
+describe('ReactDOMEventListener — native and framework cancellation', () => {
+	// Source-derived parity regressions, not direct ports of an upstream test:
+	// React initializes logical propagation independently of native cancelBubble,
+	// then checks that logical flag between framework listeners.
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom-bindings/src/events/SyntheticEvent.js#L81
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js#L266
+	it.each(['stopPropagation', 'stopImmediatePropagation'] as const)(
+		'honors an earlier root-native %s before framework handlers',
+		(method) => {
+			const log: string[] = [];
+			const observed: Event[] = [];
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.addEventListener('click', (event) => {
+				log.push('native before');
+				event[method]();
+			});
+			const root = createRoot(container);
+			root.render(PropagationTree, {
+				onTarget: (event: Event) => {
+					log.push('target');
+					observed.push(event);
+				},
+				onParent: (event: Event) => {
+					log.push('parent');
+					observed.push(event);
+				},
+			});
+			container.addEventListener('click', () => log.push('native after'));
+			const outside = () => log.push('outside');
+			document.body.addEventListener('click', outside);
+			const event = new MouseEvent('click', { bubbles: true });
+			try {
+				container.querySelector('.propagation-target')!.dispatchEvent(event);
+				expect(log).toEqual(
+					method === 'stopPropagation'
+						? ['native before', 'target', 'parent', 'native after']
+						: ['native before'],
+				);
+				expect(observed.map((seen) => seen === event)).toEqual(
+					method === 'stopPropagation' ? [true, true] : [],
+				);
+			} finally {
+				document.body.removeEventListener('click', outside);
+				root.unmount();
+				container.remove();
+			}
+		},
+	);
+
+	// Calling stopPropagation in a framework handler cancels logical ancestors.
+	// stopImmediatePropagation retains the native-only behavior of React's
+	// nativeEvent.stopImmediatePropagation: it blocks subsequent native listeners,
+	// not the already-running framework queue (source references above).
+	it.each(['stopPropagation', 'stopImmediatePropagation'] as const)(
+		'preserves the selected framework/native scope of %s inside a handler',
+		(method) => {
+			const log: string[] = [];
+			const observed: Event[] = [];
+			const r = mount(PropagationTree, {
+				onTarget: (event) => {
+					log.push('target');
+					observed.push(event);
+					event[method]();
+				},
+				onParent: (event) => {
+					log.push('parent');
+					observed.push(event);
+				},
+			});
+			r.container.addEventListener('click', () => log.push('native after'));
+			const outside = () => log.push('outside');
+			document.body.addEventListener('click', outside);
+			const event = new MouseEvent('click', { bubbles: true });
+			try {
+				r.find('.propagation-target').dispatchEvent(event);
+				expect(log).toEqual(
+					method === 'stopPropagation' ? ['target', 'native after'] : ['target', 'parent'],
+				);
+				expect(observed.map((seen) => seen === event)).toEqual(
+					method === 'stopPropagation' ? [true] : [true, true],
+				);
+			} finally {
+				document.body.removeEventListener('click', outside);
+				r.unmount();
+			}
+		},
+	);
+
+	// Capture has its own logical queue; native immediate cancellation must not
+	// truncate that queue, but the browser still prevents target/bubble delivery.
+	it.each(['stopPropagation', 'stopImmediatePropagation'] as const)(
+		'keeps capture-queue cancellation distinct from native %s',
+		(method) => {
+			const log: string[] = [];
+			let nativeStopped: boolean | undefined;
+			const r = mount(PropagationTree, {
+				onParentCapture: (event: Event) => {
+					log.push('parent capture');
+					event[method]();
+				},
+				onTargetCapture: (event: Event) => {
+					log.push('target capture');
+					nativeStopped = event.cancelBubble;
+				},
+				onTarget: () => log.push('target bubble'),
+			});
+			r.container.addEventListener('click', () => log.push('native capture'), true);
+			try {
+				(r.find('.propagation-target') as HTMLElement).click();
+				expect(log).toEqual(
+					method === 'stopPropagation'
+						? ['parent capture', 'native capture']
+						: ['parent capture', 'target capture'],
+				);
+				if (method === 'stopImmediatePropagation') expect(nativeStopped).toBe(true);
+			} finally {
+				r.unmount();
+			}
+		},
+	);
+
+	// Reentrant extension of the same source-derived cancellation contract:
+	// stopping a nested native event must not stop its caller's logical ancestors.
+	it('isolates nested cancellation and restores the native event after dispatch', () => {
+		const log: string[] = [];
+		const resumedTargets: (EventTarget | null)[] = [];
+		const r = mount(PropagationTree, {
+			onTarget: (event) => {
+				const detail = (event as MouseEvent).detail;
+				log.push('target:' + detail);
+				if (detail === 2) event.stopPropagation();
+				else {
+					r.find('.propagation-target').dispatchEvent(
+						new MouseEvent('click', { bubbles: true, detail: 2 }),
+					);
+					resumedTargets.push(event.currentTarget);
+				}
+			},
+			onParent: (event) => log.push('parent:' + (event as MouseEvent).detail),
+		});
+		const event = new MouseEvent('click', { bubbles: true, detail: 1 });
+		const stopPropagation = event.stopPropagation;
+		try {
+			r.find('.propagation-target').dispatchEvent(event);
+			expect(log).toEqual(['target:1', 'target:2', 'parent:1']);
+			expect(resumedTargets[0]).toBe(r.find('.propagation-target'));
+			expect(event.stopPropagation).toBe(stopPropagation);
+			expect(event.currentTarget).toBe(null);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Native EventTarget permits redispatch after a dispatch returns; logical
+	// propagation state must be scoped to that dispatch, not the Event's lifetime.
+	it('runs both phases again when the same native event is synchronously redispatched', () => {
+		const log: string[] = [];
+		let stop = true;
+		const r = mount(PropagationTree, {
+			onParentCapture: () => log.push('capture'),
+			onTarget: (event) => {
+				log.push('target');
+				if (stop) event.stopPropagation();
+			},
+			onParent: () => log.push('parent'),
+		});
+		const event = new MouseEvent('click', { bubbles: true });
+		try {
+			const target = r.find('.propagation-target');
+			target.dispatchEvent(event);
+			stop = false;
+			target.dispatchEvent(event);
+			expect(log).toEqual(['capture', 'target', 'capture', 'target', 'parent']);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Octane uses the native object rather than a SyntheticEvent wrapper. A
+	// consumer's own stopPropagation method and descriptor must survive dispatch.
+	it.each([
+		{ configurable: true, writable: false },
+		{ configurable: false, writable: true },
+	])('restores an own stopPropagation descriptor (%j) before later native listeners', (flags) => {
+		const log: string[] = [];
+		const event = new MouseEvent('click', { bubbles: true });
+		const stopPropagation = function (this: Event) {
+			log.push('own stop');
+			Event.prototype.stopPropagation.call(this);
+		};
+		Object.defineProperty(event, 'stopPropagation', {
+			value: stopPropagation,
+			enumerable: true,
+			...flags,
+		});
+		const descriptor = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
+		const observed: (PropertyDescriptor | undefined)[] = [];
+		const r = mount(PropagationTree, {
+			onTarget: (event) => {
+				log.push('target');
+				event.stopPropagation();
+			},
+			onParent: () => log.push('parent'),
+		});
+		r.container.addEventListener('click', (nativeEvent) => {
+			log.push('native after');
+			observed.push(Object.getOwnPropertyDescriptor(nativeEvent, 'stopPropagation'));
+		});
+		try {
+			r.find('.propagation-target').dispatchEvent(event);
+			expect(log).toEqual(['target', 'own stop', 'native after']);
+			expect(observed).toEqual([descriptor]);
+			expect(Object.getOwnPropertyDescriptor(event, 'stopPropagation')).toEqual(descriptor);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// A retained native method remains callable after the framework's dispatch
+	// scope has ended; it still sets the original Event's native stop flag.
+	it.each(['stopPropagation', 'stopImmediatePropagation'] as const)(
+		'keeps a retained %s callable after dispatch',
+		(method) => {
+			const retained: (() => void)[] = [];
+			const r = mount(PropagationTree, {
+				onTarget: (event) => retained.push(event[method]),
+			});
+			const event = new MouseEvent('click', { bubbles: true });
+			try {
+				r.find('.propagation-target').dispatchEvent(event);
+				expect(event.cancelBubble).toBe(false);
+				retained[0].call(event);
+				expect(event.cancelBubble).toBe(true);
+			} finally {
+				r.unmount();
+			}
+		},
+	);
+
+	// An immutable own method cannot be interposed without replacing the Event.
+	// It retains native-only cancellation, like calling Event.prototype directly.
+	it('keeps a locked own stop method native-only without affecting the next event', () => {
+		const log: string[] = [];
+		const nativeFlags: boolean[] = [];
+		const event = new MouseEvent('click', { bubbles: true });
+		const stopPropagation = function (this: Event) {
+			log.push('own stop');
+			Event.prototype.stopPropagation.call(this);
+		};
+		Object.defineProperty(event, 'stopPropagation', {
+			value: stopPropagation,
+			configurable: false,
+			writable: false,
+		});
+		const descriptor = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
+		const r = mount(PropagationTree, {
+			onTarget: (event) => {
+				log.push('target');
+				event.stopPropagation();
+			},
+			onParent: (event) => {
+				log.push('parent');
+				nativeFlags.push(event.cancelBubble);
+			},
+		});
+		r.container.addEventListener('click', () => log.push('native after'));
+		try {
+			const target = r.find('.propagation-target');
+			target.dispatchEvent(event);
+			expect(log).toEqual(['target', 'own stop', 'parent', 'native after']);
+			expect(nativeFlags).toEqual([true]);
+			expect(Object.getOwnPropertyDescriptor(event, 'stopPropagation')).toEqual(descriptor);
+			log.length = 0;
+			target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(log).toEqual(['target', 'native after']);
+		} finally {
+			r.unmount();
+		}
 	});
 });
 

--- a/packages/octane/tests/conformance/event-listener.test.ts
+++ b/packages/octane/tests/conformance/event-listener.test.ts
@@ -19,6 +19,7 @@ import * as ServerRT from 'octane/server';
 import {
 	RootDiv,
 	PropagationTree,
+	DeferredPortalEvents,
 	DisappearingButton,
 	BatchChild,
 	BatchParent,
@@ -36,6 +37,126 @@ import {
 
 const outLogger = (log: EffectLog) => (e: Event) =>
 	log.push('out:' + (e.currentTarget as Element).className);
+
+describe('portal events after descendant updates', () => {
+	// Lifecycle extension of React's logical portal propagation, not an exact
+	// upstream test port: a child can reveal its first host without rerendering
+	// the component that created the portal. Its events still belong to that tree.
+	// https://github.com/facebook/react/blob/6117d7cca4906492c51fe6a03381e35adfd86e7d/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js#L630
+	it.each(['separate container', 'another root'] as const)(
+		'delivers both portal phases after child-local state reveals content in %s',
+		(placement) => {
+			const log: string[] = [];
+			const physicalRoot =
+				placement === 'another root'
+					? mount(PropagationTree, {
+							onParentCapture: () => log.push('physical capture'),
+							onParent: () => log.push('physical bubble'),
+						})
+					: null;
+			const target = document.createElement('div');
+			(physicalRoot?.find('.propagation-parent') ?? document.body).appendChild(target);
+			let setVisible: (visible: boolean) => void = () => {};
+			const logicalRoot = mount(DeferredPortalEvents, {
+				target,
+				register: (setter) => {
+					setVisible = setter;
+				},
+				log: (label) => log.push(label),
+			});
+			try {
+				expect(target.querySelector('.deferred-portal-target')).toBeNull();
+				flushSync(() => setVisible(true));
+				const button = target.querySelector<HTMLButtonElement>('.deferred-portal-target');
+				expect(button).not.toBeNull();
+				button!.click();
+				const expected = ['logical capture', 'target capture', 'target bubble', 'logical bubble'];
+				if (physicalRoot !== null) {
+					expected.unshift('physical capture');
+					expected.push('physical bubble');
+				}
+				expect(log).toEqual(expected);
+			} finally {
+				logicalRoot.unmount();
+				physicalRoot?.unmount();
+				target.remove();
+			}
+		},
+	);
+
+	it('keeps late portal content with its own logical parent when a shared target owner unmounts', () => {
+		const log: string[] = [];
+		const target = document.createElement('div');
+		document.body.appendChild(target);
+		const emptyOwner = mount(DeferredPortalEvents, {
+			target,
+			register: () => {},
+			log: (label) => log.push('empty: ' + label),
+		});
+		let setVisible: (visible: boolean) => void = () => {};
+		const visibleOwner = mount(DeferredPortalEvents, {
+			target,
+			register: (setter) => {
+				setVisible = setter;
+			},
+			log: (label) => log.push('visible: ' + label),
+		});
+		try {
+			flushSync(() => setVisible(true));
+			target.querySelector<HTMLButtonElement>('.deferred-portal-target')!.click();
+			const expected = [
+				'visible: logical capture',
+				'visible: target capture',
+				'visible: target bubble',
+				'visible: logical bubble',
+			];
+			expect(log).toEqual(expected);
+			emptyOwner.unmount();
+			flushSync(() => setVisible(false));
+			expect(target.querySelector('.deferred-portal-target')).toBeNull();
+			flushSync(() => setVisible(true));
+			target.querySelector<HTMLButtonElement>('.deferred-portal-target')!.click();
+			expect(log).toEqual([...expected, ...expected]);
+		} finally {
+			emptyOwner.unmount();
+			visibleOwner.unmount();
+			target.remove();
+		}
+	});
+
+	it('preserves late portal ownership when a native target listener moves the host before bubbling', () => {
+		const log: string[] = [];
+		const target = document.createElement('div');
+		const destination = document.createElement('div');
+		document.body.append(target, destination);
+		target.addEventListener('auxclick', () => log.push('native capture'), true);
+		let setVisible: (visible: boolean) => void = () => {};
+		const root = mount(DeferredPortalEvents, {
+			target,
+			register: (setter) => {
+				setVisible = setter;
+			},
+			log: (label) => log.push(label),
+		});
+		try {
+			flushSync(() => setVisible(true));
+			const button = target.querySelector<HTMLButtonElement>('.deferred-portal-target')!;
+			button.addEventListener('auxclick', () => {
+				log.push('native move');
+				destination.appendChild(button);
+			});
+			// No auxclick capture binding is authored: ordinary native capture must
+			// preserve the original portal route before the target listener moves it.
+			button.dispatchEvent(new MouseEvent('auxclick', { bubbles: true }));
+			expect(destination.firstElementChild).toBe(button);
+			expect(log).toEqual(['native capture', 'native move', 'target bubble', 'logical bubble']);
+		} finally {
+			root.unmount();
+			target.remove();
+			destination.remove();
+		}
+	});
+});
 
 describe('ReactDOMEventListener — propagation across nested roots', () => {
 	// Per ReactDOMEventListener-test.js:32 — should propagate events one level down

--- a/packages/octane/typetests/jsx-runtime.test-d.tsx
+++ b/packages/octane/typetests/jsx-runtime.test-d.tsx
@@ -47,6 +47,27 @@ export function TypeSurface() {
 			<div onKeyDown={(event) => use<KeyboardEvent>(event)} />
 			<div onClickCapture={(event) => use<MouseEvent>(event)} />
 			<input onInput={(event) => use<Event>(event)} />
+			{/* Dialog lifecycle events also propagate to generic logical ancestors. */}
+			<div
+				onCancel={(event) => {
+					use<Event>(event);
+					use<HTMLDivElement>(event.currentTarget);
+					// @ts-expect-error — the event is native, not a React wrapper
+					event.nativeEvent;
+				}}
+				onCancelCapture={(event) => use<Event>(event)}
+				onClose={(event) => use<Event>(event)}
+				onCloseCapture={(event) => use<Event>(event)}
+			/>
+			<dialog
+				onCancel={(event) => {
+					use<Event>(event);
+					use<HTMLDialogElement>(event.currentTarget);
+				}}
+				onClose={(event) => use<Event>(event)}
+			/>
+			{/* @ts-expect-error — cancel handlers cannot require a KeyboardEvent */}
+			<div onCancel={(event: KeyboardEvent) => {}} />
 			{/* @ts-expect-error — handlers are functions, not strings */}
 			<button onClick="handleClick()" />
 			{/* @ts-expect-error — a click handler cannot demand a KeyboardEvent */}

--- a/packages/visx/tests/types/parity.test-d.ts
+++ b/packages/visx/tests/types/parity.test-d.ts
@@ -31,8 +31,8 @@ type IsRenderable<T> = IsUnknown<T> extends true ? true : Equal<T, import('react
 // OCTANE DIVERGENCE: components whose rest props spread an octane attribute
 // bag (`Octane.SVGProps` / `Octane.HTMLAttributes`, e.g. via `AddSVGProps`)
 // diverge from upstream exactly where octane's JSX surface diverges from
-// React's: `on*` handlers receive NATIVE DOM events (octane has no synthetic
-// event layer; the handler NAMES are identical), `className` composes
+// React's: shared `on*` handlers receive NATIVE DOM events (octane has no
+// synthetic event layer), `className` composes
 // clsx-style (`ClassValue`), `style` additionally accepts a plain string,
 // `ref` accepts (nested) ref arrays, and octane adds the native `class` /
 // `for` attribute aliases. Compare those components' props with the bag
@@ -95,11 +95,11 @@ type AttributeBagNormalizedPropsExtends<LocalComponent, UpstreamComponent> = Ext
 // element type, not a renderable hole, so the bag inside its type argument is
 // unreachable. Like Drag, whose divergence is the native event union rather
 // than a bag, their props surface is pinned key-for-key. Such a pin must also
-// ignore what a TOP-LEVEL bag contributes to the key set: octane's bags add
-// exactly `class`, `for`, `hidden`, and `tabindex` beside React's canonical
-// camelCase props and drop nothing, so those keys are excluded from both
-// sides. They are optional, which is why the member-by-member comparisons
-// above tolerate them without listing them.
+// ignore the common TOP-LEVEL bag additions `class`, `for`, `hidden`, and
+// `tabindex` beside React's canonical camelCase props. Host-specific additions
+// are listed only for the affected component below. These additions are
+// optional, which is why the member-by-member comparisons above tolerate them
+// without listing them.
 type OctaneOnlyAttributeSurfaceKeys = OctaneOnlyAttributeKeys | 'hidden' | 'tabindex';
 type PropsShapeEqual<
 	LocalComponent,
@@ -490,11 +490,32 @@ type _Point = Assert<Equal<Local['Point'], Upstream['Point']>>;
 // ParentSize spreads `Octane.HTMLAttributes` — see the attribute-bag
 // carve-out above (`style` stays `CSSProperties` locally because ParentSize
 // merges style objects; it collapses with the bag members either way).
-// Octane also supports the native xmlns attribute on HTML hosts, whereas
-// React includes it only in SVG props. Normalize that extra key only here.
+// Octane also supports xmlns and both phases of native dialog lifecycle events
+// on HTML ancestors; React restricts xmlns to SVG and these handlers to dialogs.
+// Normalize only those extra keys here, then pin the native handler surface.
+type ParentSizeDialogLifecycleKeys = 'onCancel' | 'onCancelCapture' | 'onClose' | 'onCloseCapture';
 type _ResponsiveParentSizeProps = Assert<
-	PropsShapeEqual<Local['Responsive']['ParentSize'], Upstream['Responsive']['ParentSize'], 'xmlns'>
+	PropsShapeEqual<
+		Local['Responsive']['ParentSize'],
+		Upstream['Responsive']['ParentSize'],
+		'xmlns' | ParentSizeDialogLifecycleKeys
+	>
 >;
+type _ResponsiveParentSizeNativeDialogEvents = Assert<
+	Equal<
+		Pick<ComponentProps<Local['Responsive']['ParentSize']>, ParentSizeDialogLifecycleKeys>,
+		{
+			[K in ParentSizeDialogLifecycleKeys]?: (
+				event: Event & { currentTarget: HTMLDivElement },
+			) => void;
+		}
+	>
+>;
+type ParentSizeDialogLifecycleEvent = Parameters<
+	NonNullable<ComponentProps<Local['Responsive']['ParentSize']>[ParentSizeDialogLifecycleKeys]>
+>[0];
+// @ts-expect-error Dialog lifecycle handlers receive native events, not synthetic wrappers or any.
+type _ResponsiveParentSizeDialogEventHasNoWrapper = ParentSizeDialogLifecycleEvent['nativeEvent'];
 type _ResponsiveScaleSvg = Assert<
 	Extends<Local['Responsive']['ScaleSVG'], Upstream['Responsive']['ScaleSVG']>
 >;


### PR DESCRIPTION
## Summary

- Bound delegated capture/bubble queues to native root delivery, so external listeners between roots interleave before the next root and can stop it.
- Traverse observer-specific composed paths for shadow roots and distributed slots while preserving native event identity, retargeting, and logical portal ancestry.
- Separate framework propagation from native stop flags: an earlier same-root native `stopPropagation()` does not truncate the framework queue; native `stopImmediatePropagation()` does not truncate an already-running logical phase. Call both methods to stop both queues.
- Preserve root boundaries when a handler unmounts/reinserts a nested root during dispatch; restore temporary method descriptors, support same-Event redispatch, and expose native dialog lifecycle handlers on logical ancestors in JSX types.

- Recover ownership for portal hosts that appear after child-local updates, including shared targets and native listeners moving the host before bubbling.

- Unregister compiled-portal ownership during scope teardown, with a deterministic shared-target lifecycle cleanup regression.

## Why

Follow-up to #925, based on independently reproduced event-system interop defects. This does not claim to resolve the original application-level missing-submit report.

The former dispatcher stamped each native event as handled and walked the entire logical ancestry from the first listener. That crossed intervening native listeners, skipped shadow/slot handlers, and treated an external native stop flag as cancellation of the framework's own queue.

## Validation

- [x] Current-head CI: all 26 jobs passed on `c3c476eb0` ([run 33567573036](https://github.com/octanejs/octane/actions/runs/33567573036)); current-head Cursor Bugbot passed with no issues.
- [ ] Repository-wide `pnpm format:check` (scoped formatting used instead).
- [ ] Repository-wide `pnpm typecheck` (scoped source, fixture, browser, and JSX type checks used instead).
- [ ] All-workspace `pnpm test` (both complete core Vitest projects used locally; CI covers the workspace).
- [x] Scoped `format-files.mjs --check` and `typecheck-files.mjs` with the existing imported `slot-hooks.js` included for the SSR test loader.
- [x] `vitest run --project octane --project octane-prod --project radix --project shadcn --project vaul`: 15,896 tests passed across 937 files.
- [x] Trusted Chromium event-boundary, continuous-action, and Vaul snap-drag suites: 24 tests passed, including shared React 19.2.7 oracle cases.
- [x] Full Visx package typecheck; native lifecycle additions are normalized precisely and pinned to optional native handlers, with a negative synthetic-wrapper check.
- [x] New work-only benchmark helper/fixture passed strict isolated `tsrx-tsc`; no existing TypeScript project owns these benchmark files.
- [x] Compiled-portal cleanup regression: the prior head performed 256 leftover sibling reads after six owners unmounted; the final source performs zero with identical event/ref/DOM controls.
- [x] `pnpm sync` and `git diff --check`.
- [x] Red evidence: original conformance regressions failed in both compile modes; 8 of 15 initial Chromium cases failed; 8 unmount/reinsert cases reproduced duplicate inner handlers; the new capture-immediate case failed in both modes on the base. A dropped-handler mutation made 78 conformance assertions fail, then the candidate was restored. The first CI run exposed late portal ownership loss in Vaul, Radix Select, and shadcn; eight added dev/prod regressions fail on the initial PR head and pass on the corrected runtime. The existing binding/browser tests remain unchanged.

### Performance

Paired production Chromium runs against base `f6bea3704`, identical dependency graph, 30 samples per version, macOS arm64 / Node 26.4.0. Commands: `node benchmarks/event-delegation/work.mjs` and `node benchmarks/event-delegation/run.mjs octane-tsrx 30`.

| Metric | Base | Candidate |
| --- | ---: | ---: |
| 128-input burst mean | 6.07 ms | 6.69 ms |
| Median | 7.10 ms | 7.50 ms |
| p95 | 7.60 ms | 8.20 ms |
| Mean relative margin of error | 9.86% | 8.30% |
| Four fixture JS assets, raw | 197,772 B | 202,216 B |
| Same assets, gzip | 63,889 B | 65,273 B |

The timing difference is within observed variance; there is no speedup or no-regression claim. The definite bundle cost is +1,384 gzip bytes. Both deterministic gates pass: 512 hosts, 128 native captures/bubbles/framework captures, 128 correct controlled inputs/outputs, no invalid currentTargets, and 256 currentTarget definitions sharing one descriptor/getter/path. Ordinary single-root dispatch avoids foreign-root ownership lookups; only emulated bubbling interposes native immediate cancellation. Root-history allocations and cleanup are confined to root lifecycle changes; events retain numeric epochs, not root sets.

A separate exploratory production Chromium probe used 20 alternating paired samples after five warmups, 1,000 untrusted native events per sample, and no state updates. All eight placement, logical phase-order, native identity/currentTarget, and teardown controls passed. With 200 body portals, portal clicks measured 2.51 → 3.13 µs/event and input in an unrelated root before the ranges measured 2.56 → 4.49 µs/event. An earlier correction scanned every range; the final boundary walk removes those repeated DOM-order comparisons. It is not order-independent constant work: a root after the 200 ranges measured 2.59 → 8.80 µs/event (201 sibling reads/event), or 9.24 µs with 64 additional preceding siblings (265 reads/event). These exploratory comparisons include the broader PR changes, not only the late-ownership correction. No negative cache assumes the DOM stayed put.

The work gate also covers six compiled portal owners over three shared-target cycles: nine deliveries in each logical phase, six ref cleanups, no detached clicks or leftover nodes, and zero sibling/DOM-order work on subsequent ordinary inputs. The ordinary timing fixture does not include these intrinsic observers.

## Risk / follow-ups

- Intentional cancellation behavior change: consumers using only native `stopImmediatePropagation()` to stop logical propagation must also call `stopPropagation()`. Direct native prototype calls, `cancelBubble` assignment, and immutable own stop methods remain native-only.
- Closed-shadow portals physically inside their own outer root can still duplicate shared outer delivery because the outer observer cannot see the hidden portal boundary. A trusted-click probe reproduced the same closed-shadow duplication in React 19.2.7. No universal React parity is claimed for shadow/portal cross-products or emulated non-bubbling plugin timing.
- Discrete work now flushes at each delivered root bubble boundary. Explicit transitions, pending-Action isolation, controlled restoration, hydration, portals, error handling, and reentrancy are covered by the core and browser runs.
- Chromium was exercised locally; other browser engines were not measured. Root lifecycle changes before the first framework capture observer are not a claim of full React Fiber ownership equivalence.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790891611&installation_model_id=432790&pr_number=926&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F926&signature=c8dcf3c0e4161c5c2bfc0b13db56760725728f64770816df7cf8f503e685aa45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites core delegated event dispatch, nested-root ordering, portal ownership, and stop-propagation semantics—behavior changes that affect every interactive app and require callers who relied on native `stopImmediatePropagation()` alone to also call `stopPropagation()`.
> 
> **Overview**
> **Replaces the single global delegated walk** with per-root (and per-portal-target) native delivery: each `createRoot` container is an event root, handlers run only on that listener’s logical segment, and native listeners between nested roots interleave and can block the next root. Shadow/slot paths use `composedPath()`; portals still bubble through logical ancestors via portal range bookkeeping and late ownership resolution when children mount hosts after the portal render.
> 
> **Propagation cancellation** now mirrors React’s split between the framework queue and the browser event: handler `stopPropagation()` stops remaining logical handlers and calls native stop; an earlier same-root native stop does not truncate Octane’s queue; native `stopImmediatePropagation()` does not cut off an in-flight logical phase (both stops are needed to halt both). Temporary `stopPropagation`/`currentTarget` wiring is restored after dispatch, including redispatch of the same `Event`.
> 
> **JSX** allows `onCancel` / `onClose` (and capture variants) on non-`dialog` ancestors. **Benchmarks** add a portal mount/unmount gate before the 128-input stress run and assert no leftover portal DOM walks. **Tests** add Chromium React-oracle boundary cases plus conformance coverage for nested roots, deferred portal content, shared targets, and cancellation edge cases. **Docs** and the changeset describe the new semantics and the `stopImmediatePropagation` migration note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c476eb0199301f210cc709fd76bc0e0aba5c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->