### PR TITLE
perf: skip unchanged composed class writes

### DIFF
--- a/.changeset/guard-composed-classes.md
+++ b/.changeset/guard-composed-classes.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip repeated class writes for fresh array, object, and function values when their composed class string has not changed. Preserve class composition, hydration, and SVG attribute behavior.

--- a/packages/octane-evals/tests/_client-runtime.ts
+++ b/packages/octane-evals/tests/_client-runtime.ts
@@ -12,6 +12,8 @@ export {
 	setAriaAttributeIfChanged,
 	setClassNameIfChanged,
 	setClassAttrIfChanged,
+	updateFreshClassName,
+	updateFreshClassAttr,
 	textHoleUpdate,
 	childTextHoleUpdate,
 } from '../../octane/src/internal/client.js';

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -444,8 +444,8 @@ function attrBindingHelper(bind) {
 // repeating the guard and previous-value publication in every component.
 // Certified repeated host rows select the ordinary writer and emit an inline
 // guard instead, avoiding a call and cache publication on unchanged rows.
-// Fresh classes deliberately remain unguarded; controlled form properties
-// likewise must reassert the live DOM value on every render.
+// Fresh classes compare their composed string in emitBindingUpdate; controlled
+// form properties must reassert the live DOM value on every render.
 function attrBindingUpdateHelper(bind, inlineBindingGuards = false) {
 	const helper = attrBindingHelper(bind);
 	if (inlineBindingGuards) return helper;
@@ -456,7 +456,7 @@ function attrBindingUpdateHelper(bind, inlineBindingGuards = false) {
 		case 'ariaAttr':
 			return `${helper}IfChanged`;
 		case 'class':
-			return bind.fresh ? helper : `${helper}IfChanged`;
+			return `${helper}IfChanged`;
 		default:
 			return helper;
 	}
@@ -14929,10 +14929,8 @@ function isMountStableInlineHandler(node, ctx) {
 	return true;
 }
 
-// Object/array/function literals allocate a new identity on every evaluation,
-// so an identity diff can never skip their update. This currently feeds the
-// class binding path, where dropping the dead previous-value field preserves
-// the exact setter frequency while shrinking both code and the binding bag.
+// Object/array/function literals allocate a new identity on every evaluation.
+// Class bindings compare their composed string instead of that fresh identity.
 function isFreshBindingExpr(node) {
 	const value = unwrapTsExpr(node);
 	return (
@@ -22466,6 +22464,7 @@ function planJsx(
 		// a mount-only import for deferred writes.
 		const attrHelper = attrBindingHelper(b);
 		if (attrHelper !== null) {
+			if (b.kind === 'class' && b.fresh) ctx.runtimeNeeded.add('normalizeClass');
 			if (!b.deferred) {
 				ctx.runtimeNeeded.add(attrHelper);
 				registerAttrLoweringOrigin(ctx, b.nameOrigin, attrHelper, b.name);
@@ -23875,12 +23874,10 @@ function commitSourceRows(sources, valueOf) {
 // is byte-identical to the old unconditional mount write).
 function emitDeferredMount(bind, elVar, bag) {
 	// Whole-object `style` diffs on `_sty`; scalar styles and other values on `_prev`.
-	if (!(bind.kind === 'class' && bind.fresh)) {
-		bag.constField(
-			bind.kind === 'style' ? `_sty$${bind.id}` : `_prev$${bind.id}`,
-			bind.kind === 'styleProperty' ? 'style-unset' : 'undefined',
-		);
-	}
+	bag.constField(
+		bind.kind === 'style' ? `_sty$${bind.id}` : `_prev$${bind.id}`,
+		bind.kind === 'styleProperty' ? 'style-unset' : 'undefined',
+	);
 	const key = `_el$${bind.id}`;
 	if (!bag.host(key, elVar)) return null;
 	return inheritOriginLoc(
@@ -24088,9 +24085,15 @@ function emitBindingMount(bind, elVar, bag) {
 		}
 		case 'class': {
 			// On SVG/MathML hosts the `className` property is read-only — fall back
-			// to setAttribute. Compile-time choice, zero runtime branching.
-			const body = [b.const('_v', bind.expr), b.stmt(b.call(callee(), el(), V())), ...mountHost()];
-			if (!bind.fresh) body.push(b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())));
+			// to setAttribute. A fresh literal is always truthy, so composing it
+			// before the write preserves the nullish-vs-empty attribute contract.
+			const value = bind.fresh ? b.call('_$normalizeClass', bind.expr) : bind.expr;
+			const body = [
+				b.const('_v', value),
+				b.stmt(b.call(callee(), el(), V())),
+				...mountHost(),
+				b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())),
+			];
 			return st(b.block(body));
 		}
 		case 'style': {
@@ -24385,13 +24388,13 @@ function emitBindingUpdate(bind, bag, inlineBindingGuards = false) {
 			return st(b.stmt(b.call(callee(), F('_el'), bind.expr)));
 		}
 		case 'class': {
-			if (bind.fresh) {
-				return st(b.stmt(b.call(callee(), F('_el'), bind.expr)));
-			}
+			// Recompose fresh literal values on every render, including when their
+			// members have getters, but skip the DOM write for an unchanged class.
+			const value = bind.fresh ? b.call('_$normalizeClass', bind.expr) : bind.expr;
 			if (inlineBindingGuards) {
 				return st(
 					b.block([
-						b.const('_v', bind.expr),
+						b.const('_v', value),
 						b.if(
 							b.binary('!==', F('_prev'), V()),
 							b.block([
@@ -24404,7 +24407,7 @@ function emitBindingUpdate(bind, bag, inlineBindingGuards = false) {
 				);
 			}
 			return st(
-				b.stmt(b.assignment('=', F('_prev'), b.call(callee(), bind.expr, F('_prev'), F('_el')))),
+				b.stmt(b.assignment('=', F('_prev'), b.call(callee(), value, F('_prev'), F('_el')))),
 			);
 		}
 		case 'style': {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -22464,7 +22464,7 @@ function planJsx(
 		// a mount-only import for deferred writes.
 		const attrHelper = attrBindingHelper(b);
 		if (attrHelper !== null) {
-			if (b.kind === 'class' && b.fresh) ctx.runtimeNeeded.add('normalizeClass');
+			if (b.kind === 'class' && b.fresh && !b.mountOnly) ctx.runtimeNeeded.add('normalizeClass');
 			if (!b.deferred) {
 				ctx.runtimeNeeded.add(attrHelper);
 				registerAttrLoweringOrigin(ctx, b.nameOrigin, attrHelper, b.name);
@@ -24085,11 +24085,17 @@ function emitBindingMount(bind, elVar, bag) {
 		}
 		case 'class': {
 			// On SVG/MathML hosts the `className` property is read-only — fall back
-			// to setAttribute. A fresh literal is always truthy, so composing it
-			// before the write preserves the nullish-vs-empty attribute contract.
-			const value = bind.fresh ? b.call('_$normalizeClass', bind.expr) : bind.expr;
+			// to setAttribute. The ordinary setter returns the composed string so a
+			// fresh literal can seed its update guard with no second composition.
+			if (bind.fresh)
+				return st(
+					b.block([
+						b.stmt(b.assignment('=', local(`_prev$${bind.id}`), b.call(callee(), el(), bind.expr))),
+						...mountHost(),
+					]),
+				);
 			const body = [
-				b.const('_v', value),
+				b.const('_v', bind.expr),
 				b.stmt(b.call(callee(), el(), V())),
 				...mountHost(),
 				b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())),

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -456,7 +456,11 @@ function attrBindingUpdateHelper(bind, inlineBindingGuards = false) {
 		case 'ariaAttr':
 			return `${helper}IfChanged`;
 		case 'class':
-			return `${helper}IfChanged`;
+			return bind.fresh
+				? bind.ns && bind.ns !== 'html'
+					? 'updateFreshClassAttr'
+					: 'updateFreshClassName'
+				: `${helper}IfChanged`;
 		default:
 			return helper;
 	}
@@ -1172,6 +1176,8 @@ const INTERNAL_CLIENT_RUNTIME_HELPERS = new Set([
 	'setAriaAttributeIfChanged',
 	'setClassNameIfChanged',
 	'setClassAttrIfChanged',
+	'updateFreshClassName',
+	'updateFreshClassAttr',
 	'textHoleUpdate',
 	'childTextHoleUpdate',
 	...HOOK_MEMO_RUNTIME_HELPERS,
@@ -22464,7 +22470,8 @@ function planJsx(
 		// a mount-only import for deferred writes.
 		const attrHelper = attrBindingHelper(b);
 		if (attrHelper !== null) {
-			if (b.kind === 'class' && b.fresh && !b.mountOnly) ctx.runtimeNeeded.add('normalizeClass');
+			if (b.kind === 'class' && b.fresh && (!b.deferred || (!b.mountOnly && inlineBindingGuards)))
+				ctx.runtimeNeeded.add('normalizeClass');
 			if (!b.deferred) {
 				ctx.runtimeNeeded.add(attrHelper);
 				registerAttrLoweringOrigin(ctx, b.nameOrigin, attrHelper, b.name);
@@ -24085,17 +24092,11 @@ function emitBindingMount(bind, elVar, bag) {
 		}
 		case 'class': {
 			// On SVG/MathML hosts the `className` property is read-only — fall back
-			// to setAttribute. The ordinary setter returns the composed string so a
-			// fresh literal can seed its update guard with no second composition.
-			if (bind.fresh)
-				return st(
-					b.block([
-						b.stmt(b.assignment('=', local(`_prev$${bind.id}`), b.call(callee(), el(), bind.expr))),
-						...mountHost(),
-					]),
-				);
+			// to setAttribute. A fresh literal is truthy even when it composes to
+			// an empty string, so caching its composition preserves class="".
+			const value = bind.fresh ? b.call('_$normalizeClass', bind.expr) : bind.expr;
 			const body = [
-				b.const('_v', bind.expr),
+				b.const('_v', value),
 				b.stmt(b.call(callee(), el(), V())),
 				...mountHost(),
 				b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())),
@@ -24396,7 +24397,8 @@ function emitBindingUpdate(bind, bag, inlineBindingGuards = false) {
 		case 'class': {
 			// Recompose fresh literal values on every render, including when their
 			// members have getters, but skip the DOM write for an unchanged class.
-			const value = bind.fresh ? b.call('_$normalizeClass', bind.expr) : bind.expr;
+			const value =
+				bind.fresh && inlineBindingGuards ? b.call('_$normalizeClass', bind.expr) : bind.expr;
 			if (inlineBindingGuards) {
 				return st(
 					b.block([

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -16710,14 +16710,14 @@ import {
 } from './css.js';
 export { normalizeClass };
 
-export function setClassName(el: Element, value: unknown): void {
+export function setClassName(el: Element, value: unknown): string {
 	// clsx-compose first so arrays / objects become a class string (and the hydration
 	// compare below sees the value we actually write).
 	const cls = normalizeClass(value);
 	const hydration = activeHydration();
 	if (hydration !== null) {
 		hydration.queueClass(el, cls, true, false, value == null || value === false);
-		return;
+		return cls;
 	}
 	// Fast path on HTMLElement. For SVG/MathML hosts the compiler emits
 	// setAttribute(el, 'class', normalizeClass(...)) directly — never routes here —
@@ -16730,6 +16730,7 @@ export function setClassName(el: Element, value: unknown): void {
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'class');
 	if (value == null || value === false) el.removeAttribute('class');
 	else (el as any).className = cls;
+	return cls;
 }
 
 // Attribute-based class setter: SVG/MathML compiled TEMPLATE bindings (where
@@ -16738,16 +16739,17 @@ export function setClassName(el: Element, value: unknown): void {
 // clsx-composes the value; a nullish/false value REMOVES the attribute (parity with
 // the generic setAttribute this binding routed through before clsx composition
 // existed).
-export function setClassAttr(el: Element, value: unknown): void {
+export function setClassAttr(el: Element, value: unknown): string | null {
 	const cls = value == null || value === false ? null : normalizeClass(value);
 	const hydration = activeHydration();
 	if (hydration !== null) {
 		hydration.queueClass(el, cls, false, true, cls === null);
-		return;
+		return cls;
 	}
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'class');
 	if (cls === null) el.removeAttribute('class');
 	else el.setAttribute('class', cls);
+	return cls;
 }
 
 // SVG-safe class setter for the de-opt / hostComponent paths, which (unlike the

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -15052,6 +15052,22 @@ export function setClassAttrIfChanged(value: unknown, previous: unknown, el: Ele
 	return value;
 }
 
+// Compiler-only path for a fresh class literal: compare its composed value,
+// while still evaluating its array/object entries on every render. Fresh
+// literals are always truthy, so an empty result writes class="" rather than
+// removing the attribute. The ordinary setter owns hydration and journaling.
+export function updateFreshClassName(value: unknown, previous: unknown, el: Element): string {
+	const next = normalizeClass(value);
+	if (previous !== next) setClassName(el, next);
+	return next;
+}
+
+export function updateFreshClassAttr(value: unknown, previous: unknown, el: Element): string {
+	const next = normalizeClass(value);
+	if (previous !== next) setClassAttr(el, next);
+	return next;
+}
+
 /**
  * Set authored inline-script source without asking the HTML parser to interpret it.
  * This is the client half of the compiler's `<script dangerouslySetInnerHTML>`
@@ -16710,14 +16726,14 @@ import {
 } from './css.js';
 export { normalizeClass };
 
-export function setClassName(el: Element, value: unknown): string {
+export function setClassName(el: Element, value: unknown): void {
 	// clsx-compose first so arrays / objects become a class string (and the hydration
 	// compare below sees the value we actually write).
 	const cls = normalizeClass(value);
 	const hydration = activeHydration();
 	if (hydration !== null) {
 		hydration.queueClass(el, cls, true, false, value == null || value === false);
-		return cls;
+		return;
 	}
 	// Fast path on HTMLElement. For SVG/MathML hosts the compiler emits
 	// setAttribute(el, 'class', normalizeClass(...)) directly — never routes here —
@@ -16730,7 +16746,6 @@ export function setClassName(el: Element, value: unknown): string {
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'class');
 	if (value == null || value === false) el.removeAttribute('class');
 	else (el as any).className = cls;
-	return cls;
 }
 
 // Attribute-based class setter: SVG/MathML compiled TEMPLATE bindings (where
@@ -16739,17 +16754,16 @@ export function setClassName(el: Element, value: unknown): string {
 // clsx-composes the value; a nullish/false value REMOVES the attribute (parity with
 // the generic setAttribute this binding routed through before clsx composition
 // existed).
-export function setClassAttr(el: Element, value: unknown): string | null {
+export function setClassAttr(el: Element, value: unknown): void {
 	const cls = value == null || value === false ? null : normalizeClass(value);
 	const hydration = activeHydration();
 	if (hydration !== null) {
 		hydration.queueClass(el, cls, false, true, cls === null);
-		return cls;
+		return;
 	}
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'class');
 	if (cls === null) el.removeAttribute('class');
 	else el.setAttribute('class', cls);
-	return cls;
 }
 
 // SVG-safe class setter for the de-opt / hostComponent paths, which (unlike the

--- a/packages/octane/tests/_fixtures/fresh-root-scope-hold.tsrx
+++ b/packages/octane/tests/_fixtures/fresh-root-scope-hold.tsrx
@@ -19,7 +19,13 @@ export function FreshRootScopeHold(props) @{
 		@if (props.show) {
 			<NewRow label={props.label} external={props.external} />
 		}
-		<span id="committed-label" title={props.label}>{props.label as string}</span>
+		<span
+			id="committed-label"
+			title={props.label}
+			class={{ initial: props.label === 'initial', next: props.label === 'next' }}
+		>
+			{props.label as string}
+		</span>
 		<Reader promise={props.promise} />
 	</main>
 }

--- a/packages/octane/tests/_fixtures/fresh-root-scope-hold.tsrx
+++ b/packages/octane/tests/_fixtures/fresh-root-scope-hold.tsrx
@@ -23,9 +23,7 @@ export function FreshRootScopeHold(props) @{
 			id="committed-label"
 			title={props.label}
 			class={{ initial: props.label === 'initial', next: props.label === 'next' }}
-		>
-			{props.label as string}
-		</span>
+		>{props.label as string}</span>
 		<Reader promise={props.promise} />
 	</main>
 }

--- a/packages/octane/tests/clsx-class.test.ts
+++ b/packages/octane/tests/clsx-class.test.ts
@@ -160,6 +160,54 @@ describe('clsx class composition — client mount', () => {
 		r.unmount();
 	});
 
+	it('writes a composed object class only when its value changes', () => {
+		const r = mount(ObjectClass, { active: true, disabled: false });
+		const div = r.find('div');
+		const observer = new MutationObserver(() => {});
+		observer.observe(div, { attributes: true, attributeFilter: ['class'] });
+		try {
+			r.update(ObjectClass, { active: true, disabled: false });
+			expect(r.find('div')).toBe(div);
+			expect(div.getAttribute('class')).toBe('active');
+			expect(observer.takeRecords()).toHaveLength(0);
+
+			r.update(ObjectClass, { active: false, disabled: true });
+			expect(div.getAttribute('class')).toBe('disabled');
+			expect(observer.takeRecords()).toHaveLength(1);
+
+			r.update(ObjectClass, { active: false, disabled: false });
+			expect(div.getAttribute('class')).toBe('');
+			expect(div.hasAttribute('class')).toBe(true);
+			expect(observer.takeRecords()).toHaveLength(1);
+
+			r.update(ObjectClass, { active: false, disabled: false });
+			expect(observer.takeRecords()).toHaveLength(0);
+		} finally {
+			observer.disconnect();
+			r.unmount();
+		}
+	});
+
+	it('writes a composed array class only when its value changes on SVG', () => {
+		const r = mount(SvgClass, { on: true });
+		const svg = r.find('svg');
+		const observer = new MutationObserver(() => {});
+		observer.observe(svg, { attributes: true, attributeFilter: ['class'] });
+		try {
+			r.update(SvgClass, { on: true });
+			expect(r.find('svg')).toBe(svg);
+			expect(svg.getAttribute('class')).toBe('a b');
+			expect(observer.takeRecords()).toHaveLength(0);
+
+			r.update(SvgClass, { on: false });
+			expect(svg.getAttribute('class')).toBe('a');
+			expect(observer.takeRecords()).toHaveLength(1);
+		} finally {
+			observer.disconnect();
+			r.unmount();
+		}
+	});
+
 	it('scoped component composes the array AND appends the scope hash', () => {
 		const r = mount(ScopedArray, { on: true });
 		const cls = r.find('div').className;

--- a/packages/octane/tests/fresh-root-scope-hold.test.ts
+++ b/packages/octane/tests/fresh-root-scope-hold.test.ts
@@ -29,6 +29,7 @@ describe('new scopes in a held root render', () => {
 		});
 		try {
 			const label = root.find('#committed-label');
+			expect(label.getAttribute('class')).toBe('initial');
 			const reader = root.find('#root-read');
 			root.update(FreshRootScopeHold, {
 				show: true,
@@ -40,12 +41,14 @@ describe('new scopes in a held root render', () => {
 			expect(root.find('#committed-label')).toBe(label);
 			expect(label.textContent).toBe('initial');
 			expect(label.getAttribute('title')).toBe('initial');
+			expect(label.getAttribute('class')).toBe('initial');
 			expect(root.find('#root-read')).toBe(reader);
 			expect(reader.textContent).toBe('first');
 			expect(external.textContent).toBe('external:initial');
 			expect(external.getAttribute('data-state')).toBe('initial');
 
 			await act(() => pending.resolve('second'));
+			expect(label.getAttribute('class')).toBe('next');
 			const row = root.find('#new-row');
 			expect(row.textContent).toBe('row:next:0');
 			expect(row.getAttribute('title')).toBe('row:next');


### PR DESCRIPTION
## Summary

- Cache the composed string for fresh literal `class` bindings and skip unchanged DOM class writes on update. This addresses the remaining class-write item in #981.
- Keep the initial mount/hydration write and SVG attribute routing; verify object/array updates and root suspension rollback with DOM-facing regressions.

## Why

Fresh object and array literals have a new identity on every render, even when `normalizeClass` returns the same string. The compiler currently omits the previous-value binding field and calls the DOM class setter unconditionally. In a repeated row this invokes browser class invalidation for unchanged values.

## Changes

- Normalize fresh class literals once per render, save the string in the existing binding bag, and use the ordinary changed-value guard.
- Keep nullish/false removal semantics on the nonfresh path; a fresh literal is always truthy, including when it composes to an empty string.
- Add a patch changeset and public DOM mutation and suspended-root regression coverage.
- Expose the two private compiler helpers through the evaluator’s bounded runtime bridge so generated user-app fixtures execute against the same runtime.

## Validation

- [x] `node --check packages/octane/src/compiler/compile.js`
- [x] `git diff --check` and scoped cached Prettier check for changed JS/TS/Markdown
- [x] `node scripts/workspace-packages.mjs --check`
- [ ] `pnpm sync`, local Vitest and typecheck: the configured dependency registry is currently preventing the pinned TSRX package from installing in a fresh worktree; `generate-version.mjs` ran without changing tracked files.
- [x] [Pinned baseline](https://github.com/openai-oss-forks/octane/actions/runs/34254906362) and [candidate](https://github.com/openai-oss-forks/octane/actions/runs/34255757915) used identical workflow/lockfile blobs. Weather raw: 22,595 → 22,619 bytes (22,624 budget); no new ratio breaches (57/95 on both). Compiled corpus raw/min/gzip: 159,633/78,003/27,898 → 159,919/78,133/27,927 bytes. The identical scratch workflows supply TodoMVC’s missing `window.__benchFlush = () => flushSync(() => {})` adapter so each dispatched event commits before verification; both sides pass all eight correctness targets, with exact changed-row class writes of 25 and identical DOM census. Timings on separate hosted runners are inconclusive.
- [x] [Pinned pre-fix RED](https://github.com/openai-oss-forks/octane/actions/runs/34247102733): the new unchanged-class DOM mutation assertions failed in both dev and prod on merged main (four intended failures, 72 other tests passed).
- [x] Current-head [CI attempt 2](https://github.com/octanejs/octane/actions/runs/34257053546/attempts/2) on `3d18ef459`: 26/26 jobs successful. An unrelated pristine Input OTP browser selection test failed on attempt 1 and passed on the identical-head retry.

## Risk / follow-ups

- The optimization changes the prior fresh-literal behavior of reasserting an externally edited `class` on an unrelated render. It matches the existing value guard for scalar class bindings.
- A fresh class literal retains one additional previous-value field in its binding bag; benchmark results will quantify output and runtime tradeoffs.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791474183&installation_model_id=432790&pr_number=996&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F996&signature=587f4bbf98de197c29edd75849757fb01334e89d502eebd6ad720ccba64450a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reactive class DOM write timing for fresh literals (aligned with scalar `*IfChanged` guards), so externally mutated classes may not be reasserted on unrelated re-renders; core binding and SVG routing paths are touched.
> 
> **Overview**
> Fresh **object/array/function** `class` bindings no longer hit the DOM on every render when `normalizeClass` produces the same string. The compiler now routes those updates through **`updateFreshClassName`** / **`updateFreshClassAttr`**, caches the composed string in the binding bag’s **`_prev`** field (including deferred mounts), and normalizes fresh literals on mount/update so empty compositions still emit **`class=""`** instead of removing the attribute.
> 
> The eval client runtime re-exports the new helpers. Tests use **`MutationObserver`** to assert skipped **`class`** mutations on no-op re-renders (HTML objects and SVG arrays), and the suspended-root fixture now covers object **`class`** during scope hold/rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d18ef459f093a0efff9b946978e39f5798853df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



