### PR TITLE
fix: restore hoisted head listeners after transition rollback

### DIFF
--- a/.changeset/restore-head-transition-listeners.md
+++ b/.changeset/restore-head-transition-listeners.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Restore direct listeners on hoisted head elements after a suspended transition rolls back, including aliased native event handlers.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -17410,15 +17410,51 @@ interface HeadSlot {
 	attrNames?: string[];
 }
 
-function removeHeadEventListeners(state: HeadSlot, attrs: Record<string, any> | null): void {
+// A shallow HeadSlot snapshot cannot undo mutations to its listener Map or the
+// native registrations. Snapshot once before the first change in a headBlock
+// pass: two different props can resolve to the same native event and handler,
+// which addEventListener deduplicates, so per-prop inverse operations are unsafe.
+function journalHeadEventListeners(state: HeadSlot): void {
+	const before = state.handlers === undefined ? null : new Map(state.handlers);
+	journalUndo(() => {
+		const handlers = state.handlers;
+		if (handlers !== undefined) {
+			for (const [name, listener] of handlers) {
+				const event = eventSlot(name)!;
+				state.el.removeEventListener(event.type, listener, event.capture);
+			}
+			handlers.clear();
+		}
+		if (before !== null) {
+			const restored = handlers ?? (state.handlers = new Map<string, EventListener>());
+			for (const [name, listener] of before) {
+				const event = eventSlot(name)!;
+				state.el.addEventListener(event.type, listener, event.capture);
+				restored.set(name, listener);
+			}
+		}
+	});
+}
+
+function removeHeadEventListeners(
+	state: HeadSlot,
+	attrs: Record<string, any> | null,
+	journalChanges = false,
+): boolean {
 	const handlers = state.handlers;
-	if (handlers === undefined) return;
+	if (handlers === undefined) return false;
+	let journaled = false;
 	for (const [name, listener] of handlers) {
 		if (attrs !== null && name in attrs) continue;
+		if (journalChanges && !journaled) {
+			journalHeadEventListeners(state);
+			journaled = true;
+		}
 		const event = eventSlot(name)!;
 		state.el.removeEventListener(event.type, listener, event.capture);
 		handlers.delete(name);
 	}
+	return journaled;
 }
 
 // Find the server-rendered `tag` inside `key`'s paired marker interval in <head>,
@@ -17506,7 +17542,9 @@ export function headBlock(
 		journalObjectOnce(state);
 		journalBag();
 	}
-	if (state.handlers !== undefined) removeHeadEventListeners(state, attrs);
+	let journaledHandlers =
+		state.handlers !== undefined &&
+		removeHeadEventListeners(state, attrs, TRANSITION_JOURNAL !== null);
 	const previousNames = state.attrNames;
 	if (previousNames !== undefined) {
 		for (let i = 0; i < previousNames.length; i++) {
@@ -17527,13 +17565,19 @@ export function headBlock(
 				const hs = state.handlers;
 				const prevH = hs?.get(k);
 				if (prevH === listener) continue;
+				const nextH = typeof listener === 'function' ? (listener as EventListener) : undefined;
+				if (
+					TRANSITION_JOURNAL !== null &&
+					!journaledHandlers &&
+					(prevH !== undefined || nextH !== undefined)
+				) {
+					journalHeadEventListeners(state);
+					journaledHandlers = true;
+				}
 				if (prevH !== undefined) el.removeEventListener(ev.type, prevH, ev.capture);
-				if (typeof listener === 'function') {
-					el.addEventListener(ev.type, listener as EventListener, ev.capture);
-					(hs ?? (state.handlers = new Map<string, EventListener>())).set(
-						k,
-						listener as EventListener,
-					);
+				if (nextH !== undefined) {
+					el.addEventListener(ev.type, nextH, ev.capture);
+					(hs ?? (state.handlers = new Map<string, EventListener>())).set(k, nextH);
 				} else {
 					hs?.delete(k);
 				}

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -535,10 +535,9 @@ function TransitionHeadListener(props: {
 				: props.onNext === undefined
 					? {}
 					: { onClick: props.onNext ?? undefined };
-	<title
-		data-transition-held-listener="yes"
-		{...handlerProps}
-	>{(props.step === 0 ? 'Old' : 'New') as string}</title>
+	<title data-transition-held-listener="yes" {...handlerProps}>{(props.step === 0
+		? 'Old'
+		: 'New') as string}</title>
 }
 
 export function TransitionHeadListenerInsideBoundary(props: {

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -518,6 +518,42 @@ export function TransitionHeadInsideBoundary(props: {
 	</div>
 }
 
+function TransitionHeadListener(props: {
+	step: number;
+	onOld: () => void;
+	onNext?: (() => void) | null;
+}) @{
+	const handlerProps =
+		props.step === 0
+			? { onClick: props.onOld }
+			: props.onNext === undefined
+				? {}
+				: { onClick: props.onNext ?? undefined };
+	<title
+		data-transition-held-listener="yes"
+		{...handlerProps}
+	>{(props.step === 0 ? 'Old' : 'New') as string}</title>
+}
+
+export function TransitionHeadListenerInsideBoundary(props: {
+	load: (step: number) => PromiseLike<string>;
+	onOld: () => void;
+	onNext?: (() => void) | null;
+}) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<TransitionHeadListener step={step} onOld={props.onOld} onNext={props.onNext} />
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
 // ---------------------------------------------------------------------------
 // A controlled input and checkbox inside a boundary. Their values live on the
 // DOM properties AND in a per-element record, so a suspended transition has to

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -522,13 +522,19 @@ function TransitionHeadListener(props: {
 	step: number;
 	onOld: () => void;
 	onNext?: (() => void) | null;
+	onAlias?: () => void;
 }) @{
 	const handlerProps =
-		props.step === 0
-			? { onClick: props.onOld }
-			: props.onNext === undefined
-				? {}
-				: { onClick: props.onNext ?? undefined };
+		props.onAlias !== undefined
+			? {
+					onDoubleClick: props.step === 0 ? props.onOld : props.onAlias,
+					onDblClick: props.onAlias,
+				}
+			: props.step === 0
+				? { onClick: props.onOld }
+				: props.onNext === undefined
+					? {}
+					: { onClick: props.onNext ?? undefined };
 	<title
 		data-transition-held-listener="yes"
 		{...handlerProps}
@@ -539,13 +545,19 @@ export function TransitionHeadListenerInsideBoundary(props: {
 	load: (step: number) => PromiseLike<string>;
 	onOld: () => void;
 	onNext?: (() => void) | null;
+	onAlias?: () => void;
 }) @{
 	const [step, setStep] = useState(0);
 	<div>
 		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
 		@try {
 			<>
-				<TransitionHeadListener step={step} onOld={props.onOld} onNext={props.onNext} />
+				<TransitionHeadListener
+					step={step}
+					onOld={props.onOld}
+					onNext={props.onNext}
+					onAlias={props.onAlias}
+				/>
 				<ControlledValue load={props.load} step={step} />
 			</>
 		} @pending {

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -21,6 +21,7 @@ import {
 	TransitionNamespacedAttr,
 	TransitionHeadAndDefault,
 	TransitionHeadInsideBoundary,
+	TransitionHeadListenerInsideBoundary,
 	TransitionControlledInput,
 	TransitionRadioGroup,
 	TransitionKeyedRemoval,
@@ -1036,6 +1037,50 @@ describe('useTransition — the old screen stays whole', () => {
 			r.unmount();
 		}
 	});
+
+	it.each(['replace', 'remove', 'unset'] as const)(
+		'keeps the committed head listener while held, then %ss it on commit',
+		async (action) => {
+			const first = deferred<string>();
+			const next = deferred<string>();
+			first.resolve('zero');
+			const onOld = vi.fn();
+			const onNext = vi.fn();
+			const r = mount(TransitionHeadListenerInsideBoundary, {
+				load: (step: number) => (step === 0 ? first.promise : next.promise),
+				onOld,
+				onNext: action === 'replace' ? onNext : action === 'unset' ? null : undefined,
+			});
+			const title = document.head.querySelector('title[data-transition-held-listener="yes"]')!;
+			const clickTitle = () => title.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			try {
+				await act(() => {});
+				clickTitle();
+				expect(onOld).toHaveBeenCalledTimes(1);
+				expect(onNext).not.toHaveBeenCalled();
+
+				r.click('#bump');
+				expect(document.head.querySelector('title[data-transition-held-listener="yes"]')).toBe(title);
+				expect(title.textContent).toBe('Old');
+				expect(r.findAll('#fallback')).toHaveLength(0);
+				clickTitle();
+				expect(onOld).toHaveBeenCalledTimes(2);
+				expect(onNext).not.toHaveBeenCalled();
+
+				await act(() => next.resolve('one'));
+				expect(document.head.querySelector('title[data-transition-held-listener="yes"]')).toBe(title);
+				expect(title.textContent).toBe('New');
+				clickTitle();
+				expect(onOld).toHaveBeenCalledTimes(2);
+				expect(onNext).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
+			} finally {
+				r.unmount();
+			}
+			clickTitle();
+			expect(onOld).toHaveBeenCalledTimes(2);
+			expect(onNext).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
+		},
+	);
 
 	it('holds a controlled input and checkbox, records included', async () => {
 		const entries = new Map<number, Deferred<string>>();

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -1060,15 +1060,22 @@ describe('useTransition — the old screen stays whole', () => {
 				expect(onNext).not.toHaveBeenCalled();
 
 				r.click('#bump');
-				expect(document.head.querySelector('title[data-transition-held-listener="yes"]')).toBe(title);
-				expect(title.textContent).toBe('Old');
-				expect(r.findAll('#fallback')).toHaveLength(0);
+				const heldTitle = document.head.querySelector('title[data-transition-held-listener="yes"]');
+				const heldText = title.textContent;
+				const heldFallbackCount = r.findAll('#fallback').length;
 				clickTitle();
-				expect(onOld).toHaveBeenCalledTimes(2);
-				expect(onNext).not.toHaveBeenCalled();
+				const heldOldCalls = onOld.mock.calls.length;
+				const heldNextCalls = onNext.mock.calls.length;
 
 				await act(() => next.resolve('one'));
-				expect(document.head.querySelector('title[data-transition-held-listener="yes"]')).toBe(title);
+				expect(heldTitle).toBe(title);
+				expect(heldText).toBe('Old');
+				expect(heldFallbackCount).toBe(0);
+				expect(heldOldCalls).toBe(2);
+				expect(heldNextCalls).toBe(0);
+				expect(document.head.querySelector('title[data-transition-held-listener="yes"]')).toBe(
+					title,
+				);
 				expect(title.textContent).toBe('New');
 				clickTitle();
 				expect(onOld).toHaveBeenCalledTimes(2);
@@ -1081,6 +1088,52 @@ describe('useTransition — the old screen stays whole', () => {
 			expect(onNext).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
 		},
 	);
+
+	it('restores aliased native head listeners when a candidate reuses an unchanged handler', async () => {
+		const first = deferred<string>();
+		const next = deferred<string>();
+		first.resolve('zero');
+		const onOld = vi.fn();
+		const onAlias = vi.fn();
+		const r = mount(TransitionHeadListenerInsideBoundary, {
+			load: (step: number) => (step === 0 ? first.promise : next.promise),
+			onOld,
+			onAlias,
+		});
+		await act(() => {});
+		const title = document.head.querySelector('title[data-transition-held-listener="yes"]')!;
+		const doubleClickTitle = () =>
+			title.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+		try {
+			doubleClickTitle();
+			expect(onOld).toHaveBeenCalledTimes(1);
+			expect(onAlias).toHaveBeenCalledTimes(1);
+
+			r.click('#bump');
+			const heldTitle = document.head.querySelector('title[data-transition-held-listener="yes"]');
+			const heldText = title.textContent;
+			const heldFallbackCount = r.findAll('#fallback').length;
+			doubleClickTitle();
+			const heldOldCalls = onOld.mock.calls.length;
+			const heldAliasCalls = onAlias.mock.calls.length;
+
+			await act(() => next.resolve('one'));
+			expect(heldTitle).toBe(title);
+			expect(heldText).toBe('Old');
+			expect(heldFallbackCount).toBe(0);
+			expect(heldOldCalls).toBe(2);
+			expect(heldAliasCalls).toBe(2);
+			expect(title.textContent).toBe('New');
+			doubleClickTitle();
+			expect(onOld).toHaveBeenCalledTimes(2);
+			expect(onAlias).toHaveBeenCalledTimes(3);
+		} finally {
+			r.unmount();
+		}
+		doubleClickTitle();
+		expect(onOld).toHaveBeenCalledTimes(2);
+		expect(onAlias).toHaveBeenCalledTimes(3);
+	});
 
 	it('holds a controlled input and checkbox, records included', async () => {
 		const entries = new Map<number, Deferred<string>>();

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -1051,10 +1051,10 @@ describe('useTransition — the old screen stays whole', () => {
 				onOld,
 				onNext: action === 'replace' ? onNext : action === 'unset' ? null : undefined,
 			});
+			await act(() => {});
 			const title = document.head.querySelector('title[data-transition-held-listener="yes"]')!;
 			const clickTitle = () => title.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 			try {
-				await act(() => {});
 				clickTitle();
 				expect(onOld).toHaveBeenCalledTimes(1);
 				expect(onNext).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Restore direct listeners on retained hoisted head elements when a suspended transition rolls back.
- Track issue #967.

## Why
- Head elements live outside the delegated event root. Their native listeners currently change during speculative rendering, while the visible head node and text roll back. An old screen can therefore respond with the next handler or none at all.

## Changes
- Snapshot direct head listeners once before the first speculative change and restore native registrations plus the handler map on rollback, including aliased native events.
- Keep teardown listener removals outside the rollback journal and avoid snapshots when handlers are unchanged.
- Cover replacement, omission, explicit undefined, and alias collision in development and production; add an `octane` patch changeset.

## Validation
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34238634744) passed `pnpm format:check`, typecheck, all four Node 24 test shards, React parity, integrations, examples, and required aggregate checks.
- [x] Pre-fix [test shard 4/4](https://github.com/octanejs/octane/actions/runs/34237650837/job/102099670312) failed in development and production: the unchanged aliased handler fired once instead of twice while the old screen was held.
- [x] `git diff --check`; same esbuild 0.28.1 production minifier: 334,263 → 334,745 bytes of unbundled `runtime.ts` (+482 bytes, 0.14%).
- Local `pnpm sync` passed lockfile supply-chain verification but dependency installation was blocked by the configured registry's 403 for `@tsrx/prettier-plugin@0.3.135`; CI validated the final head.

## Risk / follow-ups
- Runtime timing could not be measured locally because dependency installation is blocked; snapshots allocate only when a head listener changes inside an active rollback journal.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791467877&installation_model_id=432790&pr_number=994&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F994&signature=cf465c4a05f1f0c513e01d8bad5baa4d71010ce7cc6f976ede56bd164ca7bac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transition rollback and native event registration on document.head; incorrect journaling could leave wrong handlers or duplicate listeners, but scope is limited to hoisted head slots during suspended transitions.
> 
> **Overview**
> **Fixes suspended transitions mutating direct `on*` listeners on hoisted `<head>` nodes while the visible head (text/attrs) is held on the old screen** — listeners now participate in the same transition journal/rollback as other head slot state.
> 
> The runtime adds **`journalHeadEventListeners`**, which snapshots the per-prop listener map once per head update pass and records undo steps that tear down and re-register native listeners. That avoids unsafe per-prop reversals when multiple props alias the same native event (`addEventListener` dedupes). **`removeHeadEventListeners`** and head `on*` patching now opt into journaling when `TRANSITION_JOURNAL` is active, with a single journal per pass.
> 
> **Regression coverage** adds a boundary + `<title>` fixture with direct click handlers (replace / omit / explicit clear) and a case for **aliased handlers** (`onDoubleClick` / `onDblClick`). Ships an **octane patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87286830f5191936b99403b200009040d5f82eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

