### PR TITLE
fix: refresh injectStyle sheets when HMR keeps the hash

### DIFF
--- a/.changeset/inject-style-hmr-refresh.md
+++ b/.changeset/inject-style-hmr-refresh.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Refresh an already-injected scoped stylesheet when `injectStyle` is called again with the same hash and different CSS, so HMR updates take effect.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -16892,8 +16892,9 @@ export function setSpread(
 }
 
 // ---------------------------------------------------------------------------
-// Component-scoped <style> injection — idempotent, keyed by the compiled
-// stylesheet hash so repeated mounts (or HMR re-imports) inject once.
+// Component-scoped <style> injection — keyed by the compiled stylesheet hash
+// so repeated mounts inject once. HMR re-imports with the same hash and
+// different CSS refresh the owned sheet in place.
 // ---------------------------------------------------------------------------
 
 const _injectedStyles = new Set<string>();
@@ -17113,18 +17114,33 @@ export function namespaceHeadElement(
 }
 
 export function injectStyle(id: string, css: string, nonce?: string): void {
+	if (typeof document === 'undefined') {
+		_injectedStyles.add(id);
+		return;
+	}
+	const existing = document.querySelector<HTMLStyleElement>(`style[data-octane="${id}"]`);
+	if (existing !== null) {
+		// A scope hash derives from its first block's position and content, so an
+		// HMR re-evaluation after editing a later block of the same scope arrives
+		// with an unchanged id and different css: refresh a sheet this runtime
+		// already owns in place. A sheet seen for the first time was emitted by
+		// the server (its text may differ only in serialization) and is adopted.
+		if (_injectedStyles.has(id)) {
+			if (existing.textContent !== css) existing.textContent = css;
+		} else {
+			_injectedStyles.add(id);
+		}
+		return;
+	}
 	if (_injectedStyles.has(id)) return;
 	// SSR de-dup: the server already emitted this scoped stylesheet (the css of
-	// the RenderResult, a `<style data-octane="hash">` — or, for a React-hosted
-	// island, a React 19 style RESOURCE whose href React serializes as
-	// `data-href="octane-<hash>"`; React drops other attributes from hoisted
-	// resources). On a hydrated page the per-runtime Set is empty, so also
-	// check the DOM before re-injecting — otherwise hydration would append a
-	// duplicate <style>.
-	if (
-		typeof document !== 'undefined' &&
-		document.querySelector(`style[data-octane="${id}"], style[data-href="octane-${id}"]`)
-	) {
+	// the RenderResult, a `<style data-octane="hash">` handled above — or, for a
+	// React-hosted island, a React 19 style RESOURCE whose href React
+	// serializes as `data-href="octane-<hash>"`; React drops other attributes
+	// from hoisted resources). On a hydrated page the per-runtime Set is empty,
+	// so also check the DOM before re-injecting — otherwise hydration would
+	// append a duplicate <style>.
+	if (document.querySelector(`style[data-href="octane-${id}"]`)) {
 		_injectedStyles.add(id);
 		return;
 	}

--- a/packages/octane/tests/runtime/style-hmr-reinject.test.ts
+++ b/packages/octane/tests/runtime/style-hmr-reinject.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { injectStyle } from '../../src/index.js';
+
+// Plan S3.6 — the client `injectStyle(id, css)` dedupes by id (a per-runtime
+// Set plus a DOM query for `style[data-octane=id]`). A module re-evaluation
+// that keeps a scope hash but changes the CSS (an HMR edit inside a later
+// block; the hash is position-derived) reaches the runtime as a second call
+// with the same id. These tests pin what that second call does.
+
+let counter = 0;
+function freshId(): string {
+	counter += 1;
+	return `tsrx-hmr-reinject-${counter}`;
+}
+
+function sheets(id: string): HTMLStyleElement[] {
+	return Array.from(document.head.querySelectorAll(`style[data-octane="${id}"]`));
+}
+
+describe('injectStyle dedupe (S3.6)', () => {
+	it('injects one <style data-octane> per id and ignores an identical repeat', () => {
+		const id = freshId();
+		const css = `.a.${id} { color: rgb(1, 1, 1); }`;
+		injectStyle(id, css);
+		injectStyle(id, css);
+		const tags = sheets(id);
+		expect(tags).toHaveLength(1);
+		expect(tags[0].textContent).toBe(css);
+	});
+
+	it('adopts a server-emitted sheet instead of appending a duplicate', () => {
+		const id = freshId();
+		const serverCss = `.b.${id} { color: rgb(2, 2, 2); }`;
+		const serverSheet = document.createElement('style');
+		serverSheet.setAttribute('data-octane', id);
+		serverSheet.textContent = serverCss;
+		document.head.appendChild(serverSheet);
+
+		injectStyle(id, `.b.${id} { color: rgb(3, 3, 3); }`);
+		const tags = sheets(id);
+		expect(tags).toHaveLength(1);
+		expect(tags[0]).toBe(serverSheet);
+		expect(tags[0].textContent).toBe(serverCss);
+		serverSheet.remove();
+	});
+
+	// After an HMR re-evaluation the scope hash is unchanged (it derives from
+	// the first block's position and content) but a later block's CSS may
+	// differ; the runtime refreshes the sheet in place instead of keeping the
+	// stale one.
+	it('re-injecting an unchanged hash with changed css replaces the sheet', () => {
+		const id = freshId();
+		const before = `.d.${id} { color: rgb(6, 6, 6); }`;
+		const after = `.d.${id} { color: rgb(7, 7, 7); }`;
+		injectStyle(id, before);
+		injectStyle(id, after);
+		const tags = sheets(id);
+		expect(tags).toHaveLength(1);
+		expect(tags[0].textContent).toBe(after);
+	});
+
+	it('records the id without creating a sheet when document is missing', () => {
+		const id = freshId();
+		const first = `.e.${id} { color: rgb(8, 8, 8); }`;
+		const second = `.e.${id} { color: rgb(9, 9, 9); }`;
+		const held = globalThis.document;
+		Reflect.deleteProperty(globalThis, 'document');
+		try {
+			injectStyle(id, first);
+			injectStyle(id, second);
+		} finally {
+			globalThis.document = held;
+		}
+		expect(sheets(id)).toHaveLength(0);
+		injectStyle(id, first);
+		expect(sheets(id)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #938. `injectStyle(id, css)` on the client now refreshes an already-owned `<style data-octane>` when a later call arrives with the same id and different CSS (HMR of a later block in a multi-block scope). A server-emitted sheet seen for the first time is still adopted untouched, and the no-DOM path still records the id in `_injectedStyles` without creating a tag.

**Base verification:** `feat/scoped-styles-apply` already contains this contract as part of #939 (the `it.fails` pin was flipped there in `e8ac8adb5`). `main` still had first-wins-only dedupe and no `style-hmr-reinject` suite. This PR lands only the isolated runtime fix on `main` so #938 can close independently of the scoped-styles RFC.

## Why

The compiled scope hash is derived from the first block's position and content. Editing a later block under HMR keeps the hash, so `injectStyle(id, css1); injectStyle(id, css2)` used to leave `css1` in the document.

## Changes

- Client `injectStyle`: if `style[data-octane=id]` exists and this runtime already owns it, replace `textContent` when it differs. Otherwise adopt (SSR) or record the id (no `document`).
- Add `packages/octane/tests/runtime/style-hmr-reinject.test.ts` with identical-repeat, server-adopt first-wins, HMR replace, and no-DOM first-wins.
- Patch changeset for `octane`.

No content-hash-in-id change (plan D12); not required for this fix.

## Validation

- [ ] `pnpm format:check` (not run; used scoped format)
- [x] `pnpm typecheck:files` on the two changed source files
- [ ] `pnpm test` (full suite not run)
- [x] targeted tests: `packages/octane/tests/runtime/style-hmr-reinject.test.ts` (dev + `octane-prod`), `ssr-control.test.ts`, `style.test.ts`

Before the runtime change, the HMR case failed (kept `css1`) and a first no-DOM call threw on `document.createElement`. After the change, 8/8 pass in both `octane` and `octane-prod`. Removing the `textContent` assign made only the HMR case fail again; first-wins and no-DOM stayed green. Nearby injectStyle coverage: 136 passed.

`pnpm format:files` on the changed paths: unchanged. `pnpm sync`: no generated files.

## Risk / follow-ups

- #939 already has a slightly broader client `injectStyle` (token-match `data-href` for React batched resources). Merging both will need a small reconcile in that function; this PR does not take the `~=` change.
- Content hash in the compiled id (RFC optional runtime dedupe, S8.6 / D12) is still open if HMR-without-DOM or multi-runtime cases need it.
- `injectStyle` is module-eval / HMR, not a per-render hot path. Extra work is one `data-octane` query plus a string compare on the existing-sheet branch.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f971e3fa-c959-47cb-a902-269f4aa0645d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f971e3fa-c959-47cb-a902-269f4aa0645d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791140566&installation_model_id=432790&pr_number=957&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F957&signature=b8827518928a46bbbe5eb0b5dacd46b10c1dd45515abd9446e933c417fa278b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->