### PR TITLE
fix: merge styled host scope class with a spread class

### DIFF
--- a/.changeset/styled-spread-scope-class.md
+++ b/.changeset/styled-spread-scope-class.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Keep a spread `class` when a styled host adds its scope hash.
+
+A synthesized scope class now merges with a preceding spread's class instead of
+replacing it, so `props.class` reaches the DOM on both client and SSR.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -317,6 +317,13 @@ function markSynthesizedAttr(attr) {
 	return attr;
 }
 
+/** A compiler-added scope-hash class, not an authored `class`/`className`. */
+function isSynthesizedClassAttr(attr) {
+	const raw = jsxAttrRawName(attr);
+	if (raw !== 'class' && raw !== 'className') return false;
+	return attr.name?.metadata?.tsrx_synthesized_origin === true;
+}
+
 // Curated exact origins (`inspect: true`). A generated token whose authored
 // counterpart the compiler KNOWS — the `$$click` slot key of an `onClick`, the
 // block helper an `@if`/`@for` lowers to — but which the module map alone
@@ -11097,17 +11104,17 @@ function ssrSourcePair(present, value, origin) {
 }
 
 /**
- * One `[spread, name, value]` source row for a grouped attribute helper. The
- * name literal is the only token in the group that names THIS attribute, so it
- * is what the authored name is claimed against (see registerAttrLoweringOrigin);
- * the helper itself stays anchored on the element it serializes.
+ * One `[spread, name, value, merge?]` source row for a grouped attribute helper.
+ * The name literal is the only token in the group that names THIS attribute, so
+ * it is what the authored name is claimed against (see registerAttrLoweringOrigin);
+ * the helper itself stays anchored on the element it serializes. A trailing
+ * `true` marks a synthesized scope class that must merge with a spread's class.
  */
-function ssrDirectSource(ctx, name, value, origin) {
+function ssrDirectSource(ctx, name, value, origin, merge) {
 	registerAttrLoweringOrigin(ctx, origin?.name, null, name);
-	return inheritOriginLoc(
-		b.array([b.literal(false, 'false'), b.literal(name, JSON.stringify(name)), value]),
-		origin,
-	);
+	const cells = [b.literal(false, 'false'), b.literal(name, JSON.stringify(name)), value];
+	if (merge) cells.push(b.literal(true, 'true'));
+	return inheritOriginLoc(b.array(cells), origin);
 }
 
 /**
@@ -11866,7 +11873,15 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 				);
 				attrExpr = tsrxExprNode(attrInner, ctx, name, inlinedSubs);
 			}
-			attrSources.push(ssrDirectSource(ctx, rawAttrName, bindAttributeEvaluation(attrExpr), attr));
+			attrSources.push(
+				ssrDirectSource(
+					ctx,
+					rawAttrName,
+					bindAttributeEvaluation(attrExpr),
+					attr,
+					isSynthesizedClassAttr(attr),
+				),
+			);
 			continue;
 		}
 
@@ -24116,7 +24131,7 @@ function cleanupsPush(fnNode) {
 }
 
 /**
- * The `[spread, name, value]` rows a commit-phase source collector
+ * The `[spread, name, value, merge?]` rows a commit-phase source collector
  * (`setHostPropSources` / `setFormControlSources`) resolves in authored order.
  * Shared by the mount and update emits, which differ only in how a source's
  * value is read back — a bag local at mount, a bag field on update.
@@ -24126,20 +24141,26 @@ function cleanupsPush(fnNode) {
  * split ssrDirectSource makes on the server); the collector itself serializes
  * every source of the element and stays anchored there. Nothing else in a row
  * reproduces the authored name — the value is the prop's expression — so
- * without this the whole group answered only for the element.
+ * without this the whole group answered only for the element. A trailing `true`
+ * marks a synthesized scope class that must merge with a spread's class.
  */
 function commitSourceRows(sources, valueOf) {
-	return b.array(
-		sources.map(({ spread, name, nameOrigin, binding }) =>
-			spread
-				? b.array([b.literal(true), valueOf(binding, true)])
-				: b.array([
-						b.literal(false),
-						inheritOriginLoc(b.literal(name), nameOrigin ?? null),
-						valueOf(binding, false),
-					]),
-		),
-	);
+	const rows = [];
+	for (let i = 0; i < sources.length; i++) {
+		const source = sources[i];
+		if (source.spread) {
+			rows.push(b.array([b.literal(true), valueOf(source.binding, true)]));
+			continue;
+		}
+		const cells = [
+			b.literal(false),
+			inheritOriginLoc(b.literal(source.name), source.nameOrigin ?? null),
+			valueOf(source.binding, false),
+		];
+		if (source.merge) cells.push(b.literal(true));
+		rows.push(b.array(cells));
+	}
+	return b.array(rows);
 }
 
 // Mount for a DEFERRED property-write binding: store the element ref + seed the
@@ -25630,6 +25651,7 @@ function emitElementHtml(
 				name: rawAttrName,
 				nameOrigin: attr.name,
 				binding,
+				merge: isSynthesizedClassAttr(attr),
 			});
 			continue;
 		}

--- a/packages/octane/src/css.ts
+++ b/packages/octane/src/css.ts
@@ -30,6 +30,20 @@ export function normalizeClass(value: unknown): string {
 	return str;
 }
 
+/**
+ * Append a later class source onto an earlier one. Used when a synthesized
+ * scope hash must share the element with a spread's class instead of replacing
+ * it. Both sides go through `normalizeClass` so arrays / objects compose the
+ * same way they would as a lone `class` value.
+ */
+export function mergeClass(left: unknown, right: unknown): string {
+	const a = normalizeClass(left);
+	const b = normalizeClass(right);
+	if (!a) return b;
+	if (!b) return a;
+	return a + ' ' + b;
+}
+
 import { hyphenateStyleName } from './dom-tables.js';
 
 /**

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -2597,13 +2597,9 @@ export function ssrAttrs(
 	const props = new Map<string, PropWriter>();
 	let classMerges: Array<{ rawName: string; value: unknown; order: number }> | null = null;
 	let sourceOrder = 0;
-	function record(rawName: unknown, value: unknown, merge = false): void {
+	function record(rawName: unknown, value: unknown): void {
 		if (typeof rawName !== 'string') return;
 		const order = sourceOrder++;
-		if (merge && (rawName === 'class' || rawName === 'className')) {
-			(classMerges ??= []).push({ rawName, value, order });
-			return;
-		}
 		const previous = props.get(rawName);
 		props.set(rawName, {
 			rawName,
@@ -2615,7 +2611,19 @@ export function ssrAttrs(
 
 	for (const [isSpread, sourceOrName, directValue, merge] of sources) {
 		if (!isSpread) {
-			record(sourceOrName, directValue, merge === true);
+			if (
+				merge === true &&
+				typeof sourceOrName === 'string' &&
+				(sourceOrName === 'class' || sourceOrName === 'className')
+			) {
+				(classMerges ??= []).push({
+					rawName: sourceOrName,
+					value: directValue,
+					order: sourceOrder++,
+				});
+				continue;
+			}
+			record(sourceOrName, directValue);
 			continue;
 		}
 		const source = sourceOrName;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -87,7 +87,13 @@ import {
 
 // Shared client/SSR CSS helpers (single source in css.ts so class strings and
 // hyphenated style keys stay byte-equal across the two runtimes).
-import { devWarnStyleCoercion, devWarnStyleProperty, normalizeClass, styleName } from './css.js';
+import {
+	devWarnStyleCoercion,
+	devWarnStyleProperty,
+	mergeClass,
+	normalizeClass,
+	styleName,
+} from './css.js';
 import {
 	invalidHtmlNestingWithAncestor,
 	invalidHtmlNestingWithParent,
@@ -2535,7 +2541,12 @@ function ssrAttrEntry(
 	return '';
 }
 
-type SsrAttributeSource = readonly [isSpread: boolean, sourceOrName: unknown, value?: unknown];
+type SsrAttributeSource = readonly [
+	isSpread: boolean,
+	sourceOrName: unknown,
+	value?: unknown,
+	merge?: boolean,
+];
 
 function normalizeSsrAttributeName(
 	name: string,
@@ -2565,6 +2576,10 @@ function isAggregatedFormAttribute(tag: string | undefined, name: string): boole
  * writes of the same JSX prop retain its first insertion position like
  * Object.assign. Distinct aliases that target one native attr still choose the
  * latest authored writer and retain that winning prop's insertion position.
+ *
+ * A synthesized scope-hash class (4th tuple flag) composes onto the winning
+ * class identity after that last-writer fold, matching the client so a spread
+ * `class` is not replaced by the hash alone.
  */
 export function ssrAttrs(
 	sources: readonly SsrAttributeSource[],
@@ -2580,10 +2595,15 @@ export function ssrAttrs(
 		lastOrder: number;
 	}
 	const props = new Map<string, PropWriter>();
+	let classMerges: Array<{ rawName: string; value: unknown; order: number }> | null = null;
 	let sourceOrder = 0;
-	const record = (rawName: unknown, value: unknown): void => {
+	function record(rawName: unknown, value: unknown, merge = false): void {
 		if (typeof rawName !== 'string') return;
 		const order = sourceOrder++;
+		if (merge && (rawName === 'class' || rawName === 'className')) {
+			(classMerges ??= []).push({ rawName, value, order });
+			return;
+		}
 		const previous = props.get(rawName);
 		props.set(rawName, {
 			rawName,
@@ -2591,11 +2611,11 @@ export function ssrAttrs(
 			firstOrder: previous?.firstOrder ?? order,
 			lastOrder: order,
 		});
-	};
+	}
 
-	for (const [isSpread, sourceOrName, directValue] of sources) {
+	for (const [isSpread, sourceOrName, directValue, merge] of sources) {
 		if (!isSpread) {
-			record(sourceOrName, directValue);
+			record(sourceOrName, directValue, merge === true);
 			continue;
 		}
 		const source = sourceOrName;
@@ -2650,6 +2670,24 @@ export function ssrAttrs(
 			firstOrder,
 			lastOrder,
 		]);
+	}
+	if (classMerges !== null) {
+		for (const extra of classMerges) {
+			const name = normalizeSsrAttributeName(extra.rawName, tag, namespace);
+			if (!VALID_ATTR_NAME.test(name)) continue;
+			const identity = namespace === 'html' ? name.toLowerCase() : name;
+			const previous = resolved.get(identity);
+			if (previous !== undefined) {
+				resolved.set(identity, [
+					previous[0],
+					mergeClass(previous[1], extra.value),
+					previous[2],
+					extra.order,
+				]);
+				continue;
+			}
+			resolved.set(identity, [name, extra.value, extra.order, extra.order]);
+		}
 	}
 
 	let out = '';

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -16257,7 +16257,13 @@ function coerceAttrValue(el: Element, name: string, value: any): string | null {
 // clsx-style `class`/`className` composition — shared with the SSR serializer
 // via css.ts so client and server compose byte-equal class strings (hydration
 // parity). Re-exported here because it is part of the semi-public surface.
-import { devWarnStyleCoercion, devWarnStyleProperty, normalizeClass, styleName } from './css.js';
+import {
+	devWarnStyleCoercion,
+	devWarnStyleProperty,
+	mergeClass,
+	normalizeClass,
+	styleName,
+} from './css.js';
 export { normalizeClass };
 
 export function setClassName(el: Element, value: unknown): void {
@@ -16573,7 +16579,12 @@ export function snapshotSpread(value: unknown): Record<string, unknown> | null {
 	return snapshot;
 }
 
-type HostPropSource = readonly [isSpread: boolean, sourceOrName: unknown, value?: unknown];
+type HostPropSource = readonly [
+	isSpread: boolean,
+	sourceOrName: unknown,
+	value?: unknown,
+	merge?: boolean,
+];
 
 function formActionAttributeName(el: Element, name: string): string | null {
 	if (name === 'action' && el.localName === 'form') return 'action';
@@ -16626,6 +16637,12 @@ function normalizedHostProp(
  * property. Canonical identities ensure a vanished earlier source cannot
  * remove an unchanged later winner, and hydration compares only the final
  * client value against the final server value.
+ *
+ * A synthesized scope-hash class (4th tuple flag) is not an authored later
+ * writer: after identity last-writer-wins, it composes onto the winning class
+ * instead of replacing a spread's class. An authored `class` beside a spread
+ * stays last-writer-wins because its hash is baked into that authored value
+ * and carries no merge flag.
  */
 export function setHostPropSources(
 	el: Element,
@@ -16641,10 +16658,15 @@ export function setHostPropSources(
 		lastOrder: number;
 	}
 	const props = new Map<string, PropWriter>();
+	let classMerges: Array<{ rawName: string; value: unknown; order: number }> | null = null;
 	let sourceOrder = 0;
-	const record = (rawName: unknown, value: unknown): void => {
+	function record(rawName: unknown, value: unknown, merge = false): void {
 		if (typeof rawName !== 'string') return;
 		const order = sourceOrder++;
+		if (merge && (rawName === 'class' || rawName === 'className')) {
+			(classMerges ??= []).push({ rawName, value, order });
+			return;
+		}
 		const previous = props.get(rawName);
 		props.set(rawName, {
 			rawName,
@@ -16652,11 +16674,11 @@ export function setHostPropSources(
 			firstOrder: previous?.firstOrder ?? order,
 			lastOrder: order,
 		});
-	};
+	}
 
 	for (const source of sources) {
 		if (!source[0]) {
-			record(source[1], source[2]);
+			record(source[1], source[2], source[3] === true);
 			continue;
 		}
 		const spread = source[1];
@@ -16690,6 +16712,22 @@ export function setHostPropSources(
 			writer.firstOrder,
 			writer.lastOrder,
 		]);
+	}
+	if (classMerges !== null) {
+		for (const extra of classMerges) {
+			const [identity, name] = normalizedHostProp(el, extra.rawName);
+			const previous = values.get(identity);
+			if (previous !== undefined) {
+				values.set(identity, [
+					previous[0],
+					mergeClass(previous[1], extra.value),
+					previous[2],
+					extra.order,
+				]);
+				continue;
+			}
+			values.set(identity, [name, extra.value, extra.order, extra.order]);
+		}
 	}
 	const resolved: Record<string, unknown> = Object.create(null);
 	const ordered = [...values.values()];

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14756,7 +14756,12 @@ export function setDangerouslySetInnerHTML(el: Element, value: any): void {
 /** Resolve source-ordered direct/spread raw-HTML writers and apply only the winner. */
 export function setDangerouslySetInnerHTMLSources(
 	el: Element,
-	sources: readonly (readonly [isSpread: boolean, sourceOrName: unknown, value?: unknown])[],
+	sources: readonly (readonly [
+		isSpread: boolean,
+		sourceOrName: unknown,
+		value?: unknown,
+		merge?: boolean,
+	])[],
 	ignoreSourceChildren = false,
 ): void {
 	let foundDanger = false;
@@ -16660,13 +16665,9 @@ export function setHostPropSources(
 	const props = new Map<string, PropWriter>();
 	let classMerges: Array<{ rawName: string; value: unknown; order: number }> | null = null;
 	let sourceOrder = 0;
-	function record(rawName: unknown, value: unknown, merge = false): void {
+	function record(rawName: unknown, value: unknown): void {
 		if (typeof rawName !== 'string') return;
 		const order = sourceOrder++;
-		if (merge && (rawName === 'class' || rawName === 'className')) {
-			(classMerges ??= []).push({ rawName, value, order });
-			return;
-		}
 		const previous = props.get(rawName);
 		props.set(rawName, {
 			rawName,
@@ -16678,7 +16679,16 @@ export function setHostPropSources(
 
 	for (const source of sources) {
 		if (!source[0]) {
-			record(source[1], source[2], source[3] === true);
+			const rawName = source[1];
+			if (
+				source[3] === true &&
+				typeof rawName === 'string' &&
+				(rawName === 'class' || rawName === 'className')
+			) {
+				(classMerges ??= []).push({ rawName, value: source[2], order: sourceOrder++ });
+				continue;
+			}
+			record(rawName, source[2]);
 			continue;
 		}
 		const spread = source[1];
@@ -19495,7 +19505,7 @@ export function setDefaultChecked(el: Element, value: unknown): void {
  */
 export function setFormControlSources(
 	el: Element,
-	sources: ReadonlyArray<readonly [boolean, unknown, unknown?]>,
+	sources: ReadonlyArray<readonly [boolean, unknown, unknown?, boolean?]>,
 ): void {
 	let value: unknown;
 	let defaultValue: unknown;

--- a/packages/octane/tests/_fixtures/style.tsrx
+++ b/packages/octane/tests/_fixtures/style.tsrx
@@ -293,3 +293,42 @@ export function ScopedGlobalTag() @{
 		</style>
 	</>
 }
+
+// Styled host with a spread and no authored class. The scope hash must merge
+// with `props.class` rather than replace it (later-writer would otherwise keep
+// only the synthesized hash).
+export function ScopedSpreadOnly(props) @{
+	<>
+		<style>
+			.a {
+				color: rgb(200, 0, 0);
+			}
+		</style>
+		<div {...props}>{'x'}</div>
+	</>
+}
+
+// Authored class after a spread: last-writer still owns the class. The hash is
+// baked into the authored value, so the spread's class is replaced.
+export function ScopedSpreadThenAuthored(props) @{
+	<>
+		<style>
+			.a {
+				color: rgb(200, 0, 0);
+			}
+		</style>
+		<div {...props.attrs} class={props.cls}>{'x'}</div>
+	</>
+}
+
+// Authored class before a spread: the later spread still owns the class.
+export function ScopedAuthoredThenSpread(props) @{
+	<>
+		<style>
+			.a {
+				color: rgb(200, 0, 0);
+			}
+		</style>
+		<div class={props.cls} {...props.attrs}>{'x'}</div>
+	</>
+}

--- a/packages/octane/tests/style.test.ts
+++ b/packages/octane/tests/style.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import { flushSync, hydrateRoot } from '../src/index.js';
@@ -27,6 +29,9 @@ import {
 	ScopedKeyframes,
 	ScopedGlobal,
 	ScopedGlobalTag,
+	ScopedSpreadOnly,
+	ScopedSpreadThenAuthored,
+	ScopedAuthoredThenSpread,
 } from './_fixtures/style.tsrx';
 
 const MIXED_INLINE_STYLE_SOURCE = `
@@ -1214,5 +1219,190 @@ describe('scoped CSS — :global escape hatch', () => {
 		expect(css).toMatch(new RegExp(`\\.local\\.${hashClass}\\s+em\\b`));
 		expect(css).not.toContain(`${hashClass}em`);
 		r.unmount();
+	});
+});
+
+function scopeHashClass(el: Element): string {
+	const hashClass = Array.from(el.classList).find(function (name) {
+		return name.startsWith('tsrx-');
+	});
+	if (!hashClass) throw new Error('element has no tsrx-<hash> class');
+	return hashClass;
+}
+
+describe('scoped style + spread class', () => {
+	it('keeps a spread class together with the synthesized scope hash', function () {
+		const r = mount(ScopedSpreadOnly, { class: 'from-spread' });
+		const div = r.find('div');
+		const hash = scopeHashClass(div);
+		expect(div.classList.contains('from-spread')).toBe(true);
+		expect(div.className).toBe('from-spread ' + hash);
+		r.unmount();
+	});
+
+	it('keeps a spread className together with the synthesized scope hash', function () {
+		const r = mount(ScopedSpreadOnly, { className: 'alias-spread' });
+		const div = r.find('div');
+		const hash = scopeHashClass(div);
+		expect(div.classList.contains('alias-spread')).toBe(true);
+		expect(div.className).toBe('alias-spread ' + hash);
+		r.unmount();
+	});
+
+	it('composes a spread array class before the synthesized scope hash', function () {
+		const r = mount(ScopedSpreadOnly, { class: ['from-spread', { extra: true }] });
+		const div = r.find('div');
+		const hash = scopeHashClass(div);
+		expect(div.className).toBe('from-spread extra ' + hash);
+		r.unmount();
+	});
+
+	it('keeps only the hash when the spread omits class', function () {
+		const r = mount(ScopedSpreadOnly, { id: 'no-class' });
+		const div = r.find('div');
+		expect(div.getAttribute('id')).toBe('no-class');
+		expect(div.className).toBe(scopeHashClass(div));
+		r.unmount();
+	});
+
+	it('recomposes the spread class across updates while keeping the hash', function () {
+		const r = mount(ScopedSpreadOnly, { class: 'first' });
+		const div = r.find('div');
+		const hash = scopeHashClass(div);
+		expect(div.className).toBe('first ' + hash);
+
+		r.update(ScopedSpreadOnly, { class: 'second' });
+		expect(r.find('div')).toBe(div);
+		expect(div.className).toBe('second ' + hash);
+
+		r.update(ScopedSpreadOnly, { title: 'only-title' });
+		expect(div.className).toBe(hash);
+		expect(div.getAttribute('title')).toBe('only-title');
+		r.unmount();
+	});
+
+	it('lets an authored class after a spread replace the spread class and keep the hash', function () {
+		const r = mount(ScopedSpreadThenAuthored, {
+			attrs: { class: 'from-spread', id: 'after' },
+			cls: 'host',
+		});
+		const div = r.find('div');
+		const hash = scopeHashClass(div);
+		expect(div.classList.contains('from-spread')).toBe(false);
+		expect(div.className).toBe('host ' + hash);
+		expect(div.getAttribute('id')).toBe('after');
+		r.unmount();
+	});
+
+	it('lets a later spread replace an authored class including its baked-in hash', function () {
+		const r = mount(ScopedAuthoredThenSpread, {
+			cls: 'host',
+			attrs: { class: 'from-spread', id: 'before' },
+		});
+		const div = r.find('div');
+		expect(div.className).toBe('from-spread');
+		expect(div.getAttribute('id')).toBe('before');
+		r.unmount();
+	});
+
+	it('merges the hash onto the spread class/className last writer', function () {
+		const classThenAlias = mount(ScopedSpreadOnly, {
+			class: 'from-class',
+			className: 'from-alias',
+		});
+		const aliasWins = classThenAlias.find('div');
+		expect(aliasWins.className).toBe('from-alias ' + scopeHashClass(aliasWins));
+		classThenAlias.unmount();
+
+		const aliasThenClass = mount(ScopedSpreadOnly, {
+			className: 'from-alias',
+			class: 'from-class',
+		});
+		const classWins = aliasThenClass.find('div');
+		expect(classWins.className).toBe('from-class ' + scopeHashClass(classWins));
+		aliasThenClass.unmount();
+	});
+});
+
+const STYLE_FIXTURE = join(process.cwd(), 'packages/octane/tests/_fixtures/style.tsrx');
+const PROD_COMPILE = process.env.OCTANE_TEST_COMPILE_MODE === 'prod';
+
+function loadStyleFixture(mode: 'server' | 'client'): Record<string, any> {
+	return loadCompiledFixtureSource(readFileSync(STYLE_FIXTURE, 'utf8'), {
+		id: 'style.tsrx',
+		mode,
+		compileOptions: { dev: mode === 'client' && !PROD_COMPILE },
+	});
+}
+
+describe('scoped style + spread class — SSR and hydration', () => {
+	const server = loadStyleFixture('server');
+	const client = loadStyleFixture('client');
+
+	it('serialises the spread class and the scope hash together', async function () {
+		const { html } = await ServerRuntime.renderToString(server.ScopedSpreadOnly, {
+			class: 'from-spread',
+		});
+		expect(html).toMatch(/class="from-spread tsrx-[0-9a-f]+"/);
+		expect(html).toContain('from-spread');
+	});
+
+	it('serialises an authored class after a spread without the spread class', async function () {
+		const { html } = await ServerRuntime.renderToString(server.ScopedSpreadThenAuthored, {
+			attrs: { class: 'from-spread', id: 'after' },
+			cls: 'host',
+		});
+		expect(html).toMatch(/class="host tsrx-[0-9a-f]+"/);
+		expect(html).not.toContain('from-spread');
+		expect(html).toContain('id="after"');
+	});
+
+	it('serialises a later spread class in place of an authored class', async function () {
+		const { html } = await ServerRuntime.renderToString(server.ScopedAuthoredThenSpread, {
+			cls: 'host',
+			attrs: { class: 'from-spread', id: 'before' },
+		});
+		expect(html).toContain('class="from-spread"');
+		expect(html).not.toMatch(/class="[^"]*host/);
+		expect(html).toContain('id="before"');
+	});
+
+	it('hydrates a spread class plus scope hash with no mismatch', async function () {
+		const props = { class: 'from-spread' };
+		const { html } = await ServerRuntime.renderToString(server.ScopedSpreadOnly, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const serverDiv = container.querySelector('div')!;
+		const expected = serverDiv.getAttribute('class')!;
+		expect(expected).toMatch(/^from-spread tsrx-[0-9a-f]+$/);
+
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(function () {});
+		const observer = new MutationObserver(function () {});
+		observer.observe(serverDiv, {
+			attributes: true,
+			attributeFilter: ['class'],
+			attributeOldValue: true,
+		});
+
+		hydrateRoot(container, client.ScopedSpreadOnly, props);
+		flushSync(function () {});
+		const classMutations = observer.takeRecords();
+		observer.disconnect();
+
+		const warned = errSpy.mock.calls
+			.map(function (c) {
+				return String(c[0]);
+			})
+			.some(function (m) {
+				return m.includes('hydration');
+			});
+		expect(warned).toBe(false);
+		expect(container.querySelector('div')).toBe(serverDiv);
+		expect(serverDiv.getAttribute('class')).toBe(expected);
+		expect(classMutations).toHaveLength(0);
+
+		errSpy.mockRestore();
+		container.remove();
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #941.

## Summary
- A styled host with a spread and no authored `class` was appending a synthesized scope hash after the spread. Last-writer-wins then replaced `props.class`, so the spread class never reached the DOM. Client and SSR agreed on the wrong value.
- Host-prop source resolution now treats a synthesized scope class as a merge onto the winning class identity, not a replacement. An authored `class` beside a spread is unchanged: its hash is still baked into that authored value and stays last-writer-wins.

## Why
- Bugbot flagged this on #939; the same gap is on `main`.
- The fix belongs in source resolution (compiler emit + client/SSR collectors), not a stamping-order tweak. Stamping still appends the hash when no authored class exists.

## Changes
- Compiler marks a synthesized `class`/`className` source with a trailing merge flag.
- `setHostPropSources` and `ssrAttrs` apply that flag after identity last-writer-wins, composing via `mergeClass`.
- Regression fixtures cover spread-only, authored-after-spread, authored-then-spread, alias last-writer, updates, SSR, and hydration.

## Validation
- [x] `pnpm format:check` (CI lint on `7350af1f9`)
- [x] `pnpm typecheck` (CI typecheck on `7350af1f9`)
- [x] `pnpm test` (CI `test (24)` plus shards on `7350af1f9`)
- [x] targeted tests: 24/24 scoped style+spread cases in `style.test.ts` (dev + prod); 264/264 across `style.test.ts`, `clsx-class.test.ts`, `tsrx-features.test.ts`, `css-module-constants.test.ts` (dev + prod projects)

Head `7350af1f9` is current with `main` (`28907dbd8`). Required and relevant checks are green. No review threads.

## Risk / follow-ups
- Merge work is gated on the synthesized-class flag, so ordinary spread/authored last-writer paths stay allocation-identical except that one extra boolean read on direct sources.
- Authored `class` + spread last-writer-wins is intentionally unchanged, including the case where a later spread drops the baked-in hash.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-456c3e70-a235-4b86-82fd-8358f131582a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-456c3e70-a235-4b86-82fd-8358f131582a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791141183&installation_model_id=432790&pr_number=961&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F961&signature=0ab03d049f69b3b7f6028c44f7a100bc67030cd429e91f281f62cbc04566dfb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->