### PR TITLE
perf: memoize unitless CSS property classification

### DIFF
--- a/.changeset/style-unitless-cache.md
+++ b/.changeset/style-unitless-cache.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Memoize unitless CSS property classification so numeric style writes skip repeated string allocation.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -251,6 +251,7 @@ internally, get their own baseline and guard namespace.
 | `radix-collection-order` | radix-collection-order | none (Node-only) | production Radix collection ordering versus the prior comparator at 16, 64, 256, and 4,096 items, with missing-ref and stable-order controls |
 | `router-dispatch` | router-dispatch | none (Node-only) | app-core static, wrong-method, and dynamic matching across 1,000-route tables |
 | `visx-categorical-scale` | visx-categorical-scale | none (Node-only) | production Visx categorical lookup versus repeated linear scans at 16, 64, and 4,096 domain keys |
+| `style-unitless` | style-unitless | none (Node-only) | production numeric style serialization versus repeated unitless-name normalization on a mixed-repeat key bag |
 | `rspack-css-graph` | rspack-css-graph | none (Node-only) | CSS-module proof collection and verification across zero, one, and sixteen requests, with deterministic module-graph traversal and connection-visit guards |
 | `floating-tree-navigation` | floating-tree-navigation | none (Node-only) | Floating UI deepest-open-node lookup on deep chains, equal-depth forks, and a root-only control, with exact previous-behavior and deterministic node-read gates |
 | `ink-cursor-update` | ink-cursor-update | none (Node-only) | Ink standard/incremental cursor-only updates over equal 20,000-line frames, with exact previous branches, byte/split gates, stable-frame stress scaling, and initial/changed-render controls |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -604,8 +604,8 @@
     "op": "lookup_per_1000",
     "target": "cached-mixed",
     "reference": "scan-mixed",
-    "maxRatio": 0.25,
-    "note": "Same-process numeric cssStyleValue writes through a mixed bag of unitless, px, kebab, vendor-prefixed, and custom-property keys. Uncached replaceAll+toLowerCase measured at ~1.8M object-serializations/s; the bounded name cache measured at ~12M (~0.15x). The 0.25 ceiling leaves more than 1.5x timing headroom while catching restoration of per-write string allocation."
+    "maxRatio": 0.5,
+    "note": "Same-process numeric cssStyleValue writes through a mixed bag of unitless, px, kebab, vendor-prefixed, and custom-property keys. The linear replaceAll+toLowerCase scan measured at 0.96ms/1,000 lookups; the bounded name cache measured at 0.30ms (~0.31x) on Node 22.22.2. The 0.5 ceiling leaves more than 1.5x timing headroom while catching restoration of per-write string allocation."
   },
   {
     "suite": "rspack-css-graph",

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -600,6 +600,14 @@
     "note": "Same-process categorical color lookup across 4,096 domain keys, with index construction included in every sample and first-match duplicate and missing-key gates. Repeated linear scans measured 1.59ms per 1,000 lookups while the first-occurrence index measured 0.04ms, a 0.02x ratio across three normal runs. The 0.08 ceiling leaves more than 3x timing headroom while catching restoration of quadratic lookup work."
   },
   {
+    "suite": "style-unitless",
+    "op": "lookup_per_1000",
+    "target": "cached-mixed",
+    "reference": "scan-mixed",
+    "maxRatio": 0.25,
+    "note": "Same-process numeric cssStyleValue writes through a mixed bag of unitless, px, kebab, vendor-prefixed, and custom-property keys. Uncached replaceAll+toLowerCase measured at ~1.8M object-serializations/s; the bounded name cache measured at ~12M (~0.15x). The 0.25 ceiling leaves more than 1.5x timing headroom while catching restoration of per-write string allocation."
+  },
+  {
     "suite": "rspack-css-graph",
     "op": "graph_traversals",
     "target": "sixteen-requests",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -486,6 +486,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Node-only numeric style serialization through the production unitless
+		// cache and the prior replaceAll+toLowerCase scan on mixed repeating keys.
+		name: 'style-unitless',
+		cwd: 'style-unitless',
+		servers: [],
+		iter: { normal: 8, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Node-only Rspack CSS-module proof collection and verification with
 		// deterministic graph traversal and yielded-connection counts.
 		name: 'rspack-css-graph',

--- a/benchmarks/style-unitless/README.md
+++ b/benchmarks/style-unitless/README.md
@@ -1,0 +1,18 @@
+# Style unitless-property benchmark
+
+This Node-only suite measures numeric `cssStyleValue` writes through the
+production `isUnitlessStyleProp` helper and the prior
+`replaceAll` + `toLowerCase` scan. Each sample serializes a mixed bag of
+unitless, px, kebab, vendor-prefixed, and custom-property keys.
+
+The mixed case is the animation-frequency path: the same authored keys repeat.
+A never-repeated key stream is not the target — that path still pays the
+original normalize plus a Map miss, and is not claimed as a win. Correctness
+gates require identical CSS strings and the same unitless classification
+before timings are accepted.
+
+Run it through the unified harness:
+
+```bash
+node benchmarks/bench.mjs --quick --ratios style-unitless
+```

--- a/benchmarks/style-unitless/run.mjs
+++ b/benchmarks/style-unitless/run.mjs
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { cssStyleValue, isUnitlessStyleProp } from '../../packages/octane/src/dom-tables.js';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const iterations = Number.parseInt(process.argv[2] ?? '8', 10);
+const LOOKUPS_PER_SAMPLE = 1_000_000;
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('style-unitless iterations must be a positive integer');
+}
+
+const UNITLESS_STYLE_PROPS = new Set();
+for (const base of [
+	'animationIterationCount',
+	'aspectRatio',
+	'borderImageOutset',
+	'borderImageSlice',
+	'borderImageWidth',
+	'boxFlex',
+	'boxFlexGroup',
+	'boxOrdinalGroup',
+	'columnCount',
+	'columns',
+	'flex',
+	'flexGrow',
+	'flexPositive',
+	'flexShrink',
+	'flexNegative',
+	'flexOrder',
+	'gridArea',
+	'gridRow',
+	'gridRowEnd',
+	'gridRowSpan',
+	'gridRowStart',
+	'gridColumn',
+	'gridColumnEnd',
+	'gridColumnSpan',
+	'gridColumnStart',
+	'fontWeight',
+	'lineClamp',
+	'lineHeight',
+	'opacity',
+	'order',
+	'orphans',
+	'scale',
+	'tabSize',
+	'widows',
+	'zIndex',
+	'zoom',
+	'fillOpacity',
+	'floodOpacity',
+	'stopOpacity',
+	'strokeDasharray',
+	'strokeDashoffset',
+	'strokeMiterlimit',
+	'strokeOpacity',
+	'strokeWidth',
+]) {
+	const canonical = base.toLowerCase();
+	UNITLESS_STYLE_PROPS.add(canonical);
+	UNITLESS_STYLE_PROPS.add('webkit' + canonical);
+	UNITLESS_STYLE_PROPS.add('ms' + canonical);
+	UNITLESS_STYLE_PROPS.add('moz' + canonical);
+	UNITLESS_STYLE_PROPS.add('o' + canonical);
+}
+
+function isUnitlessScan(name) {
+	return UNITLESS_STYLE_PROPS.has(name.replaceAll('-', '').toLowerCase());
+}
+
+function cssStyleValueScan(name, value) {
+	if (
+		typeof value === 'number' &&
+		value !== 0 &&
+		name.charCodeAt(0) !== 45 &&
+		!isUnitlessScan(name)
+	) {
+		return value + 'px';
+	}
+	return typeof value === 'string' ? value.trim() : '' + value;
+}
+
+const keys = [
+	'width',
+	'height',
+	'fontSize',
+	'marginTop',
+	'opacity',
+	'zIndex',
+	'lineHeight',
+	'line-height',
+	'flexGrow',
+	'WebkitLineClamp',
+	'paddingLeft',
+	'--gap',
+];
+const values = [100, 48, 14, 8, 0.5, 3, 1.4, 2, 2, 3, 16, 8];
+
+function expectedCss(name, value) {
+	return cssStyleValueScan(name, value);
+}
+
+function runLookups(serialize, names, nums, count) {
+	const started = performance.now();
+	let checksum = 0;
+	for (let n = 0; n < count; n++) {
+		for (let i = 0; i < names.length; i++) {
+			const css = serialize(names[i], nums[i]);
+			checksum += css.length;
+		}
+	}
+	return { elapsed: performance.now() - started, checksum };
+}
+
+const scenarios = [
+	{
+		name: 'scan-mixed',
+		serialize: cssStyleValueScan,
+		names: keys,
+		nums: values,
+	},
+	{
+		name: 'cached-mixed',
+		serialize: cssStyleValue,
+		names: keys,
+		nums: values,
+	},
+];
+
+for (let i = 0; i < keys.length; i++) {
+	assert.equal(
+		isUnitlessStyleProp(keys[i]),
+		isUnitlessScan(keys[i]),
+		keys[i] + ' unitless classification drifted',
+	);
+	assert.equal(cssStyleValue(keys[i], values[i]), expectedCss(keys[i], values[i]), keys[i]);
+}
+assert.equal(cssStyleValue('fontSize', 12), '12px', 'fontSize lost px');
+assert.equal(cssStyleValue('opacity', 0.5), '0.5', 'opacity gained px');
+assert.equal(cssStyleValue('line-height', 2), '2', 'kebab line-height gained px');
+assert.equal(cssStyleValue('WebkitLineClamp', 3), '3', 'vendor line-clamp gained px');
+assert.equal(cssStyleValue('--gap', 8), '8', 'custom property gained px');
+
+const expectedChecksums = new Map();
+for (const scenario of scenarios) {
+	const warmup = runLookups(scenario.serialize, scenario.names, scenario.nums, 200);
+	const control = runLookups(cssStyleValueScan, scenario.names, scenario.nums, 200);
+	assert.equal(warmup.checksum, control.checksum, scenario.name + ' warmup drifted');
+	expectedChecksums.set(scenario.name, warmup.checksum);
+}
+
+const samples = new Map();
+for (const scenario of scenarios) samples.set(scenario.name, []);
+
+for (let iteration = 0; iteration < iterations; iteration++) {
+	const order = iteration % 2 === 0 ? scenarios : scenarios.slice().reverse();
+	for (const scenario of order) {
+		const sample = runLookups(
+			scenario.serialize,
+			scenario.names,
+			scenario.nums,
+			LOOKUPS_PER_SAMPLE,
+		);
+		assert.equal(
+			sample.checksum,
+			expectedChecksums.get(scenario.name),
+			scenario.name + ' timed checksum drifted',
+		);
+		samples.get(scenario.name).push((sample.elapsed * 1_000) / LOOKUPS_PER_SAMPLE);
+	}
+}
+
+const rows = scenarios.map(function (scenario) {
+	const summary = summarizeSamples(samples.get(scenario.name));
+	console.log(
+		'PASS style-unitless/' + scenario.name + ': ' + summary.score.toFixed(3) + 'ms/1,000 lookups',
+	);
+	return {
+		name: scenario.name,
+		ops: { lookup_per_1000: timingStatForJson(summary) },
+		meta: {
+			keys: scenario.names.length,
+			lookupsPerSample: LOOKUPS_PER_SAMPLE * scenario.names.length,
+			correctness: 'pass',
+		},
+	};
+});
+
+const payload = {
+	suite: 'style-unitless',
+	iterations,
+	targets: rows,
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');
+}

--- a/benchmarks/style-unitless/run.mjs
+++ b/benchmarks/style-unitless/run.mjs
@@ -101,6 +101,14 @@ function expectedCss(name, value) {
 	return cssStyleValueScan(name, value);
 }
 
+function bagChecksum(serialize, names, nums) {
+	let checksum = 0;
+	for (let i = 0; i < names.length; i++) {
+		checksum += serialize(names[i], nums[i]).length;
+	}
+	return checksum;
+}
+
 function runLookups(serialize, names, nums, count) {
 	const started = performance.now();
 	let checksum = 0;
@@ -145,11 +153,14 @@ assert.equal(cssStyleValue('--gap', 8), '8', 'custom property gained px');
 const WARMUP_LOOKUPS = 200;
 const expectedChecksums = new Map();
 for (const scenario of scenarios) {
-	const warmup = runLookups(scenario.serialize, scenario.names, scenario.nums, WARMUP_LOOKUPS);
-	const control = runLookups(cssStyleValueScan, scenario.names, scenario.nums, WARMUP_LOOKUPS);
-	assert.equal(warmup.checksum, control.checksum, scenario.name + ' warmup drifted');
-	assert.equal(warmup.checksum % WARMUP_LOOKUPS, 0, scenario.name + ' warmup checksum not uniform');
-	expectedChecksums.set(scenario.name, warmup.checksum / WARMUP_LOOKUPS);
+	runLookups(scenario.serialize, scenario.names, scenario.nums, WARMUP_LOOKUPS);
+	const perBag = bagChecksum(scenario.serialize, scenario.names, scenario.nums);
+	assert.equal(
+		perBag,
+		bagChecksum(cssStyleValueScan, scenario.names, scenario.nums),
+		scenario.name + ' bag checksum drifted',
+	);
+	expectedChecksums.set(scenario.name, perBag * LOOKUPS_PER_SAMPLE);
 }
 
 const samples = new Map();
@@ -166,7 +177,7 @@ for (let iteration = 0; iteration < iterations; iteration++) {
 		);
 		assert.equal(
 			sample.checksum,
-			expectedChecksums.get(scenario.name) * LOOKUPS_PER_SAMPLE,
+			expectedChecksums.get(scenario.name),
 			scenario.name + ' timed checksum drifted',
 		);
 		samples.get(scenario.name).push((sample.elapsed * 1_000) / LOOKUPS_PER_SAMPLE);

--- a/benchmarks/style-unitless/run.mjs
+++ b/benchmarks/style-unitless/run.mjs
@@ -142,12 +142,14 @@ assert.equal(cssStyleValue('line-height', 2), '2', 'kebab line-height gained px'
 assert.equal(cssStyleValue('WebkitLineClamp', 3), '3', 'vendor line-clamp gained px');
 assert.equal(cssStyleValue('--gap', 8), '8', 'custom property gained px');
 
+const WARMUP_LOOKUPS = 200;
 const expectedChecksums = new Map();
 for (const scenario of scenarios) {
-	const warmup = runLookups(scenario.serialize, scenario.names, scenario.nums, 200);
-	const control = runLookups(cssStyleValueScan, scenario.names, scenario.nums, 200);
+	const warmup = runLookups(scenario.serialize, scenario.names, scenario.nums, WARMUP_LOOKUPS);
+	const control = runLookups(cssStyleValueScan, scenario.names, scenario.nums, WARMUP_LOOKUPS);
 	assert.equal(warmup.checksum, control.checksum, scenario.name + ' warmup drifted');
-	expectedChecksums.set(scenario.name, warmup.checksum);
+	assert.equal(warmup.checksum % WARMUP_LOOKUPS, 0, scenario.name + ' warmup checksum not uniform');
+	expectedChecksums.set(scenario.name, warmup.checksum / WARMUP_LOOKUPS);
 }
 
 const samples = new Map();
@@ -164,7 +166,7 @@ for (let iteration = 0; iteration < iterations; iteration++) {
 		);
 		assert.equal(
 			sample.checksum,
-			expectedChecksums.get(scenario.name),
+			expectedChecksums.get(scenario.name) * LOOKUPS_PER_SAMPLE,
 			scenario.name + ' timed checksum drifted',
 		);
 		samples.get(scenario.name).push((sample.elapsed * 1_000) / LOOKUPS_PER_SAMPLE);

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -79,6 +79,7 @@ export const BENCHMARK_SUITES = [
 	'radix-collection-order',
 	'router-dispatch',
 	'visx-categorical-scale',
+	'style-unitless',
 	'rspack-css-graph',
 	'floating-tree-navigation',
 	'ink-cursor-update',

--- a/packages/octane/src/dom-tables.js
+++ b/packages/octane/src/dom-tables.js
@@ -536,9 +536,24 @@ for (const base of [
 	UNITLESS_STYLE_PROPS.add('o' + c);
 }
 
-/** True if `name` (camelCase, kebab, or vendor-prefixed) is a unitless CSS property. */
+/**
+ * True if `name` (camelCase, kebab, or vendor-prefixed) is a unitless CSS
+ * property.
+ *
+ * Memoized: the key universe is bounded (CSS property names), and numeric
+ * style writes hit this per key per write — at animation frequency the
+ * replaceAll + toLowerCase allocation would dominate. Same rationale as
+ * `styleName` in css.ts. The cache stores the boolean so a miss (`width`)
+ * is as cheap as a hit (`opacity`) after the first lookup.
+ */
+const unitlessStylePropCache = new Map();
+
 export function isUnitlessStyleProp(name) {
-	return UNITLESS_STYLE_PROPS.has(name.replaceAll('-', '').toLowerCase());
+	const cached = unitlessStylePropCache.get(name);
+	if (cached !== undefined) return cached;
+	const result = UNITLESS_STYLE_PROPS.has(name.replaceAll('-', '').toLowerCase());
+	unitlessStylePropCache.set(name, result);
+	return result;
 }
 
 /**

--- a/packages/octane/tests/style-px.test.ts
+++ b/packages/octane/tests/style-px.test.ts
@@ -47,6 +47,25 @@ describe('numeric style px — dynamic (runtime)', () => {
 		r.unmount();
 	});
 
+	it('leaves kebab-case unitless properties unitless and still appends px to kebab lengths', function () {
+		const r = mount(DynStyle, { s: { 'line-height': 2, 'font-size': 12 } });
+		const el = r.find('#d') as HTMLElement;
+		expect(el.style.lineHeight).toBe('2');
+		expect(el.style.fontSize).toBe('12px');
+		r.unmount();
+	});
+
+	it('keeps unitless vs px rules after repeated writes of the same keys', function () {
+		const r = mount(DynStyle, { s: { width: 100, opacity: 0.5, 'line-height': 2 } });
+		const el = r.find('#d') as HTMLElement;
+		r.update(DynStyle, { s: { width: 140, opacity: 0.25, 'line-height': 1.5 } });
+		r.update(DynStyle, { s: { width: 80, opacity: 1, 'line-height': 3 } });
+		expect(el.style.width).toBe('80px');
+		expect(el.style.opacity).toBe('1');
+		expect(el.style.lineHeight).toBe('3');
+		r.unmount();
+	});
+
 	it('never adds px to a custom property (`--x`)', () => {
 		const r = mount(DynStyle, { s: { '--gap': 8 } });
 		expect((r.find('#d') as HTMLElement).style.getPropertyValue('--gap')).toBe('8');
@@ -117,6 +136,17 @@ describe('numeric style px — SSR', () => {
 		expect(html).toContain('z-index:5'); // unitless
 		expect(html).toContain('font-size:12px'); // camelCase → kebab + px
 		expect(html).toContain('--gap:8'); // custom prop → no px
+	});
+
+	it('serialises kebab-case and vendor-prefixed numeric styles with the same px rules', async function () {
+		const { html } = await ServerRT.renderToString(server.DynStyle, {
+			s: { 'line-height': 2, 'font-size': 12, WebkitLineClamp: 3 },
+		});
+		expect(html).toContain('line-height:2');
+		expect(html).not.toContain('line-height:2px');
+		expect(html).toContain('font-size:12px');
+		expect(html).toContain('-webkit-line-clamp:3');
+		expect(html).not.toContain('-webkit-line-clamp:3px');
 	});
 
 	it('static object style serialises identically to the client bake', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Memoizes `isUnitlessStyleProp` in `dom-tables.js` with the same Map-cache pattern `styleName` already uses. `cssStyleValue` called this helper on every numeric style write (client animation, SSR `styleObjectToCss`, compiler bake) and previously paid `replaceAll('-', '')` + `toLowerCase` on every lookup, including negative hits (`width`, `fontSize`).

The cache is bounded by the CSS-property key universe. Cache misses still run the original `UNITLESS_STYLE_PROPS` scan. `false` is a valid cached miss, so the lookup uses `!== undefined`.

No public API change.

Orthogonal to #951 (static router Map) and #955 (last-static-segment index). Those PRs stay untouched.

## Why this candidate

Third-pass audit measured before changing. Discarded:

- `escapeHtml` `indexOf` reject on clean strings (~1.7–2.4× helper): page-clean 500-title SSR dropped ~25µs → ~10µs, not a meaningful end-to-end win.
- `escapeHtml` dirty char-walk (~2.5× helper): same page-level reason.
- `escapeAttr` `indexOf` (~1.0×).
- `VALID_ATTR_NAME` char-walk (~1.1–1.7×, noisy).

`isUnitlessStyleProp` Map cache was ~12× on the helper and ~6.8× on `cssStyleValue` in a throwaway microbench (Node v22.22.2, 3 runs, mixed camel/kebab/vendor, 200 warmup then 1e6 timed). Production `cssStyleValue` vs inlined prior scan is ~3.1–3.4× in `benchmarks/style-unitless`. Unique never-repeated keys are not claimed as a win.

## Production bench (Node v22.22.2, Linux 6.12.94+, 4 CPUs)

```
node benchmarks/style-unitless/run.mjs 8
```

Scores are ms / 1,000 lookups (lower is better).

| run | scan-mixed | cached-mixed | ratio |
|---|---:|---:|---:|
| A | 0.994 | 0.295 | 0.297× (~3.4×) |
| B | 0.973 | 0.319 | 0.328× (~3.1×) |
| after checksum fix | 0.990 | 0.293 | 0.296× (~3.4×) |

```
node benchmarks/bench.mjs --quick --ratios style-unitless
```

| run | scan-mixed | cached-mixed | ratio |
|---|---:|---:|---:|
| quick (pre-fix) | 0.983 | 0.302 | 0.307×, guard PASS (`maxRatio` 0.5) |
| quick (after checksum fix) | 1.024 | 0.319 | guard PASS |

`cached-mixed` is production `cssStyleValue`. `scan-mixed` inlines the pre-cache `isUnitlessStyleProp` scan so the comparison is this change, not a different CSS writer.

Semantic gates: both writers emit the same CSS strings; unitless classification matches `UNITLESS_STYLE_PROPS`. Timed-sample checksum is now one bag times `LOOKUPS_PER_SAMPLE` (warmup stays 200 for JIT only).

## Files

- `packages/octane/src/dom-tables.js` — `unitlessStylePropCache`.
- `packages/octane/tests/style-px.test.ts` — kebab, repeated-key, SSR kebab + vendor cases.
- `benchmarks/style-unitless/` — Node-only suite.
- `benchmarks/baselines/ratios.json` — `cached-mixed / scan-mixed` `maxRatio` 0.5.
- `.changeset/style-unitless-cache.md` — `octane` patch.

## Validation

- [x] `pnpm format:files:check` on changed JS/TS/JSON
- [x] `tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] targeted tests: `packages/octane/tests/style-px.test.ts` (30 passed, octane + octane-prod)
- [x] `packages/octane-mcp-server/src/index.test.js` (15 passed)
- [x] `packages/octane/tests/conformance/{css-properties,ssr-serialization,dom-component-styles}.test.ts` (250 passed)
- [x] `node benchmarks/style-unitless/run.mjs 8` and `node benchmarks/bench.mjs --quick --ratios style-unitless` after the checksum fix — both complete green
- [x] GitHub Actions on `502865fb2`: lint, typecheck, test (24), React parity, examples, heavy integration, website, Three/Lynx, publishable packages, CI provenance — all successful

## Risk / follow-ups

- Cache is unbounded in theory but keyed only by CSS property names actually written; same bound as the existing `styleName` cache.
- Unique never-repeated keys pay Map.set plus the original scan; not claimed as a win.
- `escapeHtml` remains a smaller SSR helper candidate if a later pass can show a real page-level win.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
This PR memoizes `isUnitlessStyleProp` in `dom-tables.js` with a Map cache, matching `styleName`. `cssStyleValue` used to `replaceAll` + `toLowerCase` on every numeric style write. Production bench (`cssStyleValue` vs inlined prior scan): ~3.1–3.4× on mixed camel/kebab/vendor bags. Orthogonal to #951/#955.
<!-- /CURSOR_SUMMARY -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b626bea9-d822-447f-ab4f-159be215d1f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b626bea9-d822-447f-ab4f-159be215d1f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791137379&installation_model_id=432790&pr_number=956&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F956&signature=40aa375d4e38e1230833c9d3ef70ee31a3740d5d3c113c3b87c03077f9ba8d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->