### PR TITLE
fix: preserve keyed rows across @empty root rollback

### DIFF
--- a/.changeset/quiet-empty-rollback.md
+++ b/.changeset/quiet-empty-rollback.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Preserve keyed rows when a root render clears a list, mounts its `@empty` arm, refills the list, and then suspends. The empty arm now parks only its own DOM, so rollback keeps the original rows connected and reusable, including after a large owned-list clear.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3156,15 +3156,48 @@ interface ParkedItem {
 }
 let PARKED_ITEMS: ParkedItem[] | null = null;
 
+/** Top-level nodes belonging to an earlier, still-connected deletion of this list. */
+function retainedForSlotNodes(state: ForSlot, retained: Set<Node> | null): Set<Node> | null {
+	const parked = PARKED_ITEMS;
+	if (parked !== null) {
+		for (const item of parked) {
+			const previous = item.block;
+			if (
+				previous.forSlot !== state &&
+				!(
+					previous.exclusiveMarkers &&
+					previous.startMarker === state.start &&
+					previous.endMarker === state.end
+				)
+			)
+				continue;
+			for (const node of item.nodes) (retained ??= new Set()).add(node);
+		}
+	}
+	// Certified owned-list clears retire inert hosts without parking them.
+	const retired = ROOT_RENDER_TRANSACTION!.retired;
+	if (retired !== null) {
+		for (const row of retired) {
+			if (row.forSlot !== state) continue;
+			const start = row.startMarker;
+			if (start !== null && start === row.endMarker) (retained ??= new Set()).add(start);
+		}
+	}
+	return retained;
+}
+
 /** Retain an outgoing row's nodes and scope until its render can commit. */
-function parkItemForHold(block: Block): void {
+function parkItemForHold(block: Block, owningList?: ForSlot): void {
 	const retainConnected = ROOT_RENDER_TRANSACTION !== null && !ROOT_RENDER_ROLLBACK;
 	if (retainConnected) retireRootBlock(block);
+	// @empty borrows the list's markers. Its saved nodes must not overlap rows
+	// retired in an earlier window, or a prior parked @empty arm's own content.
+	const excluded =
+		owningList !== undefined && retainConnected ? retainedForSlotNodes(owningList, null) : null;
 	// A later nested window can sweep an already parked row out of the live
 	// DOM before this window rolls back. Retain the original nodes now, while
-	// the row is still attached; only detach on non-root holds. Borrowed @empty
-	// markers are excluded, but their saved content can include rows parked
-	// earlier in the same root transaction.
+	// the row is still attached; only detach on non-root holds. An @empty arm
+	// saves only nodes it owns, even though its markers span retired rows.
 	const nodes: Node[] = [];
 	const start = block.startMarker;
 	const end = block.endMarker;
@@ -3174,11 +3207,22 @@ function parkItemForHold(block: Block): void {
 			const exclusive = block.exclusiveMarkers;
 			let n: Node | null = exclusive ? start.nextSibling : start;
 			const stop = exclusive ? end : end.nextSibling;
-			while (n !== null && n !== stop) {
-				const next: Node | null = getNextSibling(n);
-				if (!retainConnected) parent.removeChild(n);
-				nodes.push(n);
-				n = next;
+			if (excluded === null) {
+				while (n !== null && n !== stop) {
+					const next: Node | null = getNextSibling(n);
+					if (!retainConnected) parent.removeChild(n);
+					nodes.push(n);
+					n = next;
+				}
+			} else {
+				while (n !== null && n !== stop) {
+					const next: Node | null = getNextSibling(n);
+					if (!excluded.has(n)) {
+						if (!retainConnected) parent.removeChild(n);
+						nodes.push(n);
+					}
+					n = next;
+				}
 			}
 		}
 	}
@@ -3323,8 +3367,14 @@ function restoreForSlot(state: ForSlot, snapshot: any, chain: Block[] | null): v
 	// their saved node lists rather than reading their current DOM position.
 	const nodes: Node[] = [];
 	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
-		const range = takeParkedItem(b) ?? collectBlockRange(b);
-		for (const node of range) nodes.push(node);
+		const parked = takeParkedItem(b);
+		if (parked !== null) for (const node of parked) nodes.push(node);
+		else if (b.startMarker !== null && b.startMarker === b.endMarker) {
+			// An inert owned-list clear can retain a single host without parking it.
+			// A later window may detach it before this snapshot is restored; the
+			// Block still holds its exact Node and can reinsert it here.
+			nodes.push(b.startMarker);
+		} else for (const node of collectBlockRange(b)) nodes.push(node);
 	}
 	// The @empty branch swaps with the rows, so it rolls back with them. A
 	// branch the aborted render mounted is scope-only torn down before the
@@ -3340,7 +3390,12 @@ function restoreForSlot(state: ForSlot, snapshot: any, chain: Block[] | null): v
 		for (const node of range) nodes.push(node);
 	}
 	const parent = state.end.parentNode;
+	// An inner boundary may restore the @empty snapshot while an outer root
+	// attempt still owns rows parked inside those borrowed markers. Leave those
+	// rows connected until the outer attempt commits or rolls back; they are not
+	// members of this snapshot and must not be reordered with its nodes.
 	const keptNodes = new Set(nodes);
+	if (ROOT_RENDER_TRANSACTION !== null) retainedForSlotNodes(state, keptNodes);
 	let current: Node | null = state.start.nextSibling;
 	while (current !== null && current !== state.end) {
 		const next: Node | null = current.nextSibling;
@@ -32417,7 +32472,7 @@ export function forBlock<T>(
 		// row removal: keep the branch's nodes and defer its teardown.
 		if (itemRemovalDefers()) {
 			journalForSlot(state);
-			parkItemForHold(state.emptyBlock);
+			parkItemForHold(state.emptyBlock, state);
 		} else unmountBlock(state.emptyBlock);
 		state.emptyBlock = null;
 	}

--- a/packages/octane/tests/_fixtures/empty-refill-rollback.tsrx
+++ b/packages/octane/tests/_fixtures/empty-refill-rollback.tsrx
@@ -1,0 +1,101 @@
+import { startTransition, use, useEffect, useLayoutEffect, useState } from 'octane';
+
+interface Controls {
+	setStep: (value: number) => void;
+	setLocal: (value: number) => void;
+	setSusp: (value: number) => void;
+}
+
+interface AppProps {
+	api: Controls;
+	load: (step: number) => Promise<string>;
+	log: (entry: string) => void;
+	onLayoutCleanup: (id: string) => void;
+	size?: number;
+}
+
+function Row(props: {
+	id: string;
+	log: AppProps['log'];
+	onLayoutCleanup: AppProps['onLayoutCleanup'];
+}) @{
+	const [local] = useState(props.id + '!');
+	useLayoutEffect(() => () => props.onLayoutCleanup(props.id), []);
+	useEffect(() => {
+		props.log('mount:' + props.id);
+		return () => props.log('cleanup:' + props.id);
+	}, []);
+	<>
+		<li id={'row-' + props.id}>{local as string}</li>
+		<li id={'detail-' + props.id}>{'detail:' + props.id}</li>
+	</>
+}
+
+function ListOwner(props: AppProps & { step: number; transitionRefill?: boolean }) @{
+	const [local, setLocal] = useState(0);
+	props.api.setLocal = setLocal;
+	const original =
+		props.size === undefined
+			? ['a', 'b', 'c']
+			: Array.from({ length: props.size }, (_, index) => String(index));
+	const inserted = [original[0], 'x', ...original.slice(1)];
+	const items =
+		local === 1
+			? ['d']
+			: local === 3
+				? inserted
+				: props.step === 0
+					? original
+					: [];
+	if (local === 1 && props.step === 1) props.api.setSusp(1);
+	<ul id="list">
+		@for (const id of items; key id) {
+			@if (props.size === undefined) {
+				<Row id={id} log={props.log} onLayoutCleanup={props.onLayoutCleanup} />
+			} @else {
+				<li id={'row-' + id}>{id as string}</li>
+			}
+		} @empty {
+			if (local === 0 && props.step === 1) {
+				if (props.transitionRefill) startTransition(() => setLocal(1));
+				else setLocal(1);
+			}
+			<li id="empty">{'nothing'}</li>
+		}
+	</ul>
+}
+
+function RootSuspender(props: AppProps) @{
+	const [susp, setSusp] = useState(0);
+	props.api.setSusp = setSusp;
+	const value = use(props.load(susp));
+	<span id="value">{value as string}</span>
+}
+
+export function EmptyRefillRollback(props: AppProps) @{
+	const [step, setStep] = useState(0);
+	props.api.setStep = setStep;
+	<div>
+		@try {
+			<ListOwner {...props} step={step} />
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+		<RootSuspender {...props} />
+	</div>
+}
+
+export function NestedCommitEmptyRefill(props: AppProps) @{
+	const [step, setStep] = useState(0);
+	props.api.setStep = setStep;
+	<div>
+		@try {
+			<div>
+				<ListOwner {...props} step={step} transitionRefill={true} />
+				<RootSuspender {...props} />
+			</div>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/empty-refill-rollback.test.ts
+++ b/packages/octane/tests/empty-refill-rollback.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { act, mount } from './_helpers';
+import {
+	EmptyRefillRollback,
+	NestedCommitEmptyRefill,
+} from './_fixtures/empty-refill-rollback.tsrx';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((accept) => {
+		resolve = accept;
+	});
+	return { promise, resolve };
+}
+
+function fulfilled(value: string): Promise<string> {
+	return {
+		status: 'fulfilled',
+		value,
+		then: (accept: (value: string) => void) => void accept(value),
+	} as unknown as Promise<string>;
+}
+
+describe('keyed @empty rollback', () => {
+	it('runs committed row cleanups while their DOM remains connected after a nested hold', async () => {
+		const pending = deferred<string>();
+		const api = {} as {
+			setStep: (value: number) => void;
+			setLocal: (value: number) => void;
+			setSusp: (value: number) => void;
+		};
+		const events: string[] = [];
+		const cleanupConnected: Array<{ id: string; connected: boolean }> = [];
+		const rows = new Map<string, Element>();
+		const r = mount(NestedCommitEmptyRefill, {
+			api,
+			load: (step: number) => (step === 0 ? fulfilled('zero') : pending.promise),
+			log: (entry: string) => events.push(entry),
+			onLayoutCleanup: (id: string) => {
+				cleanupConnected.push({ id, connected: rows.get(id)?.isConnected ?? false });
+			},
+		});
+		try {
+			await act(() => {});
+			for (const id of ['a', 'b', 'c']) rows.set(id, r.find('#row-' + id));
+			events.length = 0;
+
+			await act(() => api.setStep(1));
+
+			expect(r.findAll('#list li').map((node) => node.id)).toEqual(['empty']);
+			expect(r.findAll('#fallback')).toHaveLength(1);
+			expect(r.findAll('#row-d')).toHaveLength(0);
+			expect([...rows.values()].every((node) => !node.isConnected)).toBe(true);
+			expect(events.sort()).toEqual(['cleanup:a', 'cleanup:b', 'cleanup:c']);
+			expect(cleanupConnected.sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+				{ id: 'a', connected: true },
+				{ id: 'b', connected: true },
+				{ id: 'c', connected: true },
+			]);
+		} finally {
+			pending.resolve('one');
+			r.unmount();
+		}
+	});
+
+	it.each([
+		{ name: 'a multi-node row list', size: undefined },
+		{ name: 'a large owned list', size: 1000 },
+	])('keeps $name connected and reusable after a same-drain refill', async ({ size }) => {
+		const pending = deferred<string>();
+		const api = {} as {
+			setStep: (value: number) => void;
+			setLocal: (value: number) => void;
+			setSusp: (value: number) => void;
+		};
+		const events: string[] = [];
+		const cleanupConnected: Array<{ id: string; connected: boolean }> = [];
+		const rowNodes = new Map<string, Element>();
+		let initialRows: Element[] = [];
+		const r = mount(EmptyRefillRollback, {
+			api,
+			size,
+			load: (step: number) => (step === 0 ? fulfilled('zero') : pending.promise),
+			log: (entry: string) => events.push(entry),
+			onLayoutCleanup: (id: string) => {
+				const row = rowNodes.get(id);
+				cleanupConnected.push({ id, connected: row?.isConnected ?? false });
+			},
+		});
+		try {
+			await act(() => {});
+			initialRows = r.findAll('#list li');
+			expect(initialRows).toHaveLength(size === undefined ? 6 : size);
+			if (size === undefined) {
+				for (const id of ['a', 'b', 'c']) rowNodes.set(id, r.find('#row-' + id));
+			}
+			events.length = 0;
+
+			await act(() => api.setStep(1));
+
+			const held = r.findAll('#list li');
+			expect(held).toHaveLength(initialRows.length);
+			for (let index = 0; index < held.length; index++)
+				expect(held[index]).toBe(initialRows[index]);
+			expect(initialRows.every((node) => node.isConnected)).toBe(true);
+			expect(r.findAll('#empty')).toHaveLength(0);
+			expect(r.findAll('#row-d')).toHaveLength(0);
+			expect(r.findAll('#fallback')).toHaveLength(0);
+			expect(events).toEqual([]);
+			expect(cleanupConnected).toEqual([]);
+
+			await act(() => api.setLocal(3));
+			const ids =
+				size === undefined ? ['a', 'b', 'c'] : Array.from({ length: size }, (_, i) => String(i));
+			expect(r.findAll('#list li[id^="row-"]').map((row) => row.id)).toEqual([
+				'row-' + ids[0],
+				'row-x',
+				...ids.slice(1).map((id) => 'row-' + id),
+			]);
+			expect(r.find('#row-' + ids[1])).toBe(initialRows[size === undefined ? 2 : 1]);
+			if (size === undefined) {
+				rowNodes.set('x', r.find('#row-x'));
+				expect(r.find('#detail-b')).toBe(initialRows[3]);
+				expect(r.find('#row-b').textContent).toBe('b!');
+			}
+			expect(events).toEqual(size === undefined ? ['mount:x'] : []);
+			expect(cleanupConnected).toEqual([]);
+			if (size === undefined) {
+				await act(() => pending.resolve('one'));
+				await act(() => api.setLocal(2));
+				expect(r.findAll('#list li').map((node) => node.id)).toEqual(['empty']);
+				expect(events.filter((entry) => entry.startsWith('cleanup:')).sort()).toEqual([
+					'cleanup:a',
+					'cleanup:b',
+					'cleanup:c',
+					'cleanup:x',
+				]);
+				expect(cleanupConnected.sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+					{ id: 'a', connected: true },
+					{ id: 'b', connected: true },
+					{ id: 'c', connected: true },
+					{ id: 'x', connected: true },
+				]);
+			}
+		} finally {
+			pending.resolve('one');
+			r.unmount();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Keep committed keyed rows visible and connected when a root render clears a list, mounts `@empty`, refills it, and then suspends in the same drain.
- Preserve connected row cleanup when an inner Suspense boundary rolls back its refill and the outer clear commits.

## Why

The `@empty` arm borrows the list's markers. Its parked DOM range could include rows that an earlier render window had already parked. A root rollback then restored those rows and removed them a second time while disposing the empty arm. Filtering that overlap also requires the inner rollback to leave earlier retired rows connected until the outer attempt settles.

## Changes

- Attribute parked DOM to the earlier rows or empty arms that own it, including inert rows from the owned-list bulk clear path.
- Preserve those earlier rows across nested list restoration without moving them into the inner snapshot's row order.
- Add public `.tsrx` regressions for multi-node rows, 1,000 inert owned rows, subsequent keyed insertion, effects, and connected cleanup on a nested fallback commit.
- Add an `octane` patch changeset.

## Validation

- [x] Regression observed on merged `main`: both row lists vanish during the root hold; subsequent insertion raises `NotFoundError`.
- [x] Source-only compile and jsdom execution of the public `.tsrx` fixtures against the candidate: row identity, ordering, cleanup, nested fallback commit, and hydrated adoption pass.
- [x] Prettier check of changed files with a cached formatter; `git diff --check`; esbuild TypeScript parse.
- [x] Baseline/candidate minified full-runtime bundle smoke (mount, update, input identity, unmount); candidate adds 621 raw / 210 gzip / 66 Brotli bytes with the same esbuild options. This is a bundle size observation, not a timing claim.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34166854168) passed on `71b8e29f`: all four Node test shards, four React parity shards, Chromium integration, lint, typecheck, package validation, examples, and provenance.
- [ ] Local `pnpm sync` and pinned Vitest/typecheck could not start: frozen install returned 403 for `@tsrx/prettier-plugin@0.3.135`. The pinned-toolchain CI above passed.

## Risk / follow-ups

The rare `@empty` swap and rollback paths scan previously parked rows and certified retired hosts. Ordinary row parking retains its unfiltered node loop. The browser benchmark suite does not isolate this same-drain rollback, so no timing claim is made.

Fixes #984.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791412169&installation_model_id=432790&pr_number=986&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F986&signature=821ee2129d928d1cb8613a3412351593cbef22d05f1b10464b207e51535f4bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches root-transaction parking and keyed `@for`/`@empty` rollback in the runtime DOM reconciler; scope is a rare suspense/hold path but incorrect behavior could corrupt list DOM or lifecycle timing.
> 
> **Overview**
> Fixes a root-render hold where clearing a keyed `@for`, mounting `@empty`, refilling the list, and suspending in the same drain could drop or double-remove row DOM on rollback.
> 
> **`parkItemForHold`** now accepts the owning list and, for `@empty`, parks only nodes that belong to the empty arm—not rows already retired or parked for that slot (because `@empty` shares the list’s marker range). **`retainedForSlotNodes`** collects those earlier parked nodes and inert hosts from bulk owned-list clears. **List snapshot restore** reuses inert single-marker rows without requiring a parked range, and treats those retained nodes as “keep connected” during orphan sweeps so nested rollbacks don’t reorder or detach rows owned by an outer attempt.
> 
> Adds Vitest coverage for same-drain empty→refill→suspend (multi-node rows, 1k-item lists, keyed insert reuse) and nested Suspense commit with connected layout cleanups. Patch changeset for `octane`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b8e29fa313895cc3ea6e9dfa829a0d00ec1c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
