### PR TITLE
perf: compact delegated handler bundle literals

### DIFF
--- a/.changeset/light-event-bundle-literals.md
+++ b/.changeset/light-event-bundle-literals.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reduce the retained size of delegated event handler bundles by placing their private brand after the function and argument fields. Preserve handler updates and in-flight dispatch snapshots.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -17749,6 +17749,8 @@ function isUsableEventSlot(slot: EventSlot): boolean {
 // Arity variants mirror fireEventSlot's dispatch switch; `evtN`/`evtNu` are
 // the rest fallbacks. Arity-0 descriptors share one empty args array
 // (dispatch only reads it; the arity-0 update never writes args).
+// Keep the computed brand last in every bundle literal, including dispatch
+// snapshots, so V8 can initialize fn/args from its object-literal boilerplate.
 // ---------------------------------------------------------------------------
 
 const EMPTY_ARGS: any[] = [];
@@ -17763,7 +17765,7 @@ export function setEventHandler(el: Element, key: string, handler: any): void {
 }
 
 export function evt0(el: Element, key: string, fn: any): HandlerBundle {
-	const d: HandlerBundle = { [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND, fn, args: EMPTY_ARGS };
+	const d: HandlerBundle = { fn, args: EMPTY_ARGS, [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
 	setEventHandler(el, key, d);
 	return d;
 }
@@ -17773,7 +17775,7 @@ export function evt0u(d: HandlerBundle, fn: any): void {
 	d.fn = fn;
 }
 export function evt1(el: Element, key: string, fn: any, a0: any): HandlerBundle {
-	const d: HandlerBundle = { [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND, fn, args: [a0] };
+	const d: HandlerBundle = { fn, args: [a0], [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
 	setEventHandler(el, key, d);
 	return d;
 }
@@ -17787,7 +17789,7 @@ export function evt1u(d: HandlerBundle, fn: any, a0: any): void {
 	d.args[0] = a0;
 }
 export function evt2(el: Element, key: string, fn: any, a0: any, a1: any): HandlerBundle {
-	const d: HandlerBundle = { [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND, fn, args: [a0, a1] };
+	const d: HandlerBundle = { fn, args: [a0, a1], [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
 	setEventHandler(el, key, d);
 	return d;
 }
@@ -17803,7 +17805,7 @@ export function evt2u(d: HandlerBundle, fn: any, a0: any, a1: any): void {
 	a[1] = a1;
 }
 export function evtN(el: Element, key: string, fn: any, args: any[]): HandlerBundle {
-	const d: HandlerBundle = { [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND, fn, args };
+	const d: HandlerBundle = { fn, args, [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
 	setEventHandler(el, key, d);
 	return d;
 }
@@ -18351,9 +18353,9 @@ function preserveDispatchedBundle(bundle: HandlerBundle): void {
 	for (let index = 0; index < CAPTURE_SLOTS.length; index++) {
 		if (CAPTURE_SLOTS[index] === bundle) {
 			CAPTURE_SLOTS[index] = snapshot ??= {
-				[EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND,
 				fn: bundle.fn,
 				args: bundle.args.slice(),
+				[EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND,
 			};
 		}
 	}

--- a/packages/octane/tests/audit-events-portals.test.ts
+++ b/packages/octane/tests/audit-events-portals.test.ts
@@ -103,6 +103,33 @@ describe('audit event and portal behavior', () => {
 		}
 	});
 
+	it('preserves callback arguments during a synchronous event update', () => {
+		const { App } = fixture(
+			`export function App({report, update, label}) @{ <div onClick={() => report(label, 'parent', 'third')}><button onClickCapture={() => report()} onClick={() => update(label, 'child')}>go</button></div> }`,
+		);
+		const calls: unknown[][] = [];
+		let r: ReturnType<typeof mount>;
+		const report = (...args: unknown[]) => calls.push(args);
+		const nextReport = (...args: unknown[]) => calls.push(['next', ...args]);
+		const update = (...args: unknown[]) => {
+			calls.push(args);
+			r.update(App, { report: nextReport, update, label: 'new' });
+		};
+		r = mount(App, { report, update, label: 'old' });
+		try {
+			const button = r.find('button');
+			mouse(button);
+			// The ancestor's callback was queued before the child synchronously
+			// updated its props. The next event observes the new callback inputs.
+			expect(calls).toEqual([[], ['old', 'child'], ['old', 'parent', 'third']]);
+			calls.length = 0;
+			mouse(button);
+			expect(calls).toEqual([['next'], ['new', 'child'], ['next', 'new', 'parent', 'third']]);
+		} finally {
+			r.unmount();
+		}
+	});
+
 	it.each(['compiled', 'spread', 'descriptor'])(
 		'uses case-sensitive custom event names through %s props',
 		(kind) => {


### PR DESCRIPTION
## Summary

- Put the private computed Symbol brand last in all four delegated handler bundle factories and the in-flight dispatch snapshot.
- Keep handler function/argument storage, update behavior, and dispatch semantics unchanged.

## Why

The earlier Symbol-first literal prevents V8 from building `fn` and `args` into its object-literal boilerplate. Each event-enabled compiled row typically mounts two bundles. On current `main`, the exact production `evt1` output uses three keyed property definitions and retains a 56-byte bundle; the reordered literal uses two named definitions plus the Symbol and retains a 48-byte bundle.

## Changes

- Reorder five internal `HandlerBundle` literals and document why the computed brand is last.
- Extend the public compiled event regression to cover 0/2/N-argument callbacks, a synchronous child update during dispatch, the queued ancestor's old handler/args, and the next event's new handler/args.
- Add an `octane` patch changeset.

## Validation

- [x] Source-only delegated DOM/JSDOM harness passes with the candidate and turns red when the `evt2` bundle brand is deliberately omitted in memory. The compiled event suite passed all 18 tests in both `octane` and `octane-prod` on CI.
- [x] Exact esbuild 0.28.1 production `evt1` V8 probe (Node 26/V8 14.6): 72 → 64 bytes of bytecode, 3 keyed definitions → 2 named plus 1 keyed, 56 → 48 bytes per fast-property bundle. Two hundred thousand retained bundles use 1.6 MB less heap. Own keys/descriptors and brand values match.
- [x] Same-environment Chromium 149 keyed mount on Apple M5 Max, 4 warmups and 8 mirrored ABBA cycles: two handlers per row, native click arguments/order, keyed survivor identity, synchronous in-flight update snapshot, and detached cleanup checked. The 10,000-row median was 16.9 → 15.4 ms, faster in all eight paired cycles. Absolute timings varied across runs and one cycle had a system outlier; this is directional source-only evidence, not the canonical compiled js-framework score.
- [x] Full-index production bundle: 343,515 raw bytes unchanged; gzip 108,231 → 108,233 bytes; Brotli 92,474 → 92,398 bytes.
- [x] Cached Prettier on changed files, esbuild TypeScript parse, `git diff --check`, and source-only public-event probe.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34225020082): all 26 jobs passed, including both event test modes, lint, typecheck, integration, parity, and provenance.
- [ ] Local pinned Vitest/typecheck and `pnpm sync` could not start after the dependency registry returned 403 during the frozen install.

## Risk / follow-ups

Literal field evaluation order changes only among internal parameter reads and constants; JS own-key order and property descriptors match. Fixed-arity `args` arrays still allocate, so the separate #981 suggestion to store those arguments as fields remains open. A compiled js-framework benchmark remains useful before making a broad application-speed claim.

Refs #981. Follows merged #990.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791461684&installation_model_id=432790&pr_number=991&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F991&signature=681b809e7826b4bbe0db119f7780cc45e6918c1e6a3370cdf9a70d9fa4a85d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal literal field order only; semantics and property descriptors are unchanged, with new tests locking in sync-dispatch snapshot behavior.
> 
> **Overview**
> **Reorders delegated event `HandlerBundle` object literals** so `fn` and `args` come first and the private Symbol brand is last, in `evt0`–`evtN` and in `preserveDispatchedBundle` dispatch snapshots. Runtime comments explain this helps V8 use object-literal boilerplate and **cuts retained bundle size** (e.g. smaller per-bundle footprint at scale) without changing mount/update or dispatch behavior.
> 
> Adds a **compiled-event regression** that clicks through capture/bubble with multi-argument handlers and a synchronous child `update` during dispatch, asserting queued ancestors still see old `fn`/args and the next click sees the new ones. Includes an **octane patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2ad8c79f23099a6403cf1332ab06af9e8bbd7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
