### PR TITLE
perf: skip head-close scan for SSR fragments

### DIFF
--- a/.changeset/skip-fragment-head-scan.md
+++ b/.changeset/skip-fragment-head-scan.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Avoid scanning buffered server fragments for a document head when hoisted metadata is present.

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -6360,14 +6360,12 @@ export interface RenderOptions {
 // body with nothing to splice is returned as is, decided from its first bytes so
 // the common fragment response is never scanned for a `</head>`.
 function spliceHead(body: string, head: string): string {
-	if (head === '' && !isDocumentRoot(body)) return body;
+	if (!isDocumentRoot(body)) return head === '' ? body : head + body;
 	const headClose = body.indexOf('</head>');
 	if (headClose !== -1) return body.slice(0, headClose) + head + body.slice(headClose);
-	if (isDocumentRoot(body)) {
-		const openingEnd = documentTagEnd(body, body.indexOf('<html') + 5);
-		if (openingEnd !== -1)
-			return body.slice(0, openingEnd) + '<head>' + head + '</head>' + body.slice(openingEnd);
-	}
+	const openingEnd = documentTagEnd(body, body.indexOf('<html') + 5);
+	if (openingEnd !== -1)
+		return body.slice(0, openingEnd) + '<head>' + head + '</head>' + body.slice(openingEnd);
 	if (head === '') return body;
 	return head + body;
 }

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import * as RT from 'octane/server';
+import { prerender } from 'octane/static';
 import {
 	createElement as createClientElement,
 	flushSync,
@@ -1130,7 +1131,7 @@ describe('SSR, hoisted head channel', () => {
 
 	it('prepends metadata to a fragment even when its content mentions a head close', async () => {
 		// Raw HTML can contain these bytes without turning the fragment into a document.
-		for (const render of [RT.renderToString, RT.renderToStaticMarkup, RT.prerender]) {
+		for (const render of [RT.renderToString, RT.renderToStaticMarkup, prerender]) {
 			const folded = await render(fragmentWithHeadText.Page);
 			const separate = await render(fragmentWithHeadText.Page, undefined, {
 				headChannel: 'separate',
@@ -1147,7 +1148,7 @@ describe('SSR, hoisted head channel', () => {
 
 	it('places metadata inside an authored or synthesized document head', async () => {
 		for (const document of [documentPages.WithHead, documentPages.WithoutHead]) {
-			for (const render of [RT.renderToString, RT.renderToStaticMarkup, RT.prerender]) {
+			for (const render of [RT.renderToString, RT.renderToStaticMarkup, prerender]) {
 				const { html } = await render(document);
 				const headOpen = html.indexOf('<head>');
 				const title = html.indexOf('<title>Document title</title>');

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -1063,6 +1063,40 @@ describe('SSR, hoisted head channel', () => {
 		}
 	`;
 	const headPage = evalServer(HEAD_PAGE, 'head-channel.tsrx');
+	const fragmentWithHeadText = evalServer(
+		`
+		export function Page() @{
+			<>
+				<title>Fragment title</title>
+				<main dangerouslySetInnerHTML={{ __html: '<!-- </head> -->' }} />
+			</>
+		}
+		`,
+		'head-fragment-comment.tsrx',
+	);
+	const documentPages = evalServer(
+		`
+		export function WithHead() @{
+			<html>
+				<head />
+				<body>
+					<title>Document title</title>
+					<main>body text</main>
+				</body>
+			</html>
+		}
+
+		export function WithoutHead() @{
+			<html>
+				<body>
+					<title>Document title</title>
+					<main>body text</main>
+				</body>
+			</html>
+		}
+		`,
+		'head-document.tsrx',
+	);
 
 	it('folds metadata into html and omits the head field by default', async () => {
 		for (const render of [RT.renderToString, RT.renderToStaticMarkup]) {
@@ -1092,6 +1126,39 @@ describe('SSR, hoisted head channel', () => {
 		const folded = RT.renderToString(headPage.Page, { slug: 'a' });
 		const separated = RT.renderToString(headPage.Page, { slug: 'a' }, { headChannel: 'separate' });
 		expect(separated.head! + separated.html).toBe(folded.html);
+	});
+
+	it('prepends metadata to a fragment even when its content mentions a head close', async () => {
+		// Raw HTML can contain these bytes without turning the fragment into a document.
+		for (const render of [RT.renderToString, RT.renderToStaticMarkup, RT.prerender]) {
+			const folded = await render(fragmentWithHeadText.Page);
+			const separate = await render(fragmentWithHeadText.Page, undefined, {
+				headChannel: 'separate',
+			});
+			expect(folded.html.indexOf('<title>Fragment title</title>')).toBeLessThan(
+				folded.html.indexOf('<main'),
+			);
+			expect(folded.html).toContain('<main><!-- </head> --></main>');
+			expect(separate.head).toContain('<title>Fragment title</title>');
+			expect(separate.html).toContain('<main><!-- </head> --></main>');
+			expect(separate.head! + separate.html).toBe(folded.html);
+		}
+	});
+
+	it('places metadata inside an authored or synthesized document head', async () => {
+		for (const document of [documentPages.WithHead, documentPages.WithoutHead]) {
+			for (const render of [RT.renderToString, RT.renderToStaticMarkup, RT.prerender]) {
+				const { html } = await render(document);
+				const headOpen = html.indexOf('<head>');
+				const title = html.indexOf('<title>Document title</title>');
+				const headClose = html.indexOf('</head>');
+				const bodyOpen = html.indexOf('<body>');
+				expect(headOpen).toBeGreaterThan(html.indexOf('<html>'));
+				expect(title).toBeGreaterThan(headOpen);
+				expect(title).toBeLessThan(headClose);
+				expect(headClose).toBeLessThan(bodyOpen);
+			}
+		}
 	});
 
 	it('reports an empty head when a render hoists nothing', async () => {


### PR DESCRIPTION
## Summary

- Check whether buffered SSR output is a document before searching it for `</head>`. Fragment renders with hoisted metadata now prepend the head without scanning the entire body.
- Add a regression for a fragment containing raw `<!-- </head> -->`, plus authored and synthesized document-head controls across `renderToString`, `renderToStaticMarkup`, and `prerender`.
- Add an `octane` patch changeset. This addresses the `spliceHead` fragment-scan item in #981; the coordination issue remains open.

## Why

When a buffered fragment hoists a title or other head resource, `spliceHead` searched its entire response for `</head>` even though only a document root can have the closing head it intends to target. On a large response this flattens and scans the whole string. It can also insert the title inside raw fragment content that happens to contain `</head>` in an HTML comment.

## Validation

- [x] Baseline and candidate production/development source bundles exercised the public buffered string, static markup, and prerender APIs: the baseline misplaced the title inside a fragment comment; the candidate prepends it and preserves the raw comment. `headChannel: 'separate'` recomposes the candidate folded output. Authored and synthesized document heads retain their placement. A cached compiler emitted both test fixtures with no diagnostics in dev/prod compile modes; the pinned compiler version awaits CI.
- [x] A source-only stream check compared fragment, authored document, and synthesized-head document responses. Baseline and candidate had identical bytes and SHA-256 in both development and production runtime modes; streaming fragments already bypass this scan.
- [x] Same-toolchain production source-bundle buffered SSR ABBA probe on Node 26.4.0: 2,400-span fragment (86,648 response bytes), one hoisted title, 1,000 warmups and five 3,000-render rounds per sample, four samples per variant, charging `Buffer.byteLength`. Median of sample medians: baseline 0.0763 ms/render, candidate 0.0078 ms/render; every response SHA-256 and byte count matched. The no-hoist control was 0.00336 vs 0.00342 ms, and the document control ranged 0.00625–0.00880 vs 0.00759–0.00863 ms. This isolates the fragment scan, not typical application throughput.
- [x] Scoped Prettier check with base repository settings, `git diff --check`, direct version generation, package inventory and context-budget checks passed. The production source bundle changed from 100,909 to 100,892 raw bytes.
- [ ] Local pinned Vitest/typecheck and `pnpm sync`: dependency install stopped when the configured registry returned 403 for pinned `@tsrx/prettier-plugin@0.3.135` and `@tsrx/core@0.1.69` on successive attempts. Current-head CI covered the pinned toolchain.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34275924292) on `6056abb7497b57d38fa67780a22d74ad6eb8ad5c`: all 26 jobs passed, including the corrected SSR regression in both development and production projects, typecheck, lint, browser integration, and provenance. The first head exposed a test-only `prerender` import error, fixed in the follow-up commit. Cursor Bugbot passed with no review comments.

## Risk / follow-ups

- Document renders with hoisted metadata now perform a prefix document check before their closing-head search. Document control timings overlapped across variants; their throughput effect is unresolved at this sample size. The changed fragment path is buffered; streaming output was checked for byte identity.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791491063&installation_model_id=432790&pr_number=1001&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1001&signature=aa4cf280bb2dd35655f4b71f54127a0f2ded39912d4f274bc61dd2fcabf60359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to buffered SSR head splicing; document behavior is preserved and streaming was byte-identical in validation.
> 
> **Overview**
> **Buffered SSR fragments with hoisted metadata no longer search the full response for `</head>`.** `spliceHead` now uses a prefix `isDocumentRoot` check: non-document bodies prepend hoisted head markup (or return unchanged when empty) without scanning, which avoids wasted work on large fragments and stops false matches when raw HTML contains `</head>` (e.g. inside a comment).
> 
> **Document renders are unchanged in intent**—they still splice before an existing `</head>` or synthesize a `<head>` after `<html>`—with a small control-flow simplification after the early fragment exit.
> 
> Tests cover the comment regression, `headChannel: 'separate'` recomposing folded output, and metadata placement for authored vs synthesized document heads across `renderToString`, `renderToStaticMarkup`, and `prerender`. An `octane` patch changeset records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6e2a6003723bef39e18d58ad32f509e0c3a12c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

