### PR TITLE
perf: skip SSR transition arm scans without candidates

### DIFF
--- a/.changeset/skip-empty-ssr-transition-arms.md
+++ b/.changeset/skip-empty-ssr-transition-arms.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Skip scanning server Suspense arms for ViewTransition markers when none were rendered.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,9 +1079,10 @@ jobs:
           test "$(git -C "$THREE_CURRENT_WORKSPACE" rev-parse HEAD)" = "$GITHUB_SHA"
           test "$(git -C "$THREE_MINIMUM_WORKSPACE" rev-parse --git-dir)" != "$(git -C "$THREE_CURRENT_WORKSPACE" rev-parse --git-dir)"
 
-      # Keep the r172 differential oracle immutable. Each lane replaces only
-      # the Three runtime/type pair, then selects the Octane-owned compatibility
-      # suite so current/minimum support cannot be faked by the pinned oracle.
+      # Keep the r172 differential oracle immutable. The minimum lane uses its
+      # matching runtime/type pair; the current lane checks the newest published
+      # matching pair and tests the latest runtime even when its types lag.
+      # Both select the Octane-owned compatibility suite.
       - name: Test Three compatibility (minimum r156)
         working-directory: ${{ runner.temp }}/octane-three-compat-minimum-r156
         env:
@@ -1111,16 +1112,24 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           THREE_VERSION="$(pnpm view "three@$THREE_VERSION_SPEC" version)"
-          THREE_RELEASE_LINE="${THREE_VERSION%.*}"
-          pnpm --filter @octanejs/three add --save-dev --lockfile=false "three@$THREE_VERSION" "@types/three@${THREE_RELEASE_LINE}.x"
-          RESOLVED_THREE_VERSION="$(node -e "process.stdout.write(require('./packages/three/node_modules/three/package.json').version)")"
-          TYPES_VERSION="$(node -e "process.stdout.write(require('./packages/three/node_modules/@types/three/package.json').version)")"
+          TYPES_VERSION="$(pnpm view @types/three@latest version)"
           TYPES_RELEASE_LINE="${TYPES_VERSION%.*}"
-          echo "three=$RESOLVED_THREE_VERSION @types/three=$TYPES_VERSION"
-          test "$RESOLVED_THREE_VERSION" = "$THREE_VERSION"
-          test "$THREE_RELEASE_LINE" = "$TYPES_RELEASE_LINE"
+          pnpm --filter @octanejs/three add --save-dev --lockfile=false "three@${TYPES_RELEASE_LINE}.x" "@types/three@$TYPES_VERSION"
+          TYPED_THREE_VERSION="$(node -e "process.stdout.write(require('./packages/three/node_modules/three/package.json').version)")"
+          RESOLVED_TYPES_VERSION="$(node -e "process.stdout.write(require('./packages/three/node_modules/@types/three/package.json').version)")"
+          echo "typed pair: three=$TYPED_THREE_VERSION @types/three=$RESOLVED_TYPES_VERSION"
+          test "${TYPED_THREE_VERSION%.*}" = "$TYPES_RELEASE_LINE"
+          test "$RESOLVED_TYPES_VERSION" = "$TYPES_VERSION"
           pnpm exec tsgo --noEmit -p packages/three/tsconfig.json
           pnpm exec tsc --noEmit -p packages/three/typetests/tsconfig.json
+          OCTANE_THREE_COMPAT_VERSION="$TYPED_THREE_VERSION" pnpm --dir packages/three test:compat
+
+          pnpm --filter @octanejs/three add --save-dev --lockfile=false "three@$THREE_VERSION"
+          RESOLVED_THREE_VERSION="$(node -e "process.stdout.write(require('./packages/three/node_modules/three/package.json').version)")"
+          RESOLVED_TYPES_VERSION="$(node -e "process.stdout.write(require('./packages/three/node_modules/@types/three/package.json').version)")"
+          echo "latest runtime: three=$RESOLVED_THREE_VERSION @types/three=$RESOLVED_TYPES_VERSION"
+          test "$RESOLVED_THREE_VERSION" = "$THREE_VERSION"
+          test "$RESOLVED_TYPES_VERSION" = "$TYPES_VERSION"
           OCTANE_THREE_COMPAT_VERSION="$THREE_VERSION" pnpm --dir packages/three test:compat
 
   lynx_compat:

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -4383,6 +4383,7 @@ function vtSsrAnnotate(html: string, attrs: Array<[string, string]>): string {
  * claims nothing — that is exactly React's "top of the arm only" rule.
  */
 function vtSsrClaimArm(html: string, kind: 'enter' | 'exit'): string {
+	if (!VT_SSR_HAS_CANDIDATES) return html;
 	const start = vtSsrFirstVisibleOpenTag(html);
 	if (start === -1) return html;
 	const end = vtSsrOpenTagEnd(html, start + 1);

--- a/packages/octane/tests/view-transition.test.ts
+++ b/packages/octane/tests/view-transition.test.ts
@@ -104,6 +104,69 @@ describe('ViewTransition server output', () => {
 		expect(html).not.toContain('vt-exit=');
 	});
 
+	it('keeps ordinary Suspense arm markup in buffered and streamed output', async () => {
+		const mod = evalServer(
+			`
+				import { use } from 'octane';
+				export function Content() @{
+					@try { <x-arm id="content" title="ordinary">{'ready'}</x-arm> }
+					@pending { <i>{'waiting'}</i> }
+				}
+				export function Pending(props) @{
+					@try { <span id="settled" title="ordinary">{use(props.promise) as string}</span> }
+					@pending { <x-arm id="fallback" data-phase="waiting">{'waiting'}</x-arm> }
+				}
+			`,
+			'ordinary-suspense-arms.tsrx',
+		);
+		const content = document.createElement('div');
+		content.innerHTML = ServerRuntime.renderToString(mod.Content).html;
+		const contentArm = content.querySelector('#content')!;
+		expect(contentArm.getAttribute('title')).toBe('ordinary');
+		expect(contentArm.textContent).toBe('ready');
+
+		const fallback = document.createElement('div');
+		fallback.innerHTML = ServerRuntime.renderToString(mod.Pending, {
+			promise: new Promise<string>(() => {}),
+		}).html;
+		const fallbackArm = fallback.querySelector('#fallback')!;
+		expect(fallbackArm.getAttribute('data-phase')).toBe('waiting');
+		expect(fallbackArm.textContent).toBe('waiting');
+
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const chunks: string[] = [];
+		let finish!: () => void;
+		const ended = new Promise<void>((done) => {
+			finish = done;
+		});
+		ServerRuntime.renderToPipeableStream(mod.Pending, { promise }).pipe({
+			write: (chunk: string) => chunks.push(chunk),
+			end: finish,
+		});
+		const shell = document.createElement('div');
+		shell.innerHTML = chunks.join('');
+		const shellFallback = shell.querySelector('#fallback')!;
+		expect(shellFallback.getAttribute('data-phase')).toBe('waiting');
+		expect(shellFallback.textContent).toBe('waiting');
+		resolve('streamed');
+		await ended;
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		try {
+			container.innerHTML = chunks.join('');
+			activateStreamedMarkup(container);
+			const settled = container.querySelector('#settled')!;
+			expect(settled.getAttribute('title')).toBe('ordinary');
+			expect(settled.textContent).toBe('streamed');
+		} finally {
+			container.remove();
+			resetStreamRuntimeGlobals();
+		}
+	});
+
 	it('annotates and claims the first visible element past quoted tag delimiters', () => {
 		const mod = evalServer(
 			`

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -181,6 +181,9 @@ describe('CI workflow aggregation', () => {
 
 	test('runs both Three compatibility lanes in one job with isolated worktrees', () => {
 		const compat = jobSource('three_compat');
+		const current = compat.slice(
+			compat.indexOf('      - name: Test Three compatibility (current)'),
+		);
 		const provenance = stepScript(workflow, 'Verify full-suite provenance');
 
 		assert.match(compat, /^    name: Three compatibility$/m);
@@ -216,8 +219,32 @@ describe('CI workflow aggregation', () => {
 		);
 		assert.equal(
 			[...compat.matchAll(/test "\$THREE_RELEASE_LINE" = "\$TYPES_RELEASE_LINE"/g)].length,
-			2,
+			1,
 		);
+		assert.match(current, /TYPES_VERSION="\$\(pnpm view @types\/three@latest version\)"/);
+		assert.match(current, /test "\$\{TYPED_THREE_VERSION%\.\*\}" = "\$TYPES_RELEASE_LINE"/);
+		assert.match(current, /test "\$RESOLVED_TYPES_VERSION" = "\$TYPES_VERSION"/);
+		const typedPairInstall = current.indexOf(
+			'"three@${TYPES_RELEASE_LINE}.x" "@types/three@$TYPES_VERSION"',
+		);
+		const typecheck = current.indexOf(
+			'pnpm exec tsc --noEmit -p packages/three/typetests/tsconfig.json',
+		);
+		const typedRuntimeTest = current.indexOf(
+			'OCTANE_THREE_COMPAT_VERSION="$TYPED_THREE_VERSION" pnpm --dir packages/three test:compat',
+		);
+		const latestRuntimeInstall = current.indexOf('"three@$THREE_VERSION"');
+		const latestRuntimeAssertion = current.indexOf(
+			'test "$RESOLVED_THREE_VERSION" = "$THREE_VERSION"',
+		);
+		const latestRuntimeTest = current.indexOf(
+			'OCTANE_THREE_COMPAT_VERSION="$THREE_VERSION" pnpm --dir packages/three test:compat',
+		);
+		assert.ok(typedPairInstall >= 0 && typedPairInstall < typecheck);
+		assert.ok(typecheck < typedRuntimeTest);
+		assert.ok(typedRuntimeTest < latestRuntimeInstall);
+		assert.ok(latestRuntimeInstall < latestRuntimeAssertion);
+		assert.ok(latestRuntimeAssertion < latestRuntimeTest);
 		assert.equal(
 			[...compat.matchAll(/pnpm exec tsgo --noEmit -p packages\/three\/tsconfig\.json/g)].length,
 			2,
@@ -227,7 +254,7 @@ describe('CI workflow aggregation', () => {
 				.length,
 			2,
 		);
-		assert.equal([...compat.matchAll(/pnpm --dir packages\/three test:compat/g)].length, 2);
+		assert.equal([...compat.matchAll(/pnpm --dir packages\/three test:compat/g)].length, 3);
 		assert.match(provenance, /^\s+"Three compatibility",$/m);
 		assert.doesNotMatch(provenance, /Three compatibility \(\$\{lane\}\)/);
 	});


### PR DESCRIPTION
## Summary

- Skip the `vtSsrClaimArm` HTML scan when the active SSR pass has rendered no ViewTransition candidate. This addresses the no-ViewTransition Suspense arm item in #981.
- Add a buffered and streaming regression for ordinary `@try` content, fallback, and revealed markup; include an `octane` patch changeset.
- Repair the required Three compatibility lane for the current release gap: typecheck and test the newest matching runtime/typings pair, then run the same compatibility suite against the exact newest Three runtime.

## Why

Every ordinary Suspense/`@try` content or fallback arm currently searches its rendered HTML for a candidate attribute even on pages with no ViewTransition. On nested boundaries this repeatedly flattens the same cons-string subtree. The existing pass flag is set by ViewTransition before an arm is claimed, and is saved/restored for retries and nested renders, so a false value rules out renderer-generated candidates.

The first PR head exposed a release timing failure in the required Three compatibility job: `three@0.186.0` was published before matching `@types/three`, so the previous `@types/three@0.186.x` install could not resolve. The adjusted lane retains typechecking against a matching pair and exercises the newest runtime independently.

## Validation

- [x] Same-toolchain source-bundle SSR checks on the merged `main` baseline and this branch in development and production: ordinary content/fallback output and a real ViewTransition `vt-enter` claim behaved as expected. A source-only streaming shell and decoded reveal segment matched on both heads. Mutants that drop no-candidate arm HTML or skip actual candidates each turned the corresponding behavioral assertion red; the restored implementation passed.
- [x] Focused production SSR ABAB probe on Node 26.4.0: 12 nested no-ViewTransition `ssrTry` boundaries around 1,000 spans, 3,000 warmups and five 10,000-render rounds per sample, charging `Buffer.byteLength` for response flattening. Median per render baseline 0.02102 / 0.02063 ms, candidate 0.00512 / 0.00515 ms. Both builds emitted exactly 35,416 bytes, 24 opening markers and the same SHA-256. This isolates the arm-scan cost; it is not a claim about typical application throughput.
- [x] The source-only production SSR bundle changed from 242,865 raw / 54,449 gzip bytes to 242,908 raw / 54,456 gzip (+43/+7).
- [x] `git diff --check`, direct version generation, package inventory, and context-budget checks passed. The changed TS/Markdown files passed scoped Prettier formatting with the repository's base settings and without its unavailable plugins.
- [x] The CI workflow edit passed YAML and shell parsing, Node syntax, scoped formatting (base settings without unavailable plugins), diff checks, and focused workflow assertions. A reviewer checked the two-install version assertions. Full local workflow tests await the pinned install.
- [ ] Full pinned install, `pnpm sync`, Vitest, and typecheck: the configured local registry returned 403 for pinned `@tsrx/core@0.1.69` and could not supply `@tsrx/prettier-plugin@0.3.135` offline. The current-head CI will run these checks.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34271841857) on `91e48e7e6b37840bf663061b619230f22a97e583`: all 26 jobs passed, including the repaired Three compatibility lane, all Node and React parity shards, typecheck, lint, browser integration, and CI provenance. Cursor Bugbot passed with no review comments.

## Risk / follow-ups

- The guard is conservative: a pass that rendered then discarded a ViewTransition can still scan extra arms. Authored `vt-*-x` attributes are internal staging names; on a no-ViewTransition buffered arm this change leaves them untouched rather than claiming them, while other emission paths may still strip them.
- Production fixture and browser throughput effects remain unmeasured locally because the pinned dependencies could not be installed; CI will verify correctness on the current head.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791488590&installation_model_id=432790&pr_number=1000&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1000&signature=c34ace1d3ce91a61a4aaff98a526aaf8a8326196fd38b267fc888000a62d1861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Conservative guard on an internal SSR optimization path; ViewTransition claiming is unchanged when candidates exist, with new regression coverage for ordinary Suspense output.
> 
> **Overview**
> **SSR no longer scans every Suspense `@try` arm HTML for ViewTransition markers when the render pass never emitted any.**
> 
> `vtSsrClaimArm` now returns the arm HTML unchanged when `VT_SSR_HAS_CANDIDATES` is false, avoiding repeated tag parsing on nested boundaries on pages without `ViewTransition`. Behavior when transitions are present is unchanged because the flag is still set during annotation/claim.
> 
> A new Vitest case covers ordinary buffered and streamed Suspense content, fallback, and post-reveal markup so non–ViewTransition arms stay intact. An `octane` patch changeset documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726e42b1180393b201d28e98426edf29549a097d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

