### PR TITLE
perf(ssr): skip reaggregation of canonical attributes

### DIFF
--- a/.changeset/production-ssr-canonical-attributes.md
+++ b/.changeset/production-ssr-canonical-attributes.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Speed up production server rendering of elements with canonical attribute names
+by avoiding redundant attribute aggregation while preserving spread precedence,
+value coercion order, and rendered output.

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -2607,6 +2607,33 @@ export function ssrAttrs(
 		}
 	}
 
+	if (process.env.NODE_ENV === 'production') {
+		let canonical = true;
+		for (const name of props.keys()) {
+			if (
+				normalizeSsrAttributeName(name, tag, namespace) !== name ||
+				(namespace === 'html' && name.toLowerCase() !== name)
+			) {
+				canonical = false;
+				break;
+			}
+		}
+		// Canonical names cannot alias another raw writer. After all source reads,
+		// the original Map already holds their final values in insertion order.
+		if (canonical) {
+			let out = '';
+			for (const { rawName, value } of props.values()) {
+				if (
+					rawName === 'dangerouslySetInnerHTML' ||
+					(skipFormControls && isAggregatedFormAttribute(tag, rawName))
+				)
+					continue;
+				out += ssrAttrEntry(rawName, value, tag, namespace);
+			}
+			return out;
+		}
+	}
+
 	const resolved = new Map<
 		string,
 		readonly [name: string, value: unknown, firstOrder: number, lastOrder: number]

--- a/packages/octane/tests/ssr-production-bundle.test.ts
+++ b/packages/octane/tests/ssr-production-bundle.test.ts
@@ -68,6 +68,230 @@ async function productionServerModule<T extends Record<string, unknown>>(
 }
 
 describe('production-bundled server rendering', () => {
+	it.each([false, true])(
+		'preserves spread reads and winning prop coercion order when coercion throws: %s',
+		async (throws) => {
+			const { render } = await productionServerModule<{
+				render: (props: Record<string, unknown>) => string;
+			}>(
+				`
+import { renderToString } from 'octane/server';
+import { Page } from 'fixture:server-component';
+export const render = (props) => renderToString(Page, props).html;
+`,
+				`
+export function Page(props) @{
+	<div title={props.read('first')} {...props.spread} data-last={props.read('last')} title={props.finalTitle} />
+}
+`,
+			);
+			const trace: string[] = [];
+			const ignored = {
+				toString() {
+					throw new Error('Overwritten or filtered props must not coerce');
+				},
+			};
+			let middle = 'original';
+			const target: Record<PropertyKey, unknown> = {
+				get title() {
+					trace.push('getter:title');
+					return ignored;
+				},
+				'data-middle': {
+					toString() {
+						trace.push('coerce:middle');
+						return middle;
+					},
+				},
+				onclick: ignored,
+				key: ignored,
+				ref: ignored,
+				'bad name': ignored,
+				[Symbol('ignored')]: ignored,
+			};
+			const spread = new Proxy(target, {
+				ownKeys(object) {
+					trace.push('keys');
+					return Reflect.ownKeys(object);
+				},
+				get(object, name) {
+					trace.push(`get:${String(name)}`);
+					return Reflect.get(object, name);
+				},
+			});
+			const failure = new Error('Winning title failed');
+			const props = {
+				spread,
+				read(name: string) {
+					trace.push(`read:${name}`);
+					return name === 'first'
+						? ignored
+						: {
+								toString() {
+									trace.push('coerce:last');
+									return 'last';
+								},
+							};
+				},
+				finalTitle: {
+					toString() {
+						trace.push('coerce:title');
+						if (throws) throw failure;
+						target['data-middle'] = 'replacement';
+						middle = 'mutated <&';
+						return 'final';
+					},
+				},
+			};
+
+			if (throws) expect(() => render(props)).toThrow(failure);
+			else {
+				expect(render(props)).toBe(
+					'<div title="final" data-middle="mutated <&amp;" data-last="last"></div>',
+				);
+			}
+			expect(trace).toEqual([
+				'read:first',
+				'keys',
+				'get:title',
+				'getter:title',
+				'get:data-middle',
+				'get:onclick',
+				'get:key',
+				'get:ref',
+				'get:bad name',
+				'get:Symbol(ignored)',
+				'read:last',
+				'coerce:title',
+				...(throws ? [] : ['coerce:middle', 'coerce:last']),
+			]);
+			expect(render({ spread: {}, read: () => 'next', finalTitle: 'recovered' })).toBe(
+				'<div title="recovered" data-last="next"></div>',
+			);
+		},
+	);
+
+	it('retains winning alias positions and removes attributes with null or false final writers', async () => {
+		const { render } = await productionServerModule<{
+			render: (props: Record<string, unknown>) => string;
+		}>(
+			`
+import { renderToString } from 'octane/server';
+import { Page } from 'fixture:server-component';
+export const render = (props) => renderToString(Page, props).html;
+`,
+			`export function Page(props) @{ <label {...props.first} id={props.id} {...props.last} /> }`,
+		);
+		for (const final of ['final', null, false]) {
+			const trace: string[] = [];
+			const tracked = (value: string) => ({
+				toString() {
+					trace.push(value);
+					return value;
+				},
+			});
+			expect(
+				render({
+					first: {
+						htmlFor: tracked('overwritten'),
+						TITLE: tracked('overwritten'),
+						className: 'old',
+					},
+					id: tracked('id'),
+					last: { for: final === 'final' ? tracked(final) : final, title: null, class: false },
+				}),
+			).toBe(final === 'final' ? '<label id="id" for="final"></label>' : '<label id="id"></label>');
+			expect(trace).toEqual(final === 'final' ? ['id', 'final'] : ['id']);
+		}
+	});
+
+	it('preserves namespace-sensitive names and custom-element attributes across spreads', async () => {
+		const { render } = await productionServerModule<{
+			render: (props: Record<string, unknown>) => string;
+		}>(
+			`
+import { renderToString } from 'octane/server';
+import { Page } from 'fixture:server-component';
+export const render = (props) => renderToString(Page, props).html;
+`,
+			`
+export function Page(props) @{
+	<main>
+		<custom-panel {...props.custom} />
+		<custom-panel {...props.aliases} />
+		<svg {...props.svg} />
+		<svg {...props.svgAliases} />
+		<math {...props.math} />
+	</main>
+}
+`,
+		);
+		expect(
+			render({
+				custom: { onclick: 'custom handler', 'data-ready': false },
+				aliases: { htmlFor: 'verbatim', for: 'native', className: ['a', 'b'] },
+				svg: { viewBox: '0 0 1 1', viewbox: 'lower' },
+				svgAliases: { strokeWidth: '1', 'stroke-width': null },
+				math: { mathvariant: 'bold', mathVariant: 'mixed' },
+			}),
+		).toBe(
+			'<main><custom-panel onclick="custom handler" data-ready="false"></custom-panel>' +
+				'<custom-panel htmlFor="verbatim" for="native" class="a b"></custom-panel>' +
+				'<svg viewBox="0 0 1 1" viewbox="lower"></svg>' +
+				'<svg></svg>' +
+				'<math mathvariant="bold" mathVariant="mixed"></math></main>',
+		);
+	});
+
+	it('projects spread form state and raw content without serializing their control props', async () => {
+		const { render } = await productionServerModule<{
+			render: (props: Record<string, unknown>) => string;
+		}>(
+			`
+import { renderToString } from 'octane/server';
+import { Page } from 'fixture:server-component';
+export const render = (props) => renderToString(Page, props).html;
+`,
+			`
+export function Page(props) @{
+	<main>
+		<input {...props.input} />
+		<textarea {...props.textarea} />
+		<select {...props.select}><option value="a">A</option><option value="b">B</option></select>
+		<div {...props.content} />
+		<svg {...props.svgContent} />
+	</main>
+}
+`,
+		);
+		const document: Document = new JSDOM(
+			render({
+				input: { value: 'controlled', checked: false, title: 'input' },
+				textarea: { value: 'text <&', title: 'textarea' },
+				select: { value: ['b'], multiple: true, title: 'select' },
+				content: { dangerouslySetInnerHTML: { __html: '<strong>raw content</strong>' } },
+				svgContent: { dangerouslySetInnerHTML: { __html: '<circle r="4"></circle>' } },
+			}),
+		).window.document;
+		const input = document.querySelector('input')!;
+		expect(input.value).toBe('controlled');
+		expect(input.checked).toBe(false);
+		expect(input.title).toBe('input');
+		const textarea = document.querySelector('textarea')!;
+		expect(textarea.value).toBe('text <&');
+		expect(textarea.hasAttribute('value')).toBe(false);
+		const select = document.querySelector('select')!;
+		expect(Array.from(select.selectedOptions, (option) => option.value)).toEqual(['b']);
+		expect(select.multiple).toBe(true);
+		expect(select.hasAttribute('value')).toBe(false);
+		const content = document.querySelector('main > div')!;
+		expect(content.innerHTML).toBe('<strong>raw content</strong>');
+		expect(content.getAttributeNames()).toEqual([]);
+		const svg = document.querySelector('svg')!;
+		expect(svg.querySelector('circle')?.getAttribute('r')).toBe('4');
+		expect(svg.getAttributeNames()).toEqual([]);
+	});
+
 	it('renders public client Activity descriptors without retaining the server sentinel export', async () => {
 		const { visible, hidden } = await productionServerModule<{
 			visible: string;


### PR DESCRIPTION
Production SSR currently builds a second attribute map and an ordered array even when all final attribute names are already canonical. This change serializes those entries directly from the existing raw-writer map, preserving insertion order and final values. Aliases and noncanonical HTML casing retain the existing aggregation path.

The production-only check runs after every source read. Serialization still uses the existing escaping, filtering, class/style, namespace, and form-control rules. There are no compiler, client-runtime, public API, or persistent-cache changes.

## Performance evidence

Profiled the existing `deopt-page/octane-fast` SSR fixture before choosing the optimization: attribute aggregation accounted for 18.3% CPU self time. The fixture renders 300 cards, 601 components, and 300 aggregated attribute sets.

Two independent series used fresh processes in ABBAABBA order, four samples per version, 5-second steady windows after 0.5-second warmup. Each render includes response-body materialization. The score is the median of the four raw steady-window mean render times; no control normalization was applied.

| Workload | First series baseline -> change | Confirmation baseline -> change |
| --- | --- | --- |
| Canonical attributes (primary) | 2.4011 -> 2.0285 ms (**15.52% faster**) | 2.4220 -> 2.0014 ms (**17.36% faster**) |
| Late alias (fallback control) | 2.5289 -> 2.6311 ms (**4.04% slower**) | 2.5370 -> 2.6631 ms (**4.97% slower**) |
| Escape-heavy negative control | 1.56% faster | 2.39% faster |

**Tradeoff:** a late alias makes the new scan fall back to the original path, adding a repeatable 4-5% cost in that control. The confirmation median is just 0.03 percentage points below the preregistered 5% material-regression cutoff; two individual confirmation pairs exceeded 5%. This is a measured canonical-attribute improvement, not a universal SSR speedup.

The primary gain exceeded the registered 5.87% unchanged-run noise in both series. Every primary pair improved and the version ranges were disjoint. Confirmation baseline spread was 11.95% because one run was slower; even the smallest paired improvement was 13.34%. The escape-heavy control stayed within its independently measured noise. Descriptor, waterfall, replay/resource, and late-alias aggregate controls passed the preregistered gates. All 13 fixture modes produced matching complete responses; resource HTML, head, and CSS outputs also matched separately.

Measured on Apple M3 arm64, Node 22.22.2 / V8 12.4, against `28907dbd81c51d99732216d871c742fab2d3370a`. Results describe these workloads on this machine. The measured fixture bundle grows 554 raw bytes / 113 gzip bytes; the resource fixture bundle is unchanged. Scratch profiling and comparison harnesses are not shipped.

## Validation

- Production-bundle public rendering tests cover getter/Proxy reads, repeated writers, coercion order and exceptions, aliases/casing, custom elements, SVG/MathML, form controls, and raw HTML filtering. Relevant mutants fail these tests.
- 994 tests passed across the owning SSR, hydration, attribute, and streaming suites. The full root `pnpm test` suite was not run locally; targeted ownership suites were used for this 27-line runtime change.
- 36 website production-build browser tests passed, including hydration and interaction checks.
- Repository-wide typecheck and formatting passed; changeset and generated-file synchronization checks passed.
- Integrated-browser production smoke checks passed for `/`, `/docs/core-apis`, and `/docs/bindings`, including state updates, form actions, and category filtering; no console errors.
- Eight local specialist reviews found no actionable issues. An optional test gap remains for bundled URL sanitization/quote escaping; source tracing confirms the shared protections remain in use.
- Patch changeset included.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core production attribute serialization semantics; regressions would change HTML output or prop read/coercion order, though behavior is heavily covered by new bundled SSR tests.
> 
> **Overview**
> **Production SSR** now takes a fast path in `ssrAttrs` when every collected prop name is already canonical (no alias pairs like `className`/`class`, and HTML names are lowercased as expected). In that case it serializes straight from the existing raw-writer `Map` instead of building the second resolved map and sort path, while still honoring spread precedence, coercion order, and the same `ssrAttrEntry` filtering (form controls, `dangerouslySetInnerHTML`, etc.).
> 
> When any name would need normalization or alias merging, behavior stays on the **existing aggregation path** (dev builds always use that path).
> 
> Adds **production-bundled** SSR tests for spread/getter read order, coercion and errors, alias winners, SVG/MathML/custom elements, form control projection, and raw HTML—plus an **octane** patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04e32e3dca07d655c69bf19bfe76c581c2a095d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175371&installation_model_id=432790&pr_number=964&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F964&signature=266f335fca95f1ffbc11e66a51efabf6fa93a5364a3e764b43171fb5002333b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->