### PR TITLE
fix(tanstack-store): accept an explicit undefined comparator

### DIFF
--- a/.changeset/tanstack-store-optional-compare.md
+++ b/.changeset/tanstack-store-optional-compare.md
@@ -1,0 +1,19 @@
+---
+'@octanejs/tanstack-store': patch
+---
+
+Let `UseSelectorOptions.compare` hold `undefined` explicitly.
+
+This package publishes `src/`, so the consumer's compiler options are the ones
+that compile it. An application with `exactOptionalPropertyTypes` enabled could
+not build it at all: `useStore` normalises its variadic arguments into
+`{ compare }`, where `compare` is the optional third argument, and passing that
+object to `useSelector` failed because the target property was declared without
+`undefined`.
+
+The same wall met anyone forwarding their own optional comparator, because
+`{ compare: maybeCompare }` is not assignable to `{ compare?: Compare }` under
+that flag. Declaring the property as `compare?: Compare | undefined` accepts
+both. The runtime is unchanged: `useSelector` has always read the option with
+`options?.compare ?? defaultCompare`, so an absent key and an explicit
+`undefined` already behaved identically.

--- a/packages/tanstack-store/src/useSelector.ts
+++ b/packages/tanstack-store/src/useSelector.ts
@@ -3,7 +3,12 @@ import { splitSlot, subSlot } from './internal';
 import { useSyncExternalStoreWithSelector } from './useSyncExternalStoreWithSelector';
 
 export interface UseSelectorOptions<TSelected> {
-	compare?: (a: TSelected, b: TSelected) => boolean;
+	// Written as an optional property that also admits `undefined`, because this
+	// package publishes source and the consumer's compiler options apply to it.
+	// Under `exactOptionalPropertyTypes` a bare `compare?:` would reject both an
+	// options object forwarded from another optional value and this package's own
+	// `useStore` bridge, which always passes the key through.
+	compare?: ((a: TSelected, b: TSelected) => boolean) | undefined;
 }
 
 type SyncExternalStoreSubscribe = Parameters<typeof useSyncExternalStoreWithSelector>[0];


### PR DESCRIPTION
## Summary

`@octanejs/tanstack-store` publishes `src/`, so the consumer's `tsc` compiles it with the consumer's flags. Under `exactOptionalPropertyTypes` the package does not build at all:

```
packages/tanstack-store/src/useStore.ts(49,22): error TS2379: Argument of type
'{ compare: ((a: TSelected, b: TSelected) => boolean) | undefined; }' is not
assignable to parameter of type 'UseSelectorOptions<TSelected>' with
'exactOptionalPropertyTypes: true'.
```

`useStore` normalises its variadic arguments and always passes the `compare` key, which may hold `undefined`. `UseSelectorOptions.compare` was declared without `undefined`, so the internal bridge fails, and so does any consumer forwarding their own optional comparator (`{ compare: maybeCompare }`).

Declaring `compare?: Compare | undefined` accepts both. No runtime change: `useSelector` already read the option as `options?.compare ?? defaultCompare`, so an absent key and an explicit `undefined` behaved identically before and after.

Found while building an Octane app with `exactOptionalPropertyTypes` on. It was shipping a `pnpm patch` against the published tarball; this is the same fix upstream.

## Validation

Repo-wide `pnpm typecheck` and `pnpm test` were not run (unchanged elsewhere; the diff is one type declaration).

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted: `tsrx-tsc -p packages/tanstack-store/tsconfig.json`, `tsrx-tsc -p packages/tanstack-store/typetests/tsconfig.json`, `vitest run --project "*tanstack-store*"` (9 files, 51 tests)
- [x] reproduction: `scripts/consumer-tsconfigs/tanstack-store.json` plus `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` reports the error above before the change and nothing from this package after it

## Risk / follow-ups

No gate covers this. `scripts/consumer-tsconfigs/base.json` mirrors what `octane init` scaffolds, which leaves both flags off, and turning them on in a package tsconfig pulls `packages/octane/src` into the program, where the same classes of error exist in bulk. A real consumer never sees those, because `octane` publishes `dist` with declarations behind `skipLibCheck`, while every `@octanejs/*` binding publishes source. The header of `scripts/generate-consumer-tsconfigs.mjs` already records that debt against #721; widening those projects is worth doing once core is clean.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791130386&installation_model_id=432790&pr_number=952&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F952&signature=cb490b046591fbdde988a17b3c967fd7795fcd91bbb2d5ea40783e00e74de7cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only widening for optional properties; no runtime or behavioral change.
> 
> **Overview**
> Fixes **TypeScript compile failures** when consumers build `@octanejs/tanstack-store` with **`exactOptionalPropertyTypes`**. Because the package ships **source**, the app’s compiler type-checks `useStore` → `useSelector` and any forwarded `{ compare: maybeCompare }` objects.
> 
> **`UseSelectorOptions.compare`** is now typed as an optional property that **also allows `undefined`** (`compare?: Compare | undefined`), with a short comment explaining why. **`useStore`** can keep passing `{ compare }` when the third argument is omitted, and callers can forward optional comparators without assignment errors.
> 
> **Runtime behavior is unchanged** — `useSelector` still resolves the comparator via `options?.compare ?? defaultCompare`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6429425b7708b7f101cea22360d52e61defd8dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
