### PR TITLE
fix(tanstack-table): build atom options only when a comparator exists

### DIFF
--- a/.changeset/tanstack-table-atom-options.md
+++ b/.changeset/tanstack-table-atom-options.md
@@ -1,0 +1,19 @@
+---
+'@octanejs/tanstack-table': patch
+---
+
+Build atom options only when table-core supplies a comparator.
+
+The reactivity bindings forwarded `{ compare: options?.compare }` into
+`createAtom` for every atom, including the ones table-core creates without a
+comparator. `AtomOptions.compare` is declared optional without `undefined`, so
+that object is not an `AtomOptions` under `exactOptionalPropertyTypes`, and the
+error is worse than it looks: the failure knocks out the second `createAtom`
+overload, so `createWritableAtom` was reported as returning a `ReadonlyAtom`
+that does not satisfy the `TableReactivityBindings` contract.
+
+This package publishes `src/`, so those are the consumer's compiler options.
+An application with the flag on could not build it. The options object is now
+constructed only when there is a comparator to put in it. `createAtom` reads
+`options?.compare ?? Object.is`, so an omitted object and one holding
+`undefined` produce the same atom.

--- a/packages/tanstack-table/src/reactivity.ts
+++ b/packages/tanstack-table/src/reactivity.ts
@@ -4,7 +4,21 @@
 // risk resolving a second copy — atoms compare by identity, so a duplicate
 // would silently break every subscription.
 import { batch, createAtom } from '@octanejs/tanstack-store';
+import type { AtomOptions } from '@octanejs/tanstack-store';
 import type { TableAtomOptions, TableReactivityBindings } from '@tanstack/table-core/reactivity';
+
+/**
+ * table-core supplies a comparator for some atoms and nothing for the rest, and
+ * carries a `debugName` that `createAtom` has no use for. `AtomOptions.compare`
+ * is optional without `undefined`, so building the object unconditionally makes
+ * the call a type error under `exactOptionalPropertyTypes`, which is the
+ * consumer's flag because this package publishes source. The object therefore
+ * exists only when there is a comparator to put in it.
+ */
+function atomOptions<T>(options?: TableAtomOptions<T>): AtomOptions<T> | undefined {
+	const compare = options?.compare;
+	return compare === undefined ? undefined : { compare };
+}
 
 /**
  * Creates the table-core reactivity bindings used by the octane adapter.
@@ -31,14 +45,10 @@ export function octaneReactivity(): TableReactivityBindings {
 		batch,
 		untrack: (fn) => fn(),
 		createReadonlyAtom: <T>(fn: () => T, options?: TableAtomOptions<T>) => {
-			return createAtom(() => fn(), {
-				compare: options?.compare,
-			});
+			return createAtom(() => fn(), atomOptions<T>(options));
 		},
 		createWritableAtom: <T>(value: T, options?: TableAtomOptions<T>) => {
-			return createAtom(value, {
-				compare: options?.compare,
-			});
+			return createAtom(value, atomOptions<T>(options));
 		},
 	};
 }


### PR DESCRIPTION
## Summary

`@octanejs/tanstack-table` publishes `src/`, so the consumer's `tsc` compiles it with the consumer's flags. Under `exactOptionalPropertyTypes` the package does not build:

```
packages/tanstack-table/src/reactivity.ts(34,11): error TS2769: No overload matches this call.
packages/tanstack-table/src/reactivity.ts(38,3): error TS2322: Type '<T>(value: T, options?: TableAtomOptions<T>) => ReadonlyAtom<T>' is not
  assignable to type '<T>(initialValue: T, options?: TableAtomOptions<T> | undefined) => Atom<T>'.
  Property 'set' is missing in type 'ReadonlyAtom<T>' but required in type 'Atom<T>'.
packages/tanstack-table/src/reactivity.ts(39,11): error TS2769: No overload matches this call.
```

The bindings forwarded `{ compare: options?.compare }` for every atom, including the ones table-core creates without a comparator. `AtomOptions.compare` is optional without `undefined`, so that object is not an `AtomOptions` under the flag. The second error is the interesting one: the options mismatch knocks out `createAtom`'s writable overload, so `createWritableAtom` gets reported as returning a `ReadonlyAtom` and stops satisfying `TableReactivityBindings`.

The options object is now built only when there is a comparator to put in it. `createAtom` reads `options?.compare ?? Object.is`, so an omitted object and one holding `undefined` produce the same atom, and `debugName` was already being dropped before this change.

Found while building an Octane app with `exactOptionalPropertyTypes` on. It was shipping a `pnpm patch` against the published tarball; this is the same fix upstream.

## Validation

Repo-wide `pnpm typecheck` and `pnpm test` were not run.

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted: `tsrx-tsc -p packages/tanstack-table/tsconfig.json`, `tsrx-tsc -p scripts/consumer-tsconfigs/tanstack-table.json`, `vitest run --project "*tanstack-table*"` (9 files, 44 tests)
- [x] reproduction: `scripts/consumer-tsconfigs/tanstack-table.json` plus `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` reports the errors above before the change and nothing from this package after it

## Risk / follow-ups

No gate covers this. `scripts/consumer-tsconfigs/base.json` mirrors what `octane init` scaffolds, which leaves both flags off, and turning them on in a package tsconfig pulls `packages/octane/src` into the program, where the same classes of error exist in bulk. A real consumer never sees those, because `octane` publishes `dist` with declarations behind `skipLibCheck`, while every `@octanejs/*` binding publishes source. The header of `scripts/generate-consumer-tsconfigs.mjs` already records that debt against #721; widening those projects is worth doing once core is clean.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791131041&installation_model_id=432790&pr_number=953&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F953&signature=e3495e490fbbd65c1877304f6501a83f677d4b4c21bb62cf74e52a3fdce1973b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow typing fix in atom option forwarding; runtime atom behavior is unchanged when no comparator is supplied.
> 
> **Overview**
> Fixes a **TypeScript build failure** for apps that compile `@octanejs/tanstack-table` from published `src/` with **`exactOptionalPropertyTypes`**.
> 
> The reactivity bindings no longer pass `{ compare: options?.compare }` into `createAtom` on every call. A new **`atomOptions`** helper only builds an `AtomOptions` object when table-core actually provides a comparator; otherwise `createAtom` is called with no options (same runtime behavior via its default compare). That restores correct overload resolution so **`createWritableAtom`** types as a writable atom again and satisfies **`TableReactivityBindings`**.
> 
> Patch changeset for `@octanejs/tanstack-table`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3249d5e5c08fb88d446b0272b85a536eeed7f481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
