### PR TITLE
perf: stabilize client block shapes across boundaries

### DIFF
--- a/.changeset/quiet-block-expando-shapes.md
+++ b/.changeset/quiet-block-expando-shapes.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep client blocks on a stable object shape across ordinary renders, Suspense, Activity, and fetch-tree warming by reserving optional fields when each block is constructed.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6674,7 +6674,9 @@ function schedulePostPaint(cb: () => void): void {
  * with a less predictable optimisation profile when the literal has many
  * fields). Compiled bodies stamp their dynamic per-call-site keys on the
  * `slots[0]` binding bag, NOT on the Block/Scope instance (see Scope.slots),
- * so every BlockImpl instance shares one hidden class outright.
+ * so every BlockImpl instance shares one hidden class outright. Feature-only
+ * fields also start as undefined here, rather than transitioning the shape
+ * when Suspense, Activity, or fetch-tree warming first uses them.
  *
  * Type-only declarations leave the fixed-order constructor assignments as the
  * only runtime field definitions, including in consumers that compile source
@@ -6764,6 +6766,18 @@ class BlockImpl {
 	declare block: Block;
 	// Metadata.
 	declare kind: BlockKind;
+	// Optional render and boundary state. Keep these on the common Block shape:
+	// otherwise ordinary renders and each optional feature fork its V8 map.
+	declare __warmEpisode: number | undefined;
+	declare __thenableDone: boolean | undefined;
+	declare __thenables: TrackedThenable<unknown>[] | undefined;
+	declare $$tryHandler: TryHandler | undefined;
+	declare __suspenseHandler:
+		((thenable: TrackedThenable<unknown>, sourceBlock: Block) => void) | null | undefined;
+	declare __trySlot: TrySlot | undefined;
+	declare __activitySlot: ActivitySlot | undefined;
+	declare __warmCache: Map<HookSlot, WarmEntry[]> | undefined;
+	declare __warmCacheEpisode: number | undefined;
 
 	constructor(
 		kind: BlockKind,
@@ -6832,8 +6846,17 @@ class BlockImpl {
 		this.parent = null;
 		this.block = this as unknown as Block;
 		this.kind = kind;
-		// This field was already type-only; keep its original last own-property position.
+		// Keep its original position after kind; optional fields follow it.
 		this.createdStamp = 0;
+		this.__warmEpisode = undefined;
+		this.__thenableDone = undefined;
+		this.__thenables = undefined;
+		this.$$tryHandler = undefined;
+		this.__suspenseHandler = undefined;
+		this.__trySlot = undefined;
+		this.__activitySlot = undefined;
+		this.__warmCache = undefined;
+		this.__warmCacheEpisode = undefined;
 	}
 }
 
@@ -31811,8 +31834,8 @@ export function activityBlock(
 			hiddenDom: null,
 			portals: null,
 		};
-		// Activity is a rare boundary, so keep this back-reference off the
-		// monomorphic Block shape (matching the existing Suspense __trySlot tag).
+		// All Blocks reserve this optional back-reference so Activity boundaries
+		// keep the same shape as ordinary and Suspense blocks.
 		(b as any).__activitySlot = state;
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);

--- a/packages/octane/tests/activity-suspense-retry.test.ts
+++ b/packages/octane/tests/activity-suspense-retry.test.ts
@@ -1,0 +1,53 @@
+import { expect, it } from 'vitest';
+import { flushSync } from '../src/index.js';
+import { act, flushEffects, mount } from './_helpers';
+import { SuspenseHideOwnershipActivity } from './_fixtures/activity.tsrx';
+
+it('preserves visible content and DOM identity through a hidden Suspense retry', async () => {
+	let setStage!: (stage: string) => void;
+	let resolve!: (value: string) => void;
+	const promise = new Promise<string>((done) => (resolve = done));
+	const expose = (setter: typeof setStage) => (setStage = setter);
+	const props = { mode: 'visible', expose, promise };
+	const r = mount(SuspenseHideOwnershipActivity, props);
+	try {
+		const stable = r.find('#activity-stable-display') as HTMLElement;
+		expect(stable.style.display).toBe('inline-grid');
+
+		flushSync(() => setStage('other'));
+		flushEffects();
+		const owned = r.find('#activity-owned-display') as HTMLElement;
+		expect(r.find('#activity-stable-display')).toBe(stable);
+		expect(owned.style.display).toBe('inline-flex');
+
+		r.update(SuspenseHideOwnershipActivity, { ...props, mode: 'hidden' });
+		flushEffects();
+		expect(stable.style.display).toBe('none');
+		expect(owned.style.display).toBe('none');
+
+		flushSync(() => setStage('pending'));
+		flushEffects();
+		expect((r.find('#activity-owner-pending') as HTMLElement).style.display).toBe('none');
+
+		await act(() => resolve('loaded'));
+		flushEffects();
+		const resolved = r.find('#activity-resolved-display') as HTMLElement;
+		expect(resolved.textContent).toBe('loaded');
+		expect(resolved.style.display).toBe('none');
+
+		r.update(SuspenseHideOwnershipActivity, props);
+		flushEffects();
+		expect(r.find('#activity-stable-display')).toBe(stable);
+		expect(stable.style.display).toBe('inline-grid');
+		expect(resolved.style.display).toBe('block');
+		expect(r.find('#activity-owned-display').textContent).toBe('new');
+		expect(r.container.querySelector('#activity-owner-pending')).toBeNull();
+
+		flushSync(() => setStage('other'));
+		flushEffects();
+		expect(r.find('#activity-stable-display')).toBe(stable);
+		expect(r.find('#activity-late').textContent).toBe('late');
+	} finally {
+		r.unmount();
+	}
+});


### PR DESCRIPTION
## Summary

- Reserve nine optional `BlockImpl` fields at construction so ordinary, Suspense, Activity, and fetch-tree-warming blocks keep the same V8 object shape.
- Preserve `undefined` defaults, existing assignments, and the previous order of all preexisting fields.

## Why

After #989 removed redundant native class-field definitions, ordinary blocks still gained two fields on first render. Suspense, Activity, `use()`, and warm replay added more fields later, splitting the map at common Block read sites. A constructor-only shape probe on current `main` found 53 own fields before render, 55 afterward, and 58 on a Suspense boundary, with different V8 maps. This PR pays for fixed slots on every block while keeping feature handlers and caches lazy.

## Changes

- Add type-only field declarations and fixed-order `undefined` constructor assignments for the nine late Block fields.
- Replace the stale Activity shape comment and add a client behavior regression covering visible updates, a hidden Suspense retry, asynchronous resolution, reveal, DOM identity, and authored display.
- Add an `octane` patch changeset.

## Validation

- [x] Public compiled fixture through a source-only JSDOM harness passes; deliberately omitting the Activity back-reference assignment makes the hidden fallback visibly unhide and fails the same assertion.
- [x] Node 26.4/V8 14.6 probe: 62 own fields on fresh, ordinary, Suspense, and Activity blocks; `%HaveSameMap` matches across modes and all objects retain fast properties.
- [x] Same-source esbuild 0.28.1 / Chromium 149 ABCCBA comparison on Apple M5 Max (three warmups, six paired cycles): 1,024 keyed rows under 16 actual boundaries, 12 visible updates, exact row order/text/DOM identity/unmount. Source-only Activity median 3.95 → 3.50 ms; resolved Suspense 4.05 → 3.45 ms. This is directional and does not time actual suspension/retry or the compiled Activity benchmark.
- [x] 1,000/10,000 keyed-row mount control: 1.10 → 1.00 ms / 8.40 → 8.30 ms; both differences overlap run variation. Retained heap is approximately **+32 bytes per block** (100,000 rendered blocks, repeated GC samples). Full-index bundle is **+236 raw / +38 gzip / +102 Brotli bytes**.
- [x] Cached Prettier on changed files, esbuild TypeScript parse, `git diff --check`, and source-only behavior/shape probes.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34219298686): all 26 jobs passed, including the new regression in `octane` and `octane-prod`, lint, typecheck, Chromium integration, parity, and provenance.
- [ ] Pinned local Vitest/typecheck and `pnpm sync` could not start after the package registry returned 403 during the frozen install.

## Risk / follow-ups

Every client Block carries nine additional enumerable internal fields, costing about 32 retained bytes. The source-only boundary timings are directional; a focused compiled Activity throughput comparison remains follow-up performance evidence. Code that reflects over private Block/Scope objects can observe the extra keys, though this is not a supported component contract.

Refs #981. Follows merged #989.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791457816&installation_model_id=432790&pr_number=990&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F990&signature=3f45fee2769be1fcd4cf26be2a155eba7763dfcaf24f7a0ba8345e58bf13d808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client `BlockImpl` allocation in the renderer with a small per-block memory cost; behavior is covered by a new boundary regression test but the change affects all blocks.
> 
> **Overview**
> **Reserves nine optional boundary/render fields on every `BlockImpl` at construction** (`__warmEpisode`, thenable/Suspense/try/Activity slots, warm cache, etc.) so ordinary renders, Suspense, Activity, and fetch-tree warming no longer grow the object shape on first use.
> 
> Runtime comments now describe this as intentional: `__activitySlot` stays on the common block shape instead of being treated as a rare expando. A new Vitest case exercises **Activity + hidden Suspense retry**—visible/hidden toggles, async resolve, reveal, DOM identity, and display styles—so boundary behavior stays correct with the unified shape. An **octane patch** changeset records the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd3c16cdd94249876bcd54b36506ed5b0c2d3a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
