### PR TITLE
fix(tanstack-router): reselect useStore when the selector changes

### DIFF
--- a/.changeset/tanstack-router-usestore-selector.md
+++ b/.changeset/tanstack-router-usestore-selector.md
@@ -1,0 +1,10 @@
+---
+'@octanejs/tanstack-router': patch
+---
+
+Re-evaluate `useStore` when the selector, atom, or comparator changes.
+
+The previous snapshot cache keyed only on store input. A selector that captured a
+route match id could therefore keep the selection computed for the previous id
+after navigation had already published the new match list. Nested `Outlet`s went
+empty when moving between sibling parameterized routes until reload.

--- a/packages/tanstack-router/src/useStore.ts
+++ b/packages/tanstack-router/src/useStore.ts
@@ -45,21 +45,35 @@ export function useStore(...args: any[]): any {
 		subSlot(slot, 'us:cb'),
 	);
 
-	// Memoize selector output: same store input → same output; structurally-equal
-	// output keeps its previous reference (so useSyncExternalStore doesn't loop).
-	const cache = useRef<{ in: unknown; out: unknown } | null>(null, subSlot(slot, 'us:cache'));
-	const getSnapshot = (): unknown => {
+	// A cached snapshot belongs to its atom, selector, and comparator as well as
+	// its input. Route parameters captured by a new selector must be re-evaluated
+	// even when the atom has already published the current match-id list.
+	// Structurally-equal output keeps its previous reference so
+	// useSyncExternalStore does not loop on allocating selectors.
+	const cache = useRef<{
+		atom: Atom<unknown>;
+		in: unknown;
+		selector: typeof selector;
+		compare: typeof compare;
+		out: unknown;
+	} | null>(null, subSlot(slot, 'us:cache'));
+	function getSnapshot(): unknown {
 		const input = atom.get();
 		const prev = cache.current;
-		if (prev && Object.is(prev.in, input)) return prev.out;
-		const next = selector(input);
-		if (prev && compare(prev.out, next)) {
-			cache.current = { in: input, out: prev.out };
+		if (
+			prev &&
+			prev.atom === atom &&
+			prev.selector === selector &&
+			prev.compare === compare &&
+			Object.is(prev.in, input)
+		) {
 			return prev.out;
 		}
-		cache.current = { in: input, out: next };
-		return next;
-	};
+		const next = selector(input);
+		const out = prev && compare(prev.out, next) ? prev.out : next;
+		cache.current = { atom, in: input, selector, compare, out };
+		return out;
+	}
 
 	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot, subSlot(slot, 'us:uses'));
 }

--- a/packages/tanstack-router/tests/_fixtures/basic.tsrx
+++ b/packages/tanstack-router/tests/_fixtures/basic.tsrx
@@ -60,6 +60,22 @@ function PostsIndex() @{
 	<p class="posts-index">{'All posts'}</p>
 }
 
+// Sibling table routes share a parameterized layout Outlet. Match ids include
+// the interpolated path, so navigating /tables/users → /tables/orders changes
+// the layout's parentId after matchesId has already published.
+function TablesLayout() @{
+	const params = useParams({ strict: false });
+	<section class="tables">
+		<h2 class="table-id">{params.tableId as string}</h2>
+		<Outlet />
+	</section>
+}
+
+function TableRows() @{
+	const params = useParams({ strict: false });
+	<p class="table-rows">{'rows-' + params.tableId as string}</p>
+}
+
 // A fresh router (+ fresh route tree) per call so tests don't share router state.
 export function makeRouter(initial: string) {
 	const rootRoute = createRootRoute({ component: RootLayout });
@@ -112,6 +128,16 @@ export function makeRouter(initial: string) {
 		path: '/',
 		component: PostsIndex,
 	});
+	const tablesRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: 'tables/$tableId',
+		component: TablesLayout,
+	});
+	const tablesIndexRoute = createRoute({
+		getParentRoute: () => tablesRoute,
+		path: '/',
+		component: TableRows,
+	});
 	return createRouter({
 		routeTree: rootRoute.addChildren([
 			indexRoute,
@@ -121,6 +147,7 @@ export function makeRouter(initial: string) {
 			enterFailureRoute,
 			itemRoute,
 			postsRoute.addChildren([postsIndexRoute]),
+			tablesRoute.addChildren([tablesIndexRoute]),
 		]),
 		history: createMemoryHistory({ initialEntries: [initial] }),
 	});

--- a/packages/tanstack-router/tests/conformance/hooks.test.ts
+++ b/packages/tanstack-router/tests/conformance/hooks.test.ts
@@ -201,7 +201,138 @@ describe('@octanejs/tanstack-router — document asset ownership', () => {
 	});
 });
 
+interface TestAtom<T> {
+	get(): T;
+	publish(value: T): void;
+	subscribe(listener: () => void): { unsubscribe(): void };
+}
+
+function createTestAtom<T>(initial: T): TestAtom<T> {
+	let current = initial;
+	const listeners = new Set<() => void>();
+	return {
+		get: function get() {
+			return current;
+		},
+		publish: function publish(value: T) {
+			current = value;
+			for (const listener of listeners) {
+				listener();
+			}
+		},
+		subscribe: function subscribe(listener: () => void) {
+			listeners.add(listener);
+			return {
+				unsubscribe: function unsubscribe() {
+					listeners.delete(listener);
+				},
+			};
+		},
+	};
+}
+
+interface SelectedChildProps {
+	parentId: string;
+	atom: TestAtom<Array<string>>;
+}
+
+function SelectedChild(props: SelectedChildProps) {
+	const selected = useStore(props.atom, function selectChild(ids: Array<string>) {
+		const index = ids.indexOf(props.parentId);
+		return index >= 0 ? ids[index + 1] : undefined;
+	});
+	return createElement('output', { 'data-testid': 'selected-child' }, selected ?? 'none');
+}
+
+interface SelectedAtomValueProps {
+	atom: TestAtom<string>;
+}
+
+function SelectedAtomValue(props: SelectedAtomValueProps) {
+	const selected = useStore(props.atom, function selectValue(value: string) {
+		return value;
+	});
+	return createElement('output', { 'data-testid': 'selected-atom' }, selected);
+}
+
+interface AllocatedSelection {
+	label: string;
+}
+
+interface AllocatingSelectorProps {
+	atom: TestAtom<{ label: string; version: number }>;
+	nonce: number;
+}
+
 describe('@octanejs/tanstack-router — store selection', () => {
+	it('reselects when a captured parent id changes without another store publish', () => {
+		const atom = createTestAtom(['old', 'old-child']);
+
+		const result = mount(SelectedChild, { parentId: 'old', atom });
+		try {
+			flushEffects();
+			expect(result.find('[data-testid="selected-child"]').textContent).toBe('old-child');
+
+			flushSync(function publishWithoutParentChange() {
+				atom.publish(['new', 'new-child']);
+			});
+			expect(result.find('[data-testid="selected-child"]').textContent).toBe('none');
+
+			result.update(SelectedChild, { parentId: 'new', atom });
+			expect(result.find('[data-testid="selected-child"]').textContent).toBe('new-child');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('reads the replacement atom when its identity changes without a publish', () => {
+		const first = createTestAtom('first');
+		const second = createTestAtom('second');
+
+		const result = mount(SelectedAtomValue, { atom: first });
+		try {
+			flushEffects();
+			expect(result.find('[data-testid="selected-atom"]').textContent).toBe('first');
+
+			result.update(SelectedAtomValue, { atom: second });
+			expect(result.find('[data-testid="selected-atom"]').textContent).toBe('second');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('keeps an allocating selector stable across parent rerenders when equality holds', () => {
+		const atom = createTestAtom({ label: 'kept', version: 0 });
+		const selections: Array<AllocatedSelection> = [];
+
+		function AllocatingSelectorProbe(props: AllocatingSelectorProps) {
+			const selected = useStore(
+				props.atom,
+				function selectLabel(value: { label: string; version: number }): AllocatedSelection {
+					return { label: value.label + String(props.nonce) };
+				},
+				function compareLabel(previous: AllocatedSelection, next: AllocatedSelection) {
+					return previous.label === next.label;
+				},
+			);
+			selections.push(selected);
+			return createElement('output', { 'data-testid': 'allocated-selection' }, selected.label);
+		}
+
+		const result = mount(AllocatingSelectorProbe, { atom, nonce: 0 });
+		try {
+			flushEffects();
+			expect(result.find('[data-testid="allocated-selection"]').textContent).toBe('kept0');
+			const first = selections[selections.length - 1];
+
+			result.update(AllocatingSelectorProbe, { atom, nonce: 0 });
+			expect(result.find('[data-testid="allocated-selection"]').textContent).toBe('kept0');
+			expect(selections[selections.length - 1]).toBe(first);
+		} finally {
+			result.unmount();
+		}
+	});
+
 	it('retains custom equality on reactive client stores and publishes changed selections', () => {
 		let current = { label: 'first', version: 0 };
 		const listeners = new Set<() => void>();

--- a/packages/tanstack-router/tests/conformance/router.test.ts
+++ b/packages/tanstack-router/tests/conformance/router.test.ts
@@ -336,4 +336,20 @@ describe('@octanejs/tanstack-router core seam', () => {
 		expect(r.findAll('.posts-index').length).toBe(1); // posts index (3rd match)
 		r.unmount();
 	});
+
+	it('navigating sibling table routes updates the nested Outlet', async () => {
+		const router = makeRouter('/tables/users');
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+		expect(r.find('.table-id').textContent).toBe('users');
+		expect(r.find('.table-rows').textContent).toBe('rows-users');
+
+		await router.navigate({ to: '/tables/orders' });
+		await flush();
+
+		expect(r.find('.table-id').textContent).toBe('orders');
+		expect(r.find('.table-rows').textContent).toBe('rows-orders');
+		r.unmount();
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #962

## Summary
- `useStore` kept the previous selection whenever the atom value was unchanged, even if the selector (or atom/comparator) had changed.
- Outlet selects the next match id with a selector that captures `parentId`. After sibling table navigation, `matchesId` had already published, so the new selector never ran and the nested outlet stayed empty.
- The snapshot cache now keys on atom, selector, comparator, and input. Equal selected values still reuse the previous reference so allocating selectors do not loop.

## Why
- Navigating `/tables/users` → `/tables/orders` left the child outlet empty until reload.
- The issue's three-step selector-capture sequence reproduced on current main: after publishing `['new', 'new-child']` with `parentId` still `'old'`, updating to `parentId: 'new'` without another publish returned `undefined` instead of `'new-child'`.

## Changes
- `packages/tanstack-router/src/useStore.ts`: invalidate the snapshot cache when the selector, atom, or comparator changes.
- Store-selection regressions for captured parent id, atom replacement, and allocating selectors with equality.
- Outlet integration: sibling parameterized table routes in the basic fixture.

## Validation
- [ ] `pnpm format:check` (not run; used scoped `pnpm format:files` on the changed paths)
- [ ] `pnpm typecheck` (not run repo-wide; `pnpm typecheck:files` on the changed paths reports pre-existing errors in `hooks.tsrx` / `PreviousRouterValueBoundary`, not in this diff)
- [ ] `pnpm test` (not run repo-wide)
- [x] targeted tests: `vitest run --project tanstack-router` — 84 passed, including the new store-selection and sibling-table Outlet cases
- [x] targeted tests: `vitest run --project tanstack-router-ssr` — 7 passed
- [x] pre-fix reproduction: the captured-parent-id test returned `'none'` instead of `'new-child'`; sibling table navigation lost `.table-rows` after `/tables/users` → `/tables/orders`

## Risk / follow-ups
- Inline selectors now miss the input-only fast path every render and rely on `compare` to keep snapshot identity. That matches Outlet and the previous allocating-selector contract.
- `pnpm sync` produced no generated drift.

## Reviewers
READY FOR REVIEW. Requested reviews from @leonidaz and @trueadm.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1a56647-716e-431a-b810-d4e99e11d7be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1a56647-716e-431a-b810-d4e99e11d7be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791294611&installation_model_id=432790&pr_number=971&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F971&signature=b2a6fca7822229cefd9f92102defe5def8564073e009c825eceddb31b06c0500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->