### PR TITLE
fix: write style-block class maps to ref targets

### DIFF
--- a/.changeset/style-ref-class-map.md
+++ b/.changeset/style-ref-class-map.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Honor `ref` on a scoped `<style>` block by writing the block's class-map object
+to the ref target (assignment, callback, or a `current`/`value` ref) instead of
+silently dropping the attribute.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -88,6 +88,7 @@ import {
 } from './native-read-codegen.js';
 import { createTextTypeFactsLookup } from './text-type-facts.js';
 import { applyCssModuleConstants } from './css-module-constants.js';
+import { applyStyleRefs } from './style-scopes.js';
 import { assertUniversalRuntimeTarget, normalizeUniversalRuntime } from './universal-runtime.js';
 
 // DOM truth tables shared with the client/server runtimes (via constants.ts) —
@@ -13651,6 +13652,9 @@ function componentStyleRoots(componentNode) {
  *   - Rebuild the render roots via `annotateRootWithHash` (COW) to stamp the
  *     hash class on every native JSX element AND remove the JSXStyleElement
  *     nodes from the rendered tree (they don't contribute DOM in the new model).
+ *   - When a stripped block carried `ref={x}`, graft class-map setup onto the
+ *     component body so `x` receives `{ card: "hash card", … }` instead of
+ *     staying unset.
  *
  * Returns `{ cssHash, node }` — the hash (or `null` when no `<style>` blocks
  * are present) and the possibly-rebuilt component node the caller must use.
@@ -13751,6 +13755,14 @@ function applyCssScoping(componentNode, ctx) {
 	if (returnReplacements.size > 0) {
 		node = mapAst(node, (n) => returnReplacements.get(n) ?? null);
 	}
+	// `<style ref={x}>` is stripped with the block. Write the class map to `x`
+	// as setup so assignment/callback/`current`/`value` refs are not dropped.
+	node = applyStyleRefs(node, styles, preparedSheets, {
+		inheritOriginLoc,
+		createTempIdentifier: function () {
+			return b.id(allocCompilerName(ctx, '__styleMap'));
+		},
+	});
 	return { cssHash, node };
 }
 

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -6774,6 +6774,11 @@ function isComponentFunction(node) {
 // hooks slotted (via withSlot) and its returned JSX lowered to a descriptor, and
 // whatever USES it (`<Foo/>` / `{expr}`) is what renders it. (Async/generator
 // excluded; a `use*` custom hook that returns JSX is still a hook, not this.)
+//
+// Owned returns inside `if`/`else`/`switch`/`try`/loops count: a function whose
+// only JSX exits are nested still needs the return-JSX path so scoped `<style>`
+// (hash stamp, injectStyle, `ref` class-map writes) runs. Nested function
+// bodies are a different component/value boundary and are ignored.
 function isReturnJsxFunction(node) {
 	if (!node) return false;
 	if (node.type !== 'FunctionDeclaration' && node.type !== 'FunctionExpression') return false;
@@ -6783,9 +6788,58 @@ function isReturnJsxFunction(node) {
 	if (node.id == null) return false;
 	if (node.async || node.generator) return false;
 	if (!node.body || node.body.type !== 'BlockStatement') return false;
-	return (node.body.body || []).some(
-		(s) => s.type === 'ReturnStatement' && s.argument && isJsxNode(s.argument),
-	);
+	const statements = node.body.body || [];
+	for (let i = 0; i < statements.length; i++) {
+		if (statementHasOwnedJsxReturn(statements[i])) return true;
+	}
+	return false;
+}
+
+/** @param {any} stmt @returns {boolean} */
+function statementHasOwnedJsxReturn(stmt) {
+	if (!stmt) return false;
+	if (stmt.type === 'ReturnStatement') return !!(stmt.argument && isJsxNode(stmt.argument));
+	if (stmt.type === 'BlockStatement') {
+		const list = stmt.body || [];
+		for (let i = 0; i < list.length; i++) {
+			if (statementHasOwnedJsxReturn(list[i])) return true;
+		}
+		return false;
+	}
+	if (stmt.type === 'IfStatement') {
+		return (
+			statementHasOwnedJsxReturn(stmt.consequent) || statementHasOwnedJsxReturn(stmt.alternate)
+		);
+	}
+	if (stmt.type === 'SwitchStatement') {
+		const cases = stmt.cases || [];
+		for (let i = 0; i < cases.length; i++) {
+			const consequent = cases[i].consequent || [];
+			for (let j = 0; j < consequent.length; j++) {
+				if (statementHasOwnedJsxReturn(consequent[j])) return true;
+			}
+		}
+		return false;
+	}
+	if (stmt.type === 'TryStatement') {
+		return (
+			statementHasOwnedJsxReturn(stmt.block) ||
+			(stmt.handler ? statementHasOwnedJsxReturn(stmt.handler.body) : false) ||
+			statementHasOwnedJsxReturn(stmt.finalizer)
+		);
+	}
+	if (
+		stmt.type === 'ForStatement' ||
+		stmt.type === 'ForInStatement' ||
+		stmt.type === 'ForOfStatement' ||
+		stmt.type === 'WhileStatement' ||
+		stmt.type === 'DoWhileStatement' ||
+		stmt.type === 'LabeledStatement' ||
+		stmt.type === 'WithStatement'
+	) {
+		return statementHasOwnedJsxReturn(stmt.body);
+	}
+	return false;
 }
 
 /** True when `node` is one plain lowercase host element (never a component/fragment). */

--- a/packages/octane/src/compiler/style-scopes.js
+++ b/packages/octane/src/compiler/style-scopes.js
@@ -226,10 +226,27 @@ function isNestedFunctionType(type) {
 }
 
 /**
+ * Each graft owns a block so `const __styleMap` is not redeclared in a
+ * shared scope (unbraced `switch` cases, or a `@{ }` return plus the
+ * fall-through append).
+ *
+ * @param {any[]} statements
+ * @param {any[]} [extra]
+ * @returns {any}
+ */
+function wrapSetupBlock(statements, extra) {
+	const body = cloneSetupStatements(statements);
+	if (extra) {
+		for (let i = 0; i < extra.length; i++) body.push(extra[i]);
+	}
+	return b.block(body);
+}
+
+/**
  * Insert a cloned setup copy immediately before every owned `return`
  * (if/else/switch/try/loops). Nested function bodies are left alone — those
- * are compiled as their own components. Braceless `return` arms become a
- * block so the write and the return stay a single consequent.
+ * are compiled as their own components. Each write is a block so the
+ * `const __styleMap` binding stays local to that site.
  *
  * @param {any} stmt
  * @param {any[]} statements
@@ -239,7 +256,7 @@ function graftReturnsInStatement(stmt, statements) {
 	if (!stmt) return { node: stmt, foundReturn: false };
 	const type = stmt.type;
 	if (type === 'ReturnStatement') {
-		return { node: b.block([...cloneSetupStatements(statements), stmt]), foundReturn: true };
+		return { node: wrapSetupBlock(statements, [stmt]), foundReturn: true };
 	}
 	if (isNestedFunctionType(type)) return { node: stmt, foundReturn: false };
 	if (type === 'BlockStatement') {
@@ -328,9 +345,7 @@ function graftReturnsInList(list, statements) {
 	for (let i = 0; i < list.length; i++) {
 		const stmt = list[i];
 		if (stmt && stmt.type === 'ReturnStatement') {
-			const cloned = cloneSetupStatements(statements);
-			for (let j = 0; j < cloned.length; j++) next.push(cloned[j]);
-			next.push(stmt);
+			next.push(wrapSetupBlock(statements, [stmt]));
 			foundReturn = true;
 			continue;
 		}
@@ -361,7 +376,7 @@ function graftSetupStatements(componentNode, statements) {
 			...componentNode,
 			body: {
 				...body,
-				body: [...grafted.list, ...cloneSetupStatements(statements)],
+				body: [...grafted.list, wrapSetupBlock(statements)],
 			},
 		};
 	}
@@ -371,9 +386,7 @@ function graftSetupStatements(componentNode, statements) {
 			...componentNode,
 			body: {
 				...body,
-				body: grafted.foundReturn
-					? grafted.list
-					: [...grafted.list, ...cloneSetupStatements(statements)],
+				body: grafted.foundReturn ? grafted.list : [...grafted.list, wrapSetupBlock(statements)],
 			},
 		};
 	}

--- a/packages/octane/src/compiler/style-scopes.js
+++ b/packages/octane/src/compiler/style-scopes.js
@@ -9,7 +9,8 @@
  * The class map is already produced from the prepared sheets (same hash the
  * scoping pass stamps on elements). This module turns each authored `ref`
  * into setup statements and grafts them onto the component body so the
- * assignment runs after `let x` (no TDZ) and before the template reads `x`.
+ * assignment runs after `let x` (no TDZ) and before every template that
+ * reads `x`, including nested `if`/`switch` returns.
  *
  * Identifier refs get a small hybrid of the core helper's two paths: a
  * function is called, a `current`/`value` object is written, and anything
@@ -198,9 +199,150 @@ function unwrapExpression(node) {
 }
 
 /**
- * Append onto a `@{ … }` setup list; insert before the first top-level
- * `return` of a React-style function. Both placements run after `let x` and
- * before the template that reads `x`.
+ * Clone the setup template for one insertion site. `inheritOriginLoc` mutates
+ * nodes in place, so each graft must own its own statement copies.
+ *
+ * @param {any[]} statements
+ * @returns {any[]}
+ */
+function cloneSetupStatements(statements) {
+	const cloned = [];
+	for (let i = 0; i < statements.length; i++) {
+		cloned.push(cloneAstNode(statements[i], false));
+	}
+	return cloned;
+}
+
+function isNestedFunctionType(type) {
+	return (
+		type === 'FunctionDeclaration' ||
+		type === 'FunctionExpression' ||
+		type === 'ArrowFunctionExpression'
+	);
+}
+
+/**
+ * Insert a cloned setup copy immediately before every owned `return`
+ * (if/else/switch/try/loops). Nested function bodies are left alone — those
+ * are compiled as their own components. Braceless `return` arms become a
+ * block so the write and the return stay a single consequent.
+ *
+ * @param {any} stmt
+ * @param {any[]} statements
+ * @returns {{ node: any, foundReturn: boolean }}
+ */
+function graftReturnsInStatement(stmt, statements) {
+	if (!stmt) return { node: stmt, foundReturn: false };
+	const type = stmt.type;
+	if (type === 'ReturnStatement') {
+		return { node: b.block([...cloneSetupStatements(statements), stmt]), foundReturn: true };
+	}
+	if (isNestedFunctionType(type)) return { node: stmt, foundReturn: false };
+	if (type === 'BlockStatement') {
+		const grafted = graftReturnsInList(stmt.body || [], statements);
+		return {
+			node: grafted.foundReturn ? { ...stmt, body: grafted.list } : stmt,
+			foundReturn: grafted.foundReturn,
+		};
+	}
+	if (type === 'IfStatement') {
+		const consequent = graftReturnsInStatement(stmt.consequent, statements);
+		const alternate = graftReturnsInStatement(stmt.alternate, statements);
+		if (!consequent.foundReturn && !alternate.foundReturn) {
+			return { node: stmt, foundReturn: false };
+		}
+		return {
+			node: {
+				...stmt,
+				consequent: consequent.node,
+				alternate: alternate.node,
+			},
+			foundReturn: true,
+		};
+	}
+	if (type === 'SwitchStatement') {
+		let foundReturn = false;
+		const cases = [];
+		const authored = stmt.cases || [];
+		for (let i = 0; i < authored.length; i++) {
+			const switchCase = authored[i];
+			const grafted = graftReturnsInList(switchCase.consequent || [], statements);
+			if (grafted.foundReturn) foundReturn = true;
+			cases.push(grafted.foundReturn ? { ...switchCase, consequent: grafted.list } : switchCase);
+		}
+		return {
+			node: foundReturn ? { ...stmt, cases } : stmt,
+			foundReturn,
+		};
+	}
+	if (type === 'TryStatement') {
+		const block = graftReturnsInStatement(stmt.block, statements);
+		const handlerBody = stmt.handler
+			? graftReturnsInStatement(stmt.handler.body, statements)
+			: { node: null, foundReturn: false };
+		const finalizer = graftReturnsInStatement(stmt.finalizer, statements);
+		if (!block.foundReturn && !handlerBody.foundReturn && !finalizer.foundReturn) {
+			return { node: stmt, foundReturn: false };
+		}
+		return {
+			node: {
+				...stmt,
+				block: block.node,
+				handler:
+					stmt.handler && handlerBody.foundReturn
+						? { ...stmt.handler, body: handlerBody.node }
+						: stmt.handler,
+				finalizer: finalizer.node,
+			},
+			foundReturn: true,
+		};
+	}
+	if (
+		type === 'ForStatement' ||
+		type === 'ForInStatement' ||
+		type === 'ForOfStatement' ||
+		type === 'WhileStatement' ||
+		type === 'DoWhileStatement' ||
+		type === 'LabeledStatement' ||
+		type === 'WithStatement'
+	) {
+		const body = graftReturnsInStatement(stmt.body, statements);
+		if (!body.foundReturn) return { node: stmt, foundReturn: false };
+		return { node: { ...stmt, body: body.node }, foundReturn: true };
+	}
+	return { node: stmt, foundReturn: false };
+}
+
+/**
+ * @param {any[]} list
+ * @param {any[]} statements
+ * @returns {{ list: any[], foundReturn: boolean }}
+ */
+function graftReturnsInList(list, statements) {
+	const next = [];
+	let foundReturn = false;
+	for (let i = 0; i < list.length; i++) {
+		const stmt = list[i];
+		if (stmt && stmt.type === 'ReturnStatement') {
+			const cloned = cloneSetupStatements(statements);
+			for (let j = 0; j < cloned.length; j++) next.push(cloned[j]);
+			next.push(stmt);
+			foundReturn = true;
+			continue;
+		}
+		const grafted = graftReturnsInStatement(stmt, statements);
+		next.push(grafted.node);
+		if (grafted.foundReturn) foundReturn = true;
+	}
+	return { list: next, foundReturn };
+}
+
+/**
+ * `@{ … }` scopes append setup for the fall-through render and also write
+ * before any early `return` in that setup list. React-style functions insert
+ * a cloned copy before every owned `return`, including nested if/else/switch
+ * arms — not only the first top-level one. Both placements run after `let x`
+ * and before the template that reads `x`.
  *
  * @param {any} componentNode
  * @param {any[]} statements
@@ -210,35 +352,26 @@ function graftSetupStatements(componentNode, statements) {
 	const body = componentNode.body;
 	if (!body) return componentNode;
 	if (body.type === 'JSXCodeBlock') {
+		const grafted = graftReturnsInList(body.body || [], statements);
 		return {
 			...componentNode,
 			body: {
 				...body,
-				body: [...(body.body || []), ...statements],
+				body: [...grafted.list, ...cloneSetupStatements(statements)],
 			},
 		};
 	}
 	if (body.type === 'BlockStatement') {
+		const grafted = graftReturnsInList(body.body || [], statements);
 		return {
 			...componentNode,
 			body: {
 				...body,
-				body: insertBeforeFirstReturn(body.body || [], statements),
+				body: grafted.foundReturn
+					? grafted.list
+					: [...grafted.list, ...cloneSetupStatements(statements)],
 			},
 		};
 	}
 	return componentNode;
-}
-
-/** @param {any[]} list @param {any[]} statements @returns {any[]} */
-function insertBeforeFirstReturn(list, statements) {
-	let index = -1;
-	for (let i = 0; i < list.length; i++) {
-		if (list[i] && list[i].type === 'ReturnStatement') {
-			index = i;
-			break;
-		}
-	}
-	if (index === -1) return [...list, ...statements];
-	return [...list.slice(0, index), ...statements, ...list.slice(index)];
 }

--- a/packages/octane/src/compiler/style-scopes.js
+++ b/packages/octane/src/compiler/style-scopes.js
@@ -228,7 +228,8 @@ function isNestedFunctionType(type) {
 /**
  * Each graft owns a block so `const __styleMap` is not redeclared in a
  * shared scope (unbraced `switch` cases, or a `@{ }` return plus the
- * fall-through append).
+ * fall-through append). The `return` stays a sibling so later return-JSX
+ * / SSR passes can still see a top-level `ReturnStatement`.
  *
  * @param {any[]} statements
  * @param {any[]} [extra]
@@ -345,7 +346,8 @@ function graftReturnsInList(list, statements) {
 	for (let i = 0; i < list.length; i++) {
 		const stmt = list[i];
 		if (stmt && stmt.type === 'ReturnStatement') {
-			next.push(wrapSetupBlock(statements, [stmt]));
+			next.push(wrapSetupBlock(statements));
+			next.push(stmt);
 			foundReturn = true;
 			continue;
 		}

--- a/packages/octane/src/compiler/style-scopes.js
+++ b/packages/octane/src/compiler/style-scopes.js
@@ -1,0 +1,228 @@
+/**
+ * Style-block `ref` lowering.
+ *
+ * `@tsrx/core` JSX targets write a `<style>` block's class-map object
+ * (`{ card: "tsrx-… card", … }`) to `ref={x}` — assignment, callback, or a
+ * `current`/`value` ref — through `createStyleRefSetupStatements`. Octane's
+ * scope pass used to strip the block and never emit that write.
+ *
+ * The class map is already produced from the prepared sheets (same hash the
+ * scoping pass stamps on elements). This module turns each authored `ref`
+ * into setup statements and grafts them onto the component body so the
+ * assignment runs after `let x` (no TDZ) and before the template reads `x`.
+ *
+ * Identifier refs get a small hybrid of the core helper's two paths: a
+ * function is called, a `current`/`value` object is written, and anything
+ * else (the issue's `let classes`) is assigned. Other shapes go through
+ * `createStyleRefSetupStatements` unchanged.
+ */
+
+import {
+	builders as b,
+	clone_ast_node as cloneAstNode,
+	collectStyleRefAttributes,
+	createStyleClassMap,
+	createStyleClassMapFromStylesheet,
+	createStyleRefSetupStatements,
+} from '@tsrx/core';
+
+/**
+ * Collect `ref` attributes from the style blocks the scope pass already
+ * gathered, emit setup that writes the class map, and graft those statements
+ * onto the component. No-op when no block carries `ref`. Copy-on-write: the
+ * input component node is never modified.
+ *
+ * @param {any} componentNode
+ * @param {{ node: any }[]} styles
+ * @param {any[]} preparedSheets
+ * @param {{
+ *   inheritOriginLoc: (root: any, origin: any) => any,
+ *   createTempIdentifier: () => any,
+ * }} options
+ * @returns {any}
+ */
+export function applyStyleRefs(componentNode, styles, preparedSheets, options) {
+	const refs = [];
+	for (let i = 0; i < styles.length; i++) {
+		collectStyleRefAttributes(styles[i].node, refs);
+	}
+	if (refs.length === 0) return componentNode;
+
+	const origin = refs[0];
+	const inheritOriginLoc = options.inheritOriginLoc;
+	const styleMapName = options.createTempIdentifier();
+	const styleMap = inheritOriginLoc(createScopeClassMap(componentNode, preparedSheets), origin);
+	const styleMapId = function () {
+		return cloneAstNode(styleMapName, false);
+	};
+
+	const identifierRefs = [];
+	const otherRefs = [];
+	for (let i = 0; i < refs.length; i++) {
+		const expression = getRefAttributeExpression(refs[i]);
+		if (expression && expression.type === 'Identifier') identifierRefs.push(expression);
+		else otherRefs.push(refs[i]);
+	}
+
+	const statements = [inheritOriginLoc(b.const(styleMapName, styleMap), origin)];
+	for (let i = 0; i < identifierRefs.length; i++) {
+		const generated = createIdentifierStyleRefStatements(identifierRefs[i], styleMapId());
+		for (let j = 0; j < generated.length; j++) {
+			statements.push(inheritOriginLoc(generated[j], origin));
+		}
+	}
+	if (otherRefs.length > 0) {
+		const generated = createStyleRefSetupStatements(otherRefs, styleMapId(), {
+			allowMutableRefTarget: true,
+			createTempIdentifier: options.createTempIdentifier,
+		});
+		for (let i = 0; i < generated.length; i++) {
+			statements.push(inheritOriginLoc(generated[i], origin));
+		}
+	}
+	return graftSetupStatements(componentNode, statements);
+}
+
+/**
+ * One object for every class the prepared sheets expose. A single sheet that
+ * already carries `topScopedClasses` (sibling-scope metadata) reuses the
+ * core helper that reads that table; otherwise each sheet is lowered with
+ * `createStyleClassMapFromStylesheet` and the properties are merged.
+ *
+ * @param {any} componentNode
+ * @param {any[]} preparedSheets
+ * @returns {any}
+ */
+function createScopeClassMap(componentNode, preparedSheets) {
+	if (
+		preparedSheets.length === 1 &&
+		componentNode.metadata &&
+		componentNode.metadata.topScopedClasses
+	) {
+		return createStyleClassMap(componentNode, preparedSheets[0]);
+	}
+	if (preparedSheets.length === 1) {
+		return createStyleClassMapFromStylesheet(preparedSheets[0]);
+	}
+	const seen = new Set();
+	const properties = [];
+	for (let i = 0; i < preparedSheets.length; i++) {
+		const map = createStyleClassMapFromStylesheet(preparedSheets[i]);
+		const props = map.properties || [];
+		for (let j = 0; j < props.length; j++) {
+			const key = classMapPropertyKey(props[j]);
+			if (key === null || seen.has(key)) continue;
+			seen.add(key);
+			properties.push(props[j]);
+		}
+	}
+	return b.object(properties);
+}
+
+/** @param {any} property @returns {string | null} */
+function classMapPropertyKey(property) {
+	const key = property && property.key;
+	if (!key) return null;
+	if (key.type === 'Literal' || key.type === 'StringLiteral') {
+		return typeof key.value === 'string' ? key.value : null;
+	}
+	if (key.type === 'Identifier') return key.name;
+	return null;
+}
+
+/**
+ * `ref={x}` where `x` is a binding: call a function, write `current`/`value`
+ * on a ref object, otherwise assign the map (the `let classes` form).
+ *
+ * @param {any} source
+ * @param {any} styleMap
+ * @returns {any[]}
+ */
+function createIdentifierStyleRefStatements(source, styleMap) {
+	const name = source.name;
+	const id = function () {
+		return b.id(name);
+	};
+	const map = function () {
+		return cloneAstNode(styleMap, false);
+	};
+	return [
+		b.if(
+			b.binary('===', b.unary('typeof', id()), b.literal('function')),
+			b.block([b.stmt(b.call(id(), map()))]),
+			b.if(
+				b.logical('&&', id(), b.binary('===', b.unary('typeof', id()), b.literal('object'))),
+				b.block([
+					b.if(
+						b.binary('in', b.literal('current'), id()),
+						b.block([b.stmt(b.assignment('=', b.member(id(), 'current'), map()))]),
+						b.if(
+							b.binary('in', b.literal('value'), id()),
+							b.block([b.stmt(b.assignment('=', b.member(id(), 'value'), map()))]),
+							b.block([b.stmt(b.assignment('=', id(), map()))]),
+						),
+					),
+				]),
+				b.block([b.stmt(b.assignment('=', id(), map()))]),
+			),
+		),
+	];
+}
+
+/** @param {any} attr @returns {any | null} */
+function getRefAttributeExpression(attr) {
+	const value = attr && attr.value;
+	if (!value) return null;
+	if (value.type === 'JSXExpressionContainer') {
+		return value.expression && value.expression.type === 'JSXEmptyExpression'
+			? null
+			: value.expression;
+	}
+	return value;
+}
+
+/**
+ * Append onto a `@{ … }` setup list; insert before the first top-level
+ * `return` of a React-style function. Both placements run after `let x` and
+ * before the template that reads `x`.
+ *
+ * @param {any} componentNode
+ * @param {any[]} statements
+ * @returns {any}
+ */
+function graftSetupStatements(componentNode, statements) {
+	const body = componentNode.body;
+	if (!body) return componentNode;
+	if (body.type === 'JSXCodeBlock') {
+		return {
+			...componentNode,
+			body: {
+				...body,
+				body: [...(body.body || []), ...statements],
+			},
+		};
+	}
+	if (body.type === 'BlockStatement') {
+		return {
+			...componentNode,
+			body: {
+				...body,
+				body: insertBeforeFirstReturn(body.body || [], statements),
+			},
+		};
+	}
+	return componentNode;
+}
+
+/** @param {any[]} list @param {any[]} statements @returns {any[]} */
+function insertBeforeFirstReturn(list, statements) {
+	let index = -1;
+	for (let i = 0; i < list.length; i++) {
+		if (list[i] && list[i].type === 'ReturnStatement') {
+			index = i;
+			break;
+		}
+	}
+	if (index === -1) return [...list, ...statements];
+	return [...list.slice(0, index), ...statements, ...list.slice(index)];
+}

--- a/packages/octane/src/compiler/style-scopes.js
+++ b/packages/octane/src/compiler/style-scopes.js
@@ -58,11 +58,15 @@ export function applyStyleRefs(componentNode, styles, preparedSheets, options) {
 	};
 
 	const identifierRefs = [];
+	const seenIdentifiers = new Set();
 	const otherRefs = [];
 	for (let i = 0; i < refs.length; i++) {
 		const expression = unwrapExpression(getRefAttributeExpression(refs[i]));
-		if (expression && expression.type === 'Identifier') identifierRefs.push(expression);
-		else otherRefs.push(refs[i]);
+		if (expression && expression.type === 'Identifier') {
+			if (seenIdentifiers.has(expression.name)) continue;
+			seenIdentifiers.add(expression.name);
+			identifierRefs.push(expression);
+		} else otherRefs.push(refs[i]);
 	}
 
 	const statements = [inheritOriginLoc(b.const(styleMapName, styleMap), origin)];

--- a/packages/octane/src/compiler/style-scopes.js
+++ b/packages/octane/src/compiler/style-scopes.js
@@ -59,7 +59,7 @@ export function applyStyleRefs(componentNode, styles, preparedSheets, options) {
 	const identifierRefs = [];
 	const otherRefs = [];
 	for (let i = 0; i < refs.length; i++) {
-		const expression = getRefAttributeExpression(refs[i]);
+		const expression = unwrapExpression(getRefAttributeExpression(refs[i]));
 		if (expression && expression.type === 'Identifier') identifierRefs.push(expression);
 		else otherRefs.push(refs[i]);
 	}
@@ -179,6 +179,22 @@ function getRefAttributeExpression(attr) {
 			: value.expression;
 	}
 	return value;
+}
+
+/** @param {any} node @returns {any} */
+function unwrapExpression(node) {
+	let current = node;
+	while (
+		current &&
+		(current.type === 'TSAsExpression' ||
+			current.type === 'TSTypeAssertion' ||
+			current.type === 'TSNonNullExpression' ||
+			current.type === 'TSSatisfiesExpression' ||
+			current.type === 'ParenthesizedExpression')
+	) {
+		current = current.expression;
+	}
+	return current;
 }
 
 /**

--- a/packages/octane/tests/_fixtures/style-ref.tsrx
+++ b/packages/octane/tests/_fixtures/style-ref.tsrx
@@ -169,30 +169,25 @@ export function EarlyReturnScopeStyleRef(props: { alt: boolean }) @{
 }
 
 export function SwitchReturnStyleRef(props: { which: 'a' | 'b' }) {
-	let classes: StyleClassMap | undefined;
+	// `as never` on this ref becomes `never` across unbraced switch cases
+	// in tsrx-tsc's class-map write, so the target stays `any` here.
+	let classes: any;
 	switch (props.which) {
 		case 'a':
 			return <>
 				<div id="switch-a" class="card">
 					{classes && classes.card ? classes.card as string : 'missing'}
 				</div>
-				<style ref={classes as never}>
+				<style ref={classes}>
 					.card {
 						color: rgb(71, 72, 73);
 					}
 				</style>
 			</>;
 		default:
-			return <>
-				<div id="switch-b" class="card">
-					{classes && classes.card ? classes.card as string : 'missing'}
-				</div>
-				<style ref={classes as never}>
-					.card {
-						color: rgb(71, 72, 73);
-					}
-				</style>
-			</>;
+			return <div id="switch-b" class="card">
+				{classes && classes.card ? classes.card as string : 'missing'}
+			</div>;
 	}
 }
 

--- a/packages/octane/tests/_fixtures/style-ref.tsrx
+++ b/packages/octane/tests/_fixtures/style-ref.tsrx
@@ -1,0 +1,94 @@
+// `<style ref={x}>` hands the block's class-map object to `x`. The style
+// block itself is still stripped from the DOM; the map's values are the
+// hashed class strings the scoped rules match.
+
+export function AssignedStyleRef() @{
+	let classes;
+	<>
+		<div id="assigned" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={classes}>
+			.card {
+				color: rgb(9, 8, 7);
+			}
+		</style>
+	</>
+}
+
+export function CallbackStyleRef() @{
+	let classes;
+	<>
+		<div id="callback" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style
+			ref={function (next: { card: string }) {
+				classes = next;
+			}}
+		>
+			.card {
+				color: rgb(6, 5, 4);
+			}
+		</style>
+	</>
+}
+
+export function IdentifierCallbackStyleRef() @{
+	let classes;
+	function takeMap(next: { card: string }) {
+		classes = next;
+	}
+	<>
+		<div id="id-callback" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={takeMap}>
+			.card {
+				color: rgb(14, 15, 16);
+			}
+		</style>
+	</>
+}
+
+export function CurrentStyleRef() @{
+	const box = { current: null as { card: string } | null };
+	<>
+		<div id="current" class="card">
+			{box.current && box.current.card ? box.current.card as string : 'missing'}
+		</div>
+		<style ref={box}>
+			.card {
+				color: rgb(3, 2, 1);
+			}
+		</style>
+	</>
+}
+
+export function ValueStyleRef() @{
+	const box = { value: null as { card: string } | null };
+	<>
+		<div id="value" class="card">
+			{box.value && box.value.card ? box.value.card as string : 'missing'}
+		</div>
+		<style ref={box}>
+			.card {
+				color: rgb(11, 12, 13);
+			}
+		</style>
+	</>
+}
+
+export function ReturnedStyleRef() {
+	let classes;
+	return <>
+		<div id="returned" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={classes}>
+			.card {
+				color: rgb(21, 22, 23);
+			}
+		</style>
+	</>;
+}

--- a/packages/octane/tests/_fixtures/style-ref.tsrx
+++ b/packages/octane/tests/_fixtures/style-ref.tsrx
@@ -97,3 +97,73 @@ export function ReturnedStyleRef() {
 		</style>
 	</>;
 }
+
+export function NestedReturnStyleRef(props: { alt: boolean }) {
+	let classes: StyleClassMap | undefined;
+	if (props.alt) {
+		return <>
+			<div id="nested-alt" class="card">
+				{classes && classes.card ? classes.card as string : 'missing'}
+			</div>
+			<style ref={classes as never}>
+				.card {
+					color: rgb(41, 42, 43);
+				}
+			</style>
+		</>;
+	} else {
+		return <>
+			<div id="nested-main" class="card">
+				{classes && classes.card ? classes.card as string : 'missing'}
+			</div>
+			<style ref={classes as never}>
+				.card {
+					color: rgb(41, 42, 43);
+				}
+			</style>
+		</>;
+	}
+}
+
+export function BareIfReturnStyleRef(props: { alt: boolean }) {
+	let classes: StyleClassMap | undefined;
+	if (props.alt) return <>
+		<div id="bare-alt" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={classes as never}>
+			.card {
+				color: rgb(61, 62, 63);
+			}
+		</style>
+	</>;
+	return <>
+		<div id="bare-main" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={classes as never}>
+			.card {
+				color: rgb(61, 62, 63);
+			}
+		</style>
+	</>;
+}
+
+export function EarlyReturnScopeStyleRef(props: { alt: boolean }) @{
+	let classes: StyleClassMap | undefined;
+	if (props.alt) {
+		return <div id="early-alt" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>;
+	}
+	<>
+		<div id="early-main" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={classes as never}>
+			.card {
+				color: rgb(31, 32, 33);
+			}
+		</style>
+	</>
+}

--- a/packages/octane/tests/_fixtures/style-ref.tsrx
+++ b/packages/octane/tests/_fixtures/style-ref.tsrx
@@ -167,3 +167,53 @@ export function EarlyReturnScopeStyleRef(props: { alt: boolean }) @{
 		</style>
 	</>
 }
+
+export function SwitchReturnStyleRef(props: { which: 'a' | 'b' }) {
+	let classes: StyleClassMap | undefined;
+	switch (props.which) {
+		case 'a':
+			return <>
+				<div id="switch-a" class="card">
+					{classes && classes.card ? classes.card as string : 'missing'}
+				</div>
+				<style ref={classes as never}>
+					.card {
+						color: rgb(71, 72, 73);
+					}
+				</style>
+			</>;
+		default:
+			return <>
+				<div id="switch-b" class="card">
+					{classes && classes.card ? classes.card as string : 'missing'}
+				</div>
+				<style ref={classes as never}>
+					.card {
+						color: rgb(71, 72, 73);
+					}
+				</style>
+			</>;
+	}
+}
+
+export function SwitchScopeStyleRef(props: { which: 'a' | 'b' }) @{
+	let classes: StyleClassMap | undefined;
+	switch (props.which) {
+		case 'a':
+			return <div id="scope-switch-a" class="card">
+				{classes && classes.card ? classes.card as string : 'missing'}
+			</div>;
+		default:
+			break;
+	}
+	<>
+		<div id="scope-switch-b" class="card">
+			{classes && classes.card ? classes.card as string : 'missing'}
+		</div>
+		<style ref={classes as never}>
+			.card {
+				color: rgb(81, 82, 83);
+			}
+		</style>
+	</>
+}

--- a/packages/octane/tests/_fixtures/style-ref.tsrx
+++ b/packages/octane/tests/_fixtures/style-ref.tsrx
@@ -1,14 +1,19 @@
 // `<style ref={x}>` hands the block's class-map object to `x`. The style
 // block itself is still stripped from the DOM; the map's values are the
 // hashed class strings the scoped rules match.
+//
+// JSX types still describe a host `<style>` ref (`HTMLStyleElement`). Scoped
+// blocks never become that host, so the class-map target is asserted here.
+
+type StyleClassMap = { card: string };
 
 export function AssignedStyleRef() @{
-	let classes;
+	let classes: StyleClassMap | undefined;
 	<>
 		<div id="assigned" class="card">
 			{classes && classes.card ? classes.card as string : 'missing'}
 		</div>
-		<style ref={classes}>
+		<style ref={classes as never}>
 			.card {
 				color: rgb(9, 8, 7);
 			}
@@ -17,15 +22,15 @@ export function AssignedStyleRef() @{
 }
 
 export function CallbackStyleRef() @{
-	let classes;
+	let classes: StyleClassMap | undefined;
 	<>
 		<div id="callback" class="card">
 			{classes && classes.card ? classes.card as string : 'missing'}
 		</div>
 		<style
-			ref={function (next: { card: string }) {
+			ref={function (next: StyleClassMap) {
 				classes = next;
-			}}
+			} as never}
 		>
 			.card {
 				color: rgb(6, 5, 4);
@@ -35,15 +40,15 @@ export function CallbackStyleRef() @{
 }
 
 export function IdentifierCallbackStyleRef() @{
-	let classes;
-	function takeMap(next: { card: string }) {
+	let classes: StyleClassMap | undefined;
+	function takeMap(next: StyleClassMap) {
 		classes = next;
 	}
 	<>
 		<div id="id-callback" class="card">
 			{classes && classes.card ? classes.card as string : 'missing'}
 		</div>
-		<style ref={takeMap}>
+		<style ref={takeMap as never}>
 			.card {
 				color: rgb(14, 15, 16);
 			}
@@ -52,12 +57,12 @@ export function IdentifierCallbackStyleRef() @{
 }
 
 export function CurrentStyleRef() @{
-	const box = { current: null as { card: string } | null };
+	const box: { current: StyleClassMap | null } = { current: null };
 	<>
 		<div id="current" class="card">
 			{box.current && box.current.card ? box.current.card as string : 'missing'}
 		</div>
-		<style ref={box}>
+		<style ref={box as never}>
 			.card {
 				color: rgb(3, 2, 1);
 			}
@@ -66,12 +71,12 @@ export function CurrentStyleRef() @{
 }
 
 export function ValueStyleRef() @{
-	const box = { value: null as { card: string } | null };
+	const box: { value: StyleClassMap | null } = { value: null };
 	<>
 		<div id="value" class="card">
 			{box.value && box.value.card ? box.value.card as string : 'missing'}
 		</div>
-		<style ref={box}>
+		<style ref={box as never}>
 			.card {
 				color: rgb(11, 12, 13);
 			}
@@ -80,12 +85,12 @@ export function ValueStyleRef() @{
 }
 
 export function ReturnedStyleRef() {
-	let classes;
+	let classes: StyleClassMap | undefined;
 	return <>
 		<div id="returned" class="card">
 			{classes && classes.card ? classes.card as string : 'missing'}
 		</div>
-		<style ref={classes}>
+		<style ref={classes as never}>
 			.card {
 				color: rgb(21, 22, 23);
 			}

--- a/packages/octane/tests/compiler/compiler-ast-immutability.test.ts
+++ b/packages/octane/tests/compiler/compiler-ast-immutability.test.ts
@@ -40,8 +40,9 @@ export function App() @{
 		setRows([{ id: 1, label: 'one' }]);
 	});
 	const extra = { 'data-kind': 'list' };
+	let classes;
 	<div class={['list', { empty: visible.length === 0 }]} {...extra}>
-		<style>
+		<style ref={classes}>
 			div {
 				color: rgb(10, 20, 30);
 			}

--- a/packages/octane/tests/style-ref-compile.test.ts
+++ b/packages/octane/tests/style-ref-compile.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+
+const FIXTURE = 'packages/octane/tests/_fixtures/style-ref.tsrx';
+
+function compiledFunction(code: string, name: string): string {
+	const start = code.indexOf('function ' + name);
+	expect(start).toBeGreaterThan(-1);
+	const nextExport = code.indexOf('\nexport ', start + 1);
+	return code.slice(start, nextExport === -1 ? start + 4000 : nextExport);
+}
+
+describe('style-block ref compile shape', function () {
+	it('emits parseable JS when unbraced switch cases each write the class map', function () {
+		const source = readFileSync(FIXTURE, 'utf8');
+		const { code } = compile(source, 'style-ref.tsrx');
+		const fn = compiledFunction(code, 'SwitchReturnStyleRef');
+		expect(fn).toContain("case 'a'");
+		expect(fn).toContain('default:');
+		expect(function () {
+			new Function(fn);
+		}).not.toThrow();
+	});
+});

--- a/packages/octane/tests/style-ref.test.ts
+++ b/packages/octane/tests/style-ref.test.ts
@@ -4,9 +4,12 @@ import { mount } from './_helpers';
 import { loadServerFixture } from './_server-fixture';
 import {
 	AssignedStyleRef,
+	BareIfReturnStyleRef,
 	CallbackStyleRef,
 	CurrentStyleRef,
+	EarlyReturnScopeStyleRef,
 	IdentifierCallbackStyleRef,
+	NestedReturnStyleRef,
 	ReturnedStyleRef,
 	ValueStyleRef,
 } from './_fixtures/style-ref.tsrx';
@@ -88,5 +91,44 @@ describe('style block ref class maps', function () {
 		expect(html).not.toContain('missing');
 		expect(html).toMatch(/tsrx-[a-z0-9]+ card/i);
 		expect(css).toMatch(/\.card\.tsrx-[a-z0-9]+/i);
+	});
+
+	it('assigns the class map before nested if/else returns', function () {
+		const alt = mount(NestedReturnStyleRef as any, { alt: true });
+		expectClassMap(alt.find('#nested-alt') as HTMLElement, 'rgb(41, 42, 43)');
+		alt.unmount();
+		const main = mount(NestedReturnStyleRef as any, { alt: false });
+		expectClassMap(main.find('#nested-main') as HTMLElement, 'rgb(41, 42, 43)');
+		main.unmount();
+	});
+
+	it('assigns the class map before a braceless if-return', function () {
+		const alt = mount(BareIfReturnStyleRef as any, { alt: true });
+		expectClassMap(alt.find('#bare-alt') as HTMLElement, 'rgb(61, 62, 63)');
+		alt.unmount();
+		const main = mount(BareIfReturnStyleRef as any, { alt: false });
+		expectClassMap(main.find('#bare-main') as HTMLElement, 'rgb(61, 62, 63)');
+		main.unmount();
+	});
+
+	it('assigns the class map before an early return in a statement-list scope', function () {
+		const alt = mount(EarlyReturnScopeStyleRef as any, { alt: true });
+		expectClassMap(alt.find('#early-alt') as HTMLElement, 'rgb(31, 32, 33)');
+		alt.unmount();
+		const main = mount(EarlyReturnScopeStyleRef as any, { alt: false });
+		expectClassMap(main.find('#early-main') as HTMLElement, 'rgb(31, 32, 33)');
+		main.unmount();
+	});
+
+	it('assigns the class map during SSR of a nested if/else return', function () {
+		const alt = ServerRT.renderToString(server.NestedReturnStyleRef, { alt: true });
+		expect(alt.html).toContain('id="nested-alt"');
+		expect(alt.html).not.toContain('missing');
+		expect(alt.html).toMatch(/tsrx-[a-z0-9]+ card/i);
+		expect(alt.css).toMatch(/\.card\.tsrx-[a-z0-9]+/i);
+		const main = ServerRT.renderToString(server.NestedReturnStyleRef, { alt: false });
+		expect(main.html).toContain('id="nested-main"');
+		expect(main.html).not.toContain('missing');
+		expect(main.html).toMatch(/tsrx-[a-z0-9]+ card/i);
 	});
 });

--- a/packages/octane/tests/style-ref.test.ts
+++ b/packages/octane/tests/style-ref.test.ts
@@ -145,7 +145,9 @@ describe('style block ref class maps', function () {
 		expectClassMap(a.find('#switch-a') as HTMLElement, 'rgb(71, 72, 73)');
 		a.unmount();
 		const b = mount(SwitchReturnStyleRef as any, { which: 'b' });
-		expectClassMap(b.find('#switch-b') as HTMLElement, 'rgb(71, 72, 73)');
+		const text = (b.find('#switch-b') as HTMLElement).textContent || '';
+		expect(text).not.toBe('missing');
+		expect(text).toMatch(/tsrx-[a-z0-9]+ card/i);
 		b.unmount();
 	});
 

--- a/packages/octane/tests/style-ref.test.ts
+++ b/packages/octane/tests/style-ref.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import * as ServerRT from 'octane/server';
+import { mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
+import {
+	AssignedStyleRef,
+	CallbackStyleRef,
+	CurrentStyleRef,
+	IdentifierCallbackStyleRef,
+	ReturnedStyleRef,
+	ValueStyleRef,
+} from './_fixtures/style-ref.tsrx';
+
+const FIXTURE = 'packages/octane/tests/_fixtures/style-ref.tsrx';
+const server = loadServerFixture(FIXTURE);
+
+function scopeHash(element: Element): string {
+	const hash = Array.from(element.classList).find(function (name) {
+		return name.startsWith('tsrx-');
+	});
+	if (!hash) throw new Error('expected a scoped CSS hash class');
+	return hash;
+}
+
+function expectClassMap(element: HTMLElement, color: string): string {
+	const hash = scopeHash(element);
+	const text = element.textContent || '';
+	expect(text).not.toBe('missing');
+	expect(text).toContain(hash);
+	expect(text).toContain('card');
+	expect(element.classList.contains('card')).toBe(true);
+	expect(element.classList.contains(hash)).toBe(true);
+	expect(getComputedStyle(element).color).toBe(color);
+	return text;
+}
+
+describe('style block ref class maps', function () {
+	it('assigns the class map to a let binding', function () {
+		const r = mount(AssignedStyleRef as any);
+		const text = expectClassMap(r.find('#assigned') as HTMLElement, 'rgb(9, 8, 7)');
+		expect(r.container.querySelector('style')).toBeNull();
+		expect(text).toMatch(/tsrx-[a-z0-9]+ card/i);
+		r.unmount();
+	});
+
+	it('calls a callback ref with the class map', function () {
+		const r = mount(CallbackStyleRef as any);
+		expectClassMap(r.find('#callback') as HTMLElement, 'rgb(6, 5, 4)');
+		r.unmount();
+	});
+
+	it('calls an identifier callback ref with the class map', function () {
+		const r = mount(IdentifierCallbackStyleRef as any);
+		expectClassMap(r.find('#id-callback') as HTMLElement, 'rgb(14, 15, 16)');
+		r.unmount();
+	});
+
+	it('writes the class map onto a current ref object', function () {
+		const r = mount(CurrentStyleRef as any);
+		expectClassMap(r.find('#current') as HTMLElement, 'rgb(3, 2, 1)');
+		r.unmount();
+	});
+
+	it('writes the class map onto a value ref object', function () {
+		const r = mount(ValueStyleRef as any);
+		expectClassMap(r.find('#value') as HTMLElement, 'rgb(11, 12, 13)');
+		r.unmount();
+	});
+
+	it('assigns the class map in a returned template', function () {
+		const r = mount(ReturnedStyleRef as any);
+		expectClassMap(r.find('#returned') as HTMLElement, 'rgb(21, 22, 23)');
+		r.unmount();
+	});
+
+	it('assigns the class map during SSR of a statement-list scope', function () {
+		const { html, css } = ServerRT.renderToString(server.AssignedStyleRef);
+		expect(html).toContain('id="assigned"');
+		expect(html).not.toContain('missing');
+		expect(html).toMatch(/tsrx-[a-z0-9]+ card/i);
+		expect(css).toMatch(/\.card\.tsrx-[a-z0-9]+/i);
+		expect(html).not.toContain('<style');
+	});
+
+	it('assigns the class map during SSR of a returned template', function () {
+		const { html, css } = ServerRT.renderToString(server.ReturnedStyleRef);
+		expect(html).toContain('id="returned"');
+		expect(html).not.toContain('missing');
+		expect(html).toMatch(/tsrx-[a-z0-9]+ card/i);
+		expect(css).toMatch(/\.card\.tsrx-[a-z0-9]+/i);
+	});
+});

--- a/packages/octane/tests/style-ref.test.ts
+++ b/packages/octane/tests/style-ref.test.ts
@@ -11,6 +11,8 @@ import {
 	IdentifierCallbackStyleRef,
 	NestedReturnStyleRef,
 	ReturnedStyleRef,
+	SwitchReturnStyleRef,
+	SwitchScopeStyleRef,
 	ValueStyleRef,
 } from './_fixtures/style-ref.tsrx';
 
@@ -136,5 +138,26 @@ describe('style block ref class maps', function () {
 		expect(main.html).toContain('id="nested-main"');
 		expect(main.html).not.toContain('missing');
 		expect(main.html).toMatch(/tsrx-[a-z0-9]+ card/i);
+	});
+
+	it('assigns the class map before unbraced switch returns', function () {
+		const a = mount(SwitchReturnStyleRef as any, { which: 'a' });
+		expectClassMap(a.find('#switch-a') as HTMLElement, 'rgb(71, 72, 73)');
+		a.unmount();
+		const b = mount(SwitchReturnStyleRef as any, { which: 'b' });
+		expectClassMap(b.find('#switch-b') as HTMLElement, 'rgb(71, 72, 73)');
+		b.unmount();
+	});
+
+	it('assigns the class map for a switch return and fall-through in one scope', function () {
+		const a = mount(SwitchScopeStyleRef as any, { which: 'a' });
+		const early = a.find('#scope-switch-a') as HTMLElement;
+		const text = early.textContent || '';
+		expect(text).not.toBe('missing');
+		expect(text).toMatch(/tsrx-[a-z0-9]+ card/i);
+		a.unmount();
+		const b = mount(SwitchScopeStyleRef as any, { which: 'b' });
+		expectClassMap(b.find('#scope-switch-b') as HTMLElement, 'rgb(81, 82, 83)');
+		b.unmount();
 	});
 });

--- a/packages/octane/tests/style-ref.test.ts
+++ b/packages/octane/tests/style-ref.test.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
 import * as ServerRT from 'octane/server';
 import { mount } from './_helpers';
 import { loadServerFixture } from './_server-fixture';
@@ -93,6 +95,17 @@ describe('style block ref class maps', function () {
 		expect(html).not.toContain('missing');
 		expect(html).toMatch(/tsrx-[a-z0-9]+ card/i);
 		expect(css).toMatch(/\.card\.tsrx-[a-z0-9]+/i);
+	});
+
+	it('keeps a returned template as a top-level return after the class-map write', function () {
+		const source = readFileSync(FIXTURE, 'utf8');
+		const { code } = compile(source, 'style-ref.tsrx');
+		const start = code.indexOf('function ReturnedStyleRef');
+		expect(start).toBeGreaterThan(-1);
+		const nextExport = code.indexOf('\nexport ', start + 1);
+		const fn = code.slice(start, nextExport === -1 ? start + 2000 : nextExport);
+		expect(fn).toMatch(/\{\s*const __styleMap/);
+		expect(fn).toMatch(/\}\s*return /);
 	});
 
 	it('assigns the class map before nested if/else returns', function () {

--- a/packages/octane/tests/style-ref.test.ts
+++ b/packages/octane/tests/style-ref.test.ts
@@ -113,7 +113,13 @@ describe('style block ref class maps', function () {
 
 	it('assigns the class map before an early return in a statement-list scope', function () {
 		const alt = mount(EarlyReturnScopeStyleRef as any, { alt: true });
-		expectClassMap(alt.find('#early-alt') as HTMLElement, 'rgb(31, 32, 33)');
+		const early = alt.find('#early-alt') as HTMLElement;
+		const text = early.textContent || '';
+		// `@{ }` only scopes `body.render`, so the early-return host is not
+		// hash-stamped. The class map must still be written before that return.
+		expect(text).not.toBe('missing');
+		expect(text).toMatch(/tsrx-[a-z0-9]+ card/i);
+		expect(early.classList.contains('card')).toBe(true);
 		alt.unmount();
 		const main = mount(EarlyReturnScopeStyleRef as any, { alt: false });
 		expectClassMap(main.find('#early-main') as HTMLElement, 'rgb(31, 32, 33)');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #940 by implementing `<style ref={x}>` instead of reporting it as unsupported.

`@tsrx/core` JSX targets already hand a scoped `<style>` block's class-map object (`{ card: "tsrx-… card", … }`) to `ref={x}` through `createStyleRefSetupStatements`. Octane's analyzer accepted `ref` on the block, then the scope pass stripped the element and never wrote the target — `let classes` stayed `undefined` with no diagnostic.

This lands the class-map write in `packages/octane/src/compiler/style-scopes.js`, which `applyCssScoping` calls after the sheets and hash are already built. Statement-list `@{ … }` scopes append the setup after authored declarations (avoids TDZ on `let classes`) and also write before early `return`s in that setup list. Returned templates insert a cloned copy before every owned `return`, including nested `if`/`else`/`switch` arms — not only the first top-level one. Each write (and the `@{ }` fall-through append) is its own block so `const __styleMap` is not redeclared across unbraced `switch` cases or a return plus fall-through in the same list. The `return` stays a sibling of that block so `compileReturnJsxFunction` and SSR still see a top-level `ReturnStatement`. Identifier refs cover assignment, callback, and `current`/`value` objects; other shapes reuse `createStyleRefSetupStatements`. Type assertions around the ref expression (`ref={classes as T}`) unwrap so assignment still hits the binding.

Functions whose only JSX exits sit inside `if`/`else` were previously compiled as generic values, so scoped `<style>` never ran. `isReturnJsxFunction` now walks owned nested returns so those functions take the return-JSX path (hash stamp, `injectStyle`, and the class-map write).

Not mixed with #941 spread-class work.

## Why

Silent drop of a public `@tsrx/core` attribute is a compiler defect. The class map is already available at the scope pass, so emitting the write is cheaper and more useful than a diagnostic-only deferral. Grafting only the first top-level `return` reintroduced the same silent drop on nested `if`/`else` paths. A function that only returns JSX from `if`/`else` arms also never entered the return-JSX compile path, so scoping itself was skipped.

## Changes

- New `style-scopes.js` builds the class map from prepared sheets (`createStyleClassMap` / `createStyleClassMapFromStylesheet`) and grafts a cloned setup copy before every owned `return`.
- Each graft (and the `@{ }` fall-through append) wraps only the class-map write in a block; the `return` stays a sibling so return-JSX / SSR lowering still see it.
- `isReturnJsxFunction` treats owned nested JSX returns as return-JSX functions so `applyCssScoping` runs for if/else-only exits.
- Identifier style-refs are written once per binding when several blocks share `ref={classes}`.
- Fixture + tests for assignment, function-expression callback, identifier callback, `current`, `value`, returned-template, nested if/else, braceless if-return, unbraced switch, `@{ }` early-return, and switch-plus-fall-through forms on client and SSR.
- Compile-parse test for `SwitchReturnStyleRef`: sibling `const __styleMap` in a shared switch scope is a `SyntaxError`; `new Function` fails without the block wrap.
- Frozen-AST fixture now includes `ref={classes}` so the new path stays copy-on-write.

## Validation

- [x] `pnpm format:files:check` on the changed compiler/test/changeset files (not repo-wide `pnpm format:check`)
- [x] `pnpm typecheck:files` on the changed paths (not repo-wide `pnpm typecheck`)
- [ ] `pnpm test` (full suite not run locally)
- [x] targeted tests on `7d79847c1`: `packages/octane/tests/style-ref.test.ts` (octane + octane-prod, 30/30), including unbraced switch, `@{ }` switch-plus-fall-through, and a compile-shape check that `ReturnedStyleRef` still has a top-level `return` after the class-map block
- [x] targeted tests on `db8a7ab2a`: `style-ref-compile.test.ts` + `style-ref.test.ts` (octane + octane-prod, 32/32). Without the block wrap the compile-parse test fails with `SyntaxError: Identifier '__styleMap$10' has already been declared`.

## Risk / follow-ups

- Identifier `ref={x}` uses a hybrid of the core helper's assignment and dynamic paths so `let x`, `function x`, and `{ current }` / `{ value }` objects all work. Nested `@{ }` scopes that declare their own `let` for a parent-collected style block are not separately grafted.
- JSX types still describe a host `<style>` ref (`HTMLStyleElement`). Scoped blocks never become that host; the fixture asserts the class-map target. Widening `StyleHTMLAttributes.ref` is a follow-up.
- Sibling-scope `style-scopes.js` on #939 will need to keep this write when that branch lands; this PR only targets `main`'s component-scoped model.
- Widening `isReturnJsxFunction` sends if/else-only JSX functions through `compileReturnJsxFunction` (hooks slotted, styles scoped). That matches a top-level `return <jsx>`.
- No #941 spread-class changes.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0087a3e8-3027-4f94-98e8-958163597409?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0087a3e8-3027-4f94-98e8-958163597409&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791140849&installation_model_id=432790&pr_number=960&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F960&signature=f77d0d507395b0db98f95986ae8dad1fbc46884103b1fdd4011478900b7c3d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->