### PR TITLE
perf: reduce effect and ref postorder ancestry scans

### DIFF
--- a/.changeset/effect-postorder-parent-walk.md
+++ b/.changeset/effect-postorder-parent-walk.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid repeated ancestry scans when ordering effects and ref attachments from nearby components.

--- a/benchmarks/effect-postorder/README.md
+++ b/benchmarks/effect-postorder/README.md
@@ -1,0 +1,19 @@
+# Effect postorder comparator
+
+Run from the repository root with Node 24 or newer:
+
+```bash
+node benchmarks/effect-postorder/run.mjs upstream/main
+```
+
+The script extracts the **actual** `comparePostOrder` implementation from the
+specified Git revision and the working `packages/octane/src/runtime.ts`, strips
+its TypeScript annotations, and runs identical sorts. It checks both versions
+against tree postorder and compares sampled pairs before timing. The three
+shapes are a 400-component chain, 1,000 sibling owners, and uneven sibling
+branches. A counted pass records parent-chain reads independently of the timed
+pass. Eight interleaved, warmed batches report median microseconds per sort.
+
+This isolates sorting cost; it does not measure render, DOM, or effect callback
+time. Use `benchmarks/effectful-list` for the full 1,000-row lifecycle path,
+and the conformance effect-order tests for observable effect/ref ordering.

--- a/benchmarks/effect-postorder/run.mjs
+++ b/benchmarks/effect-postorder/run.mjs
@@ -1,0 +1,136 @@
+// Compare the actual runtime comparator from a Git revision with the worktree.
+// This focused bench runs without DOM or workspace dependencies. It also checks
+// the expected postorder, including uneven sibling depths, before timing.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+const file = 'packages/octane/src/runtime.ts';
+const baseRef = process.argv[2] ?? 'upstream/main';
+
+function comparator(source) {
+	const start = source.indexOf('function blockIsAncestorOf(');
+	const end = source.indexOf('function finishEffectCommit()', start);
+	if (start < 0 || end < 0) throw new Error('Effect comparator source moved');
+	const code = stripTypeScriptTypes(source.slice(start, end));
+	return Function(`${code}\nreturn comparePostOrder;`)();
+}
+
+const baseline = comparator(
+	execFileSync('git', ['show', `${baseRef}:${file}`], {
+		encoding: 'utf8',
+		maxBuffer: 8 * 1024 * 1024,
+	}),
+);
+const candidate = comparator(readFileSync(file, 'utf8'));
+
+function workload(shape, counted = false) {
+	let reads = 0;
+	let nextId = 0;
+	const nodes = [];
+	function add(parent, include = true) {
+		const id = nextId++;
+		const node = { id, children: [], included: include };
+		if (counted) {
+			Object.defineProperty(node, 'parentBlock', {
+				get() {
+					reads++;
+					return parent;
+				},
+			});
+		} else node.parentBlock = parent;
+		if (parent !== null) parent.children.push(node);
+		if (include) nodes.push({ block: node, seq: id, id });
+		return node;
+	}
+	const root = add(null, shape !== 'siblings' && shape !== 'mixed');
+	if (shape === 'chain') {
+		let parent = root;
+		for (let i = 1; i < 400; i++) parent = add(parent);
+	} else if (shape === 'siblings') {
+		for (let i = 0; i < 1000; i++) add(root);
+	} else if (shape === 'mixed') {
+		for (let i = 0; i < 150; i++) {
+			let parent = add(root);
+			for (let depth = 0; depth < i % 6; depth++) parent = add(parent);
+		}
+	}
+	const expected = [];
+	function visit(node) {
+		for (const child of node.children) visit(child);
+		if (node.included) expected.push(node.id);
+	}
+	visit(root);
+	return {
+		nodes,
+		expected,
+		get reads() {
+			return reads;
+		},
+	};
+}
+
+function sorted(comparison, nodes) {
+	return nodes.slice().sort((a, b) => comparison(a.block, a.seq, b.block, b.seq));
+}
+
+function median(numbers) {
+	return numbers.sort((a, b) => a - b)[Math.floor(numbers.length / 2)];
+}
+
+function time(comparison, nodes, repeats) {
+	const start = performance.now();
+	for (let i = 0; i < repeats; i++) sorted(comparison, nodes);
+	return ((performance.now() - start) * 1000) / repeats;
+}
+
+for (const shape of ['chain', 'siblings', 'mixed']) {
+	const { nodes, expected } = workload(shape);
+	assert.deepEqual(
+		sorted(baseline, nodes).map((entry) => entry.id),
+		expected,
+	);
+	assert.deepEqual(
+		sorted(candidate, nodes).map((entry) => entry.id),
+		expected,
+	);
+	for (const comparison of [baseline, candidate]) {
+		// Parent/child and disjoint comparisons must agree even when a sort uses
+		// a different comparison sequence after the optimization.
+		for (let i = 0; i < nodes.length; i += Math.max(1, Math.floor(nodes.length / 30))) {
+			for (let j = 0; j < nodes.length; j += Math.max(1, Math.floor(nodes.length / 30))) {
+				const a = nodes[i],
+					b = nodes[j];
+				assert.equal(
+					Math.sign(comparison(a.block, a.seq, b.block, b.seq)),
+					Math.sign(baseline(a.block, a.seq, b.block, b.seq)),
+				);
+			}
+		}
+	}
+	const baseCounted = workload(shape, true);
+	const nextCounted = workload(shape, true);
+	sorted(baseline, baseCounted.nodes);
+	sorted(candidate, nextCounted.nodes);
+	const repeats = shape === 'chain' ? 200 : 500;
+	for (let i = 0; i < 250; i++) {
+		sorted(baseline, nodes);
+		sorted(candidate, nodes);
+	}
+	const a = [],
+		b = [];
+	for (let i = 0; i < 8; i++) {
+		if (i % 2 === 0) {
+			a.push(time(baseline, nodes, repeats));
+			b.push(time(candidate, nodes, repeats));
+		} else {
+			b.push(time(candidate, nodes, repeats));
+			a.push(time(baseline, nodes, repeats));
+		}
+	}
+	console.log(
+		`${shape}: ${nodes.length} effects, parent reads ${baseCounted.reads} → ${nextCounted.reads}; median µs/sort ${median(a).toFixed(2)} → ${median(b).toFixed(2)}`,
+	);
+}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6265,12 +6265,24 @@ function blockIsAncestorOf(anc: Block, node: Block): boolean {
 // Nearby ancestors and siblings resolve before the full chain scans. These are
 // the common comparisons in a DFS-queued commit, including a deep linear tree.
 function comparePostOrder(
-	_aBlock: Block | null,
+	aBlock: Block | null,
 	aSeq: number,
-	_bBlock: Block | null,
+	bBlock: Block | null,
 	bSeq: number,
 ): number {
-	// Deliberate ordering fault to confirm the new consumer test detects it.
+	if (aBlock !== bBlock && aBlock !== null && bBlock !== null) {
+		const aParent = aBlock.parentBlock;
+		const bParent = bBlock.parentBlock;
+		if (aParent === bBlock) return -1;
+		if (bParent === aBlock) return 1;
+		if (aParent === bParent) return aSeq - bSeq;
+		for (let b = bParent; b !== null; b = b.parentBlock) {
+			if (b === aBlock) return 1;
+		}
+		for (let a = aParent; a !== null; a = a.parentBlock) {
+			if (a === bBlock) return -1;
+		}
+	}
 	return aSeq - bSeq;
 }
 function compareEffectPostOrder(a: PendingEffect, b: PendingEffect): number {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6262,16 +6262,15 @@ function blockIsAncestorOf(anc: Block, node: Block): boolean {
 // queue order. This is correct where a plain depth sort was not — a shallow node in an
 // earlier sibling subtree must fire before a deeper node in a LATER sibling subtree,
 // which depth alone gets backwards.
+// Nearby ancestors and siblings resolve before the full chain scans. These are
+// the common comparisons in a DFS-queued commit, including a deep linear tree.
 function comparePostOrder(
-	aBlock: Block | null,
+	_aBlock: Block | null,
 	aSeq: number,
-	bBlock: Block | null,
+	_bBlock: Block | null,
 	bSeq: number,
 ): number {
-	if (aBlock !== bBlock && aBlock !== null && bBlock !== null) {
-		if (blockIsAncestorOf(aBlock, bBlock)) return 1; // a is ancestor of b → a fires AFTER b
-		if (blockIsAncestorOf(bBlock, aBlock)) return -1; // b is ancestor of a → a fires BEFORE b
-	}
+	// Deliberate ordering fault to confirm the new consumer test detects it.
 	return aSeq - bSeq;
 }
 function compareEffectPostOrder(a: PendingEffect, b: PendingEffect): number {

--- a/packages/octane/tests/conformance/_fixtures/effect-order.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/effect-order.tsrx
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from 'octane';
+import { useEffect, useLayoutEffect } from 'octane';
 
 function Leaf(props) @{
 	useLayoutEffect((log) => {
@@ -58,5 +58,31 @@ export function CrossDepthRefs(props) @{
 	<>
 		<RefLeaf name="shallowRef" log={props.log} />
 		<RefBranch log={props.log} />
+	</>
+}
+
+// Each level owns both phases. A depth-only sort would place the later branch
+// ahead of the shallow sibling, while an enqueue-only sort would place each
+// ancestor ahead of its child.
+function NestedLifecycle(props) @{
+	useLayoutEffect((log, depth, version) => {
+		log.push('layout ' + depth + ':' + version);
+		return () => log.push('~layout ' + depth + ':' + version);
+	}, [props.log, props.depth, props.version]);
+	useEffect((log, depth, version) => {
+		log.push('passive ' + depth + ':' + version);
+		return () => log.push('~passive ' + depth + ':' + version);
+	}, [props.log, props.depth, props.version]);
+	@if (props.depth > 0) {
+		<NestedLifecycle depth={props.depth - 1} version={props.version} log={props.log} />
+	} @else {
+		<span>{props.version}</span>
+	}
+}
+
+export function NestedLifecycleOrder(props) @{
+	<>
+		<Leaf name="shallow" log={props.log} />
+		<NestedLifecycle depth={props.depth} version={props.version} log={props.log} />
 	</>
 }

--- a/packages/octane/tests/conformance/effect-order.test.ts
+++ b/packages/octane/tests/conformance/effect-order.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { mount, act, createLog } from '../_helpers';
-import { CrossDepth, ParentChild, MultiEffect } from './_fixtures/effect-order.tsrx';
+import { mount, act, createLog, flushEffects } from '../_helpers';
+import {
+	CrossDepth,
+	ParentChild,
+	MultiEffect,
+	NestedLifecycleOrder,
+} from './_fixtures/effect-order.tsrx';
 
 // React commits effects in a POST-ORDER tree walk: a node's descendants fire before it,
 // and disjoint subtrees fire in tree order. A plain deepest-first sort gets the
@@ -27,6 +32,27 @@ describe('conformance: layout-effect commit order (post-order)', () => {
 		mount(MultiEffect as any, { log });
 		await act(() => {});
 		expect(log.drain()).toEqual(['first', 'second']);
+	});
+
+	it('keeps nested layout and passive lifecycles in tree order across an update', () => {
+		const log = createLog();
+		const props = { log, depth: 8, version: 0 };
+		const r = mount(NestedLifecycleOrder as any, props);
+		const entries = (phase: string, version: number) =>
+			Array.from({ length: 9 }, (_, depth) => `${phase} ${depth}:${version}`);
+		const leaf = r.findAll('span')[1];
+		expect(leaf.textContent).toBe('0');
+		expect(log.drain()).toEqual(['shallow', ...entries('layout', 0)]);
+		flushEffects();
+		expect(log.drain()).toEqual(entries('passive', 0));
+
+		r.update(NestedLifecycleOrder as any, { ...props, version: 1 });
+		expect(r.findAll('span')[1]).toBe(leaf);
+		expect(leaf.textContent).toBe('1');
+		expect(log.drain()).toEqual([...entries('~layout', 0), ...entries('layout', 1)]);
+		flushEffects();
+		expect(log.drain()).toEqual([...entries('~passive', 0), ...entries('passive', 1)]);
+		r.unmount();
 	});
 });
 


### PR DESCRIPTION
## Summary

- Reduce ancestry walks when sorting queued effects and ref attachments for nearby component owners. Part of #967 and #981.
- Preserve nested layout and passive effect ordering with a new consumer-visible regression test, and add a focused comparator benchmark.

## Why

The previous comparator scans both complete parent chains for each comparison, even when comparing a component with its direct parent or a sibling.

## Changes

- Check direct parents and shared parents before scanning the remaining chains; preserve enqueue order for disjoint components and registration order within one component.
- Add a nested shallow-sibling/deep-branch lifecycle test for mount, cleanup, and update in development and production suites.
- Add a benchmark that checks pairwise order against upstream `main` and measures chain, sibling, and uneven-branch sort workloads. Add an `octane` patch changeset.

## Validation

- [x] [Red CI run](https://github.com/octanejs/octane/actions/runs/34259437846): the new test failed in both development and production on a deliberately broken comparator, including the child-before-parent assertion.
- [x] Focused benchmark: 400-level chain parent reads 80,199 → 798 and median comparator sort 179.99 → 5.92 µs; 1,000 siblings 3,996 → 1,998 reads, 17.46 → 14.88 µs; uneven 525-node tree 12,989 → 11,623 reads, 51.91 → 50.17 µs. These figures measure sorting alone, not full renders.
- [x] `node scripts/workspace-packages.mjs --check`, `git diff --check`, and focused benchmark ordering gates.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34260829381) passed with the repaired comparator: every runtime, React parity, lint, typecheck, integration, and package validation job succeeded.
- [ ] Local `pnpm sync`, Vitest, and typecheck: the configured Socket registry returned HTTP 403 for pinned `@tsrx/prettier-plugin@0.3.135` before scripts could start; frozen-lockfile supply-chain verification passed. The offline filtered install also lacked `@tsrx/core@0.1.69`.

## Risk / follow-ups

- Browser lifecycle timing remains unmeasured locally due to the registry failure; CI exercises the full runtime, and the benchmark isolates comparator cost.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791481787&installation_model_id=432790&pr_number=998&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F998&signature=3ddba7d87646d74baef9e8e925aa2fa3d1b65866d2f30e7efaf6b70766aa2c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commit-phase ordering logic for effects and refs; incorrect comparisons would be user-visible, though existing and new conformance tests target the tricky cross-depth and nested lifecycle cases.
> 
> **Overview**
> **Optimizes how queued layout/passive effects and ref attachments are sorted** so commit order still matches React’s post-order tree walk, with fewer `parentBlock` walks during sorting.
> 
> `comparePostOrder` in `runtime.ts` no longer calls `blockIsAncestorOf` twice per comparison. It resolves direct parent/child pairs, same-parent siblings (via enqueue `seq`), then only walks one side’s chain when needed before falling back to `aSeq - bSeq`.
> 
> Adds a **standalone benchmark** (`benchmarks/effect-postorder`) that extracts the comparator from a Git ref vs the worktree, checks postorder correctness, counts parent reads, and reports median sort time for chain, sibling, and mixed trees.
> 
> Adds **conformance coverage** (`NestedLifecycleOrder`) for shallow sibling + deep nested tree layout and passive effect order across mount and update, including cleanups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155c7dd030cb16ce2d7d5901aa12b4f563facd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->