### PR TITLE
perf: initialize client block fields once

### DIFF
--- a/.changeset/quiet-core-class-fields.md
+++ b/.changeset/quiet-core-class-fields.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid redundant emitted class-field definitions when constructing client blocks and scopes. Their existing constructors retain the same fields and property order while initializing them once.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6676,93 +6676,94 @@ function schedulePostPaint(cb: () => void): void {
  * `slots[0]` binding bag, NOT on the Block/Scope instance (see Scope.slots),
  * so every BlockImpl instance shares one hidden class outright.
  *
- * All fields initialised in a single, fixed order. Item-only fields
+ * Type-only declarations leave the fixed-order constructor assignments as the
+ * only runtime field definitions, including in consumers that compile source
+ * with native class-field semantics. Item-only fields
  * (prev/next sibling, key, itemIndex) sit on every Block as null/0 so root
  * and dynamic blocks share the same shape with for-of item blocks.
  */
 class BlockImpl {
 	// Hot fields first (touched by every renderBlock / reconcile iteration).
-	body: ComponentBody;
-	props: any;
-	extra: any;
-	outputHandler: OutputHandler | null;
-	memoInChain: boolean;
-	parentNode: Node;
-	parentBlock: Block | null;
-	idState: RootIdState;
-	startMarker: Node | null;
-	endMarker: Node | null;
-	exclusiveMarkers: boolean;
-	itemIndex: number;
-	// A type-only field avoids emitting an undefined DefineNamedOwn before its Smi initialization.
+	declare body: ComponentBody;
+	declare props: any;
+	declare extra: any;
+	declare outputHandler: OutputHandler | null;
+	declare memoInChain: boolean;
+	declare parentNode: Node;
+	declare parentBlock: Block | null;
+	declare idState: RootIdState;
+	declare startMarker: Node | null;
+	declare endMarker: Node | null;
+	declare exclusiveMarkers: boolean;
+	declare itemIndex: number;
 	declare createdStamp: number;
 	// Scheduler / lifecycle.
-	pending: boolean;
-	disposed: boolean;
-	mounted: boolean;
-	renderStatus: number;
-	pendingMode: 'urgent' | 'transition' | null;
-	currentRenderMode: 'urgent' | 'transition' | null;
-	pendingDeferred: boolean;
-	currentRenderDeferred: boolean;
-	inactive: boolean;
+	declare pending: boolean;
+	declare disposed: boolean;
+	declare mounted: boolean;
+	declare renderStatus: number;
+	declare pendingMode: 'urgent' | 'transition' | null;
+	declare currentRenderMode: 'urgent' | 'transition' | null;
+	declare pendingDeferred: boolean;
+	declare currentRenderDeferred: boolean;
+	declare inactive: boolean;
 	// Hooks + cleanups (per-block state).
-	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[] | null;
-	effectSlots: EffectSlot[] | null;
-	children: ChildScope[] | null;
-	_slots: any[] | null;
-	refFields: string[] | null;
-	$$ctxValues: Map<Context<any>, any> | null;
+	declare hooks: Map<HookSlot, any> | null;
+	declare cleanups: Cleanup[] | null;
+	declare effectSlots: EffectSlot[] | null;
+	declare children: ChildScope[] | null;
+	declare _slots: any[] | null;
+	declare refFields: string[] | null;
+	declare $$ctxValues: Map<Context<any>, any> | null;
 	// Contexts whose value this block's subtree consumes — stamped on this block
 	// AND its memo ancestors by useContextInternal. The TRANSITIVE signal: a
 	// changed version here means "a consumer somewhere at/below me needs the new
 	// value", so the memo bailout descends rather than skipping.
-	$$ctxReads: Map<Context<any>, any> | null;
+	declare $$ctxReads: Map<Context<any>, any> | null;
 	// Contexts this block's OWN render directly read (its own body, or an inline
 	// lite descendant that shares this block). The DIRECT signal: a changed
 	// version here means THIS block must re-run; if only $$ctxReads changed, the
 	// block can bail its body and refresh just its consuming child blocks.
-	$$ctxDirect: Map<Context<any>, any> | null;
+	declare $$ctxDirect: Map<Context<any>, any> | null;
 	// Resolved-provider cache for `use(ctx)` — see Scope.$$ctxCache.
-	$$ctxCache: Map<Context<any>, any> | null;
+	declare $$ctxCache: Map<Context<any>, any> | null;
 	// Armed for React's IMPLICIT same-element bailout (beginWork's
 	// oldProps === newProps skip). Set at value-position component mounts
 	// (childSlot) — the only sites that can receive a cached descriptor back.
 	// Arming makes the block a stamping target (like __memo) so the bail's lazy
 	// consumer refresh has the context deps it needs.
-	$$implicitBail: boolean;
+	declare $$implicitBail: boolean;
 	// __thenableIdx is reset every renderBlock so pre-init costs nothing.
-	__thenableIdx: number;
+	declare __thenableIdx: number;
 	// Render-loop guard bookkeeping (see the Block interface).
-	drainStamp: number;
-	drainRenders: number;
-	crossRenderUpdate: boolean;
-	nestedUpdateChain: number;
-	nestedUpdateCount: number;
-	nestedUpdateError: boolean;
-	effectEventRenderVersion: number;
-	effectEventCompletedVersion: number;
+	declare drainStamp: number;
+	declare drainRenders: number;
+	declare crossRenderUpdate: boolean;
+	declare nestedUpdateChain: number;
+	declare nestedUpdateCount: number;
+	declare nestedUpdateError: boolean;
+	declare effectEventRenderVersion: number;
+	declare effectEventCompletedVersion: number;
 	// De-opt host node managed by this Block (deoptItemBody / hostElementBody), reused
 	// across renders. Null for all other blocks; declared so the shape stays monomorphic.
-	deoptNode: Node | null;
+	declare deoptNode: Node | null;
 	// A de-opt descriptor with a `ref` was stamped in this subtree (see Block).
-	deoptRefs: boolean;
+	declare deoptRefs: boolean;
 	// Per-scope dense slot array (binding bag + control-flow/component/child slots),
 	// indexed by compile-time slot index. Keeps the scope shape monomorphic.
-	slots: any[];
+	declare slots: any[];
 	// For-block item bookkeeping.
-	forSlot: ForSlot | null;
-	prevSibling: Block | null;
-	nextSibling: Block | null;
-	key: any;
+	declare forSlot: ForSlot | null;
+	declare prevSibling: Block | null;
+	declare nextSibling: Block | null;
+	declare key: any;
 	// ViewTransition boundary props (null on every other block — see Block).
-	vt: ViewTransitionProps | null;
+	declare vt: ViewTransitionProps | null;
 	// Scope contract: a Block is its own scope.
-	parent: Scope | null;
-	block: Block;
+	declare parent: Scope | null;
+	declare block: Block;
 	// Metadata.
-	kind: BlockKind;
+	declare kind: BlockKind;
 
 	constructor(
 		kind: BlockKind,
@@ -6791,7 +6792,6 @@ class BlockImpl {
 		this.endMarker = endMarker;
 		this.exclusiveMarkers = false;
 		this.itemIndex = 0;
-		this.createdStamp = 0;
 		this.pending = false;
 		this.disposed = false;
 		this.mounted = false;
@@ -6832,6 +6832,8 @@ class BlockImpl {
 		this.parent = null;
 		this.block = this as unknown as Block;
 		this.kind = kind;
+		// This field was already type-only; keep its original last own-property position.
+		this.createdStamp = 0;
 	}
 }
 
@@ -6847,21 +6849,21 @@ class BlockImpl {
  * registerSlot / unmountScope) sees identical structure.
  */
 class ScopeImpl {
-	block: Block;
-	parent: Scope | null;
-	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[] | null;
-	effectSlots: EffectSlot[] | null;
-	children: ChildScope[] | null;
-	_slots: any[] | null;
-	refFields: string[] | null;
-	$$ctxValues: Map<Context<any>, any> | null;
-	$$ctxReads: Map<Context<any>, any> | null;
-	$$ctxCache: Map<Context<any>, any> | null;
-	mounted: boolean;
+	declare block: Block;
+	declare parent: Scope | null;
+	declare hooks: Map<HookSlot, any> | null;
+	declare cleanups: Cleanup[] | null;
+	declare effectSlots: EffectSlot[] | null;
+	declare children: ChildScope[] | null;
+	declare _slots: any[] | null;
+	declare refFields: string[] | null;
+	declare $$ctxValues: Map<Context<any>, any> | null;
+	declare $$ctxReads: Map<Context<any>, any> | null;
+	declare $$ctxCache: Map<Context<any>, any> | null;
+	declare mounted: boolean;
 	// Per-scope dense slot array (binding bag + control-flow/component/child slots),
 	// indexed by compile-time slot index. Keeps the scope shape monomorphic.
-	slots: any[];
+	declare slots: any[];
 
 	constructor(parent: Scope, block: Block) {
 		this.block = block;
@@ -6872,11 +6874,11 @@ class ScopeImpl {
 		this.children = null;
 		this._slots = null;
 		this.refFields = null;
-		this.slots = [];
 		this.$$ctxValues = null;
 		this.$$ctxReads = null;
 		this.$$ctxCache = null;
 		this.mounted = false;
+		this.slots = [];
 	}
 }
 
@@ -7617,11 +7619,11 @@ function disposeReturnSlot(block: Block, state: any): void {
  * otherwise their independent updates would lose the enclosing root transaction.
  */
 class LiteBlockImpl {
-	parentNode: Node;
-	endMarker: Node | null;
-	parentBlock: Block;
-	$$ctxValues: Map<Context<any>, any> | null;
-	idState: RootIdState;
+	declare parentNode: Node;
+	declare endMarker: Node | null;
+	declare parentBlock: Block;
+	declare $$ctxValues: Map<Context<any>, any> | null;
+	declare idState: RootIdState;
 
 	constructor(parentNode: Node, endMarker: Node | null, parentBlock: Block) {
 		this.parentNode = parentNode;

--- a/packages/octane/tests/component-mount-shapes.test.ts
+++ b/packages/octane/tests/component-mount-shapes.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
+import { KeyedPair } from './_fixtures/component-children-host.tsrx';
+import { NestedRefs } from './_fixtures/scope-lazy-collections.tsrx';
+
+const NESTED_REFS_FIXTURE = 'packages/octane/tests/_fixtures/scope-lazy-collections.tsrx';
+
+describe('component placement and identity', () => {
+	it('keeps nested hookless children attached through a parent update and detaches their refs', () => {
+		const attached: Element[] = [];
+		const detached: Array<Element | null> = [];
+		const collect = (node: Element | null) => {
+			if (node === null) detached.push(node);
+			else attached.push(node);
+		};
+		const r = mount(NestedRefs, { collect });
+		try {
+			const leaves = r.findAll('.leaf');
+			expect(leaves).toHaveLength(2);
+			expect(attached).toHaveLength(2);
+			for (let index = 0; index < leaves.length; index++)
+				expect(attached[index]).toBe(leaves[index]);
+
+			r.update(NestedRefs, { collect });
+			const updated = r.findAll('.leaf');
+			for (let index = 0; index < leaves.length; index++)
+				expect(updated[index]).toBe(leaves[index]);
+			r.click('.toggle');
+			expect(r.findAll('.leaf')).toHaveLength(0);
+			expect(detached).toHaveLength(2);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('resets a keyed component while keeping its hookless sibling', () => {
+		const r = mount(KeyedPair, { k: 1 });
+		try {
+			const counter = r.find('.c');
+			const sibling = r.find('.leaf');
+			r.click('.c');
+			expect(counter.textContent).toBe('A:1');
+
+			r.update(KeyedPair, { k: 1 });
+			expect(r.find('.c')).toBe(counter);
+			expect(r.find('.leaf')).toBe(sibling);
+			expect(counter.textContent).toBe('A:1');
+
+			r.update(KeyedPair, { k: 2 });
+			expect(r.find('.c')).not.toBe(counter);
+			expect(r.find('.c').textContent).toBe('A:0');
+			expect(r.find('.leaf')).toBe(sibling);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('adopts nested hookless children without replacing their server nodes', () => {
+		const server = loadServerFixture(NESTED_REFS_FIXTURE);
+		const { html } = ServerRuntime.renderToString(server.NestedRefs, {
+			collect: () => {},
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const leaves = Array.from(container.querySelectorAll('.leaf'));
+		expect(leaves).toHaveLength(2);
+
+		const attached: Element[] = [];
+		const collect = (node: Element | null) => {
+			if (node !== null) attached.push(node);
+		};
+		const root = hydrateRoot(container, NestedRefs, { collect });
+		try {
+			flushSync(() => {});
+			const hydrated = Array.from(container.querySelectorAll('.leaf'));
+			for (let index = 0; index < leaves.length; index++)
+				expect(hydrated[index]).toBe(leaves[index]);
+			expect(attached).toHaveLength(2);
+			for (let index = 0; index < leaves.length; index++)
+				expect(attached[index]).toBe(leaves[index]);
+
+			root.render(NestedRefs, { collect });
+			flushSync(() => {});
+			const updated = Array.from(container.querySelectorAll('.leaf'));
+			for (let index = 0; index < leaves.length; index++)
+				expect(updated[index]).toBe(leaves[index]);
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Make `BlockImpl`, `ScopeImpl`, and `LiteBlockImpl` field declarations type-only; their constructors remain the single source of runtime field initialization.
- Preserve the existing own-property order by keeping `createdStamp` last on blocks and `slots` last on scopes.

## Why

With native class-field semantics, the previous declarations defined 70 properties as `undefined` before the constructors assigned their values. That work occurs for every client block, keyed row, and child scope. It also generalized several numeric fields during warm-up.

## Changes

- Replace uninitialized field declarations with `declare` in the three runtime classes, retaining every constructor assignment and field.
- Add a public mount/hydration/keyed regression for nested hookless scopes, row identity/state, ref cleanup, and server-node adoption.
- Add an `octane` patch changeset.

## Validation

- [x] Source-only public fixture mount and hydration pass; deliberately omitting `LiteBlockImpl.parentNode` initialization makes the same mount fail at the DOM insertion boundary.
- [x] Exact-class esbuild/V8 probe: emitted undefined field definitions **70 → 0** (Block 52, Scope 13, Lite 5); all 53/13/5 own properties, key order, fast-property status, and per-class instance maps match baseline.
- [x] Same-environment source-only Chromium 149 keyed mount, eight ABBA paired cycles with exact DOM/order/identity/unmount controls: 1,000 rows median 1.30 → 1.10 ms; 10,000 rows 10.55 → 9.00 ms. These timings are directional because within-run variation overlaps the delta; this is not a canonical compiled js-framework result.
- [x] Same-esbuild production full-index bundle: 344,044 → 343,279 raw bytes; 108,478 → 108,248 gzip bytes.
- [x] Cached Prettier check on changed files, esbuild TypeScript parse, and `git diff --check`.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34207207709): all 26 jobs passed, including the new regression in both `octane` and `octane-prod` (3 tests each), Chromium integration, parity, lint, typecheck, and provenance.
- [ ] Local `pnpm sync` and pinned Vitest/typecheck could not start: frozen install returned 403 for `@tsrx/core@0.1.69`, and the sync preflight returned 403 for `@tsrx/prettier-plugin@0.3.135`.

## Risk / follow-ups

Native field definitions previously shadowed deliberately installed setters on internal class prototypes; constructor assignments can invoke such setters. No supported API promises prototype mutation of framework-owned Blocks/Scopes. The source-only mount timings need corroboration by the compiled benchmark before any broad speed claim.

Refs #981.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791449738&installation_model_id=432790&pr_number=989&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F989&signature=a6928c912fef3e6089b4531f43cbe85493b6779653fad1206d6d2753fecb3a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot-path client runtime object layout; behavior is guarded by new mount/hydration tests, with a noted edge case if prototype setters were installed on framework-owned block/scope classes.
> 
> **Overview**
> **Runtime object construction** no longer emits native class-field initializers for `BlockImpl`, `ScopeImpl`, and `LiteBlockImpl`. Uninitialized instance fields are now **`declare`** (type-only), so each new block/scope/lite proxy is shaped **only** by the existing constructor assignments—avoiding dozens of redundant `undefined` definitions per allocation under native class-field compilation while keeping the same fields and V8 hidden-class intent.
> 
> **Property order** is explicitly preserved: `createdStamp` stays last on blocks and `slots` last on scopes (constructor assignment order adjusted where needed).
> 
> **Regression coverage** adds `component-mount-shapes.test.ts` for nested hookless children (DOM identity, ref detach), keyed vs sibling identity, and hydration adopting server nodes without replacement. An **octane patch** changeset documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d907d42d88aaa0715cb2760529174f90732d7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
