### PR TITLE
fix: preserve scoped classes in production SSR spreads

### DIFF
--- a/.changeset/ssr-scoped-spread-classes.md
+++ b/.changeset/ssr-scoped-spread-classes.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Preserve scoped CSS classes on elements with spread attributes during production server rendering.

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -2635,7 +2635,7 @@ export function ssrAttrs(
 		}
 	}
 
-	if (process.env.NODE_ENV === 'production') {
+	if (process.env.NODE_ENV === 'production' && classMerges === null) {
 		let canonical = true;
 		for (const name of props.keys()) {
 			if (

--- a/packages/octane/tests/ssr-production-bundle.test.ts
+++ b/packages/octane/tests/ssr-production-bundle.test.ts
@@ -68,6 +68,69 @@ async function productionServerModule<T extends Record<string, unknown>>(
 }
 
 describe('production-bundled server rendering', () => {
+	it.each([
+		{ name: 'class', attrs: { class: 'spread' }, classes: ['spread'] },
+		{ name: 'className', attrs: { className: 'spread' }, classes: ['spread'] },
+		{
+			name: 'an array class',
+			attrs: { class: ['spread', { extra: true }] },
+			classes: ['spread', 'extra'],
+		},
+		{ name: 'an empty spread', attrs: {}, classes: [] },
+		{ name: 'a null class', attrs: { class: null }, classes: [] },
+		{ name: 'a false class', attrs: { class: false }, classes: [] },
+	])('keeps scoped styles and authored class precedence with $name', async ({ attrs, classes }) => {
+		const { render } = await productionServerModule<{
+			render: (attrs: Record<string, unknown>) => { html: string; css: string };
+		}>(
+			`
+import { renderToString } from 'octane/server';
+import { Page } from 'fixture:server-component';
+export const render = (attrs) => renderToString(Page, { attrs });
+`,
+			`
+export function Page(props: { attrs: Record<string, unknown> }) @{
+	<main>
+		<style>
+			div { color: red; }
+		</style>
+		<div data-case="spread" {...props.attrs}>{'Spread'}</div>
+		<div data-case="after" {...props.attrs} class="authored">{'After'}</div>
+		<div data-case="before" class="authored" {...props.attrs}>{'Before'}</div>
+	</main>
+}
+`,
+		);
+		const { html, css } = render(attrs);
+		const browser = new JSDOM(`<html><head>${css}</head><body>${html}</body></html>`);
+		try {
+			const document = browser.window.document;
+			const rule = document.styleSheets[0].cssRules[0] as CSSStyleRule;
+			const spread = document.querySelector('[data-case="spread"]')!;
+			const after = document.querySelector('[data-case="after"]')!;
+			const before = document.querySelector('[data-case="before"]')!;
+
+			expect(rule.style.getPropertyValue('color')).toBe('red');
+			expect(spread.matches(rule.selectorText)).toBe(true);
+			for (const name of classes) expect(spread.classList.contains(name)).toBe(true);
+
+			expect(after.matches(rule.selectorText)).toBe(true);
+			expect(after.classList.contains('authored')).toBe(true);
+			for (const name of classes) expect(after.classList.contains(name)).toBe(false);
+
+			if ('class' in attrs || 'className' in attrs) {
+				// A later spread still replaces the earlier authored class, including its scope.
+				expect(before.className).toBe(classes.join(' '));
+				expect(before.matches(rule.selectorText)).toBe(false);
+			} else {
+				expect(before.className).toBe(after.className);
+				expect(before.matches(rule.selectorText)).toBe(true);
+			}
+		} finally {
+			browser.window.close();
+		}
+	});
+
 	it.each([false, true])(
 		'preserves spread reads and winning prop coercion order when coercion throws: %s',
 		async (throws) => {


### PR DESCRIPTION
## Summary

Fix production server rendering dropping synthesized scoped CSS classes on elements with spread attributes. The canonical-attribute fast path returned before applying pending class merges; it now runs only when no class merges are pending.

The ordinary canonical-attribute path remains unchanged. Merge-bearing calls use the existing normalization and class-composition path, preserving authored-class precedence. No compiler, client runtime, or Strong-mode changes.

## Validation

- [x] `pnpm install --frozen-lockfile` completed with the unchanged lockfile; the earlier registry cooldown no longer blocks installation.
- [x] Regression red/green: temporarily removing the runtime guard caused all five affected spread variants to fail their emitted-CSS selector match in both `octane` and `octane-prod` (10 failures); `className` remained the unaffected control. Restoring the guard passed all six variants in both projects.
- [x] `pnpm exec vitest run packages/octane/tests/ssr-production-bundle.test.ts packages/octane/tests/ssr.test.ts packages/octane/tests/style-map.test.ts packages/octane/tests/streaming-ssr.test.ts --project octane --project octane-prod --reporter=dot`: 300 test executions passed across eight suite executions.
- [x] `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json`.
- [x] `pnpm format:files:check packages/octane/tests/ssr-production-bundle.test.ts packages/octane/src/runtime.server.ts .changeset/ssr-scoped-spread-classes.md` and `git diff --check`.
- [x] `pnpm sync` completed without generated changes; the worktree is clean.
- [x] [Current-head CI run](https://github.com/octanejs/octane/actions/runs/34061641832) passed on `6cf95d710a8715be5cc49ac7a679987493a19223`: all four test shards, React parity, website/browser integration, package validation, examples, lint, typechecking, and provenance. Cursor Bugbot also passed with no review threads. The PR is ready for review.
- Repository-wide `pnpm format:check`, `pnpm typecheck`, and `pnpm test` were not rerun locally; the CI workflow covers the full repository checks.

## Performance validation

Compared production SSR fixture bundles with and without the guard using the same installed dependencies on Node 24.18.0, macOS 26.6.2, arm64. Ran the existing harness in baseline/candidate/candidate/baseline order, with 0.2 seconds warmup, 2 seconds timing per case, and 1,000 memory-phase renders:

```sh
pnpm exec vite build benchmarks/ssr-throughput/fixtures --ssr src/entry-server.ts --outDir ../dist/fixtures --emptyOutDir
CONFIGS=deopt-page,escape-heavy BENCH_JSON=/tmp/ssr-sample.json node benchmarks/ssr-throughput/run.mjs 2 --no-build
```

Median render scores (baseline → candidate): compiled cards 1.300 → 1.297 ms (-0.22%); descriptor control 3.458 → 3.461 ms (+0.08%); escaping 3.275 → 3.292 ms (+0.53%). All benchmark gates passed. These small deltas do not establish a throughput change. Full HTML/CSS results matched for both card variants, escaping, and hydratable/static control-flow fixtures. The unminified fixture bundle grew by 24 bytes (178,800 → 178,824).

## Risk / follow-ups

This is a one-condition runtime fix with a patch changeset. The measured controls protect ordinary SSR paths; they do not quantify the corrected scoped-class merge path, because the old version omits required output there. Merge-bearing calls use the existing normalization/composition path and its allocations. No throughput improvement is claimed. Self-review confirmed canonical calls without pending class merges retain their fast path and the regression covers empty/null/false/array/className inputs plus authored-class precedence.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791322631&installation_model_id=432790&pr_number=974&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F974&signature=c3c53249bc8702c65e3f6896e21e0dc6a026cd2a9dd849cbce7f33098f308680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard on an existing production fast path in SSR attribute serialization; scope is limited to class handling with spreads, with targeted regression tests.
> 
> **Overview**
> Fixes **production SSR** dropping **scoped CSS classes** on elements that use attribute spreads (`{...props}`).
> 
> In `ssrAttrs`, the production-only canonical-attribute fast path could return before pending **class merges** (including synthesized scope-hash classes) were applied. That path now runs only when **`classMerges === null`**, so spread/`class`/`className` cases go through the full normalization and class-composition logic. Authored-class vs spread precedence behavior is unchanged.
> 
> Adds a **patch changeset** and **production-bundle tests** (six spread variants) that assert rendered nodes still match emitted scoped selectors and that `class` before/after spread ordering stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf95d710a8715be5cc49ac7a679987493a19223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->