### PR TITLE
fix(octane): allow complete style scopes inside Hydrate splits

### DIFF
--- a/.changeset/hydrate-split-complete-style-scope.md
+++ b/.changeset/hydrate-split-complete-style-scope.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Allow a scoped `<style>` inside a split `<Hydrate>` child when its whole lexical style scope — the block and the host elements it stamps — sits inside the boundary. Client and server keep the authored-position hash. A scope that straddles the boundary is still `OCTANE_HYDRATE_SPLIT_STYLE`.

--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -169,12 +169,20 @@ chunk would not be worthwhile:
 
 The compiler recognizes `Hydrate` imported from `octane`, including an import
 alias. Split children must be authored directly inside the boundary. Extraction
-rejects function-as-children, hook calls directly inside the extracted JSX,
-scoped `<style>` elements (their rules belong to the style scope they sit in,
-which extraction would tear in half; `OCTANE_HYDRATE_SPLIT_STYLE`), and `this`
-or `super` captures; move that work into a child component or opt out with
-`split={false}`. Ordinary lexical values can be
-captured by the generated child component.
+rejects function-as-children, hook calls directly inside the extracted JSX, and
+`this` or `super` captures; move that work into a child component or opt out
+with `split={false}`. Ordinary lexical values can be captured by the generated
+child component.
+
+A scoped `<style>` whose whole lexical style scope sits inside the split child
+compiles (plan S8.5). The scope is the children list the block is written in:
+its sibling blocks and the host elements they stamp. Both the server compile and
+the extracted child keep the authored-position hash, so hydration adopts the
+server classes. A scope that straddles the boundary — blocks or stamped host
+elements on both sides — is still a compile error (`OCTANE_HYDRATE_SPLIT_STYLE`).
+Keep that scope entirely inside the boundary, move it entirely outside, extract
+a child component, or set `split={false}`. A `<style>` nested in a function
+never joined the enclosing scopes and may move with the split child.
 
 Generated Hydrate chunks are not eagerly module-preloaded. Lazy-module discovery
 for independently suspended siblings never enters a dormant Hydrate boundary,

--- a/packages/octane/src/compiler/hydrate-boundaries.js
+++ b/packages/octane/src/compiler/hydrate-boundaries.js
@@ -440,6 +440,159 @@ function isHookCall(node, hookNames) {
 	);
 }
 
+function collectSubtreeNodes(value, output) {
+	if (!value || typeof value !== 'object') return;
+	if (Array.isArray(value)) {
+		for (const child of value) collectSubtreeNodes(child, output);
+		return;
+	}
+	if (output.has(value)) return;
+	output.add(value);
+	for (const [key, child] of Object.entries(value)) {
+		if (!SKIP_KEYS.has(key)) collectSubtreeNodes(child, output);
+	}
+}
+
+function subtreeContainsNode(root, target) {
+	if (root === target) return true;
+	const seen = new WeakSet();
+	const visit = (value) => {
+		if (!value || typeof value !== 'object') return false;
+		if (Array.isArray(value)) {
+			for (const child of value) {
+				if (visit(child)) return true;
+			}
+			return false;
+		}
+		if (seen.has(value)) return false;
+		seen.add(value);
+		if (value === target) return true;
+		for (const [key, child] of Object.entries(value)) {
+			if (!SKIP_KEYS.has(key) && visit(child)) return true;
+		}
+		return false;
+	};
+	return visit(root);
+}
+
+function collectOwnStyleBlocks(nodes) {
+	const blocks = [];
+	for (const node of nodes ?? []) {
+		if (node?.type === 'JSXStyleElement' && !isFloatStyleResource(node)) blocks.push(node);
+	}
+	return blocks;
+}
+
+function isFloatStyleResource(node) {
+	let hasHref = false;
+	let hasPrecedence = false;
+	for (const attribute of node.openingElement?.attributes ?? []) {
+		if (attribute?.type !== 'JSXAttribute' && attribute?.type !== 'Attribute') continue;
+		const name = jsxAttributeName(attribute);
+		if (name === 'href') hasHref = true;
+		else if (name === 'precedence') hasPrecedence = true;
+	}
+	return hasHref && hasPrecedence;
+}
+
+function isStampableHost(node) {
+	if (node?.type !== 'JSXElement' && node?.type !== 'Element') return false;
+	if (node.metadata?.dynamicElement) return true;
+	const name = node.openingElement?.name ?? node.name;
+	if (!name) return false;
+	if (name.type === 'JSXIdentifier' || name.type === 'Identifier') {
+		return name.name !== 'style' && !/^[A-Z]/.test(name.name);
+	}
+	return false;
+}
+
+function walkStampableHosts(node, visitHost) {
+	if (!node || typeof node !== 'object') return;
+	if (Array.isArray(node)) {
+		for (const child of node) walkStampableHosts(child, visitHost);
+		return;
+	}
+	if (isFunction(node)) return;
+	if (isStampableHost(node)) visitHost(node);
+	for (const [key, child] of Object.entries(node)) {
+		if (!SKIP_KEYS.has(key)) walkStampableHosts(child, visitHost);
+	}
+}
+
+/**
+ * A children list that holds standalone `<style>` blocks is one lexical style
+ * scope (plan S8.5 / RFC sibling scopes). Extraction is safe when that whole
+ * scope — its blocks and the host elements they stamp — sits inside the split
+ * boundary, because both compiles keep the authored-position hash. A scope
+ * that has blocks or stamped hosts on both sides of the boundary would emit
+ * disagreeing class lists; that is still `OCTANE_HYDRATE_SPLIT_STYLE`. Styles
+ * nested in functions never joined the enclosing scopes and are not checked.
+ */
+function styleScopeStraddlesBoundary(list, own, inside) {
+	let hasInside = false;
+	let hasOutside = false;
+	const mark = (node) => {
+		if (inside.has(node)) hasInside = true;
+		else hasOutside = true;
+	};
+	for (const block of own) mark(block);
+	for (const item of list) {
+		if (own.includes(item)) continue;
+		walkStampableHosts(item, mark);
+	}
+	return hasInside && hasOutside;
+}
+
+function assertHydrateStyleScopes(boundary, filename) {
+	const inside = new WeakSet();
+	collectSubtreeNodes(boundary.node.children, inside);
+	const seenLists = new WeakSet();
+	const seen = new WeakSet();
+	const visit = (node, inFunction) => {
+		if (!node || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child, inFunction);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		if (TRANSPARENT_TS_EXPRESSIONS.has(node.type)) {
+			visit(node.expression, inFunction);
+			return;
+		}
+		if (!inFunction && isFunction(node)) {
+			const nested = !subtreeContainsNode(node, boundary.node);
+			for (const [key, child] of Object.entries(node)) {
+				if (!SKIP_KEYS.has(key)) visit(child, nested);
+			}
+			return;
+		}
+		if (
+			!inFunction &&
+			(node.type === 'JSXElement' || node.type === 'JSXFragment' || node.type === 'Element') &&
+			Array.isArray(node.children)
+		) {
+			const own = collectOwnStyleBlocks(node.children);
+			if (own.length > 0 && !seenLists.has(node.children)) {
+				seenLists.add(node.children);
+				if (styleScopeStraddlesBoundary(node.children, own, inside)) {
+					const reported = own.find((block) => inside.has(block)) ?? own[0];
+					throw extractionError(
+						'OCTANE_HYDRATE_SPLIT_STYLE',
+						filename,
+						reported,
+						'a scoped <style> cannot straddle a split Hydrate boundary — its style scope has blocks or stamped elements on both sides. Keep the whole scope inside the boundary, move it entirely outside, extract a child component, or set `split={false}`',
+					);
+				}
+			}
+		}
+		for (const [key, child] of Object.entries(node)) {
+			if (!SKIP_KEYS.has(key)) visit(child, inFunction);
+		}
+	};
+	visit(boundary.ast ?? boundary.node, false);
+}
+
 function validateBoundary(boundary, filename, hookNames) {
 	for (const child of boundary.node.children ?? []) {
 		if (child?.type === 'JSXExpressionContainer' && isFunction(child.expression)) {
@@ -489,20 +642,6 @@ function validateBoundary(boundary, filename, hookNames) {
 				'direct hook calls cannot move into a split child. Call the hook in a child component or set `split={false}`',
 			);
 		}
-		// `directHooks` also marks the owning component's direct render scope: a
-		// scoped <style> there belongs to the style scope it sits in, which
-		// extraction would tear in half (the server stamps that scope's hash on
-		// the elements around the boundary; the split chunk would compile the
-		// sheet under another hash). Styles nested inside functions never joined
-		// the component's scopes, so they move freely.
-		if (directHooks && node.type === 'JSXStyleElement') {
-			throw extractionError(
-				'OCTANE_HYDRATE_SPLIT_STYLE',
-				filename,
-				node,
-				'a scoped <style> cannot move into a split child — its rules belong to the style scope it sits in. Move the <style> outside the boundary, into a child component, or set `split={false}`',
-			);
-		}
 		if (isFunction(node)) {
 			// A nested function keeps hook calls in its own invocation. Ordinary
 			// functions also bind their own receiver; arrows still capture `this`
@@ -530,6 +669,7 @@ function validateBoundary(boundary, filename, hookNames) {
 		}
 	};
 	visit(boundary.node.children);
+	assertHydrateStyleScopes(boundary, filename);
 }
 
 /** Resolve Hydrate boundaries and assign source-order paths under their nearest boundary. */
@@ -1607,6 +1747,7 @@ export function prepareHydrateBoundaries(source, filename, boundaryPath = null, 
 	for (const boundary of analysis.boundaries) {
 		boundary.filename = filename;
 		boundary.hookNames = analysis.imports.hookNames;
+		boundary.ast = analysis.ast;
 	}
 	const request = sameSourceRequest(filename);
 	const moduleMovePlan = createModuleMovePlanAst(analysis, request);

--- a/packages/octane/src/compiler/hydrate-boundaries.js
+++ b/packages/octane/src/compiler/hydrate-boundaries.js
@@ -510,7 +510,9 @@ function isStampableHost(node) {
 	if (name.type === 'JSXIdentifier' || name.type === 'Identifier') {
 		return name.name !== 'style' && !/^[A-Z]/.test(name.name);
 	}
-	return false;
+	// Namespaced hosts (`svg:rect`) are stamped by the style-scope pass;
+	// member expressions are composites and are not.
+	return name.type === 'JSXNamespacedName' || name.type === 'NamespacedName';
 }
 
 function walkStampableHosts(node, visitHost) {

--- a/packages/octane/src/compiler/hydrate-boundaries.js
+++ b/packages/octane/src/compiler/hydrate-boundaries.js
@@ -30,7 +30,14 @@ function inheritGeneratedOrigin(root, origin) {
 			for (const item of value) visit(item);
 			return;
 		}
-		if (typeof value.type === 'string' && value.loc == null && origin?.loc != null) {
+		// Adopted parser nodes (including StyleSheet subtrees) may be frozen
+		// and already carry CSS-relative positions; only stamp generated nodes.
+		if (
+			typeof value.type === 'string' &&
+			value.loc == null &&
+			origin?.loc != null &&
+			!Object.isFrozen(value)
+		) {
 			value.start = origin.start;
 			value.end = origin.end;
 			value.loc = origin.loc;

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -1071,7 +1071,7 @@ export function App() @{
 		expect(hashes(child.code)).toEqual(hashes(server.code));
 		expect(child.code).toContain('.x.tsrx-');
 		expect(server.code).toContain('.x.tsrx-');
-		expect(server.code).toContain('inside tsrx-');
+		expect(server.code).toContain('class="x tsrx-');
 	});
 
 	it('rejects a style scope that straddles a split boundary', () => {

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -1098,6 +1098,32 @@ export function App() @{
 		expect(thrown.message).toContain('split={false}');
 	});
 
+	it('rejects a style scope that straddles a split boundary through a namespaced host', () => {
+		// A namespaced host is stamped by the style-scope pass. If the
+		// straddle check missed it, a parent-list <style> would extract
+		// while the server still stamped the host — disagreeing class lists.
+		const source = `
+import { Hydrate } from 'octane';
+export function App() @{
+  <div>
+    <style>.x { color: red; }</style>
+    <Hydrate when={gate}>
+      <svg:rect class="x" />
+    </Hydrate>
+  </div>
+}
+`;
+		let thrown: any = null;
+		try {
+			compiler().transform(source, FILE, { environment: 'client' });
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toMatchObject({ code: 'OCTANE_HYDRATE_SPLIT_STYLE', filename: '/src/App.tsrx' });
+		expect(thrown.message).toContain('straddle a split Hydrate boundary');
+		expect(thrown.message).toContain('split={false}');
+	});
+
 	it('permits scoped styles under split={false} and inside nested split-child functions', () => {
 		// split={false} keeps children in the owning component, so its style
 		// scope stays whole; a style nested in a function never joined that

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -1002,7 +1002,7 @@ export function App() @{
 		},
 		{
 			code: 'OCTANE_HYDRATE_SPLIT_STYLE',
-			source: `import { Hydrate } from 'octane'; export function App() @{ <Hydrate when={gate}><div class="x"><style>.x { color: red; }</style></div></Hydrate> }`,
+			source: `import { Hydrate } from 'octane'; export function App() @{ <div><style>.x { color: red; }</style><p class="x">out</p><Hydrate when={gate}><span class="x">in</span></Hydrate></div> }`,
 		},
 	])('reports unsupported extraction as $code', ({ source, code }) => {
 		let thrown: any = null;
@@ -1043,6 +1043,59 @@ export function App() @{
 }
 `;
 		expect(() => compiler().transform(source, FILE, { environment: 'client' })).not.toThrow();
+	});
+
+	it('compiles a complete style scope that sits entirely inside a split child', () => {
+		// Plan S8.5: the block and the hosts it stamps are all inside the
+		// boundary, so both compiles keep the authored-position hash.
+		const source = `
+import { Hydrate } from 'octane';
+export function App() @{
+  <Hydrate when={gate}>
+    <div>
+      <style>.x { color: red; }</style>
+      <span class="x">inside</span>
+    </div>
+  </Hydrate>
+}
+`;
+		const hashes = (code: string) => new Set(code.match(/tsrx-[0-9a-z]+/g) ?? []);
+		const instance = compiler();
+		const parent = instance.transform(source, FILE, { environment: 'client' })!;
+		const child = instance.transform(source, `${FILE}?octane-hydrate=0`, {
+			environment: 'client',
+		})!;
+		const server = instance.transform(source, FILE, { environment: 'server' })!;
+		expect(dynamicImports(parent.code)).toEqual(new Set(['./App.tsrx?octane-hydrate=0']));
+		expect(hashes(child.code).size).toBeGreaterThan(0);
+		expect(hashes(child.code)).toEqual(hashes(server.code));
+		expect(child.code).toContain('.x.tsrx-');
+		expect(server.code).toContain('.x.tsrx-');
+		expect(server.code).toContain('inside tsrx-');
+	});
+
+	it('rejects a style scope that straddles a split boundary', () => {
+		const source = `
+import { Hydrate } from 'octane';
+export function App() @{
+  <div>
+    <style>.x { color: red; }</style>
+    <p class="x">outside</p>
+    <Hydrate when={gate}>
+      <span class="x">inside</span>
+    </Hydrate>
+  </div>
+}
+`;
+		let thrown: any = null;
+		try {
+			compiler().transform(source, FILE, { environment: 'client' });
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toMatchObject({ code: 'OCTANE_HYDRATE_SPLIT_STYLE', filename: '/src/App.tsrx' });
+		expect(thrown.message).toContain('straddle a split Hydrate boundary');
+		expect(thrown.message).toContain('split={false}');
 	});
 
 	it('permits scoped styles under split={false} and inside nested split-child functions', () => {

--- a/packages/octane/tests/hydration/_fixtures/deferred-hydration-styles.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/deferred-hydration-styles.tsrx
@@ -27,3 +27,24 @@ export function StyledSplitHydration(props) @{
 		</style>
 	</section>
 }
+
+// Plan S8.5: a complete lexical scope owned by the split child. The block and
+// the hosts it stamps all sit inside the boundary, so the extracted child and
+// the server compile share the authored-position hash.
+export function StyledCompleteSplitHydration(props) @{
+	<section id="styled-complete-split-host">
+		<Hydrate when={props.when} onHydrated={props.onHydrated}>
+			<div>
+				<p class="styled-complete-note" id="styled-complete-note">
+					Inside the boundary
+				</p>
+				<style>
+					.styled-complete-note {
+						color: rgb(20, 120, 80);
+					}
+				</style>
+				<p id="styled-complete-review">Deferred complete-scope review</p>
+			</div>
+		</Hydrate>
+	</section>
+}

--- a/packages/octane/tests/hydration/deferred-hydration.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration.test.ts
@@ -329,9 +329,6 @@ describe('deferred hydration', () => {
 		const serverScope = serverNote.className.match(/\btsrx-[0-9a-z]+\b/)![0];
 		expect(serverNoteClass).toContain(serverScope);
 		expect(serverReviewClass).toContain(serverScope);
-		const clientSheet = document.head.querySelector(`style[data-octane="${serverScope}"]`);
-		expect(clientSheet).not.toBeNull();
-		expect(clientSheet!.textContent).toContain(`.styled-complete-note.${serverScope}`);
 
 		root = hydrateRoot(container, styledClient.StyledCompleteSplitHydration, props);
 		await vi.waitFor(async () => {
@@ -339,6 +336,12 @@ describe('deferred hydration', () => {
 			expect(onHydrated).toHaveBeenCalledOnce();
 		});
 
+		// The sheet lives in the split child, so it appears only after the
+		// child chunk runs — under the same authored-position hash the server
+		// stamped.
+		const clientSheet = document.head.querySelector(`style[data-octane="${serverScope}"]`);
+		expect(clientSheet).not.toBeNull();
+		expect(clientSheet!.textContent).toContain(`.styled-complete-note.${serverScope}`);
 		expect(container.querySelector('#styled-complete-split-host')).toBe(serverHost);
 		expect(container.querySelector('#styled-complete-note')).toBe(serverNote);
 		expect(container.querySelector('#styled-complete-review')).toBe(serverReview);

--- a/packages/octane/tests/hydration/deferred-hydration.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration.test.ts
@@ -316,16 +316,46 @@ describe('deferred hydration', () => {
 		expect(container.querySelector('#styled-split-review')).not.toBeNull();
 	});
 
-	it('rejects a scoped <style> inside a split boundary, naming the style scope it belongs to', () => {
-		// The split child would compile the sheet under another hash while the
-		// server stamps the enclosing scope's hash around the boundary.
+	it('adopts server DOM when a complete style scope sits inside a split child', async () => {
+		const onHydrated = vi.fn();
+		const props = { when: load(), onHydrated };
+		const { html } = renderToString(styledServer.StyledCompleteSplitHydration, props);
+		container.innerHTML = html;
+		const serverHost = container.querySelector('#styled-complete-split-host') as HTMLElement;
+		const serverNote = container.querySelector('#styled-complete-note') as HTMLElement;
+		const serverReview = container.querySelector('#styled-complete-review') as HTMLElement;
+		const serverNoteClass = serverNote.className;
+		const serverReviewClass = serverReview.className;
+		const serverScope = serverNote.className.match(/\btsrx-[0-9a-z]+\b/)![0];
+		expect(serverNoteClass).toContain(serverScope);
+		expect(serverReviewClass).toContain(serverScope);
+		const clientSheet = document.head.querySelector(`style[data-octane="${serverScope}"]`);
+		expect(clientSheet).not.toBeNull();
+		expect(clientSheet!.textContent).toContain(`.styled-complete-note.${serverScope}`);
+
+		root = hydrateRoot(container, styledClient.StyledCompleteSplitHydration, props);
+		await vi.waitFor(async () => {
+			await act(() => {});
+			expect(onHydrated).toHaveBeenCalledOnce();
+		});
+
+		expect(container.querySelector('#styled-complete-split-host')).toBe(serverHost);
+		expect(container.querySelector('#styled-complete-note')).toBe(serverNote);
+		expect(container.querySelector('#styled-complete-review')).toBe(serverReview);
+		expect(serverNote.className).toBe(serverNoteClass);
+		expect(serverReview.className).toBe(serverReviewClass);
+	});
+
+	it('rejects a style scope that straddles a split boundary', () => {
 		const source = `import { Hydrate } from 'octane';
 export function App(props) @{
-	<Hydrate when={props.when}>
-		<div class="x">
-			<style>.x { color: red; }</style>
-		</div>
-	</Hydrate>
+	<div>
+		<style>.x { color: red; }</style>
+		<p class="x">outside</p>
+		<Hydrate when={props.when}>
+			<span class="x">inside</span>
+		</Hydrate>
+	</div>
 }`;
 		let thrown: any = null;
 		try {
@@ -334,9 +364,7 @@ export function App(props) @{
 			thrown = error;
 		}
 		expect(thrown).toMatchObject({ code: 'OCTANE_HYDRATE_SPLIT_STYLE' });
-		expect(thrown.message).toContain(
-			'a scoped <style> cannot move into a split child — its rules belong to the style scope it sits in',
-		);
+		expect(thrown.message).toContain('straddle a split Hydrate boundary');
 		expect(thrown.message).toContain('split={false}');
 	});
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Closes #935 / plan S8.5: lift `OCTANE_HYDRATE_SPLIT_STYLE` when a lexical style scope sits entirely inside a split `<Hydrate>` child.
- Keep the error when a scope straddles the boundary (blocks or stamped host elements on both sides).
- Update `docs/deferred-hydration.md` to describe the new contract.

## Why
`hydrate-boundaries.js` still rejected every scoped `<style>` inside a split child (v1 / plan D11). With per-scope lexical hashes, a split child that owns a complete scope can compile the sheet under the same authored-position hash on the server and in the extracted child. A scope that stamps hosts on both sides of the boundary would still disagree after extraction.

## Changes
- `packages/octane/src/compiler/hydrate-boundaries.js`: replace the blanket “any style in extracted children” check with a children-list completeness test (plan S8.5). Extraction now reaches those complete scopes, so generated-origin stamping skips frozen parser/StyleSheet nodes.
- `isStampableHost` now treats `JSXNamespacedName` hosts as stampable so a parent-list scoped style with only namespaced hosts inside a split Hydrate is rejected as `OCTANE_HYDRATE_SPLIT_STYLE`.
- Compiler and hydration tests for (a) complete scope inside a split → compiles and hydrates; (b) straddling scope, including a namespaced-host-only straddle → `OCTANE_HYDRATE_SPLIT_STYLE`.
- Docs and a patch changeset.

## Validation
- [x] `pnpm format:files` on the changed files (repo-wide `pnpm format:check` not run)
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- [ ] `pnpm test` (full suite not run; targeted files below cover both `octane` and `octane-prod`)
- [x] targeted tests: `packages/octane/tests/hydrate-compiler.test.ts` and `packages/octane/tests/hydration/deferred-hydration.test.ts` — 146 passed (4 files, both projects)

Negative controls: restoring the old “any inside style errors” policy fails the complete-scope tests; skipping the straddle check fails the `OCTANE_HYDRATE_SPLIT_STYLE` tests; leaving `isStampableHost` blind to `JSXNamespacedName` fails the namespaced-host straddle test (`thrown === null`).

## Risk / follow-ups
- Ancestor scopes that stamp into a split child with no complete inner style were already a possible mismatch and are now diagnosed when they have hosts on both sides.
- Styles nested in functions still move freely, matching the previous exception.
- Does not change the sibling-scope model, hashing, or unrelated scoped-styles work on `feat/scoped-styles-apply`.
- Compile-time diagnostic only; no runtime hot-path change and no benchmark claim.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51bc1636-ef54-4ce1-a3ea-c8a5cb9fef27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51bc1636-ef54-4ce1-a3ea-c8a5cb9fef27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791140769&installation_model_id=432790&pr_number=959&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F959&signature=d6dab9cea3b06a8ecdaaca354afcf99e0dbae3472440e29ab8b76f7d24fa2f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->