### PR TITLE
fix: address high-priority server, SSR, and adapter defects

### DIFF
--- a/.changeset/high-priority-audit-server-ssr-adapters.md
+++ b/.changeset/high-priority-audit-server-ssr-adapters.md
@@ -1,0 +1,7 @@
+---
+"@octanejs/app-core": patch
+"@octanejs/rspack-plugin": patch
+"octane": patch
+---
+
+Prevent production API errors and static-file symlinks from disclosing server details or files outside the built asset tree. Preserve injected HTML and settle streaming SSR when callbacks fail, and compile imported descriptor-children components correctly through Rspack and Rsbuild.

--- a/packages/app-core/src/server/node-http.js
+++ b/packages/app-core/src/server/node-http.js
@@ -330,6 +330,16 @@ const MIME_TYPES = {
  * @returns {boolean} true when the request was handled as a static file
  */
 export function serveStaticFile(req, res, staticDir) {
+	return serveStaticFileFromRoot(req, res, staticDir);
+}
+
+/**
+ * @param {import('node:http').IncomingMessage} req
+ * @param {import('node:http').ServerResponse} res
+ * @param {string} staticDir
+ * @param {string} [configuredRoot] Canonical root pinned by createNodeServer
+ */
+function serveStaticFileFromRoot(req, res, staticDir, configuredRoot) {
 	const method = (req.method || 'GET').toUpperCase();
 	if (method !== 'GET' && method !== 'HEAD') return false;
 
@@ -338,49 +348,79 @@ export function serveStaticFile(req, res, staticDir) {
 	const filePath = path.normalize(path.join(staticDir, pathname));
 	if (!filePath.startsWith(path.normalize(staticDir + path.sep))) return false;
 
+	/** @type {string} */
+	let resolvedFile;
 	/** @type {fs.Stats} */
 	let stat;
+	let fd = -1;
 	try {
-		stat = fs.statSync(filePath);
+		const realRoot = configuredRoot ?? fs.realpathSync.native(staticDir);
+		resolvedFile = fs.realpathSync.native(filePath);
+		const rootPrefix = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep;
+		if (!resolvedFile.startsWith(rootPrefix)) return false;
+
+		// Open the verified target before responding. Passing this descriptor to
+		// the stream prevents a later path swap from changing what is served.
+		// The built static tree must not be writable by an untrusted actor during
+		// serving: Node has no portable directory-relative open for ancestor swaps.
+		fd = fs.openSync(
+			resolvedFile,
+			fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0),
+		);
+		stat = fs.fstatSync(fd);
+		if (!stat.isFile()) {
+			fs.closeSync(fd);
+			return false;
+		}
 	} catch {
+		if (fd !== -1) fs.closeSync(fd);
 		return false;
 	}
-	if (!stat.isFile()) return false;
 
-	const ext = path.extname(filePath).toLowerCase();
-	const headers = new Headers({
-		'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
-		'Content-Length': String(stat.size),
-		'Cache-Control':
-			pathname.startsWith('/assets/') || pathname.startsWith('/static/')
-				? 'public, max-age=31536000, immutable'
-				: 'public, max-age=0, must-revalidate',
-	});
-	const gzip = shouldGzip(req, 200, headers, method !== 'HEAD');
-	if (gzip) {
-		headers.set('Content-Encoding', 'gzip');
-		headers.delete('Content-Length');
-	}
-
-	res.statusCode = 200;
-	res.setHeader('Content-Type', /** @type {string} */ (headers.get('Content-Type')));
-	const contentLength = headers.get('Content-Length');
-	if (contentLength !== null) res.setHeader('Content-Length', contentLength);
-	res.setHeader('Cache-Control', /** @type {string} */ (headers.get('Cache-Control')));
-	const contentEncoding = headers.get('Content-Encoding');
-	if (contentEncoding !== null) res.setHeader('Content-Encoding', contentEncoding);
-	const vary = headers.get('Vary');
-	if (vary !== null) res.setHeader('Vary', vary);
-	if (method === 'HEAD') {
-		res.end();
-	} else if (gzip) {
-		pipeline(fs.createReadStream(filePath), createGzip(), res, (error) => {
-			if (error && !res.destroyed) res.destroy(error);
+	try {
+		const ext = path.extname(filePath).toLowerCase();
+		const headers = new Headers({
+			'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
+			'Content-Length': String(stat.size),
+			'Cache-Control':
+				pathname.startsWith('/assets/') || pathname.startsWith('/static/')
+					? 'public, max-age=31536000, immutable'
+					: 'public, max-age=0, must-revalidate',
 		});
-	} else {
-		fs.createReadStream(filePath).pipe(res);
+		const gzip = shouldGzip(req, 200, headers, method !== 'HEAD');
+		if (gzip) {
+			headers.set('Content-Encoding', 'gzip');
+			headers.delete('Content-Length');
+		}
+
+		res.statusCode = 200;
+		res.setHeader('Content-Type', /** @type {string} */ (headers.get('Content-Type')));
+		const contentLength = headers.get('Content-Length');
+		if (contentLength !== null) res.setHeader('Content-Length', contentLength);
+		res.setHeader('Cache-Control', /** @type {string} */ (headers.get('Cache-Control')));
+		const contentEncoding = headers.get('Content-Encoding');
+		if (contentEncoding !== null) res.setHeader('Content-Encoding', contentEncoding);
+		const vary = headers.get('Vary');
+		if (vary !== null) res.setHeader('Vary', vary);
+		if (method === 'HEAD') {
+			res.end();
+		} else {
+			const source = fs.createReadStream(resolvedFile, { fd, autoClose: true });
+			fd = -1; // The stream now owns and closes the descriptor.
+			if (gzip) {
+				pipeline(source, createGzip(), res, (error) => {
+					if (error && !res.destroyed) res.destroy(error);
+				});
+			} else {
+				pipeline(source, res, (error) => {
+					if (error && !res.destroyed) res.destroy(error);
+				});
+			}
+		}
+		return true;
+	} finally {
+		if (fd !== -1) fs.closeSync(fd);
 	}
-	return true;
 }
 
 /**
@@ -394,10 +434,24 @@ export function serveStaticFile(req, res, staticDir) {
  */
 export function createNodeServer(handler, options = {}) {
 	const staticDir = options.staticDir;
+	/** @type {string | null} */
+	let configuredRoot = null;
+	try {
+		if (staticDir) configuredRoot = fs.realpathSync.native(staticDir);
+	} catch {
+		// A missing root must remain unavailable for this server's lifetime.
+		// Otherwise it could appear later as a symlink to a private directory.
+	}
 
 	const server = http.createServer((req, res) => {
 		(async () => {
-			if (staticDir && serveStaticFile(req, res, staticDir)) return;
+			if (
+				staticDir &&
+				configuredRoot &&
+				serveStaticFileFromRoot(req, res, staticDir, configuredRoot)
+			) {
+				return;
+			}
 			const response = await handler(nodeRequestToWebRequest(req));
 			await sendWebResponseForRequest(res, response, req);
 		})().catch((error) => {

--- a/packages/app-core/src/server/server-route.js
+++ b/packages/app-core/src/server/server-route.js
@@ -35,9 +35,9 @@ export async function handleServerRoute(route, context, globalMiddlewares) {
 	} catch (error) {
 		console.error('[octane] API route error:', error);
 
-		// Return error response
-		const message = error instanceof Error ? error.message : 'Internal Server Error';
-		return new Response(JSON.stringify({ error: message }), {
+		// Thrown messages can contain credentials or internal details. The server
+		// log above retains the original error for diagnostics.
+		return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
 			status: 500,
 			headers: {
 				'Content-Type': 'application/json',

--- a/packages/app-core/tests/node-http.test.ts
+++ b/packages/app-core/tests/node-http.test.ts
@@ -1,5 +1,13 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { request } from 'node:http';
+import {
+	mkdtempSync,
+	mkdirSync,
+	renameSync,
+	rmSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import { createServer, request } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { once } from 'node:events';
@@ -43,6 +51,150 @@ describe('serveStaticFile cache policy', () => {
 
 	it('keeps root public files revalidatable', () => {
 		expect(cacheControl('/robots.txt')).toBe('public, max-age=0, must-revalidate');
+	});
+});
+
+describe('built-in Node static file containment', () => {
+	let temporaryRoot: string;
+	let staticRoot: string;
+	let privateRoot: string;
+	let secretPath: string;
+	let origin: string;
+	let transport: ReturnType<typeof createNodeServer>;
+	let listener: import('node:http').Server;
+
+	beforeAll(async () => {
+		temporaryRoot = mkdtempSync(join(tmpdir(), 'octane-static-containment-'));
+		staticRoot = join(temporaryRoot, 'public');
+		privateRoot = join(temporaryRoot, 'private');
+		mkdirSync(join(staticRoot, 'assets'), { recursive: true });
+		mkdirSync(join(privateRoot, 'nested'), { recursive: true });
+		writeFileSync(join(staticRoot, 'assets', 'safe.txt'), 'public-asset');
+		secretPath = join(privateRoot, 'secret.txt');
+		writeFileSync(secretPath, 'private-data');
+		writeFileSync(join(privateRoot, 'nested', 'secret.txt'), 'nested-secret');
+		symlinkSync(secretPath, join(staticRoot, 'assets', 'file-link.txt'));
+		symlinkSync(privateRoot, join(staticRoot, 'directory-link'), 'dir');
+		symlinkSync(join(staticRoot, 'assets', 'safe.txt'), join(staticRoot, 'inside-link.txt'));
+
+		transport = createNodeServer(() => new Response('Not Found', { status: 404 }), {
+			staticDir: staticRoot,
+		});
+		listener = transport.listen(0);
+		await once(listener, 'listening');
+		const address = listener.address();
+		if (!address || typeof address === 'string') throw new Error('Node test server has no port');
+		origin = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterAll(async () => {
+		const closed = once(listener, 'close');
+		transport.close();
+		await closed;
+		rmSync(temporaryRoot, { recursive: true, force: true });
+	});
+
+	it.each(['/assets/file-link.txt', '/directory-link/nested/secret.txt'])(
+		'keeps an outside symlink target private at %s',
+		async (pathname) => {
+			for (const method of ['GET', 'HEAD']) {
+				const response = await fetch(origin + pathname, { method });
+				expect(response.status).toBe(404);
+				expect(await response.text()).toBe(method === 'HEAD' ? '' : 'Not Found');
+			}
+		},
+	);
+
+	it('still serves direct files and symlinks whose targets remain inside the static root', async () => {
+		for (const pathname of ['/assets/safe.txt', '/inside-link.txt']) {
+			const response = await fetch(origin + pathname);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe('public-asset');
+		}
+	});
+
+	it('does not follow a configured static root symlink retargeted after server startup', async () => {
+		const linkedRoot = join(temporaryRoot, 'configured-root');
+		symlinkSync(staticRoot, linkedRoot, 'dir');
+		const linkedTransport = createNodeServer(() => new Response('Not Found', { status: 404 }), {
+			staticDir: linkedRoot,
+		});
+		const linkedListener = linkedTransport.listen(0);
+		try {
+			await once(linkedListener, 'listening');
+			const address = linkedListener.address();
+			if (!address || typeof address === 'string') throw new Error('Node test server has no port');
+			const linkedOrigin = `http://127.0.0.1:${address.port}`;
+			const before = await fetch(linkedOrigin + '/assets/safe.txt', {
+				headers: { Connection: 'close' },
+			});
+			expect(before.status).toBe(200);
+			expect(await before.text()).toBe('public-asset');
+
+			unlinkSync(linkedRoot);
+			symlinkSync(privateRoot, linkedRoot, 'dir');
+			const after = await fetch(linkedOrigin + '/secret.txt', {
+				headers: { Connection: 'close' },
+			});
+			expect(after.status).toBe(404);
+			expect(await after.text()).toBe('Not Found');
+		} finally {
+			const closed = once(linkedListener, 'close');
+			linkedTransport.close();
+			await closed;
+		}
+	});
+
+	it('does not serve a static root first created as an outside symlink after startup', async () => {
+		const missingRoot = join(temporaryRoot, 'missing-at-startup');
+		const lateTransport = createNodeServer(() => new Response('Not Found', { status: 404 }), {
+			staticDir: missingRoot,
+		});
+		const lateListener = lateTransport.listen(0);
+		try {
+			await once(lateListener, 'listening');
+			symlinkSync(privateRoot, missingRoot, 'dir');
+			const address = lateListener.address();
+			if (!address || typeof address === 'string') throw new Error('Node test server has no port');
+			const response = await fetch(`http://127.0.0.1:${address.port}/secret.txt`, {
+				headers: { Connection: 'close' },
+			});
+			expect(response.status).toBe(404);
+			expect(await response.text()).toBe('Not Found');
+		} finally {
+			const closed = once(lateListener, 'close');
+			lateTransport.close();
+			await closed;
+		}
+	});
+
+	it('streams the verified file when its path is replaced before asynchronous reading', async () => {
+		const publicPath = join(staticRoot, 'race.txt');
+		writeFileSync(publicPath, 'public-asset');
+		const server = createServer((req, res) => {
+			if (!serveStaticFile(req, res, staticRoot)) {
+				res.statusCode = 404;
+				res.end('Not Found');
+				return;
+			}
+			renameSync(publicPath, join(staticRoot, 'race-original.txt'));
+			symlinkSync(secretPath, publicPath);
+		});
+		server.listen(0);
+		await once(server, 'listening');
+		try {
+			const address = server.address();
+			if (!address || typeof address === 'string') throw new Error('Node test server has no port');
+			const response = await fetch(`http://127.0.0.1:${address.port}/race.txt`, {
+				headers: { Connection: 'close' },
+			});
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe('public-asset');
+		} finally {
+			const closed = once(server, 'close');
+			server.close();
+			await closed;
+		}
 	});
 });
 

--- a/packages/app-core/tests/server-route-errors.test.ts
+++ b/packages/app-core/tests/server-route-errors.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ServerRoute } from '../src/routes.js';
+import { createHandler } from '../src/server/production.js';
+
+const TEMPLATE = `<!doctype html><html><head><!--ssr-head--></head><body><!--ssr-body-->
+<script type="module" data-octane-hydrate src="/assets/hydrate.js"></script></body></html>`;
+
+function createApiHandler(route: ServerRoute) {
+	return createHandler(
+		{ routes: [route], components: {}, layouts: {}, middlewares: [] },
+		{
+			htmlTemplate: TEMPLATE,
+			renderToReadableStream: async () => new ReadableStream(),
+			prerender: async () => ({ html: '', css: '' }),
+			executeServerFunction: async (fn, body) => String(await fn(body)),
+			Suspense: () => undefined,
+			ErrorBoundary: () => undefined,
+			createElement: () => undefined,
+		},
+	);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('production API route errors', () => {
+	it('keeps thrown details in server diagnostics without exposing them to the client', async () => {
+		const error = new Error('private database password: marker-7531');
+		const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const handler = createApiHandler(
+			new ServerRoute({
+				path: '/private',
+				handler: async () => {
+					throw error;
+				},
+			}),
+		);
+
+		const response = await handler(new Request('https://octane.test/private'));
+
+		expect(response.status).toBe(500);
+		expect(response.headers.get('content-type')).toContain('application/json');
+		await expect(response.json()).resolves.toEqual({ error: 'Internal Server Error' });
+		expect(logged).toHaveBeenCalledWith('[octane] API route error:', error);
+	});
+
+	it('preserves an intentional API error response', async () => {
+		const handler = createApiHandler(
+			new ServerRoute({
+				path: '/public-error',
+				handler: () =>
+					new Response(JSON.stringify({ error: 'Please try again' }), {
+						status: 500,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+			}),
+		);
+
+		const response = await handler(new Request('https://octane.test/public-error'));
+
+		expect(response.status).toBe(500);
+		await expect(response.json()).resolves.toEqual({ error: 'Please try again' });
+	});
+});

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -471,6 +471,13 @@ export function findDescriptorChildrenImports(source, id) {
 		if (jsxBindings.has(local)) candidates.push({ ...imported, local });
 	}
 	for (const node of ast.body || []) {
+		if (node.type === 'ExportDefaultDeclaration') {
+			if (node.declaration?.type === 'Identifier') {
+				const imported = importedBindings.get(node.declaration.name);
+				if (imported !== undefined) candidates.push({ ...imported, exported: 'default' });
+			}
+			continue;
+		}
 		if (node.type !== 'ExportNamedDeclaration') continue;
 		for (const specifier of node.specifiers || []) {
 			const exported = specifier.exported?.name ?? specifier.exported?.value;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -8347,9 +8347,16 @@ interface StreamSink {
 	/**
 	 * Returns a promise only when the transport applies pressure. `terminal`
 	 * permits the final degraded-boundary markers after an external abort; a
-	 * disconnected/cancelled consumer still rejects it.
+	 * disconnected/cancelled consumer still rejects it. `onUnaccepted` is only
+	 * called when an external abort rejects a web write before enqueueing it;
+	 * Node writes that returned false have already accepted their bytes. The
+	 * `recovery` mode accepts writes after external abort but respects demand.
 	 */
-	write(chunk: string, terminal?: boolean): void | Promise<void>;
+	write(
+		chunk: string,
+		terminal?: boolean | 'recovery',
+		onUnaccepted?: (chunk: string) => void,
+	): void | Promise<void>;
 	shellReady(): void;
 	shellError(err: unknown): void;
 	allReady(): void;
@@ -8630,11 +8637,30 @@ async function runStream(
 	// Early fatal paths can return before `done` is awaited; observe it up
 	// front so a later rejection never surfaces as an unhandled rejection.
 	if (injection !== undefined) injection.done.then(NOOP, NOOP);
+	let injectionCompleted = false;
+	const completeInjection: () => void =
+		injection === undefined
+			? NOOP
+			: () => {
+					if (injectionCompleted) return;
+					injectionCompleted = true;
+					injection.renderComplete?.();
+				};
 	let injectionUnsubscribe: (() => void) | undefined;
 	let injectionFailure: unknown;
 	let injectionFailed = false;
+	const unacceptedInjection: string[] | undefined = injection === undefined ? undefined : [];
+	const rememberUnaccepted: (chunk: string) => void =
+		injection === undefined
+			? NOOP
+			: (chunk) => {
+					unacceptedInjection!.push(chunk);
+				};
 	let signalInjectionFailure: (() => void) | undefined;
 	const failInjection = (err: unknown): void => {
+		// An external abort rejects a web write before it was enqueued. Its
+		// payload is terminal salvage, not a failure of the injection source.
+		if (signal?.aborted && err === signal.reason) return;
 		if (injectionFailed) return;
 		injectionFailed = true;
 		injectionFailure = err;
@@ -8647,11 +8673,15 @@ async function runStream(
 	// its caller. Without injection, writes go to the sink directly — the
 	// established path, no chain, no extra microtasks.
 	let writeChain: Promise<void> | null = injection === undefined ? null : Promise.resolve();
-	const write: (chunk: string, terminal?: boolean) => void | Promise<void> =
+	const write: (
+		chunk: string,
+		terminal?: boolean | 'recovery',
+		onUnaccepted?: (chunk: string) => void,
+	) => void | Promise<void> =
 		injection === undefined
 			? (chunk, terminal) => sink.write(chunk, terminal)
-			: (chunk, terminal) => {
-					const operation = writeChain!.then(() => sink.write(chunk, terminal));
+			: (chunk, terminal, onUnaccepted) => {
+					const operation = writeChain!.then(() => sink.write(chunk, terminal, onUnaccepted));
 					writeChain = operation.then(NOOP, NOOP);
 					return operation;
 				};
@@ -8665,14 +8695,42 @@ async function runStream(
 			return;
 		}
 		if (!html) return;
-		return write(html);
+		return write(html, false, rememberUnaccepted);
 	};
+	const recoveryInjection: (() => Promise<string>) | undefined =
+		injection === undefined
+			? undefined
+			: async () => {
+					if (signal?.aborted) {
+						// Pending notification writes reject before enqueue on web
+						// streams. Replay each taken chunk through consumer demand; only
+						// the final recovery markers bypass pressure.
+						await writeChain;
+						for (const html of unacceptedInjection!) {
+							const replay = write(html, 'recovery');
+							if (replay !== undefined) await replay;
+						}
+						unacceptedInjection!.length = 0;
+					}
+					if (injectionFailed) return '';
+					let queued: string;
+					try {
+						queued = injection.take();
+					} catch {
+						return '';
+					}
+					if (queued !== '' && signal?.aborted) {
+						const replay = write(queued, 'recovery');
+						if (replay !== undefined) await replay;
+						return '';
+					}
+					return queued;
+				};
 	const notifyInjection = (): void => {
 		const drained = drainInjection();
-		// A transport failure here is re-observed by the next awaited render
-		// write (or the completion wait); the notify path only must not
-		// produce an unhandled rejection.
-		if (drained !== undefined) drained.catch(NOOP);
+		// Notifications write outside the render loop; surface their transport
+		// failure even when no later render chunk needs to pass through the gate.
+		if (drained !== undefined) drained.catch(failInjection);
 	};
 	/** Resolves when `done` settles; rejects on abort, take() failure, or done rejection. */
 	const waitForInjectionDone = (): Promise<void> =>
@@ -8794,12 +8852,26 @@ async function runStream(
 		}
 		pruneStreamBoundariesAbsentFromShell(stream, shellBoundaryKeys);
 	} catch (err) {
+		try {
+			completeInjection();
+		} catch {
+			// Keep the shell failure; source finalization is best effort here.
+		}
 		const reports = signal?.aborted ? Math.max(1, preShellSuspended.length) : 1;
 		for (let i = 0; i < reports; i++) options?.onError?.(err);
 		sink.shellError(err);
 		return;
 	}
-	reportRecoverableBoundaryErrors();
+	try {
+		reportRecoverableBoundaryErrors();
+	} catch (err) {
+		try {
+			completeInjection();
+		} catch {
+			// The callback already failed; still release the injection source.
+		}
+		throw err;
+	}
 	// SHELL: styles first (so painted fallbacks are styled), hoisted head, body,
 	// the shell-scope seed script, then the swap runtime iff anything is pending.
 	// Every Float sheet the shell pass collected rides the shell head fold
@@ -8840,7 +8912,18 @@ async function runStream(
 	// The shell is vt-stripped as a whole below, so the withheld head is stripped
 	// here to keep both channels equivalent to the folded shell.
 	const separateHead = options?.headChannel === 'separate';
-	if (separateHead) options?.onHeadReady?.(pass.vtCandidates ? vtSsrStrip(pass.head) : pass.head);
+	if (separateHead) {
+		try {
+			options?.onHeadReady?.(pass.vtCandidates ? vtSsrStrip(pass.head) : pass.head);
+		} catch (err) {
+			try {
+				completeInjection();
+			} catch {
+				// The head callback already failed; still release the source.
+			}
+			throw err;
+		}
+	}
 	const shellHead = separateHead ? '' : pass.head;
 	const documentRoot = isDocumentRoot(pass.body);
 	let shell = documentRoot ? '<!DOCTYPE html>' : '';
@@ -8872,11 +8955,25 @@ async function runStream(
 		const shellWrite = write(pass.vtCandidates ? vtSsrStrip(shell) : shell);
 		if (shellWrite !== undefined) await shellWrite;
 	} catch (err) {
+		try {
+			completeInjection();
+		} catch {
+			// The shell write already failed; source finalization is best effort.
+		}
 		options?.onError?.(err);
 		sink.shellError(err);
 		return;
 	}
-	sink.shellReady();
+	try {
+		sink.shellReady();
+	} catch (err) {
+		try {
+			completeInjection();
+		} catch {
+			// Preserve the shell callback failure for the stream's rejection.
+		}
+		throw err;
+	}
 	if (injection !== undefined) {
 		// Subscribe only once the shell is on the wire: injected HTML must never
 		// precede it. HTML queued before this point is picked up by the initial
@@ -9012,20 +9109,17 @@ async function runStream(
 			injectionUnsubscribe?.();
 			injectionUnsubscribe = undefined;
 			try {
-				injection.renderComplete?.();
+				completeInjection();
 			} catch {
 				// The stream is already failing; the source's error cannot improve it.
 			}
 		}
 		let tail = '';
-		if (injection !== undefined && !injectionFailed) {
-			// Terminal salvage: queued injection HTML (typically the source's
-			// just-flushed serialization remainder) still ships, ahead of the
-			// recovery markers and the held tail.
+		if (recoveryInjection !== undefined) {
 			try {
-				tail += injection.take();
+				tail = await recoveryInjection();
 			} catch {
-				// A failing source forfeits its remainder; the terminal write goes on.
+				// A disconnected consumer cannot receive the remaining HTML.
 			}
 		}
 		for (const b of stream.boundaries.values()) {
@@ -9052,7 +9146,7 @@ async function runStream(
 		// `done` settles; abort and source failures route through the same
 		// degraded terminal path as a mid-render abort.
 		try {
-			injection.renderComplete?.();
+			completeInjection();
 		} catch (err) {
 			failInjection(err);
 		}
@@ -9060,13 +9154,18 @@ async function runStream(
 			await waitForInjectionDone();
 			const finalDrain = drainInjection();
 			if (finalDrain !== undefined) await finalDrain;
+			// A notification may already have taken the last HTML while its write
+			// waits for consumer demand. No final drain remains to await in that case.
+			await writeChain;
 			if (injectionFailed) throw injectionFailure;
 			if (heldDocumentTail !== '') {
-				// Cleared before awaiting: a post-acceptance rejection (abort racing
-				// the drain wait) must not resend the tail through the catch below.
+				// Restore the held tail only if the transport rejected before
+				// enqueueing it; Node may reject after accepting bytes under pressure.
 				const tailChunk = heldDocumentTail;
 				heldDocumentTail = '';
-				const tailWrite = write(tailChunk);
+				const tailWrite = write(tailChunk, false, (unaccepted) => {
+					heldDocumentTail = unaccepted;
+				});
 				if (tailWrite !== undefined) await tailWrite;
 			}
 		} catch (err) {
@@ -9076,14 +9175,10 @@ async function runStream(
 			injectionUnsubscribe?.();
 			injectionUnsubscribe = undefined;
 			let terminal = '';
-			if (!injectionFailed) {
-				// Terminal salvage: the source may have queued HTML (e.g. its
-				// serialization remainder) between the failure and this close.
-				try {
-					terminal = injection.take();
-				} catch {
-					// A failing source forfeits its remainder; the tail still ships.
-				}
+			try {
+				terminal = await recoveryInjection!();
+			} catch {
+				// A disconnected consumer cannot receive the remaining HTML.
 			}
 			terminal += heldDocumentTail;
 			if (terminal !== '') {
@@ -9297,7 +9392,7 @@ export function renderToPipeableStream(
 			renderOptions,
 			{
 				write(chunk, terminal) {
-					return queueWrite(chunk, terminal);
+					return queueWrite(chunk, terminal === true || terminal === 'recovery');
 				},
 				shellReady() {
 					options?.onShellReady?.();
@@ -9437,8 +9532,11 @@ export function renderToReadableStream(
 		}) as ReadableStream<Uint8Array> & { allReady: Promise<void> };
 		stream.allReady = allReady;
 		let shellDone = false;
+		let terminal = false;
+		let released = false;
+		let callbackFailure: { error: unknown } | undefined;
 
-		const waitForDemand = (): Promise<void> =>
+		const waitForDemand = (allowAborted = false): Promise<void> =>
 			new Promise<void>((resolve, reject) => {
 				let settled = false;
 				const cleanup = (): void => {
@@ -9454,19 +9552,26 @@ export function renderToReadableStream(
 				const onDemand = () => finish(resolve);
 				const onAbort = () => finish(() => reject(renderController.signal.reason));
 				wakeDemand = onDemand;
-				if (renderController.signal.aborted) onAbort();
-				else renderController.signal.addEventListener('abort', onAbort, { once: true });
+				if (!allowAborted) {
+					if (renderController.signal.aborted) onAbort();
+					else renderController.signal.addEventListener('abort', onAbort, { once: true });
+				}
 			});
 
-		const writeReadable = (chunk: string, terminal = false): void | Promise<void> => {
+		const writeReadable = (
+			chunk: string,
+			terminal: boolean | 'recovery' = false,
+			onUnaccepted?: (chunk: string) => void,
+		): void | Promise<void> => {
 			if (closed || consumerCancelled) {
 				return Promise.reject(cancelReason ?? new Error(formatServerError(44)));
 			}
-			if (!terminal && renderController.signal.aborted) {
+			if (terminal === false && renderController.signal.aborted) {
+				onUnaccepted?.(chunk);
 				return Promise.reject(renderController.signal.reason);
 			}
 			const bytes = encoder.encode(chunk);
-			if (terminal) {
+			if (terminal === true) {
 				// Recovery is the sole bounded-pressure exception: enqueue at most one
 				// final $OCTRX chunk even when the shell fills the high-water mark. That
 				// keeps abort/error `allReady` rejection deterministic without losing
@@ -9479,13 +9584,18 @@ export function renderToReadableStream(
 				return;
 			}
 			return (async () => {
-				while ((readableController.desiredSize ?? 0) <= 0) {
-					await waitForDemand();
-					if (closed || consumerCancelled) {
-						throw cancelReason ?? new Error(formatServerError(44));
+				try {
+					while ((readableController.desiredSize ?? 0) <= 0) {
+						await waitForDemand(terminal === 'recovery');
+						if (closed || consumerCancelled) {
+							throw cancelReason ?? new Error(formatServerError(44));
+						}
 					}
+					readableController.enqueue(bytes);
+				} catch (err) {
+					if (!consumerCancelled && renderController.signal.aborted) onUnaccepted?.(chunk);
+					throw err;
 				}
-				readableController.enqueue(bytes);
 			})();
 		};
 
@@ -9502,46 +9612,82 @@ export function renderToReadableStream(
 		};
 
 		const renderOptions = { ...options, signal: renderController.signal };
+		if (options?.onError !== undefined) {
+			// An observer must not interrupt the renderer's recovery or leave the
+			// shell/allReady promises pending. Keep its first failure for settlement.
+			renderOptions.onError = (error) => {
+				try {
+					options.onError!(error);
+				} catch (err) {
+					callbackFailure ??= { error: err };
+				}
+			};
+		}
 		const resolved = newResolvedMap(renderOptions);
+		const release = (): void => {
+			if (released) return;
+			released = true;
+			releaseServerRenderResources(resolved);
+		};
+		const settleFailure = (error: unknown): void => {
+			if (terminal) return;
+			terminal = true;
+			try {
+				release();
+			} catch (err) {
+				error = err;
+			}
+			const reason = callbackFailure === undefined ? error : callbackFailure.error;
+			if (!shellDone) rejectShell(reason);
+			allReadyReject(reason);
+			closeReadable();
+		};
 		runStream(
 			component,
 			props,
 			renderOptions,
 			{
-				write(chunk, terminal) {
-					return writeReadable(chunk, terminal);
+				write(chunk, terminal, onUnaccepted) {
+					return writeReadable(chunk, terminal, onUnaccepted);
 				},
 				shellReady() {
-					shellDone = true;
 					options?.onShellReady?.();
+					shellDone = true;
 					resolveShell(stream);
 				},
 				shellError(err) {
-					releaseServerRenderResources(resolved);
-					options?.onShellError?.(err);
-					if (!shellDone) rejectShell(err);
-					allReadyReject(err);
-					closeReadable();
+					try {
+						release();
+						options?.onShellError?.(err);
+					} catch (callbackError) {
+						settleFailure(callbackError);
+						return;
+					}
+					settleFailure(err);
 				},
 				allReady() {
-					releaseServerRenderResources(resolved);
-					options?.onAllReady?.();
-					allReadyResolve();
+					if (terminal) return;
+					try {
+						release();
+						options?.onAllReady?.();
+					} catch (err) {
+						renderOptions.onError?.(err);
+						settleFailure(err);
+						return;
+					}
+					terminal = true;
+					if (callbackFailure === undefined) allReadyResolve();
+					else allReadyReject(callbackFailure.error);
 					closeReadable();
 				},
 				fatal(err) {
-					releaseServerRenderResources(resolved);
-					allReadyReject(err);
-					closeReadable();
+					settleFailure(err);
 				},
 			},
 			resolved,
 		).catch((err) => {
-			releaseServerRenderResources(resolved);
-			options?.onError?.(err);
-			if (!shellDone) rejectShell(err);
-			allReadyReject(err);
-			closeReadable();
+			renderOptions.onError?.(err);
+			settleFailure(err);
 		});
 	});
 }

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -8348,8 +8348,8 @@ interface StreamSink {
 	 * Returns a promise only when the transport applies pressure. `terminal`
 	 * permits the final degraded-boundary markers after an external abort; a
 	 * disconnected/cancelled consumer still rejects it. `onUnaccepted` is only
-	 * called when an external abort rejects a web write before enqueueing it;
-	 * Node writes that returned false have already accepted their bytes. The
+	 * called when an external abort rejects before web enqueue or Node
+	 * `dest.write`; Node writes that returned false already accepted bytes. The
 	 * `recovery` mode accepts writes after external abort but respects demand.
 	 */
 	write(
@@ -8658,7 +8658,7 @@ async function runStream(
 				};
 	let signalInjectionFailure: (() => void) | undefined;
 	const failInjection = (err: unknown): void => {
-		// An external abort rejects a web write before it was enqueued. Its
+		// An external abort rejects a sink write before it was accepted. Its
 		// payload is terminal salvage, not a failure of the injection source.
 		if (signal?.aborted && err === signal.reason) return;
 		if (injectionFailed) return;
@@ -8702,8 +8702,8 @@ async function runStream(
 			? undefined
 			: async () => {
 					if (signal?.aborted) {
-						// Pending notification writes reject before enqueue on web
-						// streams. Replay each taken chunk through consumer demand; only
+						// Pending notification writes can reject before web enqueue or
+						// Node dest.write. Replay each taken chunk through demand; only
 						// the final recovery markers bypass pressure.
 						await writeChain;
 						for (const html of unacceptedInjection!) {
@@ -9239,7 +9239,11 @@ export function renderToPipeableStream(
 		}
 	}
 	let destination: Destination | null = null;
-	const buffered: { chunk: string; terminal: boolean }[] = [];
+	const buffered: {
+		chunk: string;
+		terminal: boolean | 'recovery';
+		onUnaccepted?: (chunk: string) => void;
+	}[] = [];
 	let ended = false;
 	let closed = false;
 	let endCalled = false;
@@ -9277,7 +9281,7 @@ export function renderToPipeableStream(
 		}
 	};
 
-	const waitForDrain = (dest: Destination): Promise<void> => {
+	const waitForDrain = (dest: Destination, allowAborted = false): Promise<void> => {
 		if (dest.once === undefined) {
 			return Promise.reject(new TypeError(formatServerError(39)));
 		}
@@ -9315,15 +9319,22 @@ export function renderToPipeableStream(
 			dest.once!('drain', onDrain);
 			dest.once!('error', onError);
 			dest.once!('close', onClose);
-			if (controller.signal.aborted) onAbort();
-			else controller.signal.addEventListener('abort', onAbort, { once: true });
+			if (!allowAborted) {
+				if (controller.signal.aborted) onAbort();
+				else controller.signal.addEventListener('abort', onAbort, { once: true });
+			}
 		});
 	};
 
-	const writeNow = (chunk: string, terminal: boolean): void | Promise<void> => {
+	const writeNow = (
+		chunk: string,
+		terminal: boolean | 'recovery',
+		onUnaccepted?: (chunk: string) => void,
+	): void | Promise<void> => {
 		const dest = destination!;
 		if (closed) return Promise.reject(new Error(formatServerError(40)));
-		if (!terminal && controller.signal.aborted) {
+		if (terminal === false && controller.signal.aborted) {
+			onUnaccepted?.(chunk);
 			return Promise.reject(controller.signal.reason);
 		}
 		let accepted: unknown;
@@ -9336,7 +9347,9 @@ export function renderToPipeableStream(
 		// `write(false)` still accepted the bytes. Normal chunks wait for drain
 		// before rendering more; a terminal recovery marker can call end()
 		// immediately and let the Writable flush its already-buffered final bytes.
-		return accepted === false && !terminal ? waitForDrain(dest) : undefined;
+		return accepted === false && terminal !== true
+			? waitForDrain(dest, terminal === 'recovery')
+			: undefined;
 	};
 
 	const trackWrite = (operation: Promise<void>): Promise<void> => {
@@ -9361,16 +9374,22 @@ export function renderToPipeableStream(
 		return operation;
 	};
 
-	const queueWrite = (chunk: string, terminal = false): void | Promise<void> => {
+	const queueWrite = (
+		chunk: string,
+		terminal: boolean | 'recovery' = false,
+		onUnaccepted?: (chunk: string) => void,
+	): void | Promise<void> => {
 		if (destination === null) {
-			buffered.push({ chunk, terminal });
+			buffered.push(
+				onUnaccepted === undefined ? { chunk, terminal } : { chunk, terminal, onUnaccepted },
+			);
 			return;
 		}
 		if (writeGate !== null) {
-			const operation = writeGate.then(() => writeNow(chunk, terminal));
+			const operation = writeGate.then(() => writeNow(chunk, terminal, onUnaccepted));
 			return trackWrite(operation);
 		}
-		const operation = writeNow(chunk, terminal);
+		const operation = writeNow(chunk, terminal, onUnaccepted);
 		return operation === undefined ? undefined : trackWrite(operation);
 	};
 
@@ -9391,8 +9410,8 @@ export function renderToPipeableStream(
 			props,
 			renderOptions,
 			{
-				write(chunk, terminal) {
-					return queueWrite(chunk, terminal === true || terminal === 'recovery');
+				write(chunk, terminal, onUnaccepted) {
+					return queueWrite(chunk, terminal, onUnaccepted);
 				},
 				shellReady() {
 					options?.onShellReady?.();
@@ -9452,7 +9471,11 @@ export function renderToPipeableStream(
 			// Chunks accepted into the pre-pipe buffer remain deliverable even if
 			// abort() ran meanwhile (the final item is the degraded $OCTRX tail).
 			for (const item of buffered) {
-				queueWrite(item.chunk, item.terminal || controller.signal.aborted);
+				queueWrite(
+					item.chunk,
+					item.terminal === 'recovery' ? 'recovery' : item.terminal || controller.signal.aborted,
+					item.onUnaccepted,
+				);
 			}
 			buffered.length = 0;
 			finishEnd();

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -9282,6 +9282,9 @@ export function renderToPipeableStream(
 	};
 
 	const waitForDrain = (dest: Destination, allowAborted = false): Promise<void> => {
+		// A recovery write can close the destination synchronously inside
+		// dest.write(false), before these one-shot listeners are installed.
+		if (allowAborted && closed) return Promise.reject(new Error(formatServerError(38)));
 		if (dest.once === undefined) {
 			return Promise.reject(new TypeError(formatServerError(39)));
 		}

--- a/packages/octane/tests/compiler/compiler-vite-options.test.ts
+++ b/packages/octane/tests/compiler/compiler-vite-options.test.ts
@@ -199,6 +199,7 @@ describe('octane/compiler/vite public options', () => {
 	it('carries descriptor-children export metadata through the Vite module graph', async () => {
 		const childId = `${ROOT}/src/Slot.tsrx`;
 		const barrelId = `${ROOT}/src/index.ts`;
+		const defaultBarrelId = `${ROOT}/src/default-barrel.ts`;
 		const childSource = `
 			import { Children, cloneElement, descriptorChildren } from 'octane';
 			function Impl(props) { return cloneElement(Children.only(props.children), { class: 'cloned' }); }
@@ -206,14 +207,17 @@ describe('octane/compiler/vite public options', () => {
 			export default descriptorChildren(Impl);
 			export function Ordinary(props) @{ <section>{props.children}</section> }`;
 		const barrelSource = `export { Slottable as BarrelSlot } from './Slot.tsrx';`;
+		const defaultBarrelSource = `import { Slottable } from './Slot.tsrx'; export default Slottable;`;
 		const consumerSource = `
 			import DefaultSlot, { Slottable as Alias, Ordinary } from './Slot.tsrx';
 			import { BarrelSlot } from './index.ts';
+			import BarrelDefault from './default-barrel.ts';
 			export function App() @{
 				<main>
 					<Alias><button>marked</button></Alias>
 					<DefaultSlot><button>default</button></DefaultSlot>
 					<BarrelSlot><button>barrel</button></BarrelSlot>
+					<BarrelDefault><button>default barrel</button></BarrelDefault>
 					<Ordinary><i>ordinary</i></Ordinary>
 				</main>
 			}`;
@@ -234,10 +238,21 @@ describe('octane/compiler/vite public options', () => {
 				barrelId,
 				{ ssr },
 			)) as { code: string; meta: Record<string, unknown> };
+			const defaultBarrel = (await (plugin.transform as any).call(
+				{
+					resolve: async (request: string) => (request === './Slot.tsrx' ? { id: childId } : null),
+					load: async () => ({ code: child.code, meta: child.meta }),
+				},
+				defaultBarrelSource,
+				defaultBarrelId,
+				{ ssr },
+			)) as { code: string; meta: Record<string, unknown> };
 			const consumerLoad = vi.fn(async ({ id }: { id: string }) =>
 				id === childId
 					? { code: child.code, meta: child.meta }
-					: { code: barrel.code, meta: barrel.meta },
+					: id === barrelId
+						? { code: barrel.code, meta: barrel.meta }
+						: { code: defaultBarrel.code, meta: defaultBarrel.meta },
 			);
 			const consumer = (await (plugin.transform as any).call(
 				{
@@ -246,7 +261,9 @@ describe('octane/compiler/vite public options', () => {
 							? { id: childId }
 							: request === './index.ts'
 								? { id: barrelId }
-								: null,
+								: request === './default-barrel.ts'
+									? { id: defaultBarrelId }
+									: null,
 					load: consumerLoad,
 				},
 				consumerSource,
@@ -255,10 +272,9 @@ describe('octane/compiler/vite public options', () => {
 			)) as { code: string };
 			expect(barrelLoad).toHaveBeenCalledTimes(1);
 			// Descriptor metadata is loaded once per resolved virtual module and is
-			// retained across transforms. The client pass performs two additional
-			// loads for void-component metadata.
-			expect(consumerLoad).toHaveBeenCalledTimes(ssr ? 1 : 3);
-			for (const component of ['Alias', 'DefaultSlot', 'BarrelSlot']) {
+			// retained across transforms. The client pass also loads void-component metadata.
+			expect(consumerLoad).toHaveBeenCalledTimes(ssr ? 2 : 5);
+			for (const component of ['Alias', 'DefaultSlot', 'BarrelSlot', 'BarrelDefault']) {
 				const children = componentChildren(consumer.code, component);
 				expect(children, component).toBeDefined();
 				expect(isChildrenBlock(consumer.code, children)).toBe(false);
@@ -290,6 +306,16 @@ describe('octane/compiler/vite public options', () => {
 		expect(findDescriptorChildrenImports(jsxSource, `${ROOT}/src/App.tsrx`)).toEqual([
 			{ request: './Slot.tsrx', imported: 'default', local: 'Slot' },
 		]);
+		const defaultBarrel = "import { Marked as Local } from './Slot.tsrx'; export default Local;";
+		const expectedBarrel = [{ request: './Slot.tsrx', imported: 'Marked', exported: 'default' }];
+		expect(findDescriptorChildrenImports(defaultBarrel, `${ROOT}/src/barrel.ts`)).toEqual(
+			expectedBarrel,
+		);
+		const barrelAst = parseModule(defaultBarrel, `${ROOT}/src/barrel.ts`);
+		deepFreeze(barrelAst);
+		expect(findDescriptorChildrenImports(barrelAst, `${ROOT}/src/barrel.ts`)).toEqual(
+			expectedBarrel,
+		);
 
 		// Legacy/compiler Element nodes expose the tag as Identifier `id`, not
 		// JSXOpeningElement/JSXIdentifier — the same shape void-import scanning covers.

--- a/packages/octane/tests/streaming-ssr-injection.test.ts
+++ b/packages/octane/tests/streaming-ssr-injection.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
 import * as ServerRuntime from 'octane/server';
 import { loadServerFixture } from './_server-fixture.js';
 import {
@@ -403,6 +404,62 @@ describe('streaming injection — document renders', () => {
 });
 
 describe('streaming injection — failure modes', () => {
+	it('retains a queued pipeable injection after abort without duplicating accepted bytes', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const aborter = new AbortController();
+		const events = new EventEmitter();
+		const first = '<script data-inject="node-first">window.__first=1</script>';
+		const second = '<script data-inject="node-second">window.__second=1</script>';
+		const chunks: string[] = [];
+		let didEnd = false;
+		let finish!: () => void;
+		const ended = new Promise<void>((resolve) => {
+			finish = () => {
+				didEnd = true;
+				resolve();
+			};
+		});
+		ServerRuntime.renderToPipeableStream(
+			server.DocumentApp,
+			{ promise: value.promise },
+			{ injection: injection.source, signal: aborter.signal },
+		).pipe({
+			write(chunk: string) {
+				chunks.push(chunk);
+				return chunk !== first && chunk !== second;
+			},
+			end: finish,
+			once: events.once.bind(events),
+			off: events.off.bind(events),
+		});
+		await flushMicrotasks();
+		injection.push(first);
+		await flushMicrotasks();
+		expect(chunks).toContain(first);
+		injection.push(second);
+		await flushMicrotasks();
+		const reason = new Error('request timed out');
+		aborter.abort(reason);
+		await flushMicrotasks();
+		expect(chunks).toContain(second);
+		// The recovered write is accepted under pressure; recovery markers and
+		// end() still wait for drain even though the request signal is aborted.
+		expect(chunks.join('')).not.toContain('$OCTRX(');
+		expect(didEnd).toBe(false);
+		events.emit('drain');
+		await ended;
+
+		const html = chunks.join('');
+		expect(html.split(first)).toHaveLength(2);
+		expect(html.split(second)).toHaveLength(2);
+		expect(html.indexOf(first)).toBeLessThan(html.indexOf(second));
+		expect(html.indexOf(second)).toBeLessThan(html.indexOf('$OCTRX('));
+		expect(tailOf(html)).toMatch(DOCUMENT_TAIL);
+		expect(injection.renderCompleteCalls).toBe(1);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
 	it('preserves a pending fragment injection when the source wait is aborted', async () => {
 		const injection = createTestInjection();
 		const aborter = new AbortController();

--- a/packages/octane/tests/streaming-ssr-injection.test.ts
+++ b/packages/octane/tests/streaming-ssr-injection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as ServerRuntime from 'octane/server';
 import { loadServerFixture } from './_server-fixture.js';
@@ -404,6 +404,59 @@ describe('streaming injection — document renders', () => {
 });
 
 describe('streaming injection — failure modes', () => {
+	it('finishes a pipeable render when recovery closes its destination during write', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const aborter = new AbortController();
+		const events = new EventEmitter();
+		const first = '<script data-inject="node-accepted">window.__accepted=1</script>';
+		const second = '<script data-inject="node-closing">window.__closing=1</script>';
+		const chunks: string[] = [];
+		const errors: unknown[] = [];
+		let allReady = 0;
+		let didEnd = false;
+		ServerRuntime.renderToPipeableStream(
+			server.DocumentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+				signal: aborter.signal,
+				onError: (error) => errors.push(error),
+				onAllReady: () => allReady++,
+			},
+		).pipe({
+			write(chunk: string) {
+				chunks.push(chunk);
+				if (chunk === second) {
+					events.emit('close');
+					return false;
+				}
+				return chunk !== first;
+			},
+			end() {
+				didEnd = true;
+			},
+			once: events.once.bind(events),
+			off: events.off.bind(events),
+		});
+		await flushMicrotasks();
+		injection.push(first);
+		await flushMicrotasks();
+		expect(chunks).toContain(first);
+		injection.push(second);
+		await flushMicrotasks();
+		const reason = new Error('request timed out');
+		aborter.abort(reason);
+		await vi.waitFor(() => expect(allReady).toBe(1));
+
+		const html = chunks.join('');
+		expect(errors).toContain(reason);
+		expect(html.split(first)).toHaveLength(2);
+		expect(html.split(second)).toHaveLength(2);
+		expect(didEnd).toBe(false);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
 	it('retains a queued pipeable injection after abort without duplicating accepted bytes', async () => {
 		const value = deferred<string>();
 		const injection = createTestInjection();

--- a/packages/octane/tests/streaming-ssr-injection.test.ts
+++ b/packages/octane/tests/streaming-ssr-injection.test.ts
@@ -214,9 +214,93 @@ describe('streaming injection — fragment renders', () => {
 		expect(html).toContain('streamed');
 		expect(html.indexOf('shell')).toBeLessThan(html.indexOf(script));
 	});
+
+	it('keeps notified HTML in order when the web-stream reader starts after injection completes', async () => {
+		const first = '<script data-inject="first">window.__first=1</script>';
+		const second = '<script data-inject="second">window.__second=1</script>';
+		const queue: string[] = [];
+		const done = deferred<void>();
+		let notify: (() => void) | undefined;
+		const source: ServerRuntime.StreamInjectionSource = {
+			take: () => queue.splice(0).join(''),
+			subscribe(callback) {
+				notify = callback;
+				return () => {
+					notify = undefined;
+				};
+			},
+			done: done.promise,
+			renderComplete() {
+				queue.push(first);
+				notify?.();
+				queue.push(second);
+				notify?.();
+				done.resolve();
+			},
+		};
+		const stream = await ServerRuntime.renderToReadableStream(() => 'shell', undefined, {
+			injection: source,
+		});
+		const reader = stream.getReader();
+		const decoder = new TextDecoder();
+		const chunks: string[] = [];
+		for (;;) {
+			const { done: finished, value } = await reader.read();
+			if (finished) break;
+			chunks.push(decoder.decode(value));
+		}
+		await stream.allReady;
+		expect(chunks).toEqual(['shell', first, second]);
+	});
+
+	it('rejects pending injected writes and unsubscribes when the web-stream reader cancels', async () => {
+		const injection = createTestInjection();
+		const abort = new Error('reader left');
+		const errors: unknown[] = [];
+		const stream = await ServerRuntime.renderToReadableStream(() => 'shell', undefined, {
+			injection: injection.source,
+			onError: (error) => errors.push(error),
+		});
+		injection.push('<script data-inject="cancel">window.__cancel=1</script>');
+		await stream.cancel(abort);
+		await expect(stream.allReady).rejects.toBe(abort);
+		expect(errors).toContain(abort);
+		expect(injection.renderCompleteCalls).toBe(1);
+		expect(injection.unsubscribed).toBe(true);
+	});
 });
 
 describe('streaming injection — document renders', () => {
+	it('closes a document once when the reader starts after an external abort', async () => {
+		const injection = createTestInjection();
+		injection.finish();
+		const aborter = new AbortController();
+		const document = ServerRuntime.createElement(
+			'html',
+			{ lang: 'en' },
+			ServerRuntime.createElement('head', null, ServerRuntime.createElement('title', null, 'tail')),
+			ServerRuntime.createElement('body', null, ServerRuntime.createElement('p', null, 'shell')),
+		);
+		const stream = await ServerRuntime.renderToReadableStream(document, undefined, {
+			injection: injection.source,
+			signal: aborter.signal,
+		});
+		// The shell fills the high-water slot; the held closing tags are still
+		// waiting to be accepted when the producer gives up.
+		await flushMicrotasks();
+		const reason = new Error('request timed out');
+		aborter.abort(reason);
+		const output = new Response(stream).text();
+		await expect(stream.allReady).rejects.toBe(reason);
+		const html = await output;
+		expect(html).toContain('<p>shell</p>');
+		expect(html.split('</body>')).toHaveLength(2);
+		expect(html.split('</html>')).toHaveLength(2);
+		expect(tailOf(html)).toMatch(DOCUMENT_TAIL);
+		expect(injection.renderCompleteCalls).toBe(1);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
 	it('holds </body></html> until render and injection both finish', async () => {
 		const value = deferred<string>();
 		const injection = createTestInjection();
@@ -319,6 +403,132 @@ describe('streaming injection — document renders', () => {
 });
 
 describe('streaming injection — failure modes', () => {
+	it('preserves a pending fragment injection when the source wait is aborted', async () => {
+		const injection = createTestInjection();
+		const aborter = new AbortController();
+		const script = '<script data-inject="abort-idle">window.__idle=1</script>';
+		const reason = new Error('request timed out');
+		const stream = await ServerRuntime.renderToReadableStream(() => 'shell', undefined, {
+			injection: injection.source,
+			signal: aborter.signal,
+		});
+		injection.push(script);
+		await flushMicrotasks();
+		aborter.abort(reason);
+		const output = new Response(stream).text();
+		await expect(stream.allReady).rejects.toBe(reason);
+		expect(await output).toBe('shell' + script);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
+	it('releases a pending recovery write when its reader cancels after external abort', async () => {
+		const injection = createTestInjection();
+		const aborter = new AbortController();
+		const reason = new Error('request timed out');
+		const stream = await ServerRuntime.renderToReadableStream(() => 'shell', undefined, {
+			injection: injection.source,
+			signal: aborter.signal,
+		});
+		const reader = stream.getReader();
+		injection.push('<script data-inject="disconnected">window.__disconnected=1</script>');
+		await flushMicrotasks();
+		aborter.abort(reason);
+		await flushMicrotasks();
+		await reader.cancel(new Error('client disconnected'));
+		await expect(stream.allReady).rejects.toBe(reason);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
+	it('preserves notified HTML ahead of recovery and the document tail on external abort', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const aborter = new AbortController();
+		const first = '<script data-inject="aborted-first">window.__first=1</script>';
+		const second = '<script data-inject="aborted-second">window.__second=1</script>';
+		const reason = new Error('request timed out');
+		const stream = await ServerRuntime.renderToReadableStream(
+			server.DocumentApp,
+			{ promise: value.promise },
+			{ injection: injection.source, signal: aborter.signal },
+		);
+		// Hold the shell in the web stream's high-water slot while notifications
+		// take both scripts. The reader remains alive after the producer aborts.
+		const reader = stream.getReader();
+		injection.push(first);
+		injection.push(second);
+		await flushMicrotasks();
+		aborter.abort(reason);
+		const decoder = new TextDecoder();
+		const output = (async () => {
+			let html = '';
+			for (;;) {
+				const { done, value: bytes } = await reader.read();
+				if (done) break;
+				html += decoder.decode(bytes, { stream: true });
+			}
+			return html + decoder.decode();
+		})();
+		await expect(stream.allReady).rejects.toBe(reason);
+		const html = await output;
+		const recovery = html.indexOf('$OCTRX(');
+		expect(recovery).toBeGreaterThan(-1);
+		expect(html.split(first)).toHaveLength(2);
+		expect(html.split(second)).toHaveLength(2);
+		expect(html.indexOf(first)).toBeLessThan(html.indexOf(second));
+		expect(html.indexOf(second)).toBeLessThan(recovery);
+		expect(recovery).toBeLessThan(html.indexOf('</body>'));
+		expect(tailOf(html)).toMatch(DOCUMENT_TAIL);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
+	it('finalizes injection when a web stream aborts before its shell is available', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const aborter = new AbortController();
+		const reason = new Error('request cancelled before shell');
+		const pending = ServerRuntime.renderToReadableStream(value.promise, undefined, {
+			injection: injection.source,
+			signal: aborter.signal,
+		});
+		aborter.abort(reason);
+		await expect(pending).rejects.toBe(reason);
+		expect(injection.renderCompleteCalls).toBe(1);
+		expect(injection.subscribed).toBe(false);
+	});
+
+	it('finalizes injection when a pipeable stream aborts before its shell is available', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const collector = createPipeableCollector();
+		const errors: unknown[] = [];
+		const reason = new Error('request cancelled before shell');
+		const render = ServerRuntime.renderToPipeableStream(value.promise, undefined, {
+			injection: injection.source,
+			onShellError: (error) => errors.push(error),
+		});
+		render.pipe(collector.destination);
+		render.abort(reason);
+		await collector.ended;
+		expect(errors).toContain(reason);
+		expect(injection.renderCompleteCalls).toBe(1);
+		expect(injection.subscribed).toBe(false);
+	});
+
+	it('finalizes injection when onShellReady fails before its callback returns', async () => {
+		const injection = createTestInjection();
+		const reason = new Error('shell observer failed');
+		await expect(
+			ServerRuntime.renderToReadableStream(() => 'shell', undefined, {
+				injection: injection.source,
+				onShellReady() {
+					throw reason;
+				},
+			}),
+		).rejects.toBe(reason);
+		expect(injection.renderCompleteCalls).toBe(1);
+		expect(injection.subscribed).toBe(false);
+	});
+
 	it('a rejected `done` fails the stream after rendering', async () => {
 		const value = deferred<string>();
 		const injection = createTestInjection();

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -1422,6 +1422,138 @@ describe('renderToPipeableStream — chunk protocol', () => {
 });
 
 describe('renderToReadableStream', () => {
+	async function settlesWithin<T>(value: Promise<T>): Promise<T> {
+		let timer: ReturnType<typeof setTimeout>;
+		try {
+			return await Promise.race([
+				value,
+				new Promise<never>((_resolve, reject) => {
+					timer = setTimeout(() => reject(new Error('render did not settle')), 1000);
+				}),
+			]);
+		} finally {
+			clearTimeout(timer!);
+		}
+	}
+
+	it('rejects when onShellReady throws before the stream promise settles', async () => {
+		const callbackError = new Error('shell callback failed');
+		const onError = vi.fn();
+		await expect(
+			settlesWithin(
+				ServerRT.renderToReadableStream(() => 'shell', undefined, {
+					onShellReady() {
+						throw callbackError;
+					},
+					onError,
+				}),
+			),
+		).rejects.toBe(callbackError);
+		expect(onError).toHaveBeenCalledWith(callbackError);
+	});
+
+	it('rejects when onError throws before the stream promise settles', async () => {
+		const callbackError = new Error('error callback failed');
+		const Broken = () => {
+			throw new Error('render failed');
+		};
+		await expect(
+			settlesWithin(
+				ServerRT.renderToReadableStream(Broken, undefined, {
+					onError() {
+						throw callbackError;
+					},
+				}),
+			),
+		).rejects.toBe(callbackError);
+	});
+
+	it('rejects when onShellError throws before the stream promise settles', async () => {
+		const callbackError = new Error('shell-error callback failed');
+		await expect(
+			settlesWithin(
+				ServerRT.renderToReadableStream(
+					() => {
+						throw new Error('render failed');
+					},
+					undefined,
+					{
+						onShellError() {
+							throw callbackError;
+						},
+					},
+				),
+			),
+		).rejects.toBe(callbackError);
+	});
+
+	it('rejects allReady and closes output when onAllReady throws', async () => {
+		const callbackError = new Error('completion callback failed');
+		const onError = vi.fn();
+		const stream = await ServerRT.renderToReadableStream(() => 'shell', undefined, {
+			onAllReady() {
+				throw callbackError;
+			},
+			onError,
+		});
+		const output = new Response(stream).text();
+		await expect(settlesWithin(stream.allReady)).rejects.toBe(callbackError);
+		expect(await output).toBe('shell');
+		expect(onError).toHaveBeenCalledWith(callbackError);
+	});
+
+	it('rejects allReady after a recoverable boundary error if onError throws', async () => {
+		const value = deferred<string>();
+		const callbackError = new Error('recoverable-error callback failed');
+		const stream = await ServerRT.renderToReadableStream(
+			permanentStaticServer.PermanentStaticRejectedStream,
+			{ promise: value.promise },
+			{
+				onError() {
+					throw callbackError;
+				},
+			},
+		);
+		const output = new Response(stream).text();
+		value.reject(new Error('boundary failed'));
+		await expect(settlesWithin(stream.allReady)).rejects.toBe(callbackError);
+		const html = await output;
+		expect(html).toContain('permanent-static-rejected-fallback');
+		const [id] = protocolIds(html);
+		expect(html).toContain(staticErrorCall(id));
+	});
+
+	it('rejects allReady and finalizes injection when onError throws after abort', async () => {
+		const value = deferred<string>();
+		let unsubscribed = false;
+		let renderCompleteCalls = 0;
+		const injection: ServerRT.StreamInjectionSource = {
+			take: () => '',
+			subscribe: () => () => {
+				unsubscribed = true;
+			},
+			done: new Promise<void>(() => {}),
+			renderComplete() {
+				renderCompleteCalls++;
+			},
+		};
+		const callbackError = new Error('error callback failed');
+		const stream = await ServerRT.renderToReadableStream(
+			server.Boundary,
+			{ promise: value.promise },
+			{
+				injection,
+				onError() {
+					throw callbackError;
+				},
+			},
+		);
+		await stream.cancel(new Error('consumer left'));
+		await expect(settlesWithin(stream.allReady)).rejects.toBe(callbackError);
+		expect(renderCompleteCalls).toBe(1);
+		expect(unsubscribed).toBe(true);
+	});
+
 	it('resolves at shell-ready; allReady settles after the last segment', async () => {
 		const d = deferred<string>();
 		const stream = await ServerRT.renderToReadableStream(server.Boundary, {

--- a/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
@@ -84,6 +84,7 @@ async function build(root: string, rsbuildConfig: Record<string, unknown>) {
 }
 
 function writeRoutedApp(root: string, render: 'buffered' | 'streaming' = 'buffered') {
+	const descriptorSlot = render === 'buffered';
 	write(root, 'public/favicon.svg', '<svg data-rsbuild-public="ready"></svg>\n');
 	write(
 		root,
@@ -98,7 +99,7 @@ function writeRoutedApp(root: string, render: 'buffered' | 'streaming' = 'buffer
 	write(
 		root,
 		'src/Page.tsrx',
-		`import { vendorLabel } from './vendor.js';
+		`${descriptorSlot ? "import { Slot } from './slot-barrel.ts';\n" : ''}import { vendorLabel } from './vendor.js';
 import './page.css';
 
 (globalThis as typeof globalThis & {
@@ -106,10 +107,25 @@ import './page.css';
 }).__loadRsbuildDeferredHydrationAsset = () => import('./deferred-hydration.js?octane-hydrate=0');
 
 export function Page() @{
-	<main class="route vendor" data-rsbuild-ssr="ready">Rsbuild route{vendorLabel as string}</main>
+	${descriptorSlot ? '<Slot><main class="route vendor" data-rsbuild-ssr="ready">Rsbuild route{vendorLabel as string}</main></Slot>' : '<main class="route vendor" data-rsbuild-ssr="ready">Rsbuild route{vendorLabel as string}</main>'}
 }
 `,
 	);
+	if (descriptorSlot) {
+		write(
+			root,
+			'src/Slot.tsrx',
+			`import { Children, cloneElement, descriptorChildren } from 'octane';
+
+function Impl(props: { children?: unknown }) {
+	return cloneElement(Children.only(props.children), { 'data-descriptor-slot': 'marked' });
+}
+
+export const Slot = descriptorChildren(Impl);
+`,
+		);
+		write(root, 'src/slot-barrel.ts', `export { Slot } from './Slot.tsrx';\n`);
+	}
 	write(root, 'src/page.css', '.route { color: rebeccapurple; }\n');
 	write(
 		root,
@@ -645,6 +661,7 @@ document.querySelector('#root')!.textContent = typeof Counter;
 		const body = await response.text();
 		expect(response.status).toBe(200);
 		expect(body).toContain('data-rsbuild-ssr="ready"');
+		expect(body).toContain('data-descriptor-slot="marked"');
 		expect(body).toContain('Rsbuild route');
 		expect(body).toContain('rsbuild-layout-deferred-hydration-chunk-proof: 0');
 		for (const cssFile of assetMap['/src/Page.tsrx'].css) expect(body).toContain(cssFile);

--- a/packages/rspack-plugin-octane/src/descriptor-children.js
+++ b/packages/rspack-plugin-octane/src/descriptor-children.js
@@ -1,0 +1,116 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute } from 'node:path';
+import {
+	cleanModuleId,
+	findDescriptorChildrenExports,
+	findDescriptorChildrenImports,
+} from 'octane/compiler/bundler';
+
+/**
+ * A loader runs before Rspack publishes outgoing module-graph edges. Resolve
+ * each JSX import with its ESM resolver, then prove the named export from the
+ * resolved authored source. Every file in the proof becomes a loader dependency
+ * so changing a marker or any barrel invalidates its compiled consumers.
+ */
+export async function loadDescriptorChildrenImports(context, source, id) {
+	if (typeof context.getResolve !== 'function' || !/<\s*[A-Z_$]/.test(source)) return null;
+	const imports = findDescriptorChildrenImports(source, id).filter(
+		(candidate) => candidate.local !== undefined && candidate.request !== 'octane',
+	);
+	if (imports.length === 0) return null;
+	const resolver = context.getResolve({ dependencyType: 'esm' });
+	const analyses = new Map();
+	const classifications = new Map();
+	const proven = new Set();
+
+	async function analyze(resolvedId) {
+		const filename = cleanModuleId(resolvedId);
+		if (!isAbsolute(filename) || !/\.(?:[cm]?[jt]sx?|tsrx)$/.test(filename)) return null;
+		let analysis = analyses.get(filename);
+		if (analysis === undefined) {
+			context.addDependency?.(filename);
+			analysis = readFile(filename, 'utf8')
+				.then((code) => {
+					// An ordinary source with neither the marker's name nor an
+					// import/re-export pair cannot prove any binding. Keep that
+					// common case out of the parser entirely.
+					const mayReexport = code.includes('export') && code.includes('from');
+					return {
+						exports: code.includes('descriptorChildren')
+							? new Set(findDescriptorChildrenExports(code, filename))
+							: new Set(),
+						code: mayReexport ? code : null,
+						reexports: mayReexport ? undefined : [],
+					};
+				})
+				.catch((error) => {
+					if (error?.code === 'ENOENT') context.addMissingDependency?.(filename);
+					return null;
+				});
+			analyses.set(filename, analysis);
+		}
+		return analysis;
+	}
+
+	async function resolveImport(request, importer) {
+		try {
+			return await resolver(dirname(cleanModuleId(importer)), request);
+		} catch {
+			// Let Rspack's module factory report unresolved imports with its own
+			// issuer trace; no export can be proven from a missing dependency.
+			return null;
+		}
+	}
+
+	async function isMarked(resolvedId, imported, ancestors = new Set()) {
+		const key = `${resolvedId}\0${imported}`;
+		if (ancestors.has(key)) return false;
+		let classification = ancestors.size === 0 ? classifications.get(key) : undefined;
+		if (classification === undefined) {
+			classification = (async () => {
+				const analysis = await analyze(resolvedId);
+				if (analysis === null) return false;
+				if (analysis.exports.has(imported)) return true;
+				const reexports = (analysis.reexports ??=
+					analysis.code !== null
+						? findDescriptorChildrenImports(analysis.code, cleanModuleId(resolvedId)).filter(
+								(candidate) => candidate.exported !== undefined,
+							)
+						: []);
+				const nextAncestors = new Set(ancestors);
+				nextAncestors.add(key);
+				for (const candidate of reexports) {
+					if (candidate.exported !== imported) continue;
+					const target = await resolveImport(candidate.request, resolvedId);
+					if (typeof target === 'string' && target !== resolvedId) {
+						if (await isMarked(target, candidate.imported, nextAncestors)) return true;
+					}
+				}
+				return false;
+			})();
+			// A result inside a cycle can depend on the starting point. Only root
+			// classifications are safe to share across independent import paths.
+			if (ancestors.size === 0) classifications.set(key, classification);
+		}
+		return classification;
+	}
+
+	const byRequest = new Map();
+	for (const candidate of imports) {
+		const values = byRequest.get(candidate.request) ?? [];
+		values.push(candidate);
+		byRequest.set(candidate.request, values);
+	}
+	await Promise.all(
+		[...byRequest].map(async ([request, candidates]) => {
+			const target = await resolveImport(request, id);
+			if (typeof target !== 'string' || target === id) return;
+			await Promise.all(
+				candidates.map(async ({ imported }) => {
+					if (await isMarked(target, imported)) proven.add(`${request}\0${imported}`);
+				}),
+			);
+		}),
+	);
+	return proven.size === 0 ? null : (request, imported) => proven.has(`${request}\0${imported}`);
+}

--- a/packages/rspack-plugin-octane/src/loader.js
+++ b/packages/rspack-plugin-octane/src/loader.js
@@ -13,6 +13,7 @@ import {
 	normalizeLoaderOptions,
 	selectLayerCompilerOptions,
 } from './shared.js';
+import { loadDescriptorChildrenImports } from './descriptor-children.js';
 
 function realRoot(path) {
 	try {
@@ -142,7 +143,7 @@ export default function octaneLoader(source, inputSourceMap) {
 						dev,
 					})
 				: null;
-		const finish = (clientOnlyImports, callback) => {
+		const finish = (clientOnlyImports, isDescriptorChildrenImport, callback) => {
 			try {
 				const result = compiler.transform(authoredSource, id, {
 					environment,
@@ -150,6 +151,7 @@ export default function octaneLoader(source, inputSourceMap) {
 					dev,
 					profile,
 					...(clientOnlyImports.length > 0 ? { clientOnlyImports } : null),
+					...(isDescriptorChildrenImport === null ? null : { isDescriptorChildrenImport }),
 					...cssModuleConstants?.transformOptions,
 				});
 
@@ -191,22 +193,31 @@ export default function octaneLoader(source, inputSourceMap) {
 			environment === 'server' && typeof compiler.clientReferenceForFile === 'function'
 				? compiler.clientReferenceForFile(id)
 				: null;
-		if (
+		const needsServerImports =
 			environment === 'server' &&
 			currentReference === null &&
-			typeof this.getResolve === 'function'
-		) {
-			const requests = compiler.findServerImportRequests(authoredSource, id);
-			if (requests.length > 0) {
-				const asyncCallback = this.async?.() ?? callback;
-				resolveClientOnlyImports(this, compiler, authoredSource, id).then(
-					(imports) => finish(imports, asyncCallback),
-					(error) => asyncCallback(error instanceof Error ? error : new Error(String(error))),
-				);
-				return;
-			}
+			typeof this.getResolve === 'function';
+		const requests = needsServerImports
+			? compiler.findServerImportRequests(authoredSource, id)
+			: [];
+		const mayUseDescriptorImports =
+			typeof this.getResolve === 'function' &&
+			(environment !== 'server' || currentReference === null) &&
+			/\.(?:tsrx|tsx)$/.test(cleanModuleId(id)) &&
+			/<\s*[A-Z_$]/.test(authoredSource) &&
+			authoredSource.includes('import');
+		if (requests.length > 0 || mayUseDescriptorImports) {
+			const asyncCallback = this.async?.() ?? callback;
+			Promise.all([
+				requests.length > 0 ? resolveClientOnlyImports(this, compiler, authoredSource, id) : [],
+				mayUseDescriptorImports ? loadDescriptorChildrenImports(this, authoredSource, id) : null,
+			]).then(
+				([imports, descriptorImport]) => finish(imports, descriptorImport, asyncCallback),
+				(error) => asyncCallback(error instanceof Error ? error : new Error(String(error))),
+			);
+			return;
 		}
-		finish([], callback);
+		finish([], null, callback);
 	} catch (error) {
 		this.callback(error instanceof Error ? error : new Error(String(error)));
 	}

--- a/packages/rspack-plugin-octane/tests/descriptor-children.test.ts
+++ b/packages/rspack-plugin-octane/tests/descriptor-children.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { loadDescriptorChildrenImports } from '../src/descriptor-children.js';
+
+let root: string;
+
+function write(relativePath: string, code: string) {
+	const file = join(root, relativePath);
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, code);
+	return file;
+}
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'octane-descriptor-cycle-'));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+it('does not inspect Octane runtime imports when a built-in is a JSX tag', async () => {
+	const importer = write(
+		'src/App.tsrx',
+		`import { Hydrate } from 'octane'; export function App() @{ <Hydrate><main /></Hydrate> }`,
+	);
+	const getResolve = vi.fn();
+	const result = await loadDescriptorChildrenImports(
+		{ getResolve },
+		`import { Hydrate } from 'octane'; export function App() @{ <Hydrate><main /></Hydrate> }`,
+		importer,
+	);
+	expect(result).toBeNull();
+	expect(getResolve).not.toHaveBeenCalled();
+});
+
+it('settles concurrent cyclic re-export lookups without claiming an unmarked component', async () => {
+	const first = write('src/first.ts', `export { Slot } from './second.ts';\n`);
+	const second = write('src/second.ts', `export { Slot } from './first.ts';\n`);
+	const importer = write(
+		'src/App.tsrx',
+		`import { Slot as First } from './first.ts';
+import { Slot as Second } from './second.ts';
+export function App() @{ <main><First /><Second /></main> }
+`,
+	);
+	const dependencies: string[] = [];
+	const context = {
+		getResolve: () => async (issuer: string, request: string) => resolve(issuer, request),
+		addDependency: (filename: string) => dependencies.push(filename),
+	};
+	const proof = await loadDescriptorChildrenImports(
+		context,
+		`import { Slot as First } from './first.ts';
+import { Slot as Second } from './second.ts';
+export function App() @{ <main><First /><Second /></main> }
+`,
+		importer,
+	);
+	expect(proof).toBeNull();
+	expect(new Set(dependencies)).toEqual(new Set([first, second]));
+});

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import rspack from '@rspack/core';
+import { JSDOM } from 'jsdom';
 import { compile as compileOctane } from 'octane/compiler';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getOctaneRspackBuildInfo, OctaneRspackPlugin } from '../src/index.js';
@@ -196,6 +197,7 @@ export function App() @{
 		Reflect.deleteProperty(globalThis, slotArgumentCountGlobal);
 		Reflect.deleteProperty(globalThis, lynxWorkletFeatureGlobal);
 		Reflect.deleteProperty(globalThis, lynxWorkletHelperGlobal);
+		Reflect.deleteProperty(globalThis, '__octane_descriptor_result__');
 		await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 	});
 
@@ -819,6 +821,133 @@ export function App() @{ const live = Scene as unknown; <Canvas><Scene /></Canva
 			expect(server.code).not.toContain(marker);
 		}
 	}, 30_000);
+
+	it.each(['client', 'server'] as const)(
+		'renders imported marked children through direct, named, and default re-exports in %s bundles',
+		async (environment) => {
+			rmSync(join(root, 'node_modules/octane'), { recursive: true, force: true });
+			symlinkSync(
+				join(repositoryRoot, 'packages/octane'),
+				join(root, 'node_modules/octane'),
+				'dir',
+			);
+			write(
+				root,
+				'src/Slot.tsrx',
+				`import { Children, cloneElement, descriptorChildren } from 'octane';
+
+function Slot(props: { children?: unknown }) {
+	return cloneElement(Children.only(props.children), { class: 'cloned' });
+}
+
+export const Marked = descriptorChildren(Slot);
+export default descriptorChildren(Slot);
+export function Ordinary(props: { children?: unknown }) { return props.children; }
+`,
+			);
+			write(
+				root,
+				'src/chain.ts',
+				`import { Marked } from './Slot.tsrx'; export { Marked as ChainedSlot };\n`,
+			);
+			write(root, 'src/barrel.ts', `export { ChainedSlot as BarrelSlot } from './chain.ts';\n`);
+			write(
+				root,
+				'src/default-barrel.ts',
+				`import { Marked } from './Slot.tsrx'; export default Marked;\n`,
+			);
+			write(
+				root,
+				'src/App.tsrx',
+				`import DefaultSlot, { Marked as DirectSlot } from './Slot.tsrx';
+import { BarrelSlot } from './barrel.ts';
+import BarrelDefault from './default-barrel.ts';
+
+export function App() @{
+	<main>
+		<DirectSlot><button>direct</button></DirectSlot>
+		<DefaultSlot><button>default</button></DefaultSlot>
+		<BarrelSlot><button>barrel</button></BarrelSlot>
+		<BarrelDefault><button>default barrel</button></BarrelDefault>
+	</main>
+}
+`,
+			);
+			const expected =
+				'<main><button class="cloned">direct</button><button class="cloned">default</button><button class="cloned">barrel</button><button class="cloned">default barrel</button></main>';
+			const markedBarrel = `export { ChainedSlot as BarrelSlot } from './chain.ts';\n`;
+			const ordinaryBarrel = `export { Ordinary as BarrelSlot } from './Slot.tsrx';\n`;
+			write(
+				root,
+				'src/descriptor-entry.js',
+				environment === 'client'
+					? `import { createRoot } from 'octane';
+import { App } from './App.tsrx';
+createRoot(document.getElementById('root')).render(App, {});
+globalThis.__octane_descriptor_result__ = document.getElementById('root').innerHTML;
+`
+					: `import { renderToString } from 'octane/server';
+import { App } from './App.tsrx';
+globalThis.__octane_descriptor_result__ = renderToString(App, {}).html;
+`,
+			);
+			const outputPath = join(root, `dist-descriptor-${environment}`);
+			const buildDescriptor = async (output: string) =>
+				compile({
+					context: root,
+					mode: 'production',
+					target: environment === 'client' ? 'web' : 'node',
+					entry: './src/descriptor-entry.js',
+					cache: {
+						type: 'persistent',
+						version: 'descriptor-source-v1',
+						storage: {
+							type: 'filesystem',
+							directory: join(root, `.rspack-descriptor-cache-${environment}`),
+						},
+					},
+					resolve: { extensionAlias: { '.js': ['.ts', '.js'] } },
+					optimization: { minimize: false },
+					output: { path: output, filename: 'bundle.cjs' },
+					plugins: [new OctaneRspackPlugin()],
+				});
+			await buildDescriptor(outputPath);
+			const bundlePath = join(outputPath, 'bundle.cjs');
+			if (environment === 'client') {
+				const renderClient = (file: string) => {
+					const browser = new JSDOM('<!doctype html><div id="root"></div>', {
+						runScripts: 'outside-only',
+					});
+					try {
+						browser.window.eval(readFileSync(file, 'utf8'));
+						return (browser.window as any).__octane_descriptor_result__.replace(/<!--.*?-->/g, '');
+					} finally {
+						browser.window.close();
+					}
+				};
+				expect(renderClient(bundlePath)).toBe(expected);
+				// A persistent build must recompile the importer when its barrel
+				// retargets the name to an ordinary component, and restore it later.
+				write(root, 'src/barrel.ts', ordinaryBarrel);
+				const changedOutput = join(root, 'dist-descriptor-changed');
+				await buildDescriptor(changedOutput);
+				expect(renderClient(join(changedOutput, 'bundle.cjs'))).toBe(
+					expected.replace('<button class="cloned">barrel</button>', '<button>barrel</button>'),
+				);
+				write(root, 'src/barrel.ts', markedBarrel);
+				const restoredOutput = join(root, 'dist-descriptor-restored');
+				await buildDescriptor(restoredOutput);
+				expect(renderClient(join(restoredOutput, 'bundle.cjs'))).toBe(expected);
+			} else {
+				await import(`${pathToFileURL(bundlePath).href}?descriptor`);
+				expect((globalThis as any).__octane_descriptor_result__.replace(/<!--.*?-->/g, '')).toBe(
+					expected,
+				);
+				Reflect.deleteProperty(globalThis, '__octane_descriptor_result__');
+			}
+		},
+		60_000,
+	);
 
 	it('invalidates persistent module caches when profiling toggles', async () => {
 		const cacheDirectory = join(root, '.rspack-profile-cache');


### PR DESCRIPTION
## Summary

- Return generic production API errors while retaining server-side diagnostics, and restrict the built-in Node static server to its configured canonical asset tree.
- Settle readable SSR streams when user callbacks throw, finalize injected sources on early terminal paths, and preserve injected HTML under backpressure.
- Prove imported `descriptorChildren` markers through Rspack's source graph, including explicit re-exports, so Rspack and Rsbuild builds deliver inspectable children.

## Why

Addresses the five highest-priority findings in #967 on one branch. The broader audit tracker remains open for the other correctness and performance findings.

## Changes

- Add app-core HTTP regressions for outside file/directory symlinks, static-root retargeting, a missing root at boot, a path replaced after verification, and sensitive exception text.
- Add web and Node SSR regressions for injection ordering, external abort, document-tail retention, stream cancellation, and callback settlement across shell and allReady paths.
- Add client/server Rspack bundles and routed Rsbuild regression coverage for direct and explicitly re-exported descriptor markers, including default-export barrels, plus invalidation and cycle controls.
- Add patch changesets for `@octanejs/app-core`, `octane`, and `@octanejs/rspack-plugin`.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm sync`
- [x] Node 24 focused changed-file suite: 205 tests across 8 test projects
- [x] App-core targeted suite: 131 tests
- [x] Octane SSR targeted dev and prod suites: 276 tests
- [x] Rspack package targeted suite: 157 tests
- [x] Rsbuild production routed client/server integration
- [x] `pnpm changeset:check`
- [x] Full CI on merged `main` commit `1f19beb0` ([run](https://github.com/octanejs/octane/actions/runs/33997102685))

The unsharded local `pnpm test` run on Node 26.4.0 reached Vitest's 4 GB heap limit and exited with V8 OOM after unrelated package failures. On the repository's supported Node 24 line, isolated Jotai and resizable-panels cases that failed under Node 26 passed (10/10 and 6/6). An isolated email preview watcher case remained failing on both Node versions with untouched source. The PR run was cancelled by the merge after all four Node 24 test shards passed. The merged-main CI run passed every lane, including Chromium integration and CI provenance.

## Risk / follow-ups

- Static containment assumes the built asset tree cannot be changed by an untrusted actor during a request; portable Node APIs cannot atomically anchor each ancestor lookup. Local warm built-in HTTP HEAD probes indicated roughly 1.4–1.6× latency versus the previous implementation for a tiny file. These timings are directional and do not measure production throughput.
- Descriptor proof adds build-time resolution for imported uppercase component tags; it does not add a runtime helper. A warm neutral-compiler probe saw 36.9→50.0 ms per 100 ordinary imported-component transforms, with byte-identical output; three-file marked barrels averaged 28.3 ms for 100 importers. This is build-time overhead, not an end-to-end build estimate. `export *` barrels remain an existing limitation shared with Vite's proof.
- Isolated Rsbuild dev-watch hot-rebuild testing hit Watchpack `EMFILE` even with the original fixture and the descriptor preflight disabled. Production routed client/server integration passed.
- The no-injection SSR path adds no per-node allocation. Production streaming benchmarks preserved output and chunk counts; concurrent workload made timing inconclusive.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791239147&installation_model_id=432790&pr_number=968&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F968&signature=96c2855466f92c0b0b8170e18d17a7b7f484a74f946f0f273ec8fd5cb004c003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch security-sensitive static path serving and production API error responses, plus substantial streaming SSR settlement logic on the hot request path.
> 
> **Overview**
> Hardens production defaults and fixes several high-priority server, SSR, and bundler edge cases called out in the audit.
> 
> **Production HTTP and API:** Thrown API route failures now always return a generic `{ error: 'Internal Server Error' }` JSON body while the full exception stays in server logs. The built-in Node static server pins the asset root at startup with `realpath`, rejects resolved paths outside that tree (including symlink escapes and retargeted roots), and serves from an opened read-only file descriptor so a path swap after verification cannot change the bytes streamed.
> 
> **Streaming SSR:** Injected HTML handling gains recovery/backpressure semantics (`onUnaccepted`, `'recovery'` writes) so notified fragments, document tails, and terminal salvage still land in order when readers start late, consumers abort, or Node accepts bytes under pressure. User hooks (`onShellReady`, `onError`, etc.) that throw now deterministically reject shell/`allReady` promises instead of leaving streams pending, and injection sources are finalized on early shell failures.
> 
> **Rspack / compiler:** `findDescriptorChildrenImports` follows **default re-exports** through barrels. A new Rspack pre-transform loader resolves and proves `descriptorChildren` markers (including chained re-exports) and passes that into the Octane compiler so client and server bundles treat imported slot components correctly; Rsbuild integration coverage exercises the same path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714c92de0e174c24ca366a635c80ca71f2d36d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
