### PR TITLE
fix: close the delegated capture window after trusted propagation ends

### DIFF
--- a/.changeset/trusted-capture-fallback-task.md
+++ b/.changeset/trusted-capture-fallback-task.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Fix controlled `value`/`checked` edits being reverted before their handlers ran whenever an `onXxxCapture` handler for the same event type was registered anywhere in the app. The browser runs a microtask checkpoint after every listener of an event it dispatches itself, so the capture segment's stopped-propagation fallback fired between the root's capture listener and its bubble listener and snapped every typed character back to the rendered value. Trusted events now close that window with a task, after native propagation has finished; script-dispatched events keep the microtask fallback.

--- a/benchmarks/news/runtime-stress.mjs
+++ b/benchmarks/news/runtime-stress.mjs
@@ -282,12 +282,38 @@ async function runFormSample() {
 		await input.press('ArrowLeft');
 		await input.press('X');
 		const expected = 'octane benchmaXrk';
-		await page.waitForFunction(
-			(value) =>
-				document.querySelector('input[data-field-index="37"]')?.value === value &&
-				document.querySelector('[data-field-output="37"]')?.textContent === value,
-			expected,
-		);
+		try {
+			await page.waitForFunction(
+				(value) =>
+					document.querySelector('input[data-field-index="37"]')?.value === value &&
+					document.querySelector('[data-field-output="37"]')?.textContent === value,
+				expected,
+			);
+		} catch (error) {
+			// Report what the page actually shows: a lost keystroke (the input
+			// snapped back to the rendered value), a stale output, or lost focus
+			// each point at a different owner.
+			const actual = await page.evaluate(() => {
+				const input = document.querySelector('input[data-field-index="37"]');
+				const form = window.__runtimeStress.stats.form;
+				return {
+					value: input?.value,
+					output: document.querySelector('[data-field-output="37"]')?.textContent,
+					focused: document.activeElement === input,
+					inputSame: input === window.__runtimeStress.originalInput,
+					selectionStart: input?.selectionStart,
+					selectionEnd: input?.selectionEnd,
+					fieldRenders: form.fieldRenders[37],
+					validationRequests: form.validationRequests,
+				};
+			});
+			const errors =
+				sample.failures.length > 0 ? `; browser errors: ${sample.failures.join('; ')}` : '';
+			throw new Error(
+				`${target}: controlled typing did not converge on ${JSON.stringify(expected)}: ${JSON.stringify(actual)}${errors}`,
+				{ cause: error },
+			);
+		}
 		const typed = await page.evaluate(() => {
 			const input = document.querySelector('input[data-field-index="37"]');
 			return {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -17118,15 +17118,20 @@ function finishCaptureDispatch(event: Event): void {
 			maybeFlushDiscrete(type);
 		}
 	};
-	const target = event.target as HTMLInputElement | null;
-	const checkableChange =
-		type === 'change' &&
-		target?.localName === 'input' &&
-		(target.type === 'checkbox' || target.type === 'radio');
-	// Chromium may checkpoint microtasks between a checkable's root capture
-	// and bubble observations. Other discrete events retain the established
-	// microtask fallback (notably stopped controlled-select change).
-	if (checkableChange) setTimeout(fallback, 0);
+	// The browser performs a microtask checkpoint after EVERY listener callback
+	// of an event it dispatches itself (the JS stack is empty between them), so
+	// a microtask queued here — from the root's CAPTURE listener — would run
+	// before the target's native listeners and before the root's bubble
+	// listener. For a trusted edit that is fatal: the fallback would restore the
+	// controlled value before onInput could hear the keystroke, snapping every
+	// typed character back to the last rendered value as soon as any
+	// onXxxCapture handler registers the type. Only a task runs after the whole
+	// native propagation. A script-dispatched event keeps the dispatching script
+	// on the stack, so its microtask cannot run until that script yields (after
+	// the bubble segment) and remains the earliest correct fallback there: a
+	// stopped controlled-select change restores in the same microtask batch as
+	// its handlers' updates, before the dispatcher's next task.
+	if (event.isTrusted) setTimeout(fallback, 0);
 	else queueMicrotask(fallback);
 }
 

--- a/packages/octane/tests/_fixtures/event-commit-timing.tsrx
+++ b/packages/octane/tests/_fixtures/event-commit-timing.tsrx
@@ -16,3 +16,23 @@ export function CommitTiming(props: EventProbeProps) @{
 		<button data-name="target" data-target>{count as number}</button>
 	</section>
 }
+
+// Controlled text input under a capture-phase handler. The capture handler is
+// what makes the root's capture listener run for `input`; a trusted keystroke
+// must still reach onInput with the typed value and commit it. The React
+// counterpart is written directly in the browser harness (main.ts).
+export function ControlledCapture(props: EventProbeProps) @{
+	const [value, setValue] = useState('');
+	<section data-name="form" onInputCapture={(event) => props.record('form:capture', event)}>
+		<input
+			data-name="target"
+			data-target
+			value={value}
+			onInput={(event) => {
+				setValue((event.currentTarget as HTMLInputElement).value);
+				props.record('target:bubble', event);
+			}}
+		/>
+		<output data-output>{value as string}</output>
+	</section>
+}

--- a/packages/octane/tests/browser/event-boundaries/event-boundaries.test.ts
+++ b/packages/octane/tests/browser/event-boundaries/event-boundaries.test.ts
@@ -273,3 +273,58 @@ describe.sequential('commit timing at the delegated dispatch boundary', () => {
 		});
 	}
 });
+
+describe.sequential('controlled text input under a capture-phase handler', () => {
+	// A browser-dispatched keystroke reaches the root's capture listener first,
+	// and the browser runs a microtask checkpoint after every native listener.
+	// Nothing deferred from that capture segment may restore the controlled value
+	// before the target's own listeners and the root's bubble listener have run,
+	// or every typed character snaps back to the rendered value before onInput
+	// can commit it. Octane and React must both accept the edit, and an outside
+	// native listener on the input must observe the user's text.
+	async function type(page: Page, runtime: RuntimeName, text: string): Promise<string[]> {
+		await page.locator(`#${runtime}-root [data-target]`).click();
+		await page.keyboard.type(text);
+		const records = await page.evaluate((r) => window.__eventBoundaries.logs[r], runtime);
+		expect(records.every(({ trusted }) => trusted)).toBe(true);
+		return records.map(({ label }) => label);
+	}
+
+	for (const runtime of ['octane', 'react'] as const) {
+		it(`${runtime}: commits trusted keystrokes that pass an onInputCapture ancestor`, async () => {
+			const page = await openCase({ kind: 'controlled-capture', stop: false });
+			expect(await type(page, runtime, 'ab')).toEqual([
+				'form:capture',
+				'native:target:a',
+				'target:bubble',
+				'form:capture',
+				'native:target:ab',
+				'target:bubble',
+			]);
+			expect(await page.evaluate((r) => window.__eventBoundaries.fieldState(r), runtime)).toEqual({
+				value: 'ab',
+				output: 'ab',
+				selectionStart: 2,
+				selectionEnd: 2,
+				focused: true,
+			});
+		});
+	}
+
+	it('octane: reverts a keystroke whose bubble segment a native listener stopped', async () => {
+		// OCTANE DIVERGENCE: React never restores an edit its root bubble listener
+		// did not see. Octane closes the capture segment's window once the browser
+		// has finished propagating the event, so the rendered value wins — but only
+		// after the outside listener has observed the typed text.
+		const page = await openCase({ kind: 'controlled-capture', stop: true });
+		expect(await type(page, 'octane', 'a')).toEqual(['form:capture', 'native:target:a']);
+		await page.evaluate(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+		expect(await page.evaluate(() => window.__eventBoundaries.fieldState('octane'))).toEqual({
+			value: '',
+			output: '',
+			selectionStart: 0,
+			selectionEnd: 0,
+			focused: true,
+		});
+	});
+});

--- a/packages/octane/tests/browser/event-boundaries/main.ts
+++ b/packages/octane/tests/browser/event-boundaries/main.ts
@@ -5,7 +5,10 @@ import { createRoot as createReactRoot } from 'react-dom/client';
 import { flushSync as flushReactSync } from 'react-dom';
 import { createElement, useState } from 'react';
 import * as OctaneFixture from '../../_fixtures/event-boundaries.tsrx';
-import { CommitTiming as OctaneCommitTiming } from '../../_fixtures/event-commit-timing.tsrx';
+import {
+	CommitTiming as OctaneCommitTiming,
+	ControlledCapture as OctaneControlledCapture,
+} from '../../_fixtures/event-commit-timing.tsrx';
 import * as ReactFixture from 'virtual:event-boundaries-react-fixture';
 import type { EventProbeProps } from '../../_fixtures/event-boundaries.tsrx';
 
@@ -26,7 +29,8 @@ export type ProbeOptions =
 	| { kind: 'nested'; stop: boolean }
 	| { kind: 'shadow'; mode: ShadowRootMode }
 	| { kind: 'slot' }
-	| { kind: 'commit-timing' };
+	| { kind: 'commit-timing' }
+	| { kind: 'controlled-capture'; stop: boolean };
 type HandlerRecord = {
 	label: string;
 	trusted: boolean;
@@ -179,6 +183,51 @@ function mountCommitTiming(runtime: RuntimeName): void {
 	});
 }
 
+// The controlled input's React counterpart. onChange is React's per-keystroke
+// text handler; it is dispatched from the same native `input` event as
+// Octane's onInput.
+function ReactControlledCapture(props: EventProbeProps) {
+	const [value, setValue] = useState('');
+	return createElement(
+		'section',
+		{
+			'data-name': 'form',
+			onInputCapture: (event: { nativeEvent: Event }) =>
+				props.record('form:capture', event as unknown as Event),
+		},
+		createElement('input', {
+			'data-name': 'target',
+			'data-target': '',
+			value,
+			onChange: (event: { nativeEvent: Event; currentTarget: HTMLInputElement }) => {
+				setValue(event.currentTarget.value);
+				props.record('target:bubble', event as unknown as Event);
+			},
+		}),
+		createElement('output', { 'data-output': '' }, value),
+	);
+}
+
+function mountControlledCapture(runtime: RuntimeName, stop: boolean): void {
+	const container = containers[runtime];
+	const props: EventProbeProps = { record: (label, event) => record(runtime, label, event) };
+	if (runtime === 'octane') createOctaneRoot(container).render(OctaneControlledCapture, props);
+	else {
+		flushReactSync(() => {
+			createReactRoot(container).render(createElement(ReactControlledCapture, props));
+		});
+	}
+	const target = container.querySelector<HTMLInputElement>('[data-target]')!;
+	targets[runtime] = target;
+	// An outside listener on the input itself runs between the root's capture
+	// and bubble listeners. It records the value the user's edit left in the
+	// field; stopping there keeps the bubble segment from ever reaching the root.
+	target.addEventListener('input', (event) => {
+		record(runtime, `native:target:${target.value}`, event);
+		if (stop) event.stopPropagation();
+	});
+}
+
 function mountShadow(options: Extract<ProbeOptions, { kind: 'shadow' | 'slot' }>): void {
 	const props: EventProbeProps = {
 		record: (label, event) => record('octane', label, event),
@@ -205,6 +254,8 @@ window.__eventBoundaries = {
 			for (const runtime of ['octane', 'react'] as const) {
 				if (options.kind === 'same-root') mountSameRoot(runtime, options.scenario);
 				else if (options.kind === 'commit-timing') mountCommitTiming(runtime);
+				else if (options.kind === 'controlled-capture')
+					mountControlledCapture(runtime, options.stop);
 				else mountNested(runtime, options.stop);
 			}
 		}
@@ -214,6 +265,16 @@ window.__eventBoundaries = {
 	},
 	targetText(runtime: RuntimeName) {
 		return targets[runtime]!.textContent ?? '';
+	},
+	fieldState(runtime: RuntimeName) {
+		const input = targets[runtime] as HTMLInputElement;
+		return {
+			value: input.value,
+			output: containers[runtime].querySelector('[data-output]')?.textContent ?? '',
+			selectionStart: input.selectionStart,
+			selectionEnd: input.selectionEnd,
+			focused: document.activeElement === input,
+		};
 	},
 	clickPoint(runtime: RuntimeName) {
 		const rect = targets[runtime]!.getBoundingClientRect();
@@ -237,6 +298,13 @@ declare global {
 			clickPoint(runtime: RuntimeName): { x: number; y: number };
 			scriptClick(runtime: RuntimeName): void;
 			targetText(runtime: RuntimeName): string;
+			fieldState(runtime: RuntimeName): {
+				value: string;
+				output: string;
+				selectionStart: number | null;
+				selectionEnd: number | null;
+				focused: boolean;
+			};
 			slotDistributesTarget(): boolean;
 		};
 	}


### PR DESCRIPTION
## Summary

- `node benchmarks/controlled-form/run.mjs octane-tsrx 8` timed out on `main` at the typing check (`input[data-field-index="37"]` never reached `octane benchmaXrk`). The weekly bench workflow has shown the same failure on Linux since 2026-08-17 (it passed on 2026-08-10). The React target passes on the same Playwright/Chromium, so keyboard delivery was not the problem: every keystroke into the controlled input was being reverted before `onInput` ran.
- Root cause in `finishCaptureDispatch`: when any `onXxxCapture` handler for an event type is registered, the root's capture-phase listener queues a microtask fallback that closes the capture segment's controlled-restore window in case a native listener stops the bubble below the root. Browsers run a microtask checkpoint after every listener of an event they dispatch themselves, so for a trusted event that fallback fired between the root's capture listener and its bubble listener, snapped the controlled `value` back to the last rendered value, and `onInput` then read the old value (an `Object.is`-equal update, so no render). The benchmark fixture's `onInputCapture` (added by #704) exposed the latent bug.
- Fix: trusted events close the window with a task, after native propagation has finished; script-dispatched events keep the microtask fallback, which cannot run before the dispatching script yields. The old checkable-`change` special case was the same bug misdiagnosed as checkbox-specific and is subsumed.

## Changes

- `packages/octane/src/runtime.ts`: `finishCaptureDispatch` picks the fallback scheduling from `event.isTrusted`.
- `benchmarks/news/runtime-stress.mjs`: the controlled-form typing wait now reports the input value, output text, focus, selection, input identity, field renders, validation requests, and any browser errors when it times out, so failures are diagnosable. The correctness check itself is unchanged.
- `packages/octane/tests/browser/event-boundaries/*` + `tests/_fixtures/event-commit-timing.tsrx`: real-browser regression. Octane and React type trusted keystrokes into a controlled input under an `onInputCapture` ancestor with an outside native listener on the input; both must commit the edit and the outside listener must observe the typed text. A second case pins Octane's revert of an edit whose bubble segment a native listener stopped, and that the revert happens only after propagation (marked as an Octane divergence: React never restores in that case). jsdom cannot cover this because `dispatchEvent` never checkpoints between listeners.
- `.changeset/trusted-capture-fallback-task.md`: patch for `octane`.

## Validation

- [x] `pnpm format:check` (repo-wide, passes)
- [x] `pnpm typecheck` (repo-wide, passes)
- [ ] `pnpm test` (not run in full; see below)
- [x] targeted tests: vitest projects `octane` + `octane-prod` (894 files, 15455 tests pass); `octane-events-browser` for `event-boundaries`, `native-change`, `mobile-input`, `continuous-actions` (68 tests pass)
- [x] `node benchmarks/controlled-form/run.mjs octane-tsrx 8`: PASS, 8 correctness-gated samples (typing, caret, focus, controls, submit, stale validation, reset). `react 1` also passes as a control.
- [x] Pre-fix check with the old runtime restored: the new Octane test fails (the outside listener records `native:target:` instead of `native:target:a`) while the React case passes, and the harness now reports:

```
FAIL controlled-form/octane-tsrx: Error: octane-tsrx: controlled typing did not converge on "octane benchmaXrk": {"value":"","output":"","focused":true,"inputSame":true,"selectionStart":0,"selectionEnd":0,"fieldRenders":1,"validationRequests":17}
```

- `pnpm sync` produced no generated changes.

## Risk / follow-ups

- Trusted events that a script dispatches synchronously (`requestSubmit()`, activation-fired `input`/`change` inside `click()`) now restore a stopped edit one task later than before; still after propagation, and React never restores in that case at all.
- The weekly bench workflow also has unrelated failures in other suites (a ripple identity gate, a preact suite), so it stays red until those are handled.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790942811&installation_model_id=432790&pr_number=929&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F929&signature=9ed6745145e1425bd911c2237a3841bac7f30b8ade7c9c8e37d3e9e002860b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core delegated event timing for all trusted discrete events; trusted script-dispatched edits may restore one task later than before, though still after propagation.
> 
> **Overview**
> Fixes **controlled inputs reverting on every keystroke** when any `onXxxCapture` handler is registered for that event type. The delegated capture “stopped propagation” fallback was scheduled as a **microtask**, which browsers can run between the root’s capture and bubble listeners on trusted events—restoring the rendered `value` before `onInput` runs.
> 
> **`finishCaptureDispatch`** now schedules that fallback with **`setTimeout(0)` for trusted events** (after full native propagation) and keeps **`queueMicrotask` for script-dispatched events**, replacing the old checkbox-only `change` special case.
> 
> Adds **browser regression** coverage (Octane vs React) for typing into a controlled field under `onInputCapture`, plus richer **controlled-form benchmark** timeout diagnostics. Patch changeset for `octane`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905084b0fb0879ae039fba394eb49c8be3fd4694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
