### PR TITLE
fix: ignore virtual Octane config dependencies

### DIFF
--- a/.changeset/calm-config-watch-paths.md
+++ b/.changeset/calm-config-watch-paths.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/vite-plugin': patch
+---
+
+Ignore virtual module IDs when watching `octane.config.ts` dependencies, so decorator helpers cannot crash the Vite dev server while imported files still trigger reloads.

--- a/packages/vite-plugin-octane/src/load-config.js
+++ b/packages/vite-plugin-octane/src/load-config.js
@@ -133,7 +133,8 @@ function viteConfigModuleRunner(vite) {
 			function visit(module) {
 				if (seen.has(module)) return;
 				seen.add(module);
-				if (module.file) dependencies.add(module.file);
+				// Virtual module IDs are not filesystem paths and cannot be watched.
+				if (module.file && !module.file.includes('\0')) dependencies.add(module.file);
 				for (const imported of module.importedModules) visit(imported);
 			}
 			for (const root of roots) visit(root);

--- a/packages/vite-plugin-octane/tests/plugin.test.ts
+++ b/packages/vite-plugin-octane/tests/plugin.test.ts
@@ -3,6 +3,7 @@
 // option forwarding to the bundled compiler, the appType default, and the
 // config resolution of `router.preHydrate` / RenderRoute `status`.
 import { fileURLToPath } from 'node:url';
+import { statSync } from 'node:fs';
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -380,6 +381,49 @@ describe('octane() plugin factory', () => {
 			await hotUpdate.handler.call(
 				{ environment: { name: 'client' } },
 				{ file: watchedPolicyPath, modules: [], server: { restart } },
+			);
+			expect(restart).toHaveBeenCalledOnce();
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it('watches real config imports when an imported module uses decorators', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'octane-vite-decorated-config-'));
+		const configPath = join(root, 'octane.config.ts');
+		const entityPath = join(root, 'entity.ts');
+		try {
+			await writeFile(
+				join(root, 'tsconfig.json'),
+				JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+			);
+			await writeFile(
+				entityPath,
+				'function entity(value) { return value; }\n@entity class Entity {}\nexport const strong = Entity.name === "Entity";\n',
+			);
+			await writeFile(
+				configPath,
+				"import { strong } from './entity.ts';\nexport default { compiler: { strong } };\n",
+			);
+
+			const [compiler, meta] = octane({ hmr: false });
+			await (compiler.config as (config: { root: string }) => unknown)({ root });
+
+			const add = vi.fn((files: string[]) => {
+				for (const file of files) statSync(file);
+			});
+			(meta.configureServer as (server: unknown) => void)({
+				watcher: { add },
+				middlewares: { use: vi.fn() },
+			});
+			const watchedEntityPath = await realpath(entityPath);
+			expect(add).toHaveBeenCalledWith(expect.arrayContaining([configPath, watchedEntityPath]));
+
+			const restart = vi.fn(async () => undefined);
+			const hotUpdate = meta.hotUpdate as { handler(context: unknown): Promise<unknown> };
+			await hotUpdate.handler.call(
+				{ environment: { name: 'client' } },
+				{ file: watchedEntityPath, modules: [], server: { restart } },
 			);
 			expect(restart).toHaveBeenCalledOnce();
 		} finally {


### PR DESCRIPTION
## Summary
- Prevent virtual Oxc helper IDs from entering the Vite config dependency watch list.
- Fixes octanejs/octane#988.

## Why
- When `octane.config.ts` imports decorator-using code, Vite's SSR module graph can contain a NUL-prefixed helper ID in `module.file`. Passing that ID to `vite.watcher.add()` crashes the dev server.

## Changes
- Keep traversing imported modules, but collect only filesystem-backed module paths for config watching.
- Add an integration regression with a decorated TypeScript import. It checks watcher registration and restart on a real imported file change.
- Add a patch changeset for `@octanejs/vite-plugin`.

## Validation
- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] Targeted regression: failed before the fix with the reported NUL-byte watcher path; passed after the fix.
- [x] Prettier check for the changed source and test; `git diff --check`; `node scripts/check-changesets.js`.

Local `pnpm sync` reached the parity generator with no generated diff, but the dependency install could not finish: the configured package registry returned 403 for `@tsrx/react@0.2.69`. The [current-head CI run](https://github.com/octanejs/octane/actions/runs/34235165507) completed successfully: 26 jobs, including lint, typecheck, test shards, React parity, and Chromium integration.

## Risk / follow-ups
- Config dependency traversal runs at startup, outside render and request hot paths. Current-head CI verified the full workspace.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791467821&installation_model_id=432790&pr_number=993&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F993&signature=1cf1795ca8a9efcdfcdd38dbb101ed5af6aaaf183e6c130b651cab9ffdd893e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only change to which paths are watched; behavior for real files is unchanged and covered by a new regression test.
> 
> **Overview**
> Fixes dev-server crashes when **`octane.config.ts`** imports code that uses TypeScript decorators (octanejs/octane#988). Vite’s SSR module graph can put **NUL-prefixed virtual helper IDs** in `module.file`; those paths were collected for config dependency watching and passed to **`vite.watcher.add()`**, which expects real filesystem paths.
> 
> **`getDependencies`** in `load-config.js` still walks the full import graph, but only adds **`module.file`** values that do **not** contain `\0`. Real imported files (e.g. `entity.ts`) stay on the watch list and still trigger server restarts on change.
> 
> A new integration test covers a decorated import: watcher registration uses **`statSync`** on every added path, and a change to the imported file still calls **`restart`** once. **`@octanejs/vite-plugin`** gets a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ff91085955080db9a83250cba274d4941d2ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
