### PR TITLE
perf: index static app-core routes for O(1) dispatch

### DIFF
--- a/.changeset/router-static-index.md
+++ b/.changeset/router-static-index.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/app-core': patch
+---
+
+Index static routes by exact path so request matching is O(1) instead of a linear scan, while still falling through to parameter and catch-all routes after a method miss.

--- a/packages/app-core/src/server/router.js
+++ b/packages/app-core/src/server/router.js
@@ -143,7 +143,9 @@ export function createRouter(routes) {
 					if (!methods.includes(normalizedMethod)) continue;
 				}
 
-				const match = compiled.pattern.exec(pathname);
+				const pattern = compiled.pattern;
+				if (typeof pattern === 'string') continue;
+				const match = pattern.exec(pathname);
 				if (match === null) continue;
 				const paramNames = compiled.paramNames;
 				/** @type {Record<string, string>} */

--- a/packages/app-core/src/server/router.js
+++ b/packages/app-core/src/server/router.js
@@ -92,6 +92,25 @@ export function createRouter(routes) {
 	// Sort by specificity (higher first) for correct matching order
 	compiledRoutes.sort((a, b) => b.specificity - a.specificity);
 
+	// Exact static paths are O(1). A static segment always out-scores a param or
+	// catch-all that could match the same pathname, so the map is consulted first.
+	// After a method miss, fall through to dynamic routes — a catch-all can still
+	// own the request.
+	/** @type {Map<string, CompiledRoute[]>} */
+	const staticByPath = new Map();
+	/** @type {CompiledRoute[]} */
+	const dynamicRoutes = [];
+	for (let i = 0; i < compiledRoutes.length; i++) {
+		const compiled = compiledRoutes[i];
+		if (typeof compiled.pattern === 'string') {
+			const existing = staticByPath.get(compiled.pattern);
+			if (existing === undefined) staticByPath.set(compiled.pattern, [compiled]);
+			else existing.push(compiled);
+		} else {
+			dynamicRoutes.push(compiled);
+		}
+	}
+
 	return {
 		/**
 		 * Match a request to a route
@@ -100,28 +119,37 @@ export function createRouter(routes) {
 		 * @returns {RouteMatch | null}
 		 */
 		match(method, pathname) {
+			const staticMatches = staticByPath.get(pathname);
+			if (staticMatches !== undefined) {
+				let normalizedMethod;
+				for (let i = 0; i < staticMatches.length; i++) {
+					const route = staticMatches[i].route;
+					if (route.type === 'server') {
+						const methods = /** @type {ServerRoute} */ (route).methods;
+						if (normalizedMethod === undefined) normalizedMethod = method.toUpperCase();
+						if (!methods.includes(normalizedMethod)) continue;
+					}
+					return { route, params: {} };
+				}
+			}
+
 			let normalizedMethod;
-			for (const { route, pattern, paramNames } of compiledRoutes) {
-				// Check method for ServerRoute
+			for (let i = 0; i < dynamicRoutes.length; i++) {
+				const compiled = dynamicRoutes[i];
+				const route = compiled.route;
 				if (route.type === 'server') {
 					const methods = /** @type {ServerRoute} */ (route).methods;
-					normalizedMethod ??= method.toUpperCase();
-					if (!methods.includes(normalizedMethod)) {
-						continue;
-					}
+					if (normalizedMethod === undefined) normalizedMethod = method.toUpperCase();
+					if (!methods.includes(normalizedMethod)) continue;
 				}
 
-				if (typeof pattern === 'string') {
-					if (pathname === pattern) return { route, params: {} };
-					continue;
-				}
-
-				const match = pathname.match(pattern);
-				if (!match) continue;
+				const match = compiled.pattern.exec(pathname);
+				if (match === null) continue;
+				const paramNames = compiled.paramNames;
 				/** @type {Record<string, string>} */
 				const params = {};
-				for (let i = 0; i < paramNames.length; i++) {
-					params[paramNames[i]] = decodeURIComponent(match[i + 1]);
+				for (let p = 0; p < paramNames.length; p++) {
+					params[paramNames[p]] = decodeURIComponent(match[p + 1]);
 				}
 				return { route, params };
 			}

--- a/packages/app-core/tests/router.test.ts
+++ b/packages/app-core/tests/router.test.ts
@@ -42,4 +42,59 @@ describe('app-core request router', () => {
 		expect(router.match('post', '/api/posts')).toEqual({ route: serverRoute, params: {} });
 		expect(router.match('GET', '/api/posts')).toBeNull();
 	});
+
+	it('falls through to a catch-all when a static server route rejects the method', function () {
+		const getOnly = new ServerRoute({
+			path: '/api',
+			methods: ['GET'],
+			handler: function () {
+				return new Response();
+			},
+		});
+		const catchAll = new RenderRoute({ path: '/*rest', entry: '/src/fallback.tsrx' });
+		const router = createRouter([getOnly, catchAll]);
+
+		expect(router.match('GET', '/api')).toEqual({ route: getOnly, params: {} });
+		expect(router.match('POST', '/api')).toEqual({
+			route: catchAll,
+			params: { rest: 'api' },
+		});
+	});
+
+	it('selects the matching method when several static server routes share a path', function () {
+		const getRoute = new ServerRoute({
+			path: '/api/items',
+			methods: ['GET'],
+			handler: function () {
+				return new Response('get');
+			},
+		});
+		const postRoute = new ServerRoute({
+			path: '/api/items',
+			methods: ['POST'],
+			handler: function () {
+				return new Response('post');
+			},
+		});
+		const router = createRouter([getRoute, postRoute]);
+
+		expect(router.match('GET', '/api/items')).toEqual({ route: getRoute, params: {} });
+		expect(router.match('post', '/api/items')).toEqual({ route: postRoute, params: {} });
+		expect(router.match('DELETE', '/api/items')).toBeNull();
+	});
+
+	it('uses a same-path render route after a static server method miss', function () {
+		const getOnly = new ServerRoute({
+			path: '/shared',
+			methods: ['GET'],
+			handler: function () {
+				return new Response();
+			},
+		});
+		const page = new RenderRoute({ path: '/shared', entry: '/src/shared.tsrx' });
+		const router = createRouter([getOnly, page]);
+
+		expect(router.match('GET', '/shared')).toEqual({ route: getOnly, params: {} });
+		expect(router.match('POST', '/shared')).toEqual({ route: page, params: {} });
+	});
 });

--- a/scripts/check-package-packs.mjs
+++ b/scripts/check-package-packs.mjs
@@ -478,6 +478,14 @@ async function validatePackedConsumer(tempRoot, archives) {
 					typescript: typescriptVersion,
 					vite: viteVersion,
 				},
+				// postcss 8.5.28 makes DeclarationProps extend NodeProps, but
+				// tsrx-tsc cannot resolve that named export from node.d.ts
+				// (TS2304). Pin the last types that typecheck here.
+				pnpm: {
+					overrides: {
+						postcss: '8.5.26',
+					},
+				},
 			},
 			null,
 			2,

--- a/scripts/check-package-packs.mjs
+++ b/scripts/check-package-packs.mjs
@@ -478,18 +478,17 @@ async function validatePackedConsumer(tempRoot, archives) {
 					typescript: typescriptVersion,
 					vite: viteVersion,
 				},
-				// postcss 8.5.28 makes DeclarationProps extend NodeProps, but
-				// tsrx-tsc cannot resolve that named export from node.d.ts
-				// (TS2304). Pin the last types that typecheck here.
-				pnpm: {
-					overrides: {
-						postcss: '8.5.26',
-					},
-				},
 			},
 			null,
 			2,
 		) + '\n',
+	);
+	// postcss 8.5.28 makes DeclarationProps extend NodeProps, but tsrx-tsc
+	// cannot resolve that named export from node.d.ts (TS2304). pnpm 11 reads
+	// overrides from pnpm-workspace.yaml, matching the other packed consumers.
+	writeFileSync(
+		path.join(consumerDirectory, 'pnpm-workspace.yaml'),
+		'overrides:\n  postcss: "8.5.26"\n',
 	);
 	writeFileSync(
 		path.join(sourceDirectory, 'App.tsrx'),
@@ -873,6 +872,10 @@ export function renderProbe() {
 	);
 
 	const consumerRequire = createRequire(path.join(consumerDirectory, 'package.json'));
+	const installedPostcss = consumerRequire('postcss/package.json').version;
+	if (installedPostcss !== '8.5.26') {
+		throw new Error(`packed consumer resolved postcss ${installedPostcss}; expected 8.5.26`);
+	}
 	const directRuntime = realpathSync(consumerRequire.resolve('octane'));
 	// Resolve through real ESM package specifiers from the installed consumer,
 	// not a CommonJS-resolved file URL, so conditional `import` branches remain


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Index exact (static) `@octanejs/app-core` routes by path so `createRouter().match()` is O(1) instead of a linear scan of the compiled table.
- After a static method miss, matching still falls through to parameter and catch-all routes, so a GET-only `/api` does not hide `/*rest`.
- Same-path server methods keep specificity order; render routes still match any method.

## Why
`router-dispatch` measures a 1,000-route table and still walked every candidate for a last-row static hit or a lowercase method miss. Exact-string compare already beat RegExp, but the scan itself dominated. A path map removes that work without changing match semantics.

## Changes
- `packages/app-core/src/server/router.js`: split compiled routes into a static `Map` and a dynamic list; consult the map first. Dynamic candidates narrow `pattern` to `RegExp` before `exec`.
- `packages/app-core/tests/router.test.ts`: pin method-miss → catch-all fall-through, shared-path method selection, and same-path render fallback.
- Changeset for `@octanejs/app-core` (patch).
- `scripts/check-package-packs.mjs`: pin packed-consumer PostCSS to 8.5.26 via `pnpm-workspace.yaml` (pnpm 11; `package.json` `pnpm.overrides` does not apply here). postcss 8.5.28's `DeclarationProps extends NodeProps` fails `tsrx-tsc` (`TS2304`) on every current-head pack job, including unrelated PRs. Install asserts the resolved version.

## Benchmarks

Environment: Node v22.22.2, Linux 6.12.94+ x86_64, 4 CPUs. Command: `node benchmarks/router-dispatch/run.mjs 20`. Scores are ms/million candidates (lower is better). A/B/A/B on the same machine:

| run | static | wrong-method | dynamic (control) |
| --- | ---: | ---: | ---: |
| A1 baseline | 5.554 | 5.312 | 118.997 |
| B1 indexed | 0.032 | 0.033 | 121.063 |
| A2 baseline | 5.620 | 5.328 | 120.327 |
| B2 indexed | 0.032 | 0.032 | 122.541 |

- Static: ~176× faster
- Wrong-method: ~161–166× faster
- Dynamic control: +1.7–1.8%, inside observed noise (not claimed as a regression or a win)

Existing ratio guards (`static`/`wrong-method` vs `dynamic`, `maxRatio: 0.2`) remain valid and become much looser.

## Validation
- [ ] `pnpm format:check` (not run; scoped Prettier on the changed files)
- [x] `pnpm typecheck` via CI on `9f099eca1` (required typecheck job green)
- [x] `pnpm test` via CI on `9f099eca1` (Node 24 shards, React-parity, lint, examples, Lynx/Three)
- [x] targeted tests: `packages/app-core/tests/router.test.ts` (4 tests). The catch-all fall-through case was confirmed red when the static miss returned `null` before the dynamic scan, then green after restore.
- [x] `node benchmarks/router-dispatch/run.mjs 20` A/B/A/B as above
- [x] packed-consumer gate: `9f099eca1` workspace-yaml PostCSS pin; `validate publishable packages` and `CI provenance` green

## Risk / follow-ups
- Dynamic (RegExp) matching is unchanged aside from an O(1) map miss on tables with no static routes.
- Callers still receive a fresh `params` object; public match identity and decoded params are unchanged.
- The PostCSS pin is a CI consumer override, not an application runtime change. Lift it when postcss types resolve `NodeProps` under `tsrx-tsc`.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32eea018-d4b4-4dd7-8c1a-8c3cd13e68b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32eea018-d4b4-4dd7-8c1a-8c3cd13e68b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791123246&installation_model_id=432790&pr_number=951&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F951&signature=7495e31264ba4aa38cab40efb717dd6c66301b36383ef964540e701f85f11a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->