### PR TITLE
perf(ssr): skip redundant loop HTML carriers

### DIFF
--- a/.changeset/tidy-server-loop-output.md
+++ b/.changeset/tidy-server-loop-output.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip redundant HTML wrapping in compiled server loop bodies while preserving escaping, streaming, and hydration behavior.

--- a/benchmarks/ssr-throughput/README.md
+++ b/benchmarks/ssr-throughput/README.md
@@ -74,6 +74,10 @@ Octane-specific server paths.
   Correctness gate: both bodies byte-identical after stripping HTML comments
   (hydration markers legitimately differ). **The headline number is the
   plain/compiled ratio** — the SSR authoring cliff a binding-heavy page pays.
+  An untimed observer of the clean production bundle also limits server HTML
+  factory calls to 601 (the page plus 300 cards and 300 avatars); the descriptor
+  twin must make none. Private loop bodies should concatenate serialized strings
+  without creating additional carriers.
 - **`escape-heavy`** — 10k text holes whose every value contains `&<>"'`.
   Isolates `escapeHtml`. After timing and memory measurement, a deterministic
   work gate renders the fixture again, checks that its complete response is
@@ -83,6 +87,10 @@ Octane-specific server paths.
   the list snapshot; its independently measured cost was about 0.025% of
   render time. Preserving that snapshot protects custom iterators, observable
   getters, and render-time mutations.
+  Its 10,000-item loop has a server HTML factory-call budget of one for the public
+  root component. Factory observers run after all timing and memory phases and
+  require complete body/CSS equality with the clean bundle. These count source
+  factory calls, not V8 heap allocations or allocated bytes.
 
 ## Running
 
@@ -100,6 +108,42 @@ time-budgeted; per-op sample counts are reported). `BENCH_JSON` follows the
 shared contract: ms stats under `ops.render` (plus `opsPerSec`), payload
 bytes / marker counts / memory growth under `meta`, a top-level `failed` on any
 gate failure (and a non-zero exit).
+
+### Private loop HTML carriers — 2026-09-03
+
+Compared merged main `44d50dbc0` with private loop bodies returning serialized
+strings directly, on Node 26.4.0 / macOS Darwin 25.6.0 / Apple M5 Max (arm64).
+Both clean production fixture bundles were preserved before measurement. The
+same runner loaded each bundle in a fresh process, in A-B-B-A-A-B-B-A order:
+four runs per variant, 0.2 seconds warmup, 2 seconds timing per fixture, and
+1,000 memory-phase renders. Values below are the median and range of the four
+run scores (each score is the shared harness's steady-window mean).
+
+| Fixture | Main ms, median [range] | Candidate ms, median [range] | HTML factory calls, main → candidate |
+| --- | --- | --- | --- |
+| 300 compiled cards | 1.871 [1.868–1.917] | 1.891 [1.821–1.931] | 1,801 → 601 |
+| Descriptor twin (control) | 3.814 [3.776–3.901] | 3.902 [3.803–4.080] | 0 → 0 |
+| 10,000 escaped text holes | 3.318 [3.277–3.382] | 3.338 [3.270–3.539] | 10,001 → 1 |
+
+The timing ranges overlap and paired directions vary, including the unchanged
+descriptor control: these runs establish no throughput improvement or
+regression. The deterministic result is fewer factory calls, not a measurement
+of actual heap allocations. The unminified fixture bundle shrank from 176,179
+to 176,125 bytes. Complete body/CSS output was byte-identical across both
+versions for all three fixtures and the hydratable/static control-flow pages;
+every observed copy also matched its clean bundle. Main failed only the two
+new factory-call budgets, while the candidate passed them.
+
+To reproduce, build and preserve each revision's fixture bundle with the same
+installed dependencies, restore each clean bundle to this suite's
+`dist/fixtures/`, and run the current harness in the order above. Both commands
+below run from the repository root (which also keeps emitted path comments
+consistent for the byte comparison):
+
+```bash
+pnpm exec vite build benchmarks/ssr-throughput/fixtures --ssr src/entry-server.ts --outDir ../dist/fixtures --emptyOutDir
+CONFIGS=deopt-page,escape-heavy BENCH_JSON=/tmp/ssr-sample.json node benchmarks/ssr-throughput/run.mjs 2 --no-build
+```
 
 ## Production HTML payload audit
 

--- a/benchmarks/ssr-throughput/html-work.mjs
+++ b/benchmarks/ssr-throughput/html-work.mjs
@@ -1,0 +1,54 @@
+// Observe a copy of the clean production bundle after compiler optimization
+// and tree-shaking. This copy is never used for timing or byte measurements.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+const COUNTER_NAME = 'octane.benchmark.ssrHtmlCalls';
+const COUNTER = Symbol.for(COUNTER_NAME);
+
+export async function createHtmlWorkObserver(entry) {
+	const { parseModule } = await import('../../packages/octane/src/compiler/parser.node.js');
+	const source = fs.readFileSync(entry, 'utf8');
+	const ast = parseModule(source, entry);
+	// The fixtures use an unminified, self-contained production bundle. Observe
+	// the runtime's HTML factory, not generated item-helper aliases or call sites.
+	const factories = ast.body.filter(
+		(node) => node.type === 'FunctionDeclaration' && node.id?.name === 'ssrHtml',
+	);
+	assert.equal(factories.length, 1, 'expected one bundled server HTML factory');
+	const insertion = factories[0].body.start + 1;
+	const observedSource =
+		source.slice(0, insertion) +
+		`\nglobalThis[Symbol.for(${JSON.stringify(COUNTER_NAME)})]++;\n` +
+		source.slice(insertion);
+	const observedEntry = path.join(path.dirname(entry), `.html-work-${randomUUID()}.mjs`);
+	const previousCounter = Object.getOwnPropertyDescriptor(globalThis, COUNTER);
+	Object.defineProperty(globalThis, COUNTER, { configurable: true, writable: true, value: 0 });
+	const dispose = () => {
+		fs.rmSync(observedEntry, { force: true });
+		if (previousCounter) Object.defineProperty(globalThis, COUNTER, previousCounter);
+		else delete globalThis[COUNTER];
+	};
+
+	try {
+		fs.writeFileSync(observedEntry, observedSource);
+		const observed = await import(pathToFileURL(observedEntry).href);
+		return {
+			async measure(clean, renderName) {
+				const expected = await clean[renderName]();
+				globalThis[COUNTER] = 0;
+				const actual = await observed[renderName]();
+				const htmlFactoryCalls = globalThis[COUNTER];
+				assert.deepEqual(actual, expected, `${renderName}: HTML observer changed the response`);
+				return { htmlFactoryCalls };
+			},
+			dispose,
+		};
+	} catch (error) {
+		dispose();
+		throw error;
+	}
+}

--- a/benchmarks/ssr-throughput/run.mjs
+++ b/benchmarks/ssr-throughput/run.mjs
@@ -58,6 +58,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import { createHtmlWorkObserver } from './html-work.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const NEWS = path.join(__dirname, '..', 'news');
@@ -408,6 +409,7 @@ configs.push({
 	entry: FIXTURE_ENTRY,
 	fn: (mod) => () => mod.renderDeoptFast(),
 	verify: async (mod) => bodyMeta((await deoptGate(mod)).fast),
+	htmlWork: { render: 'renderDeoptFast', maxCalls: 601 },
 });
 configs.push({
 	name: 'deopt-page/octane-deopt',
@@ -415,6 +417,7 @@ configs.push({
 	entry: FIXTURE_ENTRY,
 	fn: (mod) => () => mod.renderDeoptPlain(),
 	verify: async (mod) => bodyMeta((await deoptGate(mod)).plain),
+	htmlWork: { render: 'renderDeoptPlain', maxCalls: 0 },
 });
 
 configs.push({
@@ -432,6 +435,7 @@ configs.push({
 		return bodyMeta(body);
 	},
 	work: escapeWorkGate,
+	htmlWork: { render: 'renderEscapeHeavy', maxCalls: 1 },
 });
 
 // ── run ───────────────────────────────────────────────────────────────────────
@@ -454,17 +458,46 @@ for (const cfg of selected) {
 		const fn = cfg.fn(mod);
 		const stats = await timeLoop(fn);
 		const mem = await memGrowth(fn, cfg.batch ? Math.ceil(MEM_RENDERS / cfg.batch) : MEM_RENDERS);
-		const work = cfg.work === undefined ? undefined : await cfg.work(mod);
 		if (cfg.batch) {
 			mem.memRenders *= cfg.batch;
 			// stats time whole batches; surface the effective per-render throughput.
 			meta.rendersPerSec = stats.opsPerSec * cfg.batch;
 		}
-		results.push({ name: cfg.name, group: cfg.group, stats, meta: { ...meta, ...mem, ...work } });
+		results.push({ name: cfg.name, group: cfg.group, stats, meta: { ...meta, ...mem } });
 	} catch (err) {
 		failures.push(`${cfg.name}: ${err.message}`);
 		console.error(`  ✗ ${err.message}`);
 	}
+}
+
+// Keep observer parsing/imports and instrumentation out of every clean timing
+// and memory phase, including later configs in the same process.
+let htmlObserver;
+try {
+	for (const cfg of selected) {
+		const result = results.find((r) => r.name === cfg.name);
+		if (!result) continue;
+		try {
+			const mod = await loadEntry(cfg.entry);
+			if (cfg.work) Object.assign(result.meta, await cfg.work(mod));
+			if (cfg.htmlWork) {
+				htmlObserver ??= await createHtmlWorkObserver(FIXTURE_ENTRY);
+				const work = await htmlObserver.measure(mod, cfg.htmlWork.render);
+				Object.assign(result.meta, work, { htmlFactoryCallBudget: cfg.htmlWork.maxCalls });
+				if (work.htmlFactoryCalls > cfg.htmlWork.maxCalls) {
+					throw new Error(
+						`expected at most ${cfg.htmlWork.maxCalls} server HTML factory calls, ` +
+							`got ${work.htmlFactoryCalls}`,
+					);
+				}
+			}
+		} catch (err) {
+			failures.push(`${cfg.name}: ${err.message}`);
+			console.error(`  ✗ ${err.message}`);
+		}
+	}
+} finally {
+	htmlObserver?.dispose();
 }
 
 // ── report ────────────────────────────────────────────────────────────────────
@@ -498,6 +531,14 @@ for (const r of results) {
 	const m = r.meta;
 	console.log(
 		`${r.name.padEnd(26)} |${kb(m.bodyBytes)} | ${String(m.hydrationMarkerPairs).padStart(7)} | ${String(m.memRenders).padStart(11)} |${kb(m.rssGrowthBytes).padStart(10)} |${kb(m.heapUsedGrowthBytes).padStart(9)}`,
+	);
+}
+
+for (const r of results) {
+	if (r.meta.htmlFactoryCalls === undefined) continue;
+	console.log(
+		`${r.name}: ${r.meta.htmlFactoryCalls} server HTML factory calls ` +
+			`(budget ${r.meta.htmlFactoryCallBudget}; untimed, complete response unchanged)`,
 	);
 }
 
@@ -537,7 +578,7 @@ if (have('deopt-page/octane-deopt', 'deopt-page/octane-fast')) {
 }
 
 if (failures.length > 0) {
-	console.error(`\n✗ correctness gate failures:\n  - ${failures.join('\n  - ')}`);
+	console.error(`\n✗ benchmark gate failures:\n  - ${failures.join('\n  - ')}`);
 }
 
 // ── BENCH_JSON contract ───────────────────────────────────────────────────────

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -10450,6 +10450,7 @@ function ssrCompileBody(
 	componentNs = null,
 	returnedFragmentTemplate = false,
 	returnedFragmentRoot = false,
+	unboxedHtml = false,
 ) {
 	const prevMapTemps = ctx.currentMapTemps;
 	ctx.currentMapTemps = [];
@@ -10465,6 +10466,7 @@ function ssrCompileBody(
 			componentNs,
 			returnedFragmentTemplate,
 			returnedFragmentRoot,
+			unboxedHtml,
 		);
 	} finally {
 		ctx.currentMapTemps = prevMapTemps;
@@ -10482,6 +10484,7 @@ function ssrCompileBodyWithMapTemps(
 	componentNs,
 	returnedFragmentTemplate,
 	returnedFragmentRoot,
+	unboxedHtml,
 ) {
 	const returnedOutput = node.body?.type === 'JSXCodeBlock' && hasOwnValueReturn(node);
 	const mapTemps = ctx.currentMapTemps;
@@ -10703,8 +10706,12 @@ function ssrCompileBodyWithMapTemps(
 		node.params.length > 0
 			? [...node.params, b.id('__s'), b.id('__extra')]
 			: [b.id('__props'), b.id('__s'), b.id('__extra')];
-	ctx.runtimeNeeded.add('ssrHtml');
-	body.push(b.return(ssrCall('ssrHtml', [htmlExpr], node)));
+	// Private loop items feed only HTML concatenation, so their serialized tail
+	// needs no carrier. Other bodies can cross a component/value boundary, where
+	// the carrier distinguishes compiled HTML from authored text returns. This
+	// flag belongs to this body only; nested callbacks keep their own contract.
+	if (!unboxedHtml) ctx.runtimeNeeded.add('ssrHtml');
+	body.push(b.return(unboxedHtml ? htmlExpr : ssrCall('ssrHtml', [htmlExpr], node)));
 	const origin =
 		node.loc != null
 			? node
@@ -12416,6 +12423,7 @@ function ssrCompileSub(
 	componentNs,
 	returnedFragmentTemplate = false,
 	returnedFragmentRoot = false,
+	unboxedHtml = false,
 ) {
 	const fnName = `${baseName}$${ctx.nextHelperId++}`;
 	const synth = { params: paramNodes || [], body: bodyStmts };
@@ -12444,6 +12452,7 @@ function ssrCompileSub(
 			componentNs,
 			returnedFragmentTemplate,
 			returnedFragmentRoot,
+			unboxedHtml,
 		);
 	} finally {
 		ctx._ssrFoldedExprHoles = prevFoldedExprHoles;
@@ -12606,6 +12615,9 @@ function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs
 		cssHash,
 		parentNs,
 		componentNs,
+		false,
+		false,
+		true,
 	);
 	inlinedSubs.push(itemSub.fn);
 	let emptyCall = ssrHtmlTemplate([], node, ctx);

--- a/packages/octane/tests/_fixtures/server-renderable-contract.tsrx
+++ b/packages/octane/tests/_fixtures/server-renderable-contract.tsrx
@@ -1,4 +1,4 @@
-import { createElement, Suspense, use, useMemo } from 'octane';
+import { createElement, Suspense, use, useMemo, type ComponentBody } from 'octane';
 
 export function TextReturn(props: { value: string }) {
 	return props.value;
@@ -7,6 +7,54 @@ export function TextReturn(props: { value: string }) {
 export function MixedTextReturn(props: { value: string; text: boolean }) @{
 	if (props.text) return props.value;
 	<strong>{props.value}</strong>
+}
+
+type ListItem = { id: string; value: string; text: boolean };
+type ListGroup = { id: string; label: string; items: ListItem[] };
+
+export function NestedRenderableList(props: {
+	groups: ListGroup[];
+	onSelect?: (id: string) => void;
+}) @{
+	<section>
+		@for (const group of props.groups; key group.id) {
+			<article data-group={group.id}>
+				<h2>{group.label as string}</h2>
+				<div>
+					@for (const item of group.items; key item.id) {
+						<>
+							<button data-item={item.id} onClick={() => props.onSelect?.(item.id)}>
+								<MixedTextReturn value={item.value} text={item.text} />
+							</button>
+							<small data-caption={item.id}>{item.value as string}</small>
+						</>
+					} @empty {
+						<p data-empty="items">{group.label as string}</p>
+					}
+				</div>
+			</article>
+		} @empty {
+			<p data-empty="groups">No groups</p>
+		}
+	</section>
+}
+
+export function ForwardedLoopChildren(props: { Wrapper: ComponentBody; groups: ListGroup[] }) @{
+	<div>
+		@for (const group of props.groups; key group.id) {
+			<props.Wrapper>
+				@for (const item of group.items; key item.id) {
+					<strong>{item.value as string}</strong>
+				} @empty {
+					<em>{group.label as string}</em>
+				}
+			</props.Wrapper>
+		} @empty {
+			<props.Wrapper>
+				<em>No groups</em>
+			</props.Wrapper>
+		}
+	</div>
 }
 
 export function TextNested(props: { value: string }) @{

--- a/packages/octane/tests/server-renderable-contract.test.ts
+++ b/packages/octane/tests/server-renderable-contract.test.ts
@@ -24,6 +24,114 @@ function parsed(html: string): HTMLDivElement {
 	return container;
 }
 
+describe.each([true, false])('server-rendered lists (development compile: %s)', (dev) => {
+	const lists = loadServerFixture(
+		'packages/octane/tests/_fixtures/server-renderable-contract.tsrx',
+		{ compileOptions: { dev, hmr: dev, inlineHookMemo: false } },
+	);
+	const items = [
+		{ id: 'plain', value: hostile, text: true },
+		{ id: 'template', value: '<b>second & item</b>', text: false },
+	];
+	const groups = [
+		{ id: 'filled', label: '<h1>Filled & group</h1>', items },
+		{ id: 'empty', label: '<b>Empty & group</b>', items: [] },
+	];
+
+	it.each([false, true])(
+		'preserves nested list markup and escaped values across server APIs (empty: %s)',
+		async (empty) => {
+			const props = { groups: empty ? [] : groups };
+			for (const { html } of [
+				Server.renderToString(lists.NestedRenderableList, props),
+				Server.renderToStaticMarkup(lists.NestedRenderableList, props),
+				await Static.prerender(lists.NestedRenderableList, props),
+				await collectPipeableStream(lists.NestedRenderableList, props),
+				await collectReadableStream(lists.NestedRenderableList, props),
+			]) {
+				const node = parsed(html);
+				expect(node.querySelector('section')).not.toBeNull();
+				expect(node.querySelector('img, h1, b')).toBeNull();
+				expect(
+					[...node.querySelectorAll('article')].map((article) => article.dataset.group),
+				).toEqual(empty ? [] : ['filled', 'empty']);
+				expect([...node.querySelectorAll('h2')].map((heading) => heading.textContent)).toEqual(
+					empty ? [] : groups.map((group) => group.label),
+				);
+				expect([...node.querySelectorAll('button')].map((button) => button.textContent)).toEqual(
+					empty ? [] : items.map((item) => item.value),
+				);
+				expect([...node.querySelectorAll('small')].map((caption) => caption.textContent)).toEqual(
+					empty ? [] : items.map((item) => item.value),
+				);
+				expect([...node.querySelectorAll('strong')].map((strong) => strong.textContent)).toEqual(
+					empty ? [] : [items[1].value],
+				);
+				expect(node.querySelector('[data-empty]')?.textContent).toBe(
+					empty ? 'No groups' : groups[1].label,
+				);
+			}
+		},
+	);
+
+	it.each([false, true])(
+		'preserves loop children forwarded into an ordinary component descriptor (empty: %s)',
+		async (empty) => {
+			const Wrapper = (
+				props: { children: (arg: undefined, scope: unknown) => unknown },
+				scope: unknown,
+			) =>
+				Server.createElement('section', null, [
+					props.children(undefined, scope),
+					lists.MixedTextReturn({ value: hostile, text: false }, scope),
+				]);
+			const props = { Wrapper, groups: empty ? [] : groups };
+			for (const { html } of [
+				Server.renderToString(lists.ForwardedLoopChildren, props),
+				Server.renderToStaticMarkup(lists.ForwardedLoopChildren, props),
+				await Static.prerender(lists.ForwardedLoopChildren, props),
+				await collectPipeableStream(lists.ForwardedLoopChildren, props),
+				await collectReadableStream(lists.ForwardedLoopChildren, props),
+			]) {
+				const node = parsed(html);
+				expect(node.querySelector('section')).not.toBeNull();
+				expect([...node.querySelectorAll('strong')].map((strong) => strong.textContent)).toEqual(
+					empty ? [hostile] : [...items.map((item) => item.value), hostile, hostile],
+				);
+				expect(node.querySelector('em')?.textContent).toBe(empty ? 'No groups' : groups[1].label);
+				expect(node.querySelector('img, b')).toBeNull();
+			}
+		},
+	);
+
+	it('hydrates nested list nodes in place and activates item events', () => {
+		const onSelect = vi.fn();
+		const props = { groups, onSelect };
+		const container = parsed(Server.renderToString(lists.NestedRenderableList, props).html);
+		document.body.appendChild(container);
+		const articles = [...container.querySelectorAll('article')];
+		const buttons = [...container.querySelectorAll('button')];
+		const empty = container.querySelector('[data-empty]');
+		const onRecoverableError = vi.fn();
+		const root = hydrateRoot(container, Client.NestedRenderableList, props, { onRecoverableError });
+		try {
+			flushSync(() => {});
+			for (const article of articles)
+				expect(container.querySelector(`[data-group="${article.dataset.group}"]`)).toBe(article);
+			for (const button of buttons)
+				expect(container.querySelector(`[data-item="${button.dataset.item}"]`)).toBe(button);
+			expect(container.querySelector('[data-empty]')).toBe(empty);
+			expect(buttons.map((button) => button.textContent)).toEqual(items.map((item) => item.value));
+			flushSync(() => buttons[1].click());
+			expect(onSelect).toHaveBeenCalledExactlyOnceWith('template');
+			expect(onRecoverableError).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	});
+});
+
 describe('server renderable values', () => {
 	it.each(['value', 'defaultValue'])('omits non-serializable input %s values', (prop) => {
 		for (const value of [() => 'handler', Symbol('value')]) {


### PR DESCRIPTION
## Summary

Follow up to #943. Compiled server loops currently wrap each item's serialized HTML in a carrier, then immediately coerce it back to a string during concatenation. Return that string directly from those private item helpers.

The compiler option applies only to the current item body. Public components, opaque children callbacks, and returned fragments keep their carriers; authored early returns, replay identity, hydration boundaries, and client output are unchanged.

## Performance evidence

Baseline is merged main `44d50dbc0`. The untimed benchmark observer compares complete responses and enforces factory-call budgets:

| Fixture | Baseline calls | Candidate calls |
| --- | ---: | ---: |
| Compiled 300-card page | 1,801 | 601 |
| Descriptor control | 0 | 0 |
| 10,000-item escaping case | 10,001 | 1 |

These are source factory calls, not measured V8 heap allocations. The clean production fixture bundle shrinks by 54 bytes. Baseline and candidate HTML/CSS are byte-identical for both card variants, escaping, and hydratable/static control-flow fixtures. The instrumented bundle is never timed.

Four samples per version in ABBAABBA order, using the same production fixtures and `CONFIGS=deopt-page,escape node run.mjs 2 --no-build` on Node 26.4.0/macOS ARM64:

| Fixture | Baseline median run score | Candidate median run score |
| --- | ---: | ---: |
| Compiled 300-card page | 1.871 ms | 1.891 ms |
| Descriptor control | 3.814 ms | 3.902 ms |
| Escaping case | 3.318 ms | 3.338 ms |

Timing ranges overlap and paired directions vary, including in the unchanged descriptor control. **Throughput improvement is unproven** in these end-to-end fixtures; the demonstrated reductions are wrapper calls and emitted bytes. Full methodology and ranges are in the SSR-throughput README.

## Validation

- [x] `pnpm exec vitest run --project octane --project octane-prod --maxWorkers 4 --silent=passed-only`: 935 files, 16,242 tests passed.
- [x] Focused server-renderable contract suite: 86 passed; final new list scenarios: 20 passed.
- [x] Negative controls: unboxing opaque children fails all 8 forwarding executions; unboxing public bodies fails all 20 new list executions. Restoring the compiler byte-for-byte returns all 20 new scenarios to green.
- [x] `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json`.
- [x] Changed fixture and test pass strict `tsrx-tsc --noEmit` with `tsrx.compiler` explicitly selecting `octane/compiler/volar`. Default scoped discovery selects React lowering and also fails on the unchanged baseline; no type workaround is included.
- [x] Development/production compilation with native reads on/off, including source-map inspection.
- [x] Repository synchronization and scoped formatting checks.
- [ ] Repository-wide `pnpm format:check`, `pnpm typecheck`, and `pnpm test` were not run locally; the complete core projects and scoped checks above were run. 
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/33799406665): passed on `ae132218c`, including website/browser integration, examples, React parity, typechecking, lint, and package validation. One unchanged Volar typing test exceeded its 5-second timeout on the first attempt; the focused local reproduction passed in 1.35 seconds and the failed-job retry passed without source or timeout changes. Cursor Bugbot also passed with no findings.

## Risk / follow-ups

Coverage preserves nested and empty loops, multi-root items, escaped text, public mixed returns, opaque children forwarding, all five server-rendering APIs, and hydration adoption with live events. Broader SSR return-protocol changes and transition/manual-hook optimizations are separate follow-ups.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057399&installation_model_id=432790&pr_number=945&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F945&signature=98238cb9c2a764c6899c11759ffdb4fe9054921d77d50d7338494168f8cde83b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSR compiler return semantics for loop bodies; mitigated by broad contract tests across APIs, streaming, and hydration, with carriers unchanged for public boundaries.
> 
> **Overview**
> Compiled **`@for` item helpers** no longer wrap each iteration’s serialized markup in **`ssrHtml`**; they return the concatenation string directly, while public components, empty arms, and other SSR bodies still use the carrier so text vs template HTML stays distinguishable.
> 
> The **ssr-throughput** harness adds an untimed **`ssrHtml` call counter** (instrumented bundle copy) with budgets on the 300-card compiled page, descriptor control, and 10k-hole escape fixture, plus README notes that factory-call counts dropped sharply with **byte-identical** output and **no proven** end-to-end timing win.
> 
> **Contract tests** add nested/empty lists, hostile escaping, loop children forwarded through component descriptors, all five server render paths, and hydration with click handlers (dev and prod compile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae132218c03a18b084d9aff7e655a83a2d31cfb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
