### PR TITLE
perf: inline fixed-arity event bundle arguments

### DIFF
--- a/.changeset/tidy-event-arguments.md
+++ b/.changeset/tidy-event-arguments.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Store one- and two-argument delegated callback captures directly on their handler bundles, avoiding a separate array per mounted handler.

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -147,7 +147,7 @@ export {
 	bag15,
 	bag16,
 	bagOf,
-	// Event-bundle helpers (3b) — build the `{ fn, args }` descriptor once at
+	// Event-bundle helpers (3b) — build an arity-specific descriptor once at
 	// mount, mutate it in place on update (dispatch reads `el[key]` per event).
 	evt0,
 	evt0u,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -17676,7 +17676,10 @@ const INVALID_EVENT_LISTENER_KIND = 2;
 interface HandlerBundle {
 	[EVENT_SLOT_KIND]: typeof HANDLER_BUNDLE_KIND;
 	fn: (...args: any[]) => any;
-	args: any[];
+	// An array for arity 0/N; fixed arities carry their arguments in the bundle.
+	args: any[] | 1 | 2;
+	a0?: any;
+	a1?: any;
 }
 
 interface InvalidEventListenerSlot {
@@ -17741,14 +17744,15 @@ function isUsableEventSlot(slot: EventSlot): boolean {
 // ---------------------------------------------------------------------------
 // Event bundle helpers (compiled-output plan 3b) — compiler targets for the
 // `() => fn(arg, …)` bundle optimization. Mount (`evtN`): build the
-// nominal `{ fn, args }` descriptor ONCE, assign it to the element's event slot, and
+// nominal handler descriptor ONCE, assign it to the element's event slot, and
 // return it for the binding bag (one field instead of el + fn + each arg).
 // Update (`evtNu`): mutate the SAME descriptor in place between events. A
 // synchronous update during dispatch preserves only the queued snapshot before
 // mutating, so later events see the change without rebuilding every render.
 // Arity variants mirror fireEventSlot's dispatch switch; `evtN`/`evtNu` are
-// the rest fallbacks. Arity-0 descriptors share one empty args array
-// (dispatch only reads it; the arity-0 update never writes args).
+// the rest fallbacks. Arity-0 descriptors share one empty args array; arity-1/2
+// store their arguments in fields instead of allocating a second array. Their
+// `args` numeric tag keeps the common dispatch read in the same property slot.
 // Keep the computed brand last in every bundle literal, including dispatch
 // snapshots, so V8 can initialize fn/args from its object-literal boilerplate.
 // ---------------------------------------------------------------------------
@@ -17775,34 +17779,27 @@ export function evt0u(d: HandlerBundle, fn: any): void {
 	d.fn = fn;
 }
 export function evt1(el: Element, key: string, fn: any, a0: any): HandlerBundle {
-	const d: HandlerBundle = { fn, args: [a0], [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
+	const d: HandlerBundle = { fn, args: 1, a0, [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
 	setEventHandler(el, key, d);
 	return d;
 }
 export function evt1u(d: HandlerBundle, fn: any, a0: any): void {
 	if (_dispatchDepth !== 0) preserveDispatchedBundle(d);
-	if (TRANSITION_JOURNAL !== null) {
-		journalObjectOnce(d);
-		journalObjectOnce(d.args);
-	}
+	if (TRANSITION_JOURNAL !== null) journalObjectOnce(d);
 	d.fn = fn;
-	d.args[0] = a0;
+	d.a0 = a0;
 }
 export function evt2(el: Element, key: string, fn: any, a0: any, a1: any): HandlerBundle {
-	const d: HandlerBundle = { fn, args: [a0, a1], [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
+	const d: HandlerBundle = { fn, args: 2, a0, a1, [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
 	setEventHandler(el, key, d);
 	return d;
 }
 export function evt2u(d: HandlerBundle, fn: any, a0: any, a1: any): void {
 	if (_dispatchDepth !== 0) preserveDispatchedBundle(d);
-	if (TRANSITION_JOURNAL !== null) {
-		journalObjectOnce(d);
-		journalObjectOnce(d.args);
-	}
+	if (TRANSITION_JOURNAL !== null) journalObjectOnce(d);
 	d.fn = fn;
-	const a = d.args;
-	a[0] = a0;
-	a[1] = a1;
+	d.a0 = a0;
+	d.a1 = a1;
 }
 export function evtN(el: Element, key: string, fn: any, args: any[]): HandlerBundle {
 	const d: HandlerBundle = { fn, args, [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND };
@@ -18352,11 +18349,22 @@ function preserveDispatchedBundle(bundle: HandlerBundle): void {
 	let snapshot: HandlerBundle | undefined;
 	for (let index = 0; index < CAPTURE_SLOTS.length; index++) {
 		if (CAPTURE_SLOTS[index] === bundle) {
-			CAPTURE_SLOTS[index] = snapshot ??= {
-				fn: bundle.fn,
-				args: bundle.args.slice(),
-				[EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND,
-			};
+			if (snapshot === undefined) {
+				const args = bundle.args;
+				snapshot =
+					typeof args !== 'number'
+						? { fn: bundle.fn, args: args.slice(), [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND }
+						: args === 1
+							? { fn: bundle.fn, args: 1, a0: bundle.a0, [EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND }
+							: {
+									fn: bundle.fn,
+									args: 2,
+									a0: bundle.a0,
+									a1: bundle.a1,
+									[EVENT_SLOT_KIND]: HANDLER_BUNDLE_KIND,
+								};
+			}
+			CAPTURE_SLOTS[index] = snapshot;
 		}
 	}
 }
@@ -18561,8 +18569,8 @@ function buildDelegatedPath(event: Event, listener: Node, path = event.composedP
 	}
 }
 
-// Invoke one event slot — a bare handler `fn(event)` or a nominal `{ fn, args }` bundle
-// (the compiler's zero-argument-arrow optimisation) as `fn(...args)`. A bundled
+// Invoke one event slot — a bare handler `fn(event)` or a nominal arity-specific
+// bundle (the compiler's zero-argument-arrow optimisation) as `fn(...args)`. A bundled
 // arrow never observes its native event, so forwarding that event to its callee
 // would change the authored callback's argument list.
 //
@@ -18593,18 +18601,24 @@ function fireEventSlot(slot: EventSlot, event: Event): void {
 		if (isHandlerBundle(slot)) {
 			const bundle = slot;
 			const a = bundle.args;
-			switch (a.length) {
-				case 0:
-					bundle.fn();
-					break;
-				case 1:
-					bundle.fn(a[0]);
-					break;
-				case 2:
-					bundle.fn(a[0], a[1]);
-					break;
-				default:
-					bundle.fn.apply(null, a);
+			if (typeof a !== 'number') {
+				switch (a.length) {
+					case 0:
+						bundle.fn();
+						break;
+					case 1:
+						bundle.fn(a[0]);
+						break;
+					case 2:
+						bundle.fn(a[0], a[1]);
+						break;
+					default:
+						bundle.fn.apply(null, a);
+				}
+			} else if (a === 1) {
+				bundle.fn(bundle.a0);
+			} else {
+				bundle.fn(bundle.a0, bundle.a1);
 			}
 			return;
 		}

--- a/packages/octane/tests/audit-events-portals.test.ts
+++ b/packages/octane/tests/audit-events-portals.test.ts
@@ -3,7 +3,7 @@ import { createElement as h, createPortal, createRoot, flushSync } from '../src/
 import * as React from 'react';
 import { createRoot as createReactRoot } from 'react-dom/client';
 import { flushSync as flushReact } from 'react-dom';
-import { mount } from './_helpers.js';
+import { act, mount } from './_helpers.js';
 import { loadCompiledFixtureSource } from './_server-fixture.js';
 
 const dev = process.env.OCTANE_TEST_COMPILE_MODE !== 'prod';
@@ -125,6 +125,84 @@ describe('audit event and portal behavior', () => {
 			calls.length = 0;
 			mouse(button);
 			expect(calls).toEqual([['next'], ['new', 'child'], ['next', 'new', 'parent', 'third']]);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('preserves queued one- and two-argument bundles during a synchronous update', () => {
+		const { App } = fixture(
+			`export function App({report, change, label}) @{ <section onClick={() => report(label, 'outer')}><div onClick={() => report(label)}><button onClick={change}>go</button></div></section> }`,
+		);
+		const calls: unknown[][] = [];
+		let r: ReturnType<typeof mount>;
+		const report = (...args: unknown[]) => calls.push(['old', ...args]);
+		const nextReport = (...args: unknown[]) => calls.push(['next', ...args]);
+		const change = () => r.update(App, { report: nextReport, change, label: 'new' });
+		r = mount(App, { report, change, label: 'old' });
+		try {
+			const button = r.find('button');
+			mouse(button);
+			expect(calls).toEqual([
+				['old', 'old'],
+				['old', 'old', 'outer'],
+			]);
+			calls.length = 0;
+			mouse(button);
+			expect(calls).toEqual([
+				['next', 'new'],
+				['next', 'new', 'outer'],
+			]);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('restores one- and two-argument bundles after a suspended root update', async () => {
+		const { App } = fixture(`
+export function Reader({read, token}) @{ const value = read(token); <strong>{value as string}</strong> }
+export function App({report, label, read}) @{
+	<section>
+		<button id="event-target" onClick={() => report(label)} onDoubleClick={() => report(label, 'two')}>go</button>
+		<Reader read={read} token={label} />
+	</section>
+}
+`);
+		let resolve!: (value: string) => void;
+		const pending = new Promise<string>((done) => {
+			resolve = done;
+		});
+		let value: string | null = 'A';
+		const read = () => {
+			if (value === null) throw pending;
+			return value;
+		};
+		const calls: unknown[][] = [];
+		const report = (...args: unknown[]) => calls.push(['old', ...args]);
+		const nextReport = (...args: unknown[]) => calls.push(['next', ...args]);
+		const r = mount(App, { report, label: 'old', read });
+		try {
+			const button = r.find('#event-target');
+			value = null;
+			r.update(App, { report: nextReport, label: 'new', read });
+			expect(r.find('#event-target')).toBe(button);
+			mouse(button);
+			mouse(button, 'dblclick');
+			expect(calls).toEqual([
+				['old', 'old'],
+				['old', 'old', 'two'],
+			]);
+
+			value = 'B';
+			await act(() => resolve('ready'));
+			expect(r.find('#event-target')).toBe(button);
+			calls.length = 0;
+			mouse(button);
+			mouse(button, 'dblclick');
+			expect(calls).toEqual([
+				['next', 'new'],
+				['next', 'new', 'two'],
+			]);
 		} finally {
 			r.unmount();
 		}


### PR DESCRIPTION
## Summary

- Store compiled one- and two-argument event callback captures directly on the nominal handler bundle, removing their separate argument arrays.
- Keep the `args` slot as a numeric arity tag on these two shapes so the shared dispatch read stays in its existing offset. Arity zero retains its shared empty array; the variadic path retains an array.
- Preserve the queued callback and its original arguments during synchronous dispatch, and restore the complete bundle after a suspended root render rolls back.

## Why

The runtime currently retains one additional array per `evt1`/`evt2` handler, including two such handlers on each keyed js-framework row. Updates also journal the bundle and its mutable argument array separately. This specializes only the fixed arities and leaves the compiler call ABI unchanged.

## Changes

- Inline `a0`/`a1` fields in `evt1`/`evt2`, update them in place, and journal only the bundle for rollback.
- Snapshot scalar fields for queued handlers before an in-flight update; dispatch array bundles on their original path and scalar bundles by the numeric arity tag.
- Add public event regressions for one/two-argument queued callbacks and a held-root rollback/retry, plus an `octane` patch changeset.

## Validation

- [x] Exact production-runtime Node 26/V8 14.6 post-GC A/B, 150,000 retained instances per arity in fresh paired subprocesses: `evt1` 112.13 → 64.11 bytes and `evt2` 120.10 → 72.06–72.10 bytes per bundle, including the retained reference slot. `evt0` and `evtN` are unchanged. All candidate maps remain fast; the one shared baseline bundle map becomes three maps.
- [x] Chromium 149 source-only production-runtime A/B on the same machine, four warmups and eight mirrored ABBA cycles: 1,000-row keyed mount 1.80 → 1.80 ms; 10,000-row mount 15.75 → 15.85 ms (within sample variance). Each cycle verified native click arguments, a synchronous queued old/new handler snapshot, row order, survivor identity, and detached cleanup. The full-index bundle is +149 raw / +22 gzip / −29 Brotli bytes. No compiled application speedup is claimed.
- [x] A 2.1M-call source-only mixed-arity dispatch proxy measured 12.10 → 11.85 ms with the array-first branch; a number-first shape regressed and was rejected. Proxy results are not an application timing claim.
- [x] Source-only cached-compiler executions of the new queued-handler and suspended-root scenarios passed. Temporarily removing `preserveDispatchedBundle` or `journalObjectOnce` from the scalar update paths turned the corresponding scenario red. [Pinned current-head CI](https://github.com/octanejs/octane/actions/runs/34236271601/attempts/2) passed all 26 jobs at `19c829d16831a1e3d59a862838f380dddffccb94`; `audit-events-portals.test.ts` passed 20/20 tests in both `octane` and `octane-prod`. Typecheck, Chromium, and parity passed. The initial parity run had an asynchronous upstream Dialog `act(...)` warning that did not recur on the identical-head retry.
- [x] Cached Prettier check for changed TS and changeset, `git diff --check`, standalone version generator, and package inventory check (122 publishable packages).
- [ ] Pinned [PR-head targeted Bench](https://github.com/openai-oss-forks/octane/actions/runs/34236614808) and [latest-main baseline](https://github.com/openai-oss-forks/octane/actions/runs/34237059292) passed `event-delegation` correctness/work gates and built `bundle-size`, but both jobs failed the exact same 55 pre-existing bundle-size ratio guards, with no new guard breach. On the pinned toolchain the Octane TSRX framework bundle is +171 raw / +65 gzip / +48 Brotli bytes (84,668/28,323/25,278 → 84,839/28,388/25,326). Two-sample event timings across separate hosted VMs moved for every framework and cannot isolate this PR. Only the fork-only workflow differs from PR/main source; package source, benchmarks, and lockfile were pinned to their respective commits.
- [ ] `pnpm sync` could not reach the generators locally: the configured registry returned 403 for pinned `@tsrx/prettier-plugin@0.3.135` after lockfile policy checks. Prior automatic approval review rejected fetching this package directly from the public registry as a bypass. Current-head CI validated generated files and the pinned test suite.

## Risk / follow-ups

The extra arity distinction adds two bundle maps and a dispatch type branch; same-machine mixed-dispatch measurements were neutral, while real keyed DOM mount timings overlapped noise. The source-only browser harness does not establish a whole-app speedup. The two public tests cover the otherwise subtle reentrant and rollback semantics. This follows merged #991 and #992 and addresses the fixed-arity argument-storage suggestion in #981.

Refs #981.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791468447&installation_model_id=432790&pr_number=995&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F995&signature=71bd84e6a6aa68f58f476956ffc6499667cd13a852f224f0c4ca577791f850e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
