### PR TITLE
fix(compiler): fold tsx string-literal children for hydration

### DIFF
--- a/.changeset/tsx-string-literal-hydrate.md
+++ b/.changeset/tsx-string-literal-hydrate.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Fold `.tsx` string-literal expression children such as Prettier's `{" "}` into the client template, matching the server and `.tsrx` compilers so hydration no longer duplicates the following element.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -18326,6 +18326,15 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 			// `{/* … */}` is a `JSXEmptyExpression` container — a JSX comment, which
 			// renders to nothing (React drops it). Skip it so it never becomes a hole.
 			if (!expr || expr.type === 'JSXEmptyExpression') continue;
+			// String literals (`{" "}`, `{"hello"}`) are static text, same as JSXText.
+			// The .tsrx and server paths fold them via staticTextLiteral; hoisting one
+			// as hN here made .tsx client templates grow an extra text hole while the
+			// server baked the string, so hydration consumed the next sibling (duplicate
+			// elements). Leave the container in place so emitElementHtml bakes it.
+			if (staticTextLiteral(expr) !== null) {
+				newChildren.push(child);
+				continue;
+			}
 			const hn = `h${holeProps.length}`;
 			if (expr && expr.type === 'TSAsExpression') {
 				// Preserve the `as T` cast in the renderer (it marks a dynamic TEXT hole).

--- a/packages/octane/tests/compiler/tsx-static-string-child.test.ts
+++ b/packages/octane/tests/compiler/tsx-static-string-child.test.ts
@@ -1,0 +1,209 @@
+import { parseModule } from '@tsrx/core';
+import { describe, it, expect } from 'vitest';
+import { compile } from 'octane/compiler';
+
+// `.tsx` return-form hosts extract dynamic children as `hN` holes. A string
+// literal expression (`{" "}`, commonly inserted by Prettier) is static text,
+// not a hole: the server and `.tsrx` bake it into the template. Client/server
+// hole counts must agree or hydration consumes the next sibling and duplicates it.
+
+const PRETTIER_SPACE = `
+	function Link(props) {
+		return <a href={props.to}>{props.children}</a>;
+	}
+	export function Example() {
+		return (
+			<p>
+				Try the{" "}
+				<Link to="/items">items</Link> page
+			</p>
+		);
+	}
+`;
+
+const LITERAL_RUNS = `
+	export function Example() {
+		return <p>foo{"bar"}{"!"}baz</p>;
+	}
+`;
+
+const EMPTY_LITERAL = `
+	function Emph(props) {
+		return <em>{props.children}</em>;
+	}
+	export function Example() {
+		return (
+			<p>
+				before{""}
+				<Emph>mid</Emph>
+				{""}after
+			</p>
+		);
+	}
+`;
+
+const DYNAMIC_TEXT = `
+	function Link(props) {
+		return <a href={props.to}>{props.children}</a>;
+	}
+	export function Example(props) {
+		return (
+			<p>
+				Try the{props.space as string}
+				<Link to="/items">items</Link> page
+			</p>
+		);
+	}
+`;
+
+const TSRX_PRETTIER_SPACE = `
+	function Link(props) @{
+		<a href={props.to}>{props.children}</a>
+	}
+	export function Example() @{
+		<p>
+			Try the{" "}
+			<Link to="/items">items</Link> page
+		</p>
+	}
+`;
+
+function compileClient(src: string, filename = 'f.tsx'): string {
+	return compile(src, filename, {}).code;
+}
+
+function compileServer(src: string, filename = 'f.tsx'): string {
+	return compile(src, filename, { mode: 'server' }).code;
+}
+
+function runtimeLocal(code: string, imported: string): string | null {
+	const program = parseModule(code, 'compiled.js');
+	for (const statement of program.body) {
+		if (statement.type !== 'ImportDeclaration') continue;
+		for (const specifier of statement.specifiers) {
+			if (specifier.type !== 'ImportSpecifier') continue;
+			if (specifier.imported?.name === imported) return specifier.local.name;
+		}
+	}
+	return null;
+}
+
+function templateStrings(code: string): string[] {
+	const templateName = runtimeLocal(code, 'template');
+	if (templateName === null) return [];
+	const found: string[] = [];
+	const seen = new WeakSet<object>();
+	function visit(node: any): void {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (
+			node.type === 'CallExpression' &&
+			node.callee?.type === 'Identifier' &&
+			node.callee.name === templateName &&
+			node.arguments[0]?.type === 'Literal' &&
+			typeof node.arguments[0].value === 'string'
+		) {
+			found.push(node.arguments[0].value);
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'loc' || key === 'metadata') continue;
+			if (Array.isArray(value)) {
+				for (const item of value) visit(item);
+			} else {
+				visit(value);
+			}
+		}
+	}
+	visit(parseModule(code, 'compiled.js'));
+	return found;
+}
+
+function hostParagraphTemplate(code: string): string | undefined {
+	return templateStrings(code).find(function (html) {
+		return html.startsWith('<p>');
+	});
+}
+
+function stringLiteralHoleValues(code: string): string[] {
+	const createName = runtimeLocal(code, 'createElement');
+	if (createName === null) return [];
+	const values: string[] = [];
+	const seen = new WeakSet<object>();
+	function visit(node: any): void {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (
+			node.type === 'CallExpression' &&
+			node.callee?.type === 'Identifier' &&
+			node.callee.name === createName &&
+			node.arguments[1]?.type === 'ObjectExpression'
+		) {
+			for (const prop of node.arguments[1].properties) {
+				if (prop.type !== 'Property' || prop.computed) continue;
+				const key = prop.key?.name ?? prop.key?.value;
+				if (typeof key !== 'string' || !/^h\d+$/.test(key)) continue;
+				if (prop.value?.type === 'Literal' && typeof prop.value.value === 'string') {
+					values.push(prop.value.value);
+				}
+			}
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'loc' || key === 'metadata') continue;
+			if (Array.isArray(value)) {
+				for (const item of value) visit(item);
+			} else {
+				visit(value);
+			}
+		}
+	}
+	visit(parseModule(code, 'compiled.js'));
+	return values;
+}
+
+function countAnchors(html: string | undefined): number {
+	if (html === undefined) return 0;
+	return html.split('<!>').length - 1;
+}
+
+describe('.tsx string-literal expression children — client matches server/.tsrx fold', function () {
+	it('folds Prettier {" "} between text and a component (issue #965)', function () {
+		const client = compileClient(PRETTIER_SPACE);
+		const server = compileServer(PRETTIER_SPACE);
+		const tsrx = compileClient(TSRX_PRETTIER_SPACE, 'f.tsrx');
+
+		expect(stringLiteralHoleValues(client)).toEqual([]);
+		expect(hostParagraphTemplate(client)).toBe('<p>Try the <!> page</p>');
+		expect(countAnchors(hostParagraphTemplate(client))).toBe(1);
+		expect(countAnchors(hostParagraphTemplate(tsrx))).toBe(1);
+		expect(server).toContain('Try the ');
+		expect(server).toContain('ssrComponent');
+		expect(server).not.toContain('ssrText');
+	});
+
+	it('folds adjacent constant string expression holes into the template', function () {
+		const client = compileClient(LITERAL_RUNS);
+		const server = compileServer(LITERAL_RUNS);
+		expect(stringLiteralHoleValues(client)).toEqual([]);
+		expect(hostParagraphTemplate(client)).toBe('<p>foobar!baz</p>');
+		expect(countAnchors(hostParagraphTemplate(client))).toBe(0);
+		expect(server).toContain('foobar!baz');
+		expect(server).not.toContain('ssrText');
+	});
+
+	it('treats empty string literals as adjacency-transparent, not holes', function () {
+		const client = compileClient(EMPTY_LITERAL);
+		expect(stringLiteralHoleValues(client)).toEqual([]);
+		expect(hostParagraphTemplate(client)).toBe('<p>before<!>after</p>');
+		expect(countAnchors(hostParagraphTemplate(client))).toBe(1);
+	});
+
+	it('keeps a dynamic text expression as a hole on both compilers', function () {
+		const client = compileClient(DYNAMIC_TEXT);
+		const server = compileServer(DYNAMIC_TEXT);
+		expect(stringLiteralHoleValues(client)).toEqual([]);
+		expect(countAnchors(hostParagraphTemplate(client))).toBe(2);
+		expect(hostParagraphTemplate(client)).toBe('<p>Try the<!><!> page</p>');
+		expect(server).toContain('ssrText');
+		expect(server).toContain('ssrComponent');
+	});
+});

--- a/packages/octane/tests/hydration/tsx-string-literal-hydrate.test.ts
+++ b/packages/octane/tests/hydration/tsx-string-literal-hydrate.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRoot, hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { loadCompiledFixtureSource } from '../_server-fixture';
+
+// Prettier inserts `{" "}` to keep a space between text and an inline tag.
+// That expression is a static string. If the .tsx client treats it as a hole
+// while the server folds it, hydration consumes the following component node
+// and remounts a duplicate (e.g. `itemsitems`).
+
+const PRETTIER_SPACE = `
+	function Link(props) {
+		return <a href={props.to}>{props.children}</a>;
+	}
+	export function Example() {
+		return (
+			<p>
+				Try the{" "}
+				<Link to="/items">items</Link> page
+			</p>
+		);
+	}
+`;
+
+const SPACE_BETWEEN_COMPONENTS = `
+	function Link(props) {
+		return <a href={props.to}>{props.children}</a>;
+	}
+	export function Example() {
+		return (
+			<p>
+				<Link to="/a">alpha</Link>
+				{" "}
+				<Link to="/b">beta</Link>
+			</p>
+		);
+	}
+`;
+
+const LITERAL_AND_DYNAMIC = `
+	function Emph(props) {
+		return <em>{props.children}</em>;
+	}
+	export function Example(props) {
+		return (
+			<p>
+				Hello{" "}
+				<Emph>{props.label as string}</Emph>
+				{"-"}world
+			</p>
+		);
+	}
+`;
+
+const compileOptions = { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' };
+
+function loadPair(source: string, id: string): { client: any; server: any } {
+	return {
+		client: loadCompiledFixtureSource(source, { id, mode: 'client', compileOptions }),
+		server: loadCompiledFixtureSource(source, { id, mode: 'server', compileOptions }),
+	};
+}
+
+describe('hydrateRoot — .tsx string-literal expression children', function () {
+	let container: HTMLElement;
+	beforeEach(function () {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+	afterEach(function () {
+		container.remove();
+	});
+
+	it('hydrates Prettier {" "} before an inline component without duplicating it', function () {
+		const { client, server } = loadPair(PRETTIER_SPACE, 'prettier-space.tsx');
+		const { html } = ServerRT.renderToString(server.Example);
+		expect(html).toContain('Try the ');
+		expect(html).toContain('items');
+		container.innerHTML = html;
+		const paragraph = container.querySelector('p') as HTMLParagraphElement;
+		const link = container.querySelector('a') as HTMLAnchorElement;
+		expect(container.querySelectorAll('a').length).toBe(1);
+		expect(paragraph.textContent).toBe('Try the items page');
+
+		const root = hydrateRoot(container, client.Example);
+		try {
+			flushSync(function () {});
+			expect(container.querySelector('p')).toBe(paragraph);
+			expect(container.querySelector('a')).toBe(link);
+			expect(container.querySelectorAll('a').length).toBe(1);
+			expect(paragraph.textContent).toBe('Try the items page');
+			expect(link.getAttribute('href')).toBe('/items');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('client-only mount of the Prettier pattern matches SSR text', function () {
+		const { client, server } = loadPair(PRETTIER_SPACE, 'prettier-space-client.tsx');
+		const { html } = ServerRT.renderToString(server.Example);
+		const root = createRoot(container);
+		try {
+			flushSync(function () {
+				root.render(client.Example);
+			});
+			expect(container.querySelectorAll('a').length).toBe(1);
+			expect(container.querySelector('p')!.textContent).toBe('Try the items page');
+			expect(container.querySelector('p')!.innerHTML.replace(/<!--[^>]*-->/g, '')).toBe(
+				html
+					.replace(/^<p>/, '')
+					.replace(/<\/p>$/, '')
+					.replace(/<!--[^>]*-->/g, ''),
+			);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('hydrates a string literal between two components without duplicating either', function () {
+		const { client, server } = loadPair(SPACE_BETWEEN_COMPONENTS, 'space-between.tsx');
+		const { html } = ServerRT.renderToString(server.Example);
+		container.innerHTML = html;
+		const links = Array.from(container.querySelectorAll('a'));
+		expect(links).toHaveLength(2);
+		expect(container.querySelector('p')!.textContent).toBe('alpha beta');
+
+		const root = hydrateRoot(container, client.Example);
+		try {
+			flushSync(function () {});
+			const after = Array.from(container.querySelectorAll('a'));
+			expect(after).toHaveLength(2);
+			expect(after[0]).toBe(links[0]);
+			expect(after[1]).toBe(links[1]);
+			expect(container.querySelector('p')!.textContent).toBe('alpha beta');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('hydrates mixed static literals around a dynamic component child', function () {
+		const { client, server } = loadPair(LITERAL_AND_DYNAMIC, 'literal-and-dynamic.tsx');
+		const props = { label: 'there' };
+		const { html } = ServerRT.renderToString(server.Example, props);
+		container.innerHTML = html;
+		const emph = container.querySelector('em') as HTMLElement;
+		expect(container.querySelector('p')!.textContent).toBe('Hello there-world');
+
+		const root = hydrateRoot(container, client.Example, props);
+		try {
+			flushSync(function () {});
+			expect(container.querySelector('em')).toBe(emph);
+			expect(container.querySelectorAll('em').length).toBe(1);
+			expect(container.querySelector('p')!.textContent).toBe('Hello there-world');
+		} finally {
+			root.unmount();
+		}
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #965

## Summary
- `.tsx` return-form extraction treated string-literal children such as Prettier's `{" "}` as dynamic `hN` holes, while the server and `.tsrx` compilers baked them into the template.
- That hole-count mismatch made hydration consume the next sibling for the whitespace slot and remount a duplicate element (`itemsitems`).
- `extractFragment` now leaves string-literal expression children in place so `emitElementHtml` folds them through `staticTextLiteral`, matching `.tsrx` and the server.

## Why
- Hydration requires client and server templates to agree on hole count and positions.
- Folding the literals (instead of keeping them dynamic on both sides) matches the existing `.tsrx` / server contract and avoids a runtime text hole for constant whitespace.

## Changes
- `packages/octane/src/compiler/compile.js`: do not hoist `staticTextLiteral` children in `extractFragment`.
- Compiler regression for Prettier `{" "}`, adjacent/`{""}` literals, and still-dynamic `{expr as string}` holes.
- Hydration regression: adopt one link, no duplicates, client-only mount matches SSR.

## Validation
- [x] targeted tests: `packages/octane/tests/compiler/tsx-static-string-child.test.ts`, `packages/octane/tests/hydration/tsx-string-literal-hydrate.test.ts` (12 passed, including `octane-prod`)
- [x] nearby: `ssr-tsx-children`, `text-sibling-hydrate`, `markerless-text-hydrate`, `value-jsx-hydrate`, `component-children-hydrate` (88 passed)
- [x] `pnpm format:files:check` on changed files
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `pnpm format:check` (CI lint on `31b2912df`)
- [x] `pnpm typecheck` (CI typecheck on `31b2912df`)
- [x] `pnpm test` (CI test shards + test (24) on `31b2912df`)
- [x] `pnpm sync` (no extra generated diff)
- Current-head CI is green: required lint, typecheck, test, React parity, examples, website, heavy integration, and provenance all succeeded. GitHub reports mergeable.

## Risk / follow-ups
- Only string `Literal` / `StringLiteral` children are folded, the same set `staticTextLiteral` already bakes on the template path. `{expr as string}`, numbers, and other expressions stay holes.
- Compile-time only; fewer client holes than before. No trustworthy wall-clock measurement for this fold; residual risk is an untested parenthesized/template-literal constant that both sides already leave dynamic.

## Reviewers
Requested: @leonidaz @trueadm

READY FOR REVIEW

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09c8ddbf-07e7-406c-b33d-da34b23ff5bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09c8ddbf-07e7-406c-b33d-da34b23ff5bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791294780&installation_model_id=432790&pr_number=972&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F972&signature=e2f436a4f2513bf2088818c136b5eddc132314a4ac34185c949d1a42a7615bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->