### PR TITLE
perf(octane): clear inert keyed rows at root commit

### DIFF
--- a/.changeset/owned-list-clear-at-commit.md
+++ b/.changeset/owned-list-clear-at-commit.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Clear an owned keyed list of inert host rows with one DOM removal after the root render commits. Retain connected rows for suspension rollback and keep the existing per-row teardown for lists with effects, refs, nested scopes, or portals.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -44,6 +44,9 @@ and expose the same button + table contract:
   **same** `forBlock` fast path (the compiler recognizes a keyed JSX `.map` and
   compiles it like `@for`), so the jsx/tsrx ratio is ~1.0 — the React-JSX
   backwards-compat path carries no list-reconciliation penalty here.
+- Both Octane fixtures expose `window.__benchFlush` through public `flushSync`.
+  The harness calls it inside each timed click so a scheduled Octane commit is
+  included in the duration.
 - **`react`** — the canonical [keyed react-hooks][rh] implementation, the
   reference VDOM baseline. `dispatch` is wrapped in `flushSync` so React commits
   inside the discrete click (the harness times only the synchronous click; React
@@ -98,13 +101,29 @@ machine-readable copy of the results when `BENCH_JSON=<path>` is set
 (milliseconds; one `ops` map per target; a failed gate still writes the file
 with a top-level `"failed"` field).
 
+For the older **1,000-row clear** comparison, use `CLEAR_1K=1` with `run.mjs`.
+It defaults to 5 warmups and 15 measured samples. Set `CPU_THROTTLE=4` to apply
+Chromium's 4× CPU throttle to every target:
+
+```bash
+CLEAR_1K=1 CPU_THROTTLE=4 TARGETS='[{"name":"octane-tsrx","url":"http://localhost:5176/","ready":"#run"}]' node benchmarks/js-framework/run.mjs
+```
+
+This diagnostic reports `clear_1k` under the separate `js-framework-clear-1k`
+suite name. The canonical `clear` operation still starts from 10,000 rows.
+This local in-page click timer excludes paint and browser automation latency;
+its numbers should not be compared directly with the official benchmark's
+Chrome timeline measurements.
+
 Output is a table of median + min millis per operation: `run`, `replace`,
 `add`, `update`, `select`, `swap`, `remove`, `runlots`, `select_lots`, `clear`.
 The harness uses `page.evaluate(el.click)` to fire clicks synchronously inside
 the page — avoids per-click CDP IPC overhead (~10ms each on Chromium) so the
-numbers reflect the renderer's wall time, not Playwright transport. Before
-warmup, each target receives the same seeded `Math.random` stream so generated
-label lengths and allocation patterns cannot drift between dialects.
+numbers reflect the renderer's wall time, not Playwright transport. Each timed
+click also verifies its DOM change immediately after its timer ends, before
+another scheduler turn can commit. Before warmup, each target receives the same
+seeded `Math.random` stream so generated label lengths and allocation patterns
+cannot drift between dialects.
 
 Selection samples alternate between the fifth and sixth rows so every click
 changes the selected key instead of measuring an equal-value state bailout.

--- a/benchmarks/js-framework/octane-jsx/src/main.js
+++ b/benchmarks/js-framework/octane-jsx/src/main.js
@@ -1,7 +1,10 @@
-import { createRoot } from 'octane';
+import { createRoot, flushSync } from 'octane';
 import Main from './Main.tsx';
 
 const target = document.getElementById('main');
 if (!target) throw new Error('missing #main root');
 
 createRoot(target).render(Main);
+
+// Keep each timed click's DOM commit inside the harness's measurement window.
+window.__benchFlush = () => flushSync(() => {});

--- a/benchmarks/js-framework/octane-tsrx/src/main.js
+++ b/benchmarks/js-framework/octane-tsrx/src/main.js
@@ -1,7 +1,10 @@
-import { createRoot } from 'octane';
+import { createRoot, flushSync } from 'octane';
 import Main from './Main.tsrx';
 
 const target = document.getElementById('main');
 if (!target) throw new Error('missing #main root');
 
 createRoot(target).render(Main);
+
+// Keep each timed click's DOM commit inside the harness's measurement window.
+window.__benchFlush = () => flushSync(() => {});

--- a/benchmarks/js-framework/run-reorder.mjs
+++ b/benchmarks/js-framework/run-reorder.mjs
@@ -138,11 +138,9 @@ function summarize(samples) {
 	return summarizeSamples(samples);
 }
 
-// Reset to a fresh 1k table. Every target either commits synchronously on the
-// discrete click (octane flushes on the event; react/ripple wrap in flushSync;
-// solid calls flush()) or exposes `window.__benchFlush` (vue-vapor — microtask
-// scheduler, no public sync flush; see run.mjs's timeClick note), so the count
-// is checkable once the evaluate resolves.
+// Reset to a fresh 1k table. Octane flushes via its public flushSync, Vue
+// awaits nextTick, and the remaining targets commit on click. The count is
+// checkable once the evaluate resolves.
 async function resetRows(page) {
 	const cnt = await page.evaluate(async () => {
 		document.getElementById('run').click();
@@ -253,6 +251,11 @@ async function scratchStorageGate(page, targetName) {
 		const phases = [];
 		const readRows = () => Array.from(document.querySelectorAll('tbody tr'));
 		const rowId = (row) => row.firstElementChild.textContent;
+		const clickAndFlush = (button) => {
+			document.getElementById(button).click();
+			// This gate only runs against Octane; its fixture callback is synchronous.
+			window.__benchFlush?.();
+		};
 
 		function measure(button, repetitions) {
 			const before = readRows();
@@ -260,7 +263,7 @@ async function scratchStorageGate(page, targetName) {
 			const expected = before.map(rowId);
 			const firstAllocation = allocations.length;
 			for (let iteration = 0; iteration < repetitions; iteration++) {
-				document.getElementById(button).click();
+				clickAndFlush(button);
 				if (button === 'reverse') expected.reverse();
 				else if (button === 'rotateb') expected.push(expected.shift());
 				else if (button === 'rotatef') expected.unshift(expected.pop());
@@ -313,7 +316,7 @@ async function scratchStorageGate(page, targetName) {
 			});
 
 			// The first reverse is explicitly outside each steady-state budget.
-			document.getElementById('reverse').click();
+			clickAndFlush('reverse');
 			measure('reverse', 4);
 			measure('rotateb', 8);
 			measure('rotatef', 4);
@@ -322,7 +325,7 @@ async function scratchStorageGate(page, targetName) {
 
 			const beforeAppend = readRows();
 			const appendStart = allocations.length;
-			document.getElementById('append100').click();
+			clickAndFlush('append100');
 			const afterAppend = readRows();
 			if (
 				afterAppend.length !== beforeAppend.length + 100 ||
@@ -334,23 +337,23 @@ async function scratchStorageGate(page, targetName) {
 				throw new Error('append100 allocated typed reorder scratch');
 			}
 
-			document.getElementById('runlots').click();
+			clickAndFlush('runlots');
 			if (readRows().length !== 10000) throw new Error('runlots did not produce 10000 rows');
-			document.getElementById('reverse').click();
+			clickAndFlush('reverse');
 			measure('reverse', 2);
 			measure('rotateb', 4);
 			measure('shuffle', 2);
 			measure('swaprows', 2);
 
 			// An oversized one-shot must not evict the bounded reusable buffers.
-			for (let index = 0; index < 8; index++) document.getElementById('add').click();
+			for (let index = 0; index < 8; index++) clickAndFlush('add');
 			const oversizedBefore = readRows();
 			if (oversizedBefore.length !== 18000) {
 				throw new Error('oversized control expected 18000 rows');
 			}
 			const oversizedStart = allocations.length;
-			document.getElementById('rotateb').click();
-			document.getElementById('rotateb').click();
+			clickAndFlush('rotateb');
+			clickAndFlush('rotateb');
 			const oversizedAfter = readRows();
 			if (
 				oversizedAfter.length !== oversizedBefore.length ||
@@ -361,7 +364,7 @@ async function scratchStorageGate(page, targetName) {
 			if (allocations.length - oversizedStart !== 4) {
 				throw new Error('oversized rotations unexpectedly retained reusable scratch');
 			}
-			document.getElementById('run').click();
+			clickAndFlush('run');
 			if (readRows().length !== 1000) throw new Error('shrink control expected 1000 rows');
 			measure('rotateb', 4);
 		} finally {

--- a/benchmarks/js-framework/run.mjs
+++ b/benchmarks/js-framework/run.mjs
@@ -31,9 +31,17 @@ import { chromium } from 'playwright';
 import { deterministicCount } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
-const ITER = parseInt(process.argv[2] || '8', 10);
+// Opt-in diagnostic matching the older 1k clear comparison. Keep the canonical
+// 10k suite and its historical baseline unchanged.
+const CLEAR_1K = process.env.CLEAR_1K === '1';
+const ITER = parseInt(process.argv[2] || (CLEAR_1K ? '15' : '8'), 10);
+const WARMUP = CLEAR_1K ? 5 : 3;
 const ROW_COUNT = 1000;
 const ROW_COUNT_LARGE = 10000; // matches the canonical suite's runlots / clear table size
+const CPU_THROTTLE = Number(process.env.CPU_THROTTLE || 1);
+if (!Number.isFinite(CPU_THROTTLE) || CPU_THROTTLE < 1) {
+	throw new Error('CPU_THROTTLE must be a number >= 1');
+}
 
 const TARGETS = process.env.TARGETS
 	? JSON.parse(process.env.TARGETS)
@@ -49,7 +57,7 @@ const TARGETS = process.env.TARGETS
 			{ name: 'inferno', url: 'http://localhost:5320/', ready: '#run' },
 		];
 
-const OPS = [
+const CANONICAL_OPS = [
 	{ name: 'run', pre: 'empty', click: '#run' },
 	{ name: 'replace', pre: 'rows', click: '#run' },
 	// Canonical krausest "append 1,000 rows to a table of 1,000 rows". The
@@ -78,6 +86,7 @@ const OPS = [
 	// the upstream suite. Use `rows-large` to ensure the 10K state first.
 	{ name: 'clear', pre: 'rows-large', click: '#clear' },
 ];
+const OPS = CLEAR_1K ? [{ name: 'clear_1k', pre: 'rows', click: '#clear' }] : CANONICAL_OPS;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -128,29 +137,63 @@ async function ensureState(page, pre) {
 	await sleep(20);
 }
 
-// Time ONLY the click handler's commit: the target commits its DOM mutation
-// synchronously on the discrete click (octane flushes on the event), so the
-// post-click rAF + task wait was pure noise — ~16ms of frame latency + the paint
-// of up to 10K rows, which swamped and destabilised the real JS work. A gc()
-// right before each sample keeps a surprise collection from inflating it.
+// Time the click and its DOM commit without adding a frame or paint wait. A
+// gc() right before each sample keeps a surprise collection from inflating it.
 //
-// Any TARGETS added here must either commit synchronously on click
-// (react/ripple flushSync, solid flush()) or — for frameworks with no public
-// sync flush (vue-vapor) — expose `window.__benchFlush = () => <promise that
-// resolves once the scheduler has flushed>`; the timed window then extends
-// until that promise settles, so the framework's own microtask scheduling cost
-// stays inside the measurement.
-async function timeClick(page, sel) {
-	return await page.evaluate(async (sel) => {
-		const el = document.querySelector(sel);
-		if (!el) throw new Error('selector not found: ' + sel);
-		const flush = window.__benchFlush;
-		(window.gc || (() => {}))();
-		const t0 = performance.now();
-		el.click();
-		if (flush) await flush();
-		return performance.now() - t0;
-	}, sel);
+// Targets that schedule a later commit expose window.__benchFlush: Octane uses
+// public flushSync and Vue awaits nextTick. The call stays in the timed window.
+// Verify the resulting DOM after t1, before any further async work, so this
+// semantic gate cannot inflate the timing or accidentally observe a later commit.
+async function timeClick(page, op, selector) {
+	return await page.evaluate(
+		async ({ op, selector }) => {
+			const el = document.querySelector(selector);
+			if (!el) throw new Error('selector not found: ' + selector);
+			const tbody = document.querySelector('tbody');
+			const firstRow = tbody?.querySelector('tr');
+			const secondRow = op === 'swap' ? tbody?.rows[1] : null;
+			const removedRow = op === 'remove' ? el.closest('tr') : null;
+			const oldLabel =
+				op === 'update' ? firstRow?.querySelector('td:nth-child(2) a')?.textContent : null;
+			const flush = window.__benchFlush;
+			(window.gc || (() => {}))();
+			const t0 = performance.now();
+			el.click();
+			if (flush) await flush();
+			const elapsed = performance.now() - t0;
+			const expectedRows = {
+				run: 1000,
+				replace: 1000,
+				add: 2000,
+				update: 1000,
+				select: 1000,
+				swap: 1000,
+				remove: 999,
+				runlots: 10000,
+				select_lots: 10000,
+				clear: 0,
+				clear_1k: 0,
+			}[op];
+			if (tbody?.rows.length !== expectedRows) {
+				throw new Error(
+					`${op}: commit was not inside timed click (expected ${expectedRows} rows, found ${tbody?.rows.length})`,
+				);
+			}
+			if (
+				(op === 'replace' && firstRow === tbody.rows[0]) ||
+				(op === 'update' &&
+					oldLabel === tbody.rows[0]?.querySelector('td:nth-child(2) a')?.textContent) ||
+				(op === 'swap' && secondRow !== tbody.rows[998]) ||
+				(op === 'remove' && removedRow?.isConnected) ||
+				((op === 'select' || op === 'select_lots') &&
+					!el.closest('tr')?.classList.contains('danger'))
+			) {
+				throw new Error(`${op}: the expected DOM change was not committed inside the timed click`);
+			}
+			return elapsed;
+		},
+		{ op: op.name, selector },
+	);
 }
 
 async function verifySelection(page, selector) {
@@ -313,7 +356,7 @@ async function countProductionMountCalls(target) {
 		}
 		if (calls === 0) throw new Error('mount gate: no production asset call coverage');
 
-		await page.evaluate((expectedRows) => {
+		await page.evaluate(async (expectedRows) => {
 			const rows = Array.from(document.querySelectorAll('tbody tr'));
 			if (rows.length !== expectedRows) {
 				throw new Error(`mount gate: profiled mount produced ${rows.length} rows`);
@@ -326,6 +369,7 @@ async function countProductionMountCalls(target) {
 			}
 			const row = rows[4];
 			row.querySelector('td:nth-child(2) a').click();
+			if (window.__benchFlush) await window.__benchFlush();
 			const selected = document.querySelectorAll('tbody tr.danger');
 			if (selected.length !== 1 || selected[0] !== row) {
 				throw new Error('mount gate: profiled row event or selection failed');
@@ -350,12 +394,16 @@ async function runTarget(t) {
 	});
 	const context = await browser.newContext();
 	const page = await context.newPage();
+	if (CPU_THROTTLE > 1) {
+		const cdp = await context.newCDPSession(page);
+		await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU_THROTTLE });
+	}
 	await page.goto(t.url, { waitUntil: 'load' });
 	await page.waitForSelector(t.ready, { timeout: 10000 });
 	await seedRandom(page);
 
 	// Warmup — let JIT settle.
-	for (let i = 0; i < 3; i++) {
+	for (let i = 0; i < WARMUP; i++) {
 		await page.evaluate(() => document.getElementById('run').click());
 		await sleep(120);
 		await page.evaluate(() => document.getElementById('clear').click());
@@ -368,7 +416,7 @@ async function runTarget(t) {
 		for (let i = 0; i < ITER; i++) {
 			await ensureState(page, op.pre);
 			const selector = i % 2 === 1 && op.alternateClick ? op.alternateClick : op.click;
-			const dt = await timeClick(page, selector);
+			const dt = await timeClick(page, op, selector);
 			if (op.alternateClick) await verifySelection(page, selector);
 			samples.push(dt);
 			await sleep(60);
@@ -376,7 +424,7 @@ async function runTarget(t) {
 		results[op.name] = summarizeSamples(samples);
 	}
 
-	if (t.name === 'octane-tsrx' || t.name === 'octane-jsx') {
+	if (!CLEAR_1K && (t.name === 'octane-tsrx' || t.name === 'octane-jsx')) {
 		for (const operation of [
 			{ name: '1k', button: 'run', initialRows: 0, addedRows: ROW_COUNT },
 			{ name: '10k', button: 'runlots', initialRows: 0, addedRows: ROW_COUNT_LARGE },
@@ -482,7 +530,7 @@ async function runTarget(t) {
 	// in the benchmarks README): milliseconds, one ops map per target.
 	if (process.env.BENCH_JSON) {
 		const payload = {
-			suite: 'js-framework',
+			suite: CLEAR_1K ? 'js-framework-clear-1k' : 'js-framework',
 			iterations: ITER,
 			targets: TARGETS.map((t) => ({
 				name: t.name,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3122,11 +3122,34 @@ function journalForSlot(state: ForSlot): void {
 	});
 }
 
+/**
+ * Full clears leave the old item chain untouched. Retain its map and links by
+ * reference for rollback, then give any same-attempt refill a fresh key map.
+ * The generic journal still snapshots reordered/partially changed lists.
+ */
+function journalForOwnedListClear(state: ForSlot): void {
+	const seen = TRANSITION_JOURNAL_BAGS!;
+	const oldItems = state.items;
+	seen.set(state, TRANSITION_JOURNAL!.length);
+	const snapshot = {
+		head: state.head,
+		tail: state.tail,
+		size: state.size,
+		empty: state.emptyBlock,
+		entries: oldItems,
+	};
+	journalUndo(() => {
+		restoreForSlot(state, snapshot, null);
+		seen.delete(state);
+	});
+	state.items = new Map();
+}
+
 /** Put a keyed list back the way it was, rows and order together. */
 function restoreForSlot(
 	state: ForSlot,
 	snapshot: any,
-	chain: Array<[Block, Block | null, Block | null]>,
+	chain: Array<[Block, Block | null, Block | null]> | null,
 ): void {
 	// Rows the aborted attempt freshly mounted are not in the snapshot, so
 	// restoring the old chain would simply forget them. Their DOM goes with the
@@ -3134,11 +3157,14 @@ function restoreForSlot(
 	// them unreachable: the disposed stamp is what keeps their queued mount
 	// effects and ref attaches from firing for a row that never reached the
 	// screen, and it runs the render-time cleanups they registered. Parked rows
-	// are never on the chain, so this reaches exactly the fresh mounts.
-	const kept = new Set<Block>();
-	for (let i = 0; i < chain.length; i++) kept.add(chain[i][0]);
+	// are never on the chain, so this reaches exactly the fresh mounts. For a
+	// map-swap clear the original chain cannot become live before its own undo:
+	// later windows undo first, and later fills use the replacement map.
+	const preservedMap: Map<any, Block> | null = chain === null ? snapshot.entries : null;
+	const kept: Set<Block> | null = chain === null ? null : new Set<Block>();
+	if (chain !== null) for (let i = 0; i < chain.length; i++) kept!.add(chain[i][0]);
 	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
-		if (!kept.has(b)) unmountBlock(b, false);
+		if (preservedMap !== null || !kept!.has(b)) unmountBlock(b, false);
 	}
 	// Those teardowns dispatch their cleanup errors immediately, and an error
 	// routed to the enclosing boundary flips it to @catch — disposing this
@@ -3149,13 +3175,17 @@ function restoreForSlot(
 	state.head = snapshot.head;
 	state.tail = snapshot.tail;
 	state.size = snapshot.size;
-	state.items.clear();
-	for (let i = 0; i < snapshot.entries.length; i++) {
-		state.items.set(snapshot.entries[i][0], snapshot.entries[i][1]);
-	}
-	for (let i = 0; i < chain.length; i++) {
-		chain[i][0].nextSibling = chain[i][1];
-		chain[i][0].prevSibling = chain[i][2];
+	if (preservedMap !== null) state.items = preservedMap;
+	else {
+		const originalChain = chain!;
+		state.items.clear();
+		for (let i = 0; i < snapshot.entries.length; i++) {
+			state.items.set(snapshot.entries[i][0], snapshot.entries[i][1]);
+		}
+		for (let i = 0; i < originalChain.length; i++) {
+			originalChain[i][0].nextSibling = originalChain[i][1];
+			originalChain[i][0].prevSibling = originalChain[i][2];
+		}
 	}
 	// Collect the committed ranges before removing speculative nodes. Root
 	// transactions left outgoing rows connected; hold-only callers may have
@@ -33025,8 +33055,14 @@ function reconcileKeyed<T>(
 	if (process.env.NODE_ENV !== 'production') getKey = checkedListKey(getKey);
 	// Fast path: clear all.
 	if (newLen === 0) {
-		if (journalShape) journalForSlot(state);
-		batchClearItems(state, oldItems);
+		const ownedRootClear = journalShape && canDeferRootOwnedListClear(state);
+		if (
+			ownedRootClear &&
+			(TRANSITION_JOURNAL_BAGS!.get(state) ?? -1) < TRANSITION_JOURNAL_CHECKPOINT
+		)
+			journalForOwnedListClear(state);
+		else if (journalShape) journalForSlot(state);
+		batchClearItems(state, ownedRootClear ? state.items : oldItems, ownedRootClear);
 		state.head = null;
 		state.tail = null;
 		state.size = 0;
@@ -33484,6 +33520,111 @@ function reconcileKeyed<T>(
 const RANGE_CLEAR_MIN_ITEMS = 512;
 
 /**
+ * Keep an owned list's inert rows connected until the root accepts its render,
+ * then release their scopes and remove their host nodes in one DOM operation.
+ * Rows with lifecycle work stay on the ordinary parked-item path so their
+ * cleanup order and connected-DOM observations remain unchanged.
+ */
+function canDeferRootOwnedListClear(state: ForSlot): boolean {
+	const transaction = ROOT_RENDER_TRANSACTION;
+	const parent = state.start.parentNode;
+	if (
+		transaction === null ||
+		transaction.aborted ||
+		ROOT_RENDER_ROLLBACK ||
+		transaction.hydrating === true ||
+		state.adopt !== null ||
+		state.size < 16 ||
+		parent === null ||
+		(parent.nodeType !== 1 && parent.nodeType !== 11) ||
+		state.end.parentNode !== parent ||
+		state.start.previousSibling !== null ||
+		state.end.nextSibling !== null
+	)
+		return false;
+	const oldHead = state.head;
+	for (let block = oldHead; block !== null; block = block.nextSibling) {
+		if (
+			!block.mounted ||
+			block.idState.renderOwner !== transaction.owner ||
+			block.startMarker === null ||
+			block.startMarker !== block.endMarker ||
+			block.hooks !== null ||
+			block.effectSlots !== null ||
+			block.cleanups !== null ||
+			block.children !== null ||
+			block._slots !== null ||
+			block.refFields !== null ||
+			block.deoptNode !== null ||
+			block.vt !== null
+		)
+			return false;
+	}
+	return true;
+}
+
+function deferRootOwnedListClear(state: ForSlot, certified: boolean = false): boolean {
+	if (!certified && !canDeferRootOwnedListClear(state)) return false;
+	const transaction = ROOT_RENDER_TRANSACTION!;
+	const parent = state.start.parentNode!;
+	const oldHead = state.head;
+	const retired = (transaction.retired ??= new Set<Block>());
+	const newlyRetired: Block[] = [];
+	for (let block = oldHead; block !== null; block = block.nextSibling) {
+		if (!retired.has(block)) {
+			retired.add(block);
+			newlyRetired.push(block);
+		}
+		if (block.pending) {
+			journalRootProperty(block, 'pending');
+			block.pending = false;
+		}
+	}
+	let cancelled = false;
+	journalUndo(() => {
+		cancelled = true;
+		for (let i = 0; i < newlyRetired.length; i++) retired.delete(newlyRetired[i]);
+	});
+	const start = state.start;
+	const end = state.end;
+	(transaction.commit ??= []).push(() => {
+		if (cancelled) return;
+		// A later render may have inserted new rows, or outside code may have
+		// changed this parent. Only clear wholesale while these exact old nodes
+		// still occupy its complete content between the original two markers.
+		let wholeParent =
+			state.size === 0 &&
+			start.parentNode === parent &&
+			end.parentNode === parent &&
+			start.previousSibling === null &&
+			end.nextSibling === null;
+		if (wholeParent) {
+			let node = start.nextSibling;
+			for (let block = oldHead; block !== null; block = block.nextSibling) {
+				if (node !== block.startMarker) {
+					wholeParent = false;
+					break;
+				}
+				node = node!.nextSibling;
+			}
+			if (node !== end) wholeParent = false;
+		}
+		for (let block = oldHead; block !== null; block = block.nextSibling) block.disposed = true;
+		if (wholeParent) {
+			parent.textContent = '';
+			parent.appendChild(start);
+			parent.appendChild(end);
+		} else {
+			for (let block = oldHead; block !== null; block = block.nextSibling) {
+				const node = block.startMarker!;
+				if (node.parentNode !== null) node.parentNode.removeChild(node);
+			}
+		}
+	});
+	return true;
+}
+
+/**
  * Bulk-clear a forBlock's items. When the forBlock owns its parent (markers
  * bracket the entire content), uses `textContent = ''` — the fastest DOM clear
  * on Chromium per Ripple's measured advantage on the `clear` op. A shared
@@ -33499,13 +33640,20 @@ const RANGE_CLEAR_MIN_ITEMS = 512;
  * skipped because the batch clear already removed the whole range. Plain
  * template rows (the common bulk-clear case) hit only the three-field guard.
  */
-function batchClearItems(state: ForSlot, oldItems: Map<any, Block>): void {
-	// The bulk paths below drop the nodes wholesale, which cannot be undone.
-	// While a hold is still possible AND this list's shape is journaled (see
-	// forSlotParkable — reconcileKeyed and the @empty flip journal before they
-	// clear; teardownChildForSlot never does), take each row individually so
-	// its nodes are kept and its teardown waits for the outcome.
+function batchClearItems(
+	state: ForSlot,
+	oldItems: Map<any, Block>,
+	ownedRootClear: boolean = false,
+): void {
+	// An immediate bulk DOM removal cannot be undone after a suspended render.
+	// A journaled clear remains undoable until the attempt commits. Root-owned
+	// inert rows can stay connected and clear together at commit; all other
+	// rows park individually so their cleanup and ref behavior stays intact.
 	if (forSlotParkable(state)) {
+		if (deferRootOwnedListClear(state, ownedRootClear)) {
+			oldItems.clear();
+			return;
+		}
 		let next: Block | null;
 		for (let b: Block | null = state.head; b !== null; b = next) {
 			next = b.nextSibling;

--- a/packages/octane/tests/_fixtures/for-batch-clear.tsrx
+++ b/packages/octane/tests/_fixtures/for-batch-clear.tsrx
@@ -3,7 +3,7 @@
 // slot-stashed cross-module component (componentSlot lives on the item's
 // `_slots`, not `.children`), a cleanup-returning callback ref on the item
 // template itself, and a portal whose DOM lives in a foreign target.
-import { useEffect, useState, createPortal } from '../../src/index.js';
+import { use, useEffect, useState, createPortal } from '../../src/index.js';
 
 export const log: string[] = [];
 export const resetLog = () => {
@@ -25,6 +25,8 @@ const items3b: Item[] = [
 	{ id: 5, label: 'e' },
 	{ id: 6, label: 'f' },
 ];
+const ownedItems: Item[] = [];
+for (let i = 0; i < 1000; i++) ownedItems.push({ id: i + 10, label: 'row-' + i });
 
 function Row({ item }: { item: Item }) @{
 	useEffect(() => {
@@ -50,7 +52,7 @@ export function ComponentRows() @{
 	</div>
 }
 
-const rowRef = (el: Element) => {
+const rowRef = (_el: Element) => {
 	log.push('ref:attach');
 	return () => {
 		log.push('ref:cleanup');
@@ -67,6 +69,135 @@ export function RefRows() @{
 				<li ref={rowRef}>{item.label}</li>
 			}
 		</ul>
+	</div>
+}
+
+/** Large enough for owned-parent clear, but each row still needs ref teardown. */
+export function LargeRefRows() @{
+	const [items, setItems] = useState(ownedItems);
+	<div>
+		<button id="clear" onClick={() => setItems([])}>clear</button>
+		<ul>
+			@for (const item of items; key item.id) {
+				<li ref={rowRef}>
+					<span>{item.label}</span>
+				</li>
+			}
+		</ul>
+	</div>
+}
+
+/** The list is the only child of its parent, including while a root attempt suspends. */
+export function OwnedParentRows({
+	suspendOnClear,
+	insertForeignOnClear,
+	refillDuringClear,
+	clearTwiceOnSuspend,
+	reorderBeforeClearOnSuspend,
+}: {
+	suspendOnClear?: Promise<string>;
+	insertForeignOnClear?: boolean;
+	refillDuringClear?: boolean;
+	clearTwiceOnSuspend?: boolean;
+	reorderBeforeClearOnSuspend?: boolean;
+}) @{
+	const [items, setItems] = useState(ownedItems);
+	const [pending, setPending] = useState(false);
+	const [clearStage, setClearStage] = useState(0);
+	<div>
+		<button
+			id="clear"
+			onClick={() => {
+				setItems(reorderBeforeClearOnSuspend ? ownedItems.toReversed() : []);
+				if (suspendOnClear || insertForeignOnClear || refillDuringClear) setPending(true);
+				if (clearTwiceOnSuspend) setClearStage(1);
+				if (reorderBeforeClearOnSuspend) setClearStage(4);
+			}}
+		>clear</button>
+		<button
+			id="append"
+			onClick={() => {
+				setPending(false);
+				setItems(items3b);
+			}}
+		>append</button>
+		<button
+			id="reverse"
+			onClick={() => {
+				setPending(false);
+				setItems(ownedItems.toReversed());
+			}}
+		>reverse</button>
+		<ul id="owned-list">
+			@for (const item of items; key item.id) {
+				<li class="row">
+					<span>{item.label}</span>
+					<i aria-hidden="true" />
+				</li>
+			}
+		</ul>
+		@{
+			if (pending && suspendOnClear && !clearTwiceOnSuspend && !reorderBeforeClearOnSuspend) use(
+				suspendOnClear,
+			);
+			if (pending && refillDuringClear && items.length === 0) setItems(items3b);
+			if (clearTwiceOnSuspend) {
+				if (clearStage === 1 && items.length === 0) {
+					setItems(ownedItems.toReversed());
+					setClearStage(2);
+				} else if (clearStage === 2 && items.length === ownedItems.length) {
+					setItems([]);
+					setClearStage(3);
+				} else if (clearStage === 3 && suspendOnClear) use(suspendOnClear);
+			}
+			if (reorderBeforeClearOnSuspend) {
+				if (clearStage === 4) {
+					setItems([]);
+					setClearStage(5);
+				} else if (clearStage === 5 && suspendOnClear) use(suspendOnClear);
+			}
+			if (pending && insertForeignOnClear) {
+				const list = document.getElementById('owned-list')!;
+				const foreign = document.createElement('li');
+				foreign.id = 'foreign';
+				foreign.textContent = 'external';
+				list.insertBefore(foreign, list.lastChild);
+			}
+		}
+	</div>
+}
+
+/** An empty branch is new DOM between the markers when the owned list clears. */
+export function OwnedParentEmptyRows({ suspendOnClear }: { suspendOnClear?: Promise<string> }) @{
+	const [items, setItems] = useState(ownedItems);
+	const [pending, setPending] = useState(false);
+	<div>
+		<button
+			id="clear"
+			onClick={() => {
+				setItems([]);
+				setPending(true);
+			}}
+		>clear</button>
+		<button
+			id="append"
+			onClick={() => {
+				setPending(false);
+				setItems(items3b);
+			}}
+		>append</button>
+		<ul>
+			@for (const item of items; key item.id) {
+				<li class="row">
+					<span>{item.label}</span>
+				</li>
+			} @empty {
+				<li class="empty">No rows</li>
+			}
+		</ul>
+		@{
+			if (pending && suspendOnClear) use(suspendOnClear);
+		}
 	</div>
 }
 

--- a/packages/octane/tests/for-batch-clear.test.ts
+++ b/packages/octane/tests/for-batch-clear.test.ts
@@ -11,7 +11,10 @@ import { mount, flushEffects } from './_helpers';
 import {
 	ComponentRows,
 	RefRows,
+	LargeRefRows,
 	PortalRows,
+	OwnedParentRows,
+	OwnedParentEmptyRows,
 	SharedParentRows,
 	log,
 	resetLog,
@@ -68,6 +71,17 @@ describe('forBlock — batch-clear disposal', () => {
 		r.unmount();
 	});
 
+	it('runs every ref cleanup when a large owned-parent list clears', () => {
+		const r = mount(LargeRefRows);
+		expect(r.findAll('li')).toHaveLength(1000);
+		resetLog();
+
+		r.click('#clear');
+		expect(r.findAll('li')).toHaveLength(0);
+		expect(log.filter((entry) => entry === 'ref:cleanup')).toHaveLength(1000);
+		r.unmount();
+	});
+
 	it('removes portal DOM from the foreign target on clear', () => {
 		const target = document.createElement('div');
 		document.body.appendChild(target);
@@ -98,6 +112,171 @@ describe('forBlock — shared-parent bulk clear', () => {
 		r.click('#clear');
 		expect(r.findAll('li.row')).toHaveLength(0);
 		expect(r.findAll('li').map((li) => li.id)).toEqual(['before', 'after']);
+		r.unmount();
+	});
+});
+
+describe('forBlock — owned-parent clear', () => {
+	it('keeps the @empty branch mounted while removing a large owned list', () => {
+		const r = mount(OwnedParentEmptyRows, {});
+		const parent = r.find('ul');
+		const oldRows = r.findAll('li.row');
+		expect(oldRows).toHaveLength(1000);
+		r.click('#clear');
+		expect(r.find('ul')).toBe(parent);
+		expect(r.findAll('li.row')).toHaveLength(0);
+		expect(oldRows[0].isConnected).toBe(false);
+		expect(r.find('li.empty').textContent).toBe('No rows');
+		r.click('#append');
+		expect(r.findAll('li.empty')).toHaveLength(0);
+		expect(r.findAll('li.row').map((row) => row.textContent)).toEqual(['d', 'e', 'f']);
+		r.unmount();
+	});
+
+	it('restores a large owned list when the root suspends after mounting @empty', async () => {
+		let resolve!: (value: string) => void;
+		const suspended = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const r = mount(OwnedParentEmptyRows, { suspendOnClear: suspended });
+		const original = r.findAll('li.row');
+		r.click('#clear');
+		const retained = r.findAll('li.row');
+		expect(retained).toHaveLength(1000);
+		expect(retained[0]).toBe(original[0]);
+		expect(retained[999]).toBe(original[999]);
+		expect(r.findAll('li.empty')).toHaveLength(0);
+		resolve('ready');
+		await suspended;
+		await Promise.resolve();
+		flushEffects();
+		expect(r.findAll('li.row')).toHaveLength(0);
+		expect(r.find('li.empty').textContent).toBe('No rows');
+		r.unmount();
+	});
+
+	it('clears and fills the same list again without replacing its parent', () => {
+		const r = mount(OwnedParentRows, {});
+		const parent = r.find('ul');
+		expect(r.findAll('li.row')).toHaveLength(1000);
+		expect(r.findAll('li.row')[0].textContent).toBe('row-0');
+
+		r.click('#clear');
+		expect(r.find('ul')).toBe(parent);
+		expect(r.findAll('li.row')).toHaveLength(0);
+		r.click('#append');
+		expect(r.find('ul')).toBe(parent);
+		expect(r.findAll('li.row').map((row) => row.textContent)).toEqual(['d', 'e', 'f']);
+		r.unmount();
+	});
+
+	it('restores connected rows when a later part of the root suspends', async () => {
+		let resolve!: (value: string) => void;
+		const suspended = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const r = mount(OwnedParentRows, { suspendOnClear: suspended });
+		const original = r.findAll('li.row');
+
+		r.click('#clear');
+		expect(r.findAll('li.row')).toHaveLength(1000);
+		expect(r.findAll('li.row')[0]).toBe(original[0]);
+		expect(r.findAll('li.row')[999]).toBe(original[999]);
+		expect(original.every((row) => row.isConnected)).toBe(true);
+
+		resolve('ready');
+		await suspended;
+		await Promise.resolve();
+		flushEffects();
+		expect(r.findAll('li.row')).toHaveLength(0);
+		r.click('#append');
+		expect(r.findAll('li.row').map((row) => row.textContent)).toEqual(['d', 'e', 'f']);
+		r.unmount();
+	});
+
+	it('keeps a foreign node added during the clear render', () => {
+		const r = mount(OwnedParentRows, { insertForeignOnClear: true });
+		r.click('#clear');
+		expect(r.findAll('li.row')).toHaveLength(0);
+		expect(r.find('#foreign').textContent).toBe('external');
+		r.unmount();
+	});
+
+	it('restores the original rows after two clearing updates suspend together', async () => {
+		let resolve!: (value: string) => void;
+		const suspended = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const r = mount(OwnedParentRows, {
+			suspendOnClear: suspended,
+			clearTwiceOnSuspend: true,
+		});
+		const original = r.findAll('li.row');
+		r.click('#clear');
+		const retained = r.findAll('li.row');
+		expect(retained).toHaveLength(1000);
+		expect(retained[0]).toBe(original[0]);
+		expect(retained[999]).toBe(original[999]);
+		resolve('ready');
+		await suspended;
+		await Promise.resolve();
+		flushEffects();
+		expect(r.findAll('li.row')).toHaveLength(0);
+		r.click('#append');
+		expect(r.findAll('li.row').map((row) => row.textContent)).toEqual(['d', 'e', 'f']);
+		r.unmount();
+	});
+
+	it('restores the original order after a reorder and clear suspend in the same root attempt', async () => {
+		let resolve!: (value: string) => void;
+		const suspended = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const r = mount(OwnedParentRows, {
+			suspendOnClear: suspended,
+			reorderBeforeClearOnSuspend: true,
+		});
+		const original = r.findAll('li.row');
+		r.click('#clear');
+		const retained = r.findAll('li.row');
+		expect(retained).toHaveLength(1000);
+		expect(retained[0]).toBe(original[0]);
+		expect(retained[999]).toBe(original[999]);
+		resolve('ready');
+		await suspended;
+		await Promise.resolve();
+		flushEffects();
+		expect(r.findAll('li.row')).toHaveLength(0);
+		r.click('#append');
+		expect(r.findAll('li.row').map((row) => row.textContent)).toEqual(['d', 'e', 'f']);
+		r.unmount();
+	});
+
+	it('reuses the original keyed rows when a later update supersedes a suspended clear', async () => {
+		let resolve!: (value: string) => void;
+		const suspended = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const r = mount(OwnedParentRows, { suspendOnClear: suspended });
+		const original = r.findAll('li.row');
+		r.click('#clear');
+		r.click('#reverse');
+		const rows = r.findAll('li.row');
+		expect(rows).toHaveLength(1000);
+		expect(rows[0]).toBe(original[999]);
+		expect(rows[999]).toBe(original[0]);
+		resolve('ready');
+		await suspended;
+		await Promise.resolve();
+		flushEffects();
+		expect(r.findAll('li.row')[0]).toBe(original[999]);
+		r.unmount();
+	});
+
+	it('keeps refilled rows when clearing queues another update', () => {
+		const r = mount(OwnedParentRows, { refillDuringClear: true });
+		r.click('#clear');
+		expect(r.findAll('li.row').map((row) => row.textContent)).toEqual(['d', 'e', 'f']);
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/hydration/for-hydrate.test.ts
+++ b/packages/octane/tests/hydration/for-hydrate.test.ts
@@ -96,6 +96,28 @@ describe('hydrateRoot — @for list (SSR Phase 6 / M2)', () => {
 		root.unmount();
 	});
 
+	it('clears an adopted direct-host list and accepts new rows in the same parent', () => {
+		const items = Array.from({ length: 1000 }, (_, id) => ({ id, name: `row-${id}` }));
+		const onPick = vi.fn();
+		container.innerHTML = ServerRT.renderToString(server.List, { items, onPick }).html;
+		const list = container.querySelector('#list');
+		const first = container.querySelector('li.row');
+		const root = hydrateRoot(container, List, { items, onPick });
+		try {
+			expect(container.querySelector('li.row')).toBe(first);
+			flushSync(() => root.render(List, { items: [], onPick }));
+			expect(container.querySelector('#list')).toBe(list);
+			expect(container.querySelectorAll('li.row')).toHaveLength(0);
+			flushSync(() => root.render(List, { items: [{ id: 1000, name: 'new' }], onPick }));
+			const button = container.querySelector('li.row button') as HTMLButtonElement;
+			expect(button.textContent).toBe('pick');
+			flushSync(() => button.click());
+			expect(onPick).toHaveBeenCalledExactlyOnceWith(1000);
+		} finally {
+			root.unmount();
+		}
+	});
+
 	it('also adopts legacy per-item pairs when the client can self-delimit rows', () => {
 		const items = [
 			{ id: 1, name: 'Alpha' },


### PR DESCRIPTION
## Summary

- Defer clearing an owned keyed list of inert host rows until the root render is accepted, then remove its DOM in one operation. Keep connected rows and the old key map available for suspension rollback; rows with refs, effects, nested scopes, or foreign DOM retain the existing cleanup path.
- Make the local js-framework harness time Octane's completed script-click commit and verify each DOM result. Add an opt-in 1,000-row clear diagnostic with five warmups, 15 samples, and optional 4× CPU throttle.

## Why

[krausest/js-framework-benchmark#2093](https://github.com/krausest/js-framework-benchmark/pull/2093) reports a 28.8% clear regression while upgrading Octane. The earlier release could clear an owned table body in one DOM operation; root render transactions subsequently made the ordinary clear retain and remove each row individually. The new path preserves rollback while restoring bulk removal for safe host-only lists.

## Validation

- [x] `pnpm --config.verify-deps-before-run=warn sync` (no generated tracked changes).
- [x] Scoped `pnpm --config.verify-deps-before-run=warn format:files:check`, `git diff --check`, and `tsrx-tsc --noEmit -p packages/octane/tsconfig.json`.
- [x] 101 relevant tests in each of development and production compile modes, using the task source with cached TSRX tooling. The new rollback tests were seen failing under deliberately broken eager deletion and omitted deletion.
- [x] Same-machine production Chromium 1,000-row clear at 4× CPU, 15 samples and two target orders: old `octane@0.1.31` source **10.8 / 10.3 ms**, current unmodified source **12.6 / 12.3 ms**, candidate **10.9 / 10.7 ms** (medians). Strong mode produced byte-identical bundles for this fixture. This local click timer excludes paint and is not the upstream Chrome timeline.
- [x] Final eight-sample local js-framework run: 10,000-row clear **27.3 → 24.0 ms**; other operations were near baseline, and the DOM insertion and production-call gates passed. All 14 keyed-reorder identity/scratch gates passed.
- [x] Current-head [CI run 34065583868](https://github.com/octanejs/octane/actions/runs/34065583868) passed with frozen-lockfile dependencies: `pnpm format:check`, `pnpm typecheck`, four sharded `pnpm test` lanes, website, browser, React parity, package validation, and example checks.

## Risk / follow-ups

- Local exact dependency installation is blocked by the configured Socket registry's “Recently published” quarantine for `@tsrx/core@0.1.67` and `@tsrx/runtime@0.1.5`. Source tests and browser builds used cached older TSRX tooling, so CI must validate the locked versions.
- The upstream benchmark's exact Chrome timeline should be rerun once this Octane change is published. The optimization applies only to an owned parent with at least 16 inert, single-node rows; all other clear paths remain available.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791327566&installation_model_id=432790&pr_number=976&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F976&signature=520a47757bba81dd16c3c862eeae3cb86ac740fb17ec321935122e8adb7a62c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core keyed-list reconciliation, root transaction journaling, and suspension rollback—incorrect deferral could leak DOM, skip cleanups, or break undo on failed renders.
> 
> **Overview**
> Restores fast bulk clearing for **owned keyed lists** (≥16 inert, single-host rows with no effects, refs, or nested scopes) by **deferring DOM removal until the root render commits**, using one `textContent = ''` wipe when the parent is still wholly owned. Suspended renders keep rows connected and swap the key map via **`journalForOwnedListClear`** so rollback can restore the prior list; lists that need lifecycle teardown still use per-row parking and the existing **`batchClearItems`** paths.
> 
> The **js-framework benchmark harness** now calls Octane’s **`flushSync`** through **`window.__benchFlush`**, checks that each op’s DOM is committed inside the timed click, and adds an opt-in **`CLEAR_1K`** / **`CPU_THROTTLE`** diagnostic suite without changing the canonical 10k **`clear`** op.
> 
> **Tests** cover owned-parent clear with `@empty`, suspension rollback, refills, foreign DOM, large ref cleanups, and hydration clear/refill on adopted lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457ed79a538310675d7642f3d032ac8c0bda2b69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->