### PR TITLE
feat(octane): infer primitive DOM text children

### DIFF
--- a/.changeset/restore-dom-primitive-text.md
+++ b/.changeset/restore-dom-primitive-text.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+'@octanejs/vite-plugin': patch
+'@octanejs/rspack-plugin': patch
+'@octanejs/rsbuild-plugin': patch
+---
+
+Recognize locally proven primitive string, number, and bigint DOM children while preserving explicit `as string` text bindings. Add an optional TypeScript project proof for one-shot Vite, Rspack, and Rsbuild production builds, with matching server and hydration output.

--- a/docs/compiler-text-inference.md
+++ b/docs/compiler-text-inference.md
@@ -116,12 +116,11 @@ A TypeScript type is a static contract, not a runtime conversion. For example,
 `String(count)` when conversion is intended. The compiler never removes that
 call or changes its evaluation count. Incorrect declarations, unchecked casts,
 and deliberately replaced JavaScript built-ins can still violate a typed
-program's assumptions. Recognized direct writes to the global `String`
-constructor disable new inferred text proofs in that module; an explicit
-authored `as string` keeps
-its existing text intent. The compiler cannot detect replacement in an unrelated
-module or independently verify whether an imported type has changed since a
-snapshot was taken.
+program's assumptions. Recognized direct writes to global `String`, `Number`,
+`BigInt`, or `Date` disable new inferred text proofs in that module; an explicit
+authored `as string` keeps its existing text intent. The compiler cannot detect
+replacement in an unrelated module or independently verify whether an imported
+type has changed since a snapshot was taken.
 
 These facts specialize DOM child text only. They do not change attribute
 coercion, `dangerouslySetInnerHTML` validation, or the treatment of unproven

--- a/docs/compiler-text-inference.md
+++ b/docs/compiler-text-inference.md
@@ -1,16 +1,19 @@
 # Type-aware text compilation
 
-Octane normally classifies template children from their syntax. String and
-template literals, string concatenations, explicit string assertions, and some
-local bindings select the text-binding path. An unshadowed built-in
-`String(value)` call also selects that path; the conversion still executes.
-Other expressions remain general renderables, which can contain elements,
-arrays, components, or primitive values.
+Octane normally classifies template children from their syntax. String,
+number, and bigint literals; template literals; string concatenations;
+explicit string assertions; and some local bindings select the text-binding
+path. Unshadowed built-in `String(value)`, `Number(value)`, `BigInt(value)`,
+and `Date()` calls also select that path without removing the authored call.
+`new Date()` is an object, so render a formatted string instead. Other
+expressions remain general renderables, which can contain elements, arrays,
+components, or primitive values.
 
 The experimental, Node-only `octane/compiler/typescript` entry point can also
-prove that an authored child expression has a primitive-string TypeScript type.
+prove that an authored child expression has a primitive string, number, or
+bigint TypeScript type (including a union of those primitives).
 This covers cases such as typed properties, destructuring, imported aliases,
-string-returning functions, and control-flow narrowing. It does not make the
+primitive-returning functions, and control-flow narrowing. It does not make the
 ordinary `octane/compiler` entry point depend on a TypeScript checker.
 
 ## Use the project adapter
@@ -54,22 +57,59 @@ filename, exact source version, and project generation. Pass the same snapshot
 to client and server compilation: text classification affects SSR separators
 and hydration layout. Supplying malformed, source-stale, or wrong-file facts is an
 error; omitting `textTypeFacts` retains syntax-only compilation.
+If your tsconfig lives below the application's renderer-rule root, pass
+`root: resolve('.')` alongside `tsconfig` so the adapter selects the same
+project-relative renderer for each file as the bundler.
 
-The adapter does not install filesystem watchers or connect itself to a
-bundler's module graph. Call `project.invalidate(filename)` after a file changes,
-or `project.invalidate()` to discard every cached source. Both forms reload the
-project configuration and roots. Do not cache an unchanged component's compiled
-output across an imported type change without
-invalidating that output too. Automatic Vite, Rspack, and HMR integration is not
-part of this experimental API.
+The adapter does not install filesystem watchers. Call
+`project.invalidate(filename)` after a file changes, or `project.invalidate()`
+to discard every cached source. Both forms reload the project configuration and
+roots. Do not cache an unchanged component's compiled output across an imported
+type change without invalidating that output too.
+
+## Opt in during production builds
+
+Vite, Rspack, and Rsbuild can create the project and pass text facts to the
+compiler in a one-shot production build. The optional TypeScript peer is needed
+when this option is enabled. Point browser and server builds at the same
+tsconfig so their DOM text classification agrees.
+
+```ts
+// vite.config.ts
+import { octane } from '@octanejs/vite-plugin';
+
+export default {
+	plugins: [octane({ textTypes: { tsconfig: 'tsconfig.json' } })],
+};
+```
+
+```js
+// rspack.config.js
+import { octaneRspack } from '@octanejs/rspack-plugin';
+
+export default {
+	plugins: [octaneRspack({ textTypes: { tsconfig: 'tsconfig.json' } })],
+};
+```
+
+Rsbuild accepts the same `textTypes` option through `pluginOctane` from
+`@octanejs/rsbuild-plugin`. Relative tsconfig paths resolve from the project
+root. Development servers, HMR, and watched builds continue to use local
+syntax inference; imported type edits can fall outside a bundler's watched
+module graph. A fresh one-shot build reevaluates the TypeScript project. The
+Rspack integration also bypasses its persistent module cache for typed Octane
+modules, so an imported type edit cannot reuse a stale compiled component in a
+later build.
 
 ## Safety boundary
 
 Inference requires effective `strictNullChecks`. The analysis also enables
 `noUncheckedIndexedAccess`, so potentially missing array entries and index
-signature properties do not become non-null string proofs. `any`, `unknown`,
-`never`, boxed `String`, nullable or mixed unions, unresolved types, and
-ambiguous source mappings retain the general-renderable path.
+signature properties do not become non-null primitive proofs. `any`, `unknown`,
+`never`, boxed `String`/`Number`, unions containing booleans, nullish values, or
+objects, unresolved types, and ambiguous source mappings retain the
+general-renderable path. Boolean children stay there because `true` is empty
+as a renderable child but becomes `"true"` in an explicit text binding.
 
 A TypeScript type is a static contract, not a runtime conversion. For example,
 `count as string` can be an invalid assertion when `count` is a number; use

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -1184,6 +1184,9 @@ class OctaneBundlerCompiler {
 				hmr,
 				mode: environment,
 				dev,
+				...(renderer.target === 'dom' && options.textTypeFacts !== undefined
+					? { textTypeFacts: options.textTypeFacts }
+					: null),
 				profile,
 				profileFilename,
 				...(inlineHookMemo ? null : { inlineHookMemo: false }),

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8596,7 +8596,7 @@ function instrumentProfileComponents(ast, ctx) {
  * Compile a .tsrx source string into JS targeting `octane`.
  * @param {string} source
  * @param {string} filename
- * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, strong?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], valdiWriterFacts?: import('./compile-valdi.js').ValdiWriterFacts, textTypeFacts?: { version: 1, filename: string, sourceVersion: string, projectVersion: string, stringChildRanges: readonly (readonly [number, number])[] }, renderer?: { id: string, module: string, target: 'dom' | 'universal' | 'valdi', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal' | 'valdi', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
+ * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, strong?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], valdiWriterFacts?: import('./compile-valdi.js').ValdiWriterFacts, textTypeFacts?: { version: 1, filename: string, sourceVersion: string, projectVersion: string, stringChildRanges: readonly (readonly [number, number])[], primitiveTextChildRanges?: readonly (readonly [number, number])[] }, renderer?: { id: string, module: string, target: 'dom' | 'universal' | 'valdi', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal' | 'valdi', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
  *   `dev: true` emits client hydration source-location metadata (per-component
  *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
  *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
@@ -11060,7 +11060,7 @@ function ssrCompileBodyWithMapTemps(
 // produce mergeable text nodes:
 //   'static' — a static string-literal Text (bakes / serializes as literal text)
 //   'empty'  — a static literal that renders NOTHING (adjacency-transparent)
-//   'dyn'    — a known-string dynamic text hole (client `<!>` + htextSwap,
+//   'dyn'    — a proven primitive text hole (client `<!>` + htextSwap,
 //              server markerless ssrText)
 //   'other'  — everything else (elements, renderable `{expr}` holes, control
 //              flow — all serialize elements or `<!--[-->…<!--]-->` ranges
@@ -11069,9 +11069,7 @@ function textAdjacencyKind(node, ctx) {
 	if (node.type !== 'Text') return 'other';
 	const lit = staticTextLiteral(node.expression);
 	if (lit !== null) return lit === '' ? 'empty' : 'static';
-	return isKnownStringChildExpression(node.expression, ctx.knownStringChildLocals)
-		? 'dyn'
-		: 'other';
+	return isKnownTextChildExpression(node.expression, ctx.knownStringChildLocals) ? 'dyn' : 'other';
 }
 
 // Does the child at `i` have a text-producing sibling next to it (looking
@@ -11371,13 +11369,14 @@ function ssrEmitNode(
 						: null,
 				);
 			}
-			// `{x as string}` / literals / templates / `+`-concats → definite TEXT.
+			// String assertions / templates / string concats / proven numeric results
+			// → a text binding on both client and server.
 			// Everything else (`{children}`, `{<Comp/>}`, possibly-renderable values)
 			// → ssrChild, which RENDERS a component/element child (and coerces a
 			// primitive to text) — mirrors Ripple's `{expr}` vs `{expr as string}`.
 			// rewriteHookCalls: a `use(thenable)` in this hole bypasses the setup
 			// rewrite, so key it here too (else it collides with sibling/nested use()).
-			if (isKnownStringChildExpression(expr, ctx.knownStringChildLocals)) {
+			if (isKnownTextChildExpression(expr, ctx.knownStringChildLocals)) {
 				// ssrTextPre = ssrText + the runtime leading-'\n' protection (the value
 				// isn't known at compile time here).
 				const fn =
@@ -12263,7 +12262,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	// markerless `childTextHole` mount: a primitive is the host's bare text, an object
 	// still gets a `<!--[-->…<!--]-->` block). Must match the client's only-child
 	// markerless condition exactly so both sides agree for hydration: a single `Text`
-	// child that is neither a static literal (baked into HTML) nor a known string
+	// child that is neither a static literal (baked into HTML) nor proven text
 	// (emitted via `ssrText`).
 	const onlyChild0 =
 		normChildren.length === 1 && normChildren[0].type === 'Text' ? normChildren[0] : null;
@@ -12275,7 +12274,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 		htmlSources.length === 0 &&
 		onlyChild0 !== null &&
 		staticTextLiteral(onlyChild0.expression) === null &&
-		!isKnownStringChildExpression(onlyChild0.expression, ctx.knownStringChildLocals)
+		!isKnownTextChildExpression(onlyChild0.expression, ctx.knownStringChildLocals)
 	) {
 		const childHelper =
 			tag === 'pre' || tag === 'textarea' || tag === 'listing' ? 'ssrChildTextPre' : 'ssrChildText';
@@ -18356,22 +18355,24 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 			}
 			const hn = `h${holeProps.length}`;
 			if (expr && expr.type === 'TSAsExpression') {
-				// Preserve the `as T` cast in the renderer (it marks a dynamic TEXT hole).
+				// Preserve explicit string assertions. Numeric assertions and typed
+				// primitive proofs need a synthetic text assertion on the renderer's
+				// `props.hN` because it cannot see the original expression's proof.
 				holeProps.push(objectProp(hn, rewriteExtractedFragmentHole(expr.expression, ctx, childNs)));
+				const annotation = isKnownTextChildExpression(expr, ctx.knownStringChildLocals)
+					? b.ts_keyword_type('string')
+					: expr.typeAnnotation;
 				newChildren.push(
-					b.jsx_expression_container(
-						b.ts_as(memberProps(hn, expr.expression), expr.typeAnnotation),
-					),
+					b.jsx_expression_container(b.ts_as(memberProps(hn, expr.expression), annotation)),
 				);
 			} else {
 				holeProps.push(objectProp(hn, rewriteExtractedFragmentHole(expr, ctx, childNs)));
-				// A hole the compiler proved is a string (concat / template / tracked
-				// local) is a TEXT hole — but the renderer only sees `props.hN`, which it
-				// can't prove. Re-assert it with an `as string` cast so the renderer keeps
-				// the text-binding classification (htext, markerless) instead of falling to
-				// a renderable childSlot, preserving byte-equality with the inline form.
+				// The renderer only sees `props.hN`, so it cannot rediscover an inline
+				// string or primitive-number proof. This synthetic cast preserves the
+				// text binding across extraction; it is stripped from emitted JS and
+				// does not change the authored expression or its runtime value.
 				const member = memberProps(hn, expr);
-				const rendered = isKnownStringChildExpression(expr, ctx.knownStringChildLocals)
+				const rendered = isKnownTextChildExpression(expr, ctx.knownStringChildLocals)
 					? b.ts_as(member, b.ts_keyword_type('string'))
 					: member;
 				newChildren.push(b.jsx_expression_container(rendered));
@@ -21187,17 +21188,30 @@ function staticTextLiteral(node) {
 // to inherit a type proof. Ordinary copy-on-write expression rewrites preserve
 // the metadata, and extractFragment explicitly carries it onto its props hole.
 function applyStringChildProofs(ast, source, filename, facts) {
-	const typedRanges = createTextTypeFactsLookup(facts, filename, source);
+	const typeRanges = createTextTypeFactsLookup(facts, filename, source);
+	const typedRanges = typeRanges?.stringRanges ?? null;
+	const primitiveRanges = typeRanges?.primitiveRanges ?? null;
 	// Avoid another AST walk for the overwhelmingly common syntax-only module.
-	// Escaped identifiers can spell String too; declining a module without either
-	// spelling is safe, while the AST remains the authority for actual calls.
-	const inspectStringCalls = source.includes('String') || source.includes('\\u');
-	if ((typedRanges === null || typedRanges.size === 0) && !inspectStringCalls) return ast;
-	const remainingRanges = typedRanges;
-	const proofs = new Set();
-	const stringCalls = [];
+	// Escaped identifiers can spell these built-ins too. The AST remains the
+	// authority for calls; these substring checks only skip common files.
+	const inspectIntrinsicCalls =
+		source.includes('String') ||
+		source.includes('Number') ||
+		source.includes('BigInt') ||
+		source.includes('Date') ||
+		source.includes('\\u');
+	if (
+		(typedRanges === null || typedRanges.size === 0) &&
+		(primitiveRanges === null || primitiveRanges.size === 0) &&
+		!inspectIntrinsicCalls
+	) {
+		return ast;
+	}
+	const stringProofs = new Set();
+	const primitiveProofs = new Set();
+	const intrinsicCalls = [];
 	const writes = [];
-	let ambientStringValue = false;
+	const ambientIntrinsicValues = new Set();
 	const seen = new WeakSet();
 	const collect = (node, parent = null, key = null) => {
 		if (node === null || typeof node !== 'object') return;
@@ -21208,7 +21222,7 @@ function applyStringChildProofs(ast, source, filename, facts) {
 		if (seen.has(node)) return;
 		seen.add(node);
 		if (
-			remainingRanges !== null &&
+			(typedRanges !== null || primitiveRanges !== null) &&
 			node.type === 'JSXExpressionContainer' &&
 			((key === 'children' &&
 				(parent?.type === 'JSXElement' ||
@@ -21219,16 +21233,17 @@ function applyStringChildProofs(ast, source, filename, facts) {
 		) {
 			const expr = node.expression;
 			const range = `${expr?.start}:${expr?.end}`;
-			if (remainingRanges.delete(range)) proofs.add(expr);
+			if (typedRanges?.delete(range)) stringProofs.add(expr);
+			if (primitiveRanges?.delete(range)) primitiveProofs.add(expr);
 		}
-		if (inspectStringCalls) {
+		if (inspectIntrinsicCalls) {
 			if (
 				node.type === 'CallExpression' &&
 				node.optional !== true &&
 				node.callee?.type === 'Identifier' &&
-				node.callee.name === 'String'
+				TEXT_INTRINSICS.has(node.callee.name)
 			) {
-				stringCalls.push(node);
+				intrinsicCalls.push(node);
 			}
 			if (node.type === 'AssignmentExpression') writes.push(node.left);
 			else if (node.type === 'UpdateExpression') writes.push(node.argument);
@@ -21243,11 +21258,13 @@ function applyStringChildProofs(ast, source, filename, facts) {
 			// Ambient VALUE declarations can describe a replaced global. Type-only
 			// imports/interfaces do not shadow the JavaScript built-in.
 			if (node.type === 'TSDeclareFunction' || node.declare === true) {
-				if (node.id?.name === 'String') ambientStringValue = true;
+				if (TEXT_INTRINSICS.has(node.id?.name)) ambientIntrinsicValues.add(node.id.name);
 				if (node.type === 'VariableDeclaration') {
 					const names = new Set();
 					for (const declaration of node.declarations || []) collectBindings(declaration.id, names);
-					if (names.has('String')) ambientStringValue = true;
+					for (const name of names) {
+						if (TEXT_INTRINSICS.has(name)) ambientIntrinsicValues.add(name);
+					}
 				}
 			}
 		}
@@ -21258,33 +21275,43 @@ function applyStringChildProofs(ast, source, filename, facts) {
 		}
 	};
 	collect(ast);
-	if (remainingRanges !== null && remainingRanges.size !== 0) {
+	const remainingRange =
+		typedRanges?.values().next().value ?? primitiveRanges?.values().next().value;
+	if (remainingRange !== undefined) {
 		throw new Error(
-			`Invalid textTypeFacts for ${JSON.stringify(filename)}: range ${remainingRanges.values().next().value} is not an authored JSX child expression.`,
+			`Invalid textTypeFacts for ${JSON.stringify(filename)}: range ${remainingRange} is not an authored JSX child expression.`,
 		);
 	}
 	let lexical = null;
-	if (stringCalls.length > 0 || (proofs.size > 0 && writes.length > 0)) {
+	if (
+		intrinsicCalls.length > 0 ||
+		((stringProofs.size > 0 || primitiveProofs.size > 0) && writes.length > 0)
+	) {
 		// The existing scope analysis understands var hoisting, parameter defaults,
 		// imports, catch bindings, and TSRX @for/@try scopes. Pay for it only when
 		// an intrinsic candidate or a possible proof-invalidating write needs it.
 		lexical = createLexicalAnalysis(ast);
-		if (writes.some((target) => writesGlobalString(target, lexical))) {
-			// TypeScript still calls the global constructor's return type `string`
-			// after an asserted replacement. Decline ALL new child proofs in this
+		if (writes.some((target) => writesGlobalTextIntrinsic(target, lexical))) {
+			// TypeScript still uses a built-in constructor's declared primitive
+			// return type after an asserted replacement. Decline all new proofs in this
 			// rare module rather than attempting incomplete value-taint analysis.
 			// Supplied ranges were still validated above; explicit text syntax keeps
 			// its existing coercion meaning through isKnownStringExpression.
 			return ast;
 		}
 	}
-	if (lexical !== null && !ambientStringValue) {
-		for (const call of stringCalls) {
+	if (lexical !== null) {
+		for (const call of intrinsicCalls) {
+			const name = call.callee.name;
+			if (ambientIntrinsicValues.has(name)) continue;
 			const scope = lexical.nodeScopes.get(call);
-			if (scope !== undefined && !lexical.isBound(scope, 'String')) proofs.add(call);
+			if (scope !== undefined && !lexical.isBound(scope, name)) {
+				if (name === 'String' || name === 'Date') stringProofs.add(call);
+				else primitiveProofs.add(call);
+			}
 		}
 	}
-	if (proofs.size === 0) return ast;
+	if (stringProofs.size === 0 && primitiveProofs.size === 0) return ast;
 	const rewritten = new WeakMap();
 	const rewrite = (node) => {
 		if (node === null || typeof node !== 'object') return node;
@@ -21310,8 +21337,10 @@ function applyStringChildProofs(ast, source, filename, facts) {
 					out[key] = next;
 				}
 			}
-			if (proofs.has(node)) {
+			if (stringProofs.has(node)) {
 				out = { ...out, metadata: { ...out.metadata, octane_string_child: true } };
+			} else if (primitiveProofs.has(node)) {
+				out = { ...out, metadata: { ...out.metadata, octane_primitive_text_child: true } };
 			}
 		}
 		rewritten.set(node, out);
@@ -21320,10 +21349,12 @@ function applyStringChildProofs(ast, source, filename, facts) {
 	return rewrite(ast);
 }
 
-// A visible replacement of the global constructor invalidates intrinsic
-// recognition for the whole module. Calls still evaluate the authored callee;
-// do not silently turn a replacement's returned element into its string form.
-function writesGlobalString(target, lexical) {
+const TEXT_INTRINSICS = new Set(['String', 'Number', 'BigInt', 'Date']);
+
+// A visible replacement of a global constructor invalidates inferred text
+// proofs for the module. Calls still evaluate the authored callee: a replacement
+// may return an element rather than the built-in's primitive result.
+function writesGlobalTextIntrinsic(target, lexical) {
 	if (!target || typeof target !== 'object') return false;
 	if (
 		target.type === 'TSAsExpression' ||
@@ -21331,20 +21362,20 @@ function writesGlobalString(target, lexical) {
 		target.type === 'TSNonNullExpression' ||
 		target.type === 'ParenthesizedExpression'
 	) {
-		return writesGlobalString(target.expression, lexical);
+		return writesGlobalTextIntrinsic(target.expression, lexical);
 	}
 	const unbound = (node, name) => {
 		const scope = lexical.nodeScopes.get(node);
 		return scope !== undefined && !lexical.isBound(scope, name);
 	};
 	if (target.type === 'Identifier') {
-		return target.name === 'String' && unbound(target, 'String');
+		return TEXT_INTRINSICS.has(target.name) && unbound(target, target.name);
 	}
 	if (target.type === 'MemberExpression') {
 		const name = target.computed ? target.property?.value : target.property?.name;
 		const object = target.object;
 		return (
-			name === 'String' &&
+			TEXT_INTRINSICS.has(name) &&
 			object?.type === 'Identifier' &&
 			(object.name === 'globalThis' ||
 				object.name === 'window' ||
@@ -21353,14 +21384,14 @@ function writesGlobalString(target, lexical) {
 			unbound(object, object.name)
 		);
 	}
-	if (target.type === 'AssignmentPattern') return writesGlobalString(target.left, lexical);
-	if (target.type === 'RestElement') return writesGlobalString(target.argument, lexical);
+	if (target.type === 'AssignmentPattern') return writesGlobalTextIntrinsic(target.left, lexical);
+	if (target.type === 'RestElement') return writesGlobalTextIntrinsic(target.argument, lexical);
 	if (target.type === 'ArrayPattern') {
-		return (target.elements || []).some((element) => writesGlobalString(element, lexical));
+		return (target.elements || []).some((element) => writesGlobalTextIntrinsic(element, lexical));
 	}
 	if (target.type === 'ObjectPattern') {
 		return (target.properties || []).some((property) =>
-			writesGlobalString(property.argument ?? property.value, lexical),
+			writesGlobalTextIntrinsic(property.argument ?? property.value, lexical),
 		);
 	}
 	return false;
@@ -21373,6 +21404,7 @@ function writesGlobalString(target, lexical) {
 // Recognised shapes:
 //   - String Literal:               'foo' / "bar"
 //   - TemplateLiteral:               `${x}-${y}` (always coerces to string)
+//   - `typeof x`:                   always a string, even for unknown x
 //   - `as string` / `<string>x`:     user-asserted string-typed expression
 //   - `satisfies string`:            same intent
 //   - Wrappers (`!`, instantiation): peel and check inside
@@ -21387,6 +21419,7 @@ function isKnownStringExpression(node, locals, childProofs = false) {
 		return typeof node.value === 'string';
 	}
 	if (node.type === 'TemplateLiteral') return true;
+	if (node.type === 'UnaryExpression' && node.operator === 'typeof') return true;
 	// An identifier the compiler has tracked back to a string in this component's
 	// scope: a `const` bound to a provably-string expression, a `const x: string`,
 	// or a `string`-typed param — see collectKnownStringLocals. `locals` is
@@ -21430,6 +21463,15 @@ function isKnownStringExpression(node, locals, childProofs = false) {
 			isKnownStringExpression(node.alternate, locals, childProofs)
 		);
 	}
+	if (node.type === 'LogicalExpression') {
+		return (
+			isKnownStringExpression(node.left, locals, childProofs) &&
+			isKnownStringExpression(node.right, locals, childProofs)
+		);
+	}
+	if (node.type === 'SequenceExpression') {
+		return isKnownStringExpression(node.expressions.at(-1), locals, childProofs);
+	}
 	return false;
 }
 
@@ -21439,6 +21481,75 @@ function isKnownStringExpression(node, locals, childProofs = false) {
 function isKnownStringChildExpression(node, locals) {
 	return isKnownStringExpression(node, locals, true);
 }
+
+// Only child positions may use the primitive-text binding for numbers and
+// bigints. These expressions are primitives (or throw before returning) under
+// JavaScript's own operators. Keep the proof distinct from "known string":
+// numeric results cannot establish that `value + anotherValue` concatenates.
+function isKnownTextChildExpression(node, stringLocals) {
+	if (isKnownStringChildExpression(node, stringLocals)) return true;
+	if (node == null || typeof node !== 'object') return false;
+	if (node.metadata?.octane_primitive_text_child === true) return true;
+	if (node.type === 'Literal' || node.type === 'NumericLiteral' || node.type === 'BigIntLiteral') {
+		return (
+			typeof node.value === 'number' ||
+			typeof node.value === 'bigint' ||
+			node.type === 'BigIntLiteral'
+		);
+	}
+	if (node.type === 'UnaryExpression') {
+		return node.operator === '+' || node.operator === '-' || node.operator === '~';
+	}
+	if (node.type === 'BinaryExpression') {
+		if (node.operator === '+') {
+			return (
+				isKnownTextChildExpression(node.left, stringLocals) &&
+				isKnownTextChildExpression(node.right, stringLocals)
+			);
+		}
+		return NUMERIC_TEXT_OPERATORS.has(node.operator);
+	}
+	if (node.type === 'ConditionalExpression') {
+		return (
+			isKnownTextChildExpression(node.consequent, stringLocals) &&
+			isKnownTextChildExpression(node.alternate, stringLocals)
+		);
+	}
+	if (node.type === 'LogicalExpression') {
+		return (
+			isKnownTextChildExpression(node.left, stringLocals) &&
+			isKnownTextChildExpression(node.right, stringLocals)
+		);
+	}
+	if (node.type === 'SequenceExpression') {
+		return isKnownTextChildExpression(node.expressions.at(-1), stringLocals);
+	}
+	if (
+		node.type === 'TSAsExpression' ||
+		node.type === 'TSTypeAssertion' ||
+		node.type === 'TSSatisfiesExpression' ||
+		node.type === 'TSNonNullExpression' ||
+		node.type === 'TSInstantiationExpression' ||
+		node.type === 'ParenthesizedExpression'
+	) {
+		return isKnownTextChildExpression(node.expression, stringLocals);
+	}
+	return false;
+}
+
+const NUMERIC_TEXT_OPERATORS = new Set([
+	'-',
+	'*',
+	'/',
+	'%',
+	'**',
+	'<<',
+	'>>',
+	'>>>',
+	'|',
+	'&',
+	'^',
+]);
 
 // Annotation check: does a TS type annotation resolve to `string`? Accepts both a
 // bare type node and a `TSTypeAnnotation` wrapper (`x: string`).
@@ -22027,7 +22138,7 @@ function planJsx(
 	const coalesceChildRoot =
 		jsxNodes.length === 1 &&
 		((jsxNodes[0].type === 'Text' &&
-			!isKnownStringChildExpression(jsxNodes[0].expression, ctx.knownStringChildLocals)) ||
+			!isKnownTextChildExpression(jsxNodes[0].expression, ctx.knownStringChildLocals)) ||
 			jsxNodes[0].type === 'TSRXExpression');
 	// Top-level control-flow directives (@if/@for/@switch/@try/<Activity>). In a
 	// body that ALSO has static template roots, each construct emits a `<!>`
@@ -24861,12 +24972,11 @@ function emitNodeHtml(
 	cssHash = null,
 ) {
 	if (node.type === 'Text') {
-		if (isKnownStringChildExpression(node.expression, ctx.knownStringChildLocals)) {
+		if (isKnownTextChildExpression(node.expression, ctx.knownStringChildLocals)) {
 			bindings.push({
 				id: bindings.length,
 				kind: 'text',
 				expr: resolveStyleExpr(node.expression, cssHash),
-				knownString: true,
 				path: path.slice(0, -1),
 				childIndex: path[path.length - 1],
 			});
@@ -26064,12 +26174,11 @@ function emitElementHtml(
 						]
 					: null;
 			appendTemplatePart(html, escaped, 'text', origins);
-		} else if (isKnownStringChildExpression(txtChild.expression, ctx.knownStringChildLocals)) {
+		} else if (isKnownTextChildExpression(txtChild.expression, ctx.knownStringChildLocals)) {
 			bindings.push({
 				id: bindings.length,
 				kind: 'textOnlyChild',
 				expr: resolveStyleExpr(txtChild.expression, cssHash),
-				knownString: true,
 				path,
 			});
 			// The element stays empty in the template — runtime appends a Text node.
@@ -26238,12 +26347,11 @@ function emitElementHtml(
 					appendTemplatePart(html, escaped, 'text', origins);
 					prevBakedText = true;
 					if (!prevBaked) childIdx++;
-				} else if (isKnownStringChildExpression(child.expression, ctx.knownStringChildLocals)) {
+				} else if (isKnownTextChildExpression(child.expression, ctx.knownStringChildLocals)) {
 					bindings.push({
 						id: bindings.length,
 						kind: 'text',
 						expr: resolveStyleExpr(child.expression, cssHash),
-						knownString: true,
 						path,
 						childIndex: childIdx,
 						// A text-producing neighbour → the server emits a `<!-- -->`
@@ -26410,7 +26518,7 @@ function emitElementHtml(
 				//   - `{createPortal(BODY, TARGET, PROPS?)}` → portal() call
 				//   - `{cond ? <JSX/> : <JSX/>}` → lowered to ifBlock (so the branches
 				//      mount real DOM, not stringified text)
-				//   - a known-string expression → text-hole binding
+				//   - a proven primitive text expression → text-hole binding
 				//   - anything else → renderable childSlot hole
 				const expr = child.expression;
 				if (isCreatePortalCall(expr)) {
@@ -26438,12 +26546,11 @@ function emitElementHtml(
 					ifCalls.push(ic);
 					appendTemplatePart(html, '<!>', 'anchor');
 					childIdx++;
-				} else if (isKnownStringChildExpression(expr, ctx.knownStringChildLocals)) {
+				} else if (isKnownTextChildExpression(expr, ctx.knownStringChildLocals)) {
 					bindings.push({
 						id: bindings.length,
 						kind: 'text',
 						expr: tsrxExprNode(resolveStyleExpr(expr, cssHash), ctx, componentName, inlinedSubs),
-						knownString: true,
 						path,
 						childIndex: childIdx,
 					});

--- a/packages/octane/src/compiler/text-type-facts.js
+++ b/packages/octane/src/compiler/text-type-facts.js
@@ -35,7 +35,7 @@ export function textTypeSourceVersion(source) {
  * because independently falling back on the client/server could change the
  * hydration protocol. Nested ranges are valid when a child expression contains
  * JSX with child expressions of its own.
- * @returns {Set<string> | null}
+ * @returns {{ stringRanges: Set<string>, primitiveRanges: Set<string> } | null}
  */
 export function createTextTypeFactsLookup(facts, filename, source) {
 	if (facts === undefined) return null;
@@ -61,29 +61,43 @@ export function createTextTypeFactsLookup(facts, filename, source) {
 	if (typeof facts.projectVersion !== 'string' || facts.projectVersion.length === 0) {
 		invalid('projectVersion must identify the TypeScript project snapshot');
 	}
-	if (!Array.isArray(facts.stringChildRanges)) invalid('stringChildRanges must be an array');
-	const ranges = new Set();
-	let previousStart = -1;
-	let previousEnd = -1;
-	for (const range of facts.stringChildRanges) {
-		if (
-			!Array.isArray(range) ||
-			range.length !== 2 ||
-			!Number.isSafeInteger(range[0]) ||
-			!Number.isSafeInteger(range[1]) ||
-			range[0] < 0 ||
-			range[0] >= range[1] ||
-			range[1] > source.length
-		) {
-			invalid('stringChildRanges contains an invalid authored range');
+	const validateRanges = (value, name) => {
+		if (!Array.isArray(value)) invalid(`${name} must be an array`);
+		const ranges = new Set();
+		let previousStart = -1;
+		let previousEnd = -1;
+		for (const range of value) {
+			if (
+				!Array.isArray(range) ||
+				range.length !== 2 ||
+				!Number.isSafeInteger(range[0]) ||
+				!Number.isSafeInteger(range[1]) ||
+				range[0] < 0 ||
+				range[0] >= range[1] ||
+				range[1] > source.length
+			) {
+				invalid(`${name} contains an invalid authored range`);
+			}
+			const [start, end] = range;
+			if (start < previousStart || (start === previousStart && end <= previousEnd)) {
+				invalid(`${name} must be sorted and unique`);
+			}
+			previousStart = start;
+			previousEnd = end;
+			ranges.add(`${start}:${end}`);
 		}
-		const [start, end] = range;
-		if (start < previousStart || (start === previousStart && end <= previousEnd)) {
-			invalid('stringChildRanges must be sorted and unique');
-		}
-		previousStart = start;
-		previousEnd = end;
-		ranges.add(`${start}:${end}`);
+		return ranges;
+	};
+	const stringRanges = validateRanges(facts.stringChildRanges, 'stringChildRanges');
+	// The optional field lets older project adapters keep supplying version-1
+	// string-only snapshots. A numeric proof must never masquerade as string
+	// evidence in the compiler's concatenation and local-binding analysis.
+	const primitiveRanges = validateRanges(
+		facts.primitiveTextChildRanges === undefined ? [] : facts.primitiveTextChildRanges,
+		'primitiveTextChildRanges',
+	);
+	for (const range of primitiveRanges) {
+		if (stringRanges.has(range)) invalid('a child has conflicting text proofs');
 	}
-	return ranges;
+	return { stringRanges, primitiveRanges };
 }

--- a/packages/octane/src/compiler/typescript.d.ts
+++ b/packages/octane/src/compiler/typescript.d.ts
@@ -1,4 +1,4 @@
-/** A source-bound, serializable primitive-string proof for JSX child holes. */
+/** Source-bound, serializable primitive-text proofs for JSX child holes. */
 export interface TextTypeFacts {
 	readonly version: 1;
 	/** Clean absolute filename, with forward-slash separators. */
@@ -9,11 +9,18 @@ export interface TextTypeFacts {
 	readonly projectVersion: string;
 	/** Sorted, unique, half-open UTF-16 ranges of authored child expressions. */
 	readonly stringChildRanges: readonly (readonly [start: number, end: number])[];
+	/**
+	 * Number, bigint, and mixed string/number/bigint children. Older version-1
+	 * snapshots omit this field and retain their string-only behavior.
+	 */
+	readonly primitiveTextChildRanges?: readonly (readonly [start: number, end: number])[];
 }
 
 export interface TextTypeProjectOptions {
 	/** Path to the consumer tsconfig. Relative paths resolve from the process cwd. */
 	tsconfig: string;
+	/** Root for project-relative renderer module IDs; defaults to the tsconfig directory. */
+	root?: string;
 	/** The same renderer configuration used by the Octane compiler. */
 	renderers?: unknown;
 }

--- a/packages/octane/src/compiler/typescript.js
+++ b/packages/octane/src/compiler/typescript.js
@@ -188,15 +188,18 @@ function mappedChild(child, sourceMap, generatedChildren, generatedLength) {
 
 /**
  * TypeScript assignability alone is insufficient: `any` and `never` are both
- * assignable to string. Only a primitive-string domain is useful here. Branded
- * string intersections and bounded generic constraints retain that domain;
- * mixed unions, boxed String, and unresolved/error types do not.
+ * assignable to string. A direct child can use the text binding when every
+ * possible value is a primitive string, number, or bigint. Keep a distinct
+ * string result for the compiler's string-only proofs; a mixed union is text,
+ * but it is not evidence for string concatenation. Branded intersections and
+ * bounded generic constraints retain their primitive domain. Boxed values,
+ * nullish/boolean unions, and unresolved/error types do not.
  *
  * This is a typed-program contract, not runtime validation of inaccurate
  * declarations or values smuggled through `any`.
  */
-function isPrimitiveString(type, checker, seen = new Set()) {
-	if (!type || seen.has(type)) return false;
+function primitiveTextKind(type, checker, seen = new Set()) {
+	if (!type || seen.has(type)) return 0;
 	const flags = type.flags;
 	if (
 		flags &
@@ -207,20 +210,33 @@ function isPrimitiveString(type, checker, seen = new Set()) {
 			ts.TypeFlags.Undefined |
 			ts.TypeFlags.Null)
 	) {
-		return false;
+		return 0;
 	}
-	if (flags & ts.TypeFlags.StringLike) return true;
-	if (seen.size >= 64) return false;
+	if (flags & ts.TypeFlags.StringLike) return 1;
+	if (flags & (ts.TypeFlags.NumberLike | ts.TypeFlags.BigIntLike)) return 2;
+	if (seen.size >= 64) return 0;
 	seen.add(type);
-	let result = false;
+	let result = 0;
 	if (type.isUnion()) {
-		result =
-			type.types.length > 0 && type.types.every((part) => isPrimitiveString(part, checker, seen));
+		if (type.types.length > 0) {
+			result = 1;
+			for (const part of type.types) {
+				const kind = primitiveTextKind(part, checker, seen);
+				if (kind === 0) {
+					result = 0;
+					break;
+				}
+				if (kind === 2) result = 2;
+			}
+		}
 	} else if (type.isIntersection()) {
-		result = type.types.some((part) => isPrimitiveString(part, checker, seen));
+		for (const part of type.types) {
+			result = primitiveTextKind(part, checker, seen);
+			if (result !== 0) break;
+		}
 	} else {
 		const constraint = checker.getBaseConstraintOfType(type);
-		if (constraint && constraint !== type) result = isPrimitiveString(constraint, checker, seen);
+		if (constraint && constraint !== type) result = primitiveTextKind(constraint, checker, seen);
 	}
 	seen.delete(type);
 	return result;
@@ -232,18 +248,23 @@ function overlapsDiagnostic(diagnostic, start, end) {
 	return diagnostic.start < end && diagnostic.start + diagnostic.length > start;
 }
 
-function freezeFacts(filename, record, projectVersion, ranges) {
+function freezeRanges(ranges) {
 	const unique = new Map();
 	for (const [start, end] of ranges) unique.set(`${start}:${end}`, [start, end]);
 	const sorted = [...unique.values()].sort(
 		(left, right) => left[0] - right[0] || left[1] - right[1],
 	);
+	return Object.freeze(sorted.map((range) => Object.freeze(range)));
+}
+
+function freezeFacts(filename, record, projectVersion, stringRanges, primitiveRanges) {
 	return Object.freeze({
 		version: TEXT_TYPE_FACTS_VERSION,
 		filename,
 		sourceVersion: record.version,
 		projectVersion,
-		stringChildRanges: Object.freeze(sorted.map((range) => Object.freeze(range))),
+		stringChildRanges: freezeRanges(stringRanges),
+		primitiveTextChildRanges: freezeRanges(primitiveRanges),
 	});
 }
 
@@ -257,6 +278,10 @@ export function createTextTypeProject(options) {
 	}
 	const configFilename = absoluteFilename(options.tsconfig, process.cwd());
 	const directory = nodePath.dirname(configFilename);
+	// TypeScript resolves relative files from its tsconfig; renderer rules use
+	// bundler module IDs, which may be relative to a different project root.
+	const rendererRoot =
+		options.root === undefined ? directory : absoluteFilename(options.root, process.cwd());
 	const renderers = normalizeRendererConfig(options.renderers);
 	const caseSensitive = ts.sys.useCaseSensitiveFileNames;
 	const sources = new FileMap(caseSensitive);
@@ -394,7 +419,7 @@ export function createTextTypeProject(options) {
 		if (cached?.version === version) return cached.code;
 		let compilation = null;
 		try {
-			compilation = compileToVolarMappings(source, rendererFilename(file, directory), {
+			compilation = compileToVolarMappings(source, rendererFilename(file, rendererRoot), {
 				renderers,
 			});
 		} catch {
@@ -470,6 +495,7 @@ export function createTextTypeProject(options) {
 				options: program.getCompilerOptions(),
 				references: loadConfig().projectReferences ?? [],
 				renderers: renderers.signature,
+				rendererRoot,
 				roots: roots(),
 				inputs,
 			}),
@@ -536,7 +562,8 @@ export function createTextTypeProject(options) {
 			cached.projectVersion === version
 		)
 			return cached;
-		const ranges = [];
+		const stringRanges = [];
+		const primitiveRanges = [];
 		const compilerOptions = program.getCompilerOptions();
 		const strictNullChecks = compilerOptions.strictNullChecks ?? compilerOptions.strict ?? false;
 		const sourceFile = program.getSourceFile(file);
@@ -562,8 +589,9 @@ export function createTextTypeProject(options) {
 						) {
 							return;
 						}
-						if (isPrimitiveString(checker.getTypeAtLocation(expression), checker))
-							ranges.push([start, end]);
+						const kind = primitiveTextKind(checker.getTypeAtLocation(expression), checker);
+						if (kind === 1) stringRanges.push([start, end]);
+						else if (kind === 2) primitiveRanges.push([start, end]);
 					};
 					if (compilation) {
 						const sourceMap = new SourceMap(compilation.mappings);
@@ -583,7 +611,7 @@ export function createTextTypeProject(options) {
 				}
 			}
 		}
-		const facts = freezeFacts(file, record, version, ranges);
+		const facts = freezeFacts(file, record, version, stringRanges, primitiveRanges);
 		factsCache.set(file, facts);
 		return facts;
 	};

--- a/packages/octane/src/compiler/vite.d.ts
+++ b/packages/octane/src/compiler/vite.d.ts
@@ -88,6 +88,12 @@ export interface OctaneVitePluginOptions {
 	 */
 	strong?: boolean;
 	/**
+	 * @experimental Infer primitive child text from a TypeScript project in
+	 * one-shot production builds. Serve and watched builds retain syntax
+	 * inference. A relative tsconfig is resolved from the Vite project root.
+	 */
+	textTypes?: { tsconfig: string };
+	/**
 	 * Path fragments excluded from Octane's plain `.ts`/`.js` hook-slot pass.
 	 * Prefer package manifest `octane.hookSlots.manual` declarations for bindings.
 	 */

--- a/packages/octane/src/compiler/vite.js
+++ b/packages/octane/src/compiler/vite.js
@@ -619,7 +619,7 @@ export function octane(options = {}) {
 		typedTextEnabled = false;
 		textTypeFiles.clear();
 	};
-	const textFactsFor = (source, id) => {
+	const textFactsFor = (source, id, environment) => {
 		if (!typedTextEnabled || createTextTypeProject === null) return undefined;
 		const file = cleanModuleId(id);
 		if (!nodePath.isAbsolute(file) || !/\.(?:tsrx|tsx)$/.test(file) || !nodeFs.existsSync(file)) {
@@ -631,7 +631,12 @@ export function octane(options = {}) {
 		const canonical = compiler._canonicalModuleId(file);
 		const pragmaOwned = file.endsWith('.tsx') && compiler._pragmaClaimsOwnership(source);
 		if (!compiler._passesOwnershipGate(file, canonical, pragmaOwned)) return undefined;
-		if (resolveRendererForFile(compiler.renderers, canonical).target !== 'dom') return undefined;
+		const renderer = resolveRendererForFile(compiler.renderers, canonical);
+		if (
+			renderer.target !== 'dom' ||
+			(environment === 'server' && renderer.server === 'client-only')
+		)
+			return undefined;
 		textTypeProject ??= createTextTypeProject({
 			tsconfig: nodePath.resolve(projectRoot, options.textTypes.tsconfig),
 			root: projectRoot,
@@ -893,7 +898,7 @@ export function octane(options = {}) {
 						? null
 						: { _descriptorChildrenExportsProof: preflight.descriptorExportsProof }),
 					environment,
-					...(typedTextEnabled ? { textTypeFacts: textFactsFor(code, id) } : null),
+					...(typedTextEnabled ? { textTypeFacts: textFactsFor(code, id, environment) } : null),
 					hmr: !server && hmrEnabled ? 'vite' : false,
 					// DEV server transforms also carry SSR-only diagnostics. HMR itself
 					// remains client-only; an explicit `hmr: false` keeps both transforms

--- a/packages/octane/src/compiler/vite.js
+++ b/packages/octane/src/compiler/vite.js
@@ -26,6 +26,7 @@ import {
 	findDescriptorChildrenExports,
 	findDescriptorChildrenImports,
 	findVoidComponentImports,
+	resolveRendererForFile,
 } from './bundler.js';
 import {
 	isPlainCssModuleId,
@@ -537,6 +538,18 @@ export function octane(options = {}) {
 		throw new TypeError('octane/compiler/vite: `strong` must be a boolean when provided.');
 	}
 	if (
+		options.textTypes !== undefined &&
+		(options.textTypes === null ||
+			typeof options.textTypes !== 'object' ||
+			Array.isArray(options.textTypes) ||
+			Object.keys(options.textTypes).some((key) => key !== 'tsconfig') ||
+			typeof options.textTypes.tsconfig !== 'string' ||
+			options.textTypes.tsconfig.trim() !== options.textTypes.tsconfig ||
+			options.textTypes.tsconfig.length === 0)
+	) {
+		throw new TypeError('octane/compiler/vite: `textTypes` requires { tsconfig: string }.');
+	}
+	if (
 		options.cssModuleConstants !== undefined &&
 		typeof options.cssModuleConstants !== 'function'
 	) {
@@ -592,6 +605,58 @@ export function octane(options = {}) {
 	// CSS naming/virtual providers can differ between them, so never key a proof
 	// merely by its path or share a previous build's final-module snapshot.
 	const cssModuleProofStates = new Map();
+	let textTypeProject = null;
+	let createTextTypeProject = null;
+	let typedTextEnabled = false;
+	const textTypeFiles = new Map();
+	const releaseTextTypeProject = () => {
+		textTypeProject?.dispose();
+		textTypeProject = null;
+	};
+	const resetTextTypes = () => {
+		releaseTextTypeProject();
+		createTextTypeProject = null;
+		typedTextEnabled = false;
+		textTypeFiles.clear();
+	};
+	const textFactsFor = (source, id) => {
+		if (!typedTextEnabled || createTextTypeProject === null) return undefined;
+		const file = cleanModuleId(id);
+		if (!nodePath.isAbsolute(file) || !/\.(?:tsrx|tsx)$/.test(file) || !nodeFs.existsSync(file)) {
+			return undefined;
+		}
+		// Installed source packages may use another tsconfig and need not be in
+		// this project's TypeScript graph. Their ordinary syntax path stays intact.
+		if (!compiler._isProjectOwnedSource(file)) return undefined;
+		const canonical = compiler._canonicalModuleId(file);
+		const pragmaOwned = file.endsWith('.tsx') && compiler._pragmaClaimsOwnership(source);
+		if (!compiler._passesOwnershipGate(file, canonical, pragmaOwned)) return undefined;
+		if (resolveRendererForFile(compiler.renderers, canonical).target !== 'dom') return undefined;
+		textTypeProject ??= createTextTypeProject({
+			tsconfig: nodePath.resolve(projectRoot, options.textTypes.tsconfig),
+			root: projectRoot,
+			renderers: options.renderers,
+		});
+		const facts = textTypeProject.snapshot(file, source);
+		const previous = textTypeFiles.get(canonical);
+		if (
+			previous !== undefined &&
+			(previous.sourceVersion !== facts.sourceVersion ||
+				previous.projectVersion !== facts.projectVersion)
+		) {
+			throw new Error(
+				`Octane text types changed during the client/server build for ${JSON.stringify(canonical)}. Restart the build to keep hydration consistent.`,
+			);
+		}
+		textTypeFiles.set(canonical, {
+			sourceVersion: facts.sourceVersion,
+			projectVersion: facts.projectVersion,
+		});
+		// Runtime compiler IDs are portable root-relative paths. TypeScript reads
+		// the real file; only its filename is translated after checking that exact
+		// source against the project. Both targets reuse this one proof generation.
+		return { ...facts, filename: canonical };
+	};
 	const cssModuleProofState = (context, environment) => {
 		const key = context.environment ?? environment;
 		let state = cssModuleProofStates.get(key);
@@ -622,6 +687,7 @@ export function octane(options = {}) {
 	const forceSsr = options.ssr;
 
 	const resetCompiler = (root) => {
+		resetTextTypes();
 		descriptorSourceCache.clear();
 		descriptorExportCache.clear();
 		descriptorGraphCache.clear();
@@ -701,12 +767,20 @@ export function octane(options = {}) {
 			// proof to one-shot production builds where the graph is compiled together.
 			specializeProductionRoots = config.command === 'build' && config.build?.watch == null;
 			specializeCssModuleConstants = specializeProductionRoots && !hmrEnabled;
+			typedTextEnabled =
+				options.textTypes !== undefined && specializeProductionRoots && !hmrEnabled;
+			if (typedTextEnabled) {
+				return import('./typescript.js').then((module) => {
+					createTextTypeProject = module.createTextTypeProject;
+				});
+			}
 		},
 		buildStart() {
 			if (this.environment === undefined) cssModuleProofStates.clear();
 			else cssModuleProofStates.delete(this.environment);
 		},
 		buildEnd(error) {
+			if (error) releaseTextTypeProject();
 			const keys = this.environment === undefined ? ['client', 'server'] : [this.environment];
 			for (const key of keys) {
 				const state = cssModuleProofStates.get(key);
@@ -720,12 +794,17 @@ export function octane(options = {}) {
 		},
 		watchChange(id) {
 			compiler.invalidate(id);
+			// A one-shot build can receive a watch event mid-build and must fail closed.
+			textTypeProject?.invalidate(cleanModuleId(id));
 			// A barrel can cache a classification reached through this source, so
 			// invalidate the small descriptor graph as a unit on authored edits.
 			descriptorSourceCache.clear();
 			descriptorExportCache.clear();
 			descriptorGraphCache.clear();
 			cssModuleProofStates.clear();
+		},
+		closeBundle() {
+			releaseTextTypeProject();
 		},
 		generateBundle(_outputOptions, bundle) {
 			if (!emitClientReferenceManifest) return;
@@ -814,6 +893,7 @@ export function octane(options = {}) {
 						? null
 						: { _descriptorChildrenExportsProof: preflight.descriptorExportsProof }),
 					environment,
+					...(typedTextEnabled ? { textTypeFacts: textFactsFor(code, id) } : null),
 					hmr: !server && hmrEnabled ? 'vite' : false,
 					// DEV server transforms also carry SSR-only diagnostics. HMR itself
 					// remains client-only; an explicit `hmr: false` keeps both transforms

--- a/packages/octane/tests/_fixtures/typescript-text.tsrx
+++ b/packages/octane/tests/_fixtures/typescript-text.tsrx
@@ -29,6 +29,8 @@ export function TextScene(props: {
 		<span id="text-member">{props.label}</span>
 		<span id="text-return">{uppercase(props.label)}</span>
 		<span id="text-count">{String(count)}</span>
+		<span id="text-typed-count">{count}</span>
+		<section id="text-number-siblings"><Before />{count}<After /></section>
 		<span id="text-nullable">{props.maybe}</span>
 		<div id="text-renderable">{props.child}</div>
 	</main>

--- a/packages/octane/tests/_fixtures/typescript-text.tsrx
+++ b/packages/octane/tests/_fixtures/typescript-text.tsrx
@@ -30,7 +30,11 @@ export function TextScene(props: {
 		<span id="text-return">{uppercase(props.label)}</span>
 		<span id="text-count">{String(count)}</span>
 		<span id="text-typed-count">{count}</span>
-		<section id="text-number-siblings"><Before />{count}<After /></section>
+		<section id="text-number-siblings">
+			<Before />
+			{count}
+			<After />
+		</section>
 		<span id="text-nullable">{props.maybe}</span>
 		<div id="text-renderable">{props.child}</div>
 	</main>

--- a/packages/octane/tests/compiler/compiler-vite-options.test.ts
+++ b/packages/octane/tests/compiler/compiler-vite-options.test.ts
@@ -4,6 +4,8 @@ import { parseModule } from '@tsrx/core';
 import { describe, expect, it, vi } from 'vitest';
 import type { Plugin } from 'vite';
 import { octane } from 'octane/compiler/vite';
+import { compile } from 'octane/compiler';
+import { createTextTypeFixture } from '../_text-type-project.js';
 import {
 	findDescriptorChildrenExports,
 	findDescriptorChildrenImports,
@@ -149,6 +151,125 @@ function isChildrenBlock(code: string, value: any): boolean {
 }
 
 describe('octane/compiler/vite public options', () => {
+	it('requires an explicit nonempty tsconfig path for typed text', () => {
+		expect(() => octane({ textTypes: { tsconfig: ' tsconfig.json ' } })).toThrow(
+			'`textTypes` requires { tsconfig: string }.',
+		);
+	});
+
+	it('uses one opted-in TypeScript text proof for client and server production transforms', async () => {
+		const source = `import type { Label } from './model';
+export function App(props: { label: Label }) @{ <p>{props.label}</p> }`;
+		const consumer = createTextTypeFixture({
+			'App.tsrx': source,
+			'model.ts': 'export type Label = string;',
+		});
+		const plugin = octane({ hmr: false, textTypes: { tsconfig: consumer.tsconfig } });
+		const filename = consumer.file('App.tsrx');
+		try {
+			await (plugin.config as any)({ root: consumer.directory }, { command: 'build' });
+			await (plugin.configResolved as any)({
+				root: consumer.directory,
+				command: 'build',
+				build: {},
+				define: {},
+			});
+			const facts = consumer.project.snapshot(filename, source);
+			const canonical = '/App.tsrx';
+			for (const ssr of [false, true]) {
+				const result = await transform(plugin, source, filename, { ssr });
+				const mode = ssr ? ('server' as const) : ('client' as const);
+				const options = { hmr: false, mode, textTypeFacts: { ...facts, filename: canonical } };
+				expect(result?.code).toBe(compile(source, canonical, options).code);
+				expect(result?.code).not.toBe(compile(source, canonical, { hmr: false, mode }).code);
+				// Vite can close one environment before beginning the other.
+				if (!ssr) await (plugin.closeBundle as any)?.();
+			}
+		} finally {
+			await (plugin.closeBundle as any)?.();
+			consumer.dispose();
+		}
+	});
+	it('fails if an imported type changes between production targets', async () => {
+		const source = `import type { Label } from './model';
+export function App(props: { label: Label }) @{ <p>{props.label}</p> }`;
+		const consumer = createTextTypeFixture({
+			'App.tsrx': source,
+			'model.ts': 'export type Label = string;',
+		});
+		const plugin = octane({ hmr: false, textTypes: { tsconfig: consumer.tsconfig } });
+		const filename = consumer.file('App.tsrx');
+		try {
+			await (plugin.config as any)({ root: consumer.directory }, { command: 'build' });
+			await (plugin.configResolved as any)({
+				root: consumer.directory,
+				command: 'build',
+				build: {},
+				define: {},
+			});
+			await transform(plugin, source, filename, { ssr: false });
+			consumer.write('model.ts', 'export type Label = number;');
+			(plugin.watchChange as any)?.(consumer.file('model.ts'));
+			await expect(
+				Promise.resolve().then(() => transform(plugin, source, filename, { ssr: true })),
+			).rejects.toThrow(/text types changed during the client\/server build/);
+		} finally {
+			await (plugin.closeBundle as any)?.();
+			consumer.dispose();
+		}
+	});
+
+	it('keeps the optional checker out of watched production builds', async () => {
+		const plugin = octane({ hmr: false, textTypes: { tsconfig: 'absent.json' } });
+		await (plugin.config as any)({ root: ROOT }, { command: 'build' });
+		await (plugin.configResolved as any)({
+			root: ROOT,
+			command: 'build',
+			build: { watch: {} },
+			define: {},
+		});
+		const code = (await transform(plugin))?.code;
+		expect(code).toBe(compile(SOURCE, '/src/App.tsrx', { hmr: false }).code);
+		await (plugin.closeBundle as any)?.();
+	});
+
+	it('keeps the optional checker out of development transforms', async () => {
+		const plugin = octane({ hmr: false, textTypes: { tsconfig: 'absent.json' } });
+		await (plugin.config as any)({ root: ROOT }, { command: 'serve' });
+		await (plugin.configResolved as any)({
+			root: ROOT,
+			command: 'serve',
+			build: {},
+			define: {},
+		});
+		const code = (await transform(plugin))?.code;
+		expect(code).toBe(compile(SOURCE, '/src/App.tsrx', { hmr: false }).code);
+		await (plugin.closeBundle as any)?.();
+	});
+
+	it('skips TypeScript analysis of host-owned project TSX modules', async () => {
+		const source = 'export function App() { return <p>host-owned</p>; }';
+		const consumer = createTextTypeFixture({ 'App.tsx': source });
+		const plugin = octane({
+			hmr: false,
+			requireDirective: true,
+			textTypes: { tsconfig: 'absent.json' },
+		});
+		try {
+			await (plugin.config as any)({ root: consumer.directory }, { command: 'build' });
+			await (plugin.configResolved as any)({
+				root: consumer.directory,
+				command: 'build',
+				build: {},
+				define: {},
+			});
+			expect(await transform(plugin, source, consumer.file('App.tsx'))).toBeNull();
+		} finally {
+			await (plugin.closeBundle as any)?.();
+			consumer.dispose();
+		}
+	});
+
 	it('classifies one immutable authored AST the same as the source string', () => {
 		const id = `${ROOT}/src/App.tsrx`;
 		const source = `

--- a/packages/octane/tests/compiler/typescript-text-inference.test.ts
+++ b/packages/octane/tests/compiler/typescript-text-inference.test.ts
@@ -29,6 +29,39 @@ function childRange(source: string, expression: string): [number, number] {
 }
 
 describe('TypeScript-backed text facts', () => {
+	it('proves only primitive text domains for numeric and mixed child values', () => {
+		const source = `export function TextValues(props: {
+			count: number; large: bigint; mixed: string | number | bigint;
+			optional?: number; boxed: Number; flag: boolean; date: Date;
+			unchecked: any; unknown: unknown;
+		}) @{
+			const count = props.count;
+			<main>
+				<p>{props.count}</p><p>{count}</p><p>{props.large}</p><p>{props.mixed}</p>
+				<p>{Date()}</p><p>{props.date.toISOString()}</p>
+				<p>{props.optional}</p><p>{props.boxed}</p><p>{props.flag}</p>
+				<p>{props.date}</p><p>{props.unchecked}</p><p>{props.unknown}</p>
+			</main>
+		}`;
+		const consumer = fixture({ 'TextValues.tsrx': source });
+		const facts = consumer.project.snapshot(consumer.file('TextValues.tsrx'));
+		const primitive = (facts.primitiveTextChildRanges ?? []).map(([start, end]) =>
+			source.slice(start, end),
+		);
+		expect(primitive).toEqual(['props.count', 'count', 'props.large', 'props.mixed']);
+		expect(stringChildren(source, facts)).toEqual(['Date()', 'props.date.toISOString()']);
+		for (const uncertain of [
+			'props.optional',
+			'props.boxed',
+			'props.flag',
+			'props.date',
+			'props.unchecked',
+			'props.unknown',
+		]) {
+			expect(primitive, uncertain).not.toContain(uncertain);
+		}
+	});
+
 	it('proves exact primitive-string child expressions across declarations and calls', () => {
 		const source = `import { useState } from 'octane';
 type Label = string;
@@ -170,6 +203,9 @@ export function Imported(props: { label: Label }) @{
 		const second = consumer.project.snapshot(filename);
 		expect(stringChildren(source, second)).not.toContain('props.label');
 		expect(stringChildren(source, second)).not.toContain('readLabel()');
+		expect(
+			(second.primitiveTextChildRanges ?? []).map(([start, end]) => source.slice(start, end)),
+		).toEqual(expect.arrayContaining(['props.label', 'readLabel()']));
 		expect(second.sourceVersion).toBe(first.sourceVersion);
 		expect(second.projectVersion).not.toBe(first.projectVersion);
 		expect(JSON.stringify(first)).toBe(original);
@@ -372,6 +408,16 @@ describe('source-bound textTypeFacts compile option', () => {
 			{ ...facts, stringChildRanges: [[end, start]] },
 			{ ...facts, stringChildRanges: [[start - 1, end + 1]] },
 			{ ...facts, stringChildRanges: [[attrStart, attrStart + 'props.title'.length]] },
+			{ ...facts, primitiveTextChildRanges: null },
+			{
+				...facts,
+				primitiveTextChildRanges: [
+					[start, end],
+					[start, end],
+				],
+			},
+			{ ...facts, primitiveTextChildRanges: [[attrStart, attrStart + 'props.title'.length]] },
+			{ ...facts, primitiveTextChildRanges: [[start, end]] },
 		];
 		for (const invalid of malformed) {
 			for (const mode of ['client', 'server'] as const) {

--- a/packages/octane/tests/known-string-holes.test.ts
+++ b/packages/octane/tests/known-string-holes.test.ts
@@ -179,7 +179,8 @@ describe('dynamic text authoring', () => {
 			expect(adjacentText).toBeDefined();
 			let root: ReturnType<typeof hydrateRoot> | undefined;
 			try {
-				root = hydrateRoot(container, client.Scalar, first);
+				const hydrated = hydrateRoot(container, client.Scalar, first);
+				root = hydrated;
 				flushSync(() => {});
 				expect(numeric.firstChild).toBe(numericText);
 				expect(assertedText!.parentNode).toBe(asserted);
@@ -190,7 +191,7 @@ describe('dynamic text authoring', () => {
 				expect(container.querySelector('#arithmetic')!.textContent).toBe('5');
 				expect(container.querySelector('#type')!.textContent).toBe('object');
 				expect(adjacent.textContent).toBe('before1.5and9after');
-				flushSync(() => root.render(client.Scalar, second));
+				flushSync(() => hydrated.render(client.Scalar, second));
 				expect(numeric.firstChild).toBe(numericText);
 				expect(assertedText!.nodeValue).toBe('second');
 				expect(asserted.textContent).toBe('beforesecondafter');
@@ -242,7 +243,11 @@ describe('dynamic text authoring', () => {
 		let replacedRoot: ReturnType<typeof mount> | undefined;
 		try {
 			replacedRoot = mount(replaced.Replaced, { value: sentinel });
-			expect(replacedRoot.find('em').textContent).toBe('replacement');
+			// Selector engines rely on Number.isNaN; read the rendered child
+			// directly while the authored replacement is active.
+			const child = replacedRoot.container.firstElementChild?.firstElementChild;
+			expect(child?.tagName).toBe('EM');
+			expect(child?.textContent).toBe('replacement');
 		} finally {
 			restore();
 			replacedRoot?.unmount();

--- a/packages/octane/tests/known-string-holes.test.ts
+++ b/packages/octane/tests/known-string-holes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
 import * as ServerRT from 'octane/server';
 import { mount } from './_helpers';
-import { hydrateRoot, flushSync } from '../src/index.js';
+import { createElement, hydrateRoot, flushSync } from '../src/index.js';
 import { ConcatCount, Labelled } from './_fixtures/known-string.tsrx';
 import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture';
 
@@ -30,6 +30,17 @@ describe('dynamic text authoring', () => {
 		['mixed conditional', '', `{n === 1 ? ' item left' : props.label}`, 'zero!', ' item left'],
 		['explicit text cast', '', '{n as string}', '0', '1'],
 		['numeric identifier', '', '{n}', '0', '1'],
+		['numeric literal', '', '{42}', '42', '42'],
+		['bigint literal', '', '{42n}', '42', '42'],
+		['Number conversion', '', '{Number(n)}', '0', '1'],
+		['BigInt conversion', '', '{BigInt(n)}', '0', '1'],
+		['numeric arithmetic', '', '{n * 2}', '0', '2'],
+		['numeric addition', '', '{Number(n) + 1}', '1', '2'],
+		['numeric conditional', '', '{n === 0 ? Number(n) : 42n}', '0', '42'],
+		['numeric logical', '', '{Number(n) || 7}', '7', '1'],
+		['numeric sequence', '', '{(n, Number(n))}', '0', '1'],
+		['typeof expression', '', '{typeof n}', 'number', 'number'],
+		['string logical', '', "{(n === 0 ? '' : 'ready') || 'pending'}", 'pending', 'ready'],
 		['renderable member', '', '{props.label}', 'zero!', 'one!'],
 		[
 			'tracked concatenation',
@@ -101,6 +112,190 @@ describe('dynamic text authoring', () => {
 			expect(root.find('p').textContent).toBe('first');
 			root.update(C, 'second');
 			expect(root.find('p').textContent).toBe('second');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([false, true])(
+		'renders scalar expressions without a cast and hydrates them (dev: %s)',
+		async (dev) => {
+			const source = `export function Scalar(props) @{
+				<main>
+					<p id="numeric">{Number(props.value)}</p>
+					<p id="bigint">{BigInt(props.whole)}</p>
+					<p id="arithmetic">{props.left - props.right}</p>
+					<p id="type">{typeof props.child}</p>
+					<p id="sequence">{(props.observe(), Number(props.value))}</p>
+					<div id="asserted">before{props.label as string}after</div>
+					<div id="adjacent">before{Number(props.value)}and{BigInt(props.whole)}after</div>
+				</main>
+			}`;
+			const options = { hmr: false, dev };
+			const client = loadCompiledFixtureSource(source, {
+				id: 'numeric-text.tsrx',
+				mode: 'client',
+				compileOptions: options,
+			});
+			const server = loadCompiledFixtureSource(source, {
+				id: 'numeric-text.tsrx',
+				mode: 'server',
+				compileOptions: options,
+			});
+			const observed: string[] = [];
+			const first = {
+				value: '001.5',
+				whole: '9',
+				left: 7,
+				right: 2,
+				child: { nested: true },
+				label: 'first',
+				observe: () => observed.push('first'),
+			};
+			const second = {
+				value: '2',
+				whole: '18',
+				left: 12,
+				right: 7,
+				child: () => 'not called',
+				label: 'second',
+				observe: () => observed.push('second'),
+			};
+			const { html } = await ServerRT.renderToString(server.Scalar, first);
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			document.body.appendChild(container);
+			const numeric = container.querySelector('#numeric')!;
+			const numericText = numeric.firstChild;
+			const asserted = container.querySelector('#asserted')!;
+			const assertedText = [...asserted.childNodes].find(
+				(node) => node.nodeType === Node.TEXT_NODE && node.nodeValue === 'first',
+			);
+			expect(assertedText).toBeDefined();
+			const adjacent = container.querySelector('#adjacent')!;
+			const adjacentText = [...adjacent.childNodes].find(
+				(node) => node.nodeType === Node.TEXT_NODE && node.nodeValue === '1.5',
+			);
+			expect(adjacentText).toBeDefined();
+			let root: ReturnType<typeof hydrateRoot> | undefined;
+			try {
+				root = hydrateRoot(container, client.Scalar, first);
+				flushSync(() => {});
+				expect(numeric.firstChild).toBe(numericText);
+				expect(assertedText!.parentNode).toBe(asserted);
+				expect(asserted.textContent).toBe('beforefirstafter');
+				expect(adjacentText!.parentNode).toBe(adjacent);
+				expect(numeric.textContent).toBe('1.5');
+				expect(container.querySelector('#bigint')!.textContent).toBe('9');
+				expect(container.querySelector('#arithmetic')!.textContent).toBe('5');
+				expect(container.querySelector('#type')!.textContent).toBe('object');
+				expect(adjacent.textContent).toBe('before1.5and9after');
+				flushSync(() => root.render(client.Scalar, second));
+				expect(numeric.firstChild).toBe(numericText);
+				expect(assertedText!.nodeValue).toBe('second');
+				expect(asserted.textContent).toBe('beforesecondafter');
+				expect(adjacentText!.nodeValue).toBe('2');
+				expect(container.querySelector('#sequence')!.textContent).toBe('2');
+				expect(container.querySelector('#bigint')!.textContent).toBe('18');
+				expect(container.querySelector('#type')!.textContent).toBe('function');
+				expect(adjacent.textContent).toBe('before2and18after');
+				expect(observed).toEqual(['first', 'first', 'second']);
+			} finally {
+				root?.unmount();
+				container.remove();
+			}
+		},
+	);
+
+	it('preserves element children from a shadowed or replaced Number function', () => {
+		const local = loadCompiledFixtureSource(
+			`export function Local(props) @{
+				const Number = props.render;
+				<main>{Number(props.value)}</main>
+			}`,
+			{ id: 'shadowed-number.tsrx', mode: 'client', compileOptions },
+		);
+		const render = (value: string) => createElement('strong', null, value);
+		const localRoot = mount(local.Local, { render, value: 'one' });
+		try {
+			expect(localRoot.find('strong').textContent).toBe('one');
+			localRoot.update(local.Local, { render, value: 'two' });
+			expect(localRoot.find('strong').textContent).toBe('two');
+		} finally {
+			localRoot.unmount();
+		}
+
+		const replaced = loadCompiledFixtureSource(
+			`export function replaceNumber(replacement) {
+				const original = globalThis.Number;
+				globalThis.Number = replacement;
+				return () => { globalThis.Number = original; };
+			}
+			export function Replaced(props) @{ <main>{Number(props.value)}</main> }`,
+			{ id: 'replaced-number.tsrx', mode: 'client', compileOptions },
+		);
+		const previous = globalThis.Number;
+		const sentinel = {};
+		const restore = replaced.replaceNumber((value: unknown) =>
+			value === sentinel ? createElement('em', null, 'replacement') : previous(value),
+		);
+		let replacedRoot: ReturnType<typeof mount> | undefined;
+		try {
+			replacedRoot = mount(replaced.Replaced, { value: sentinel });
+			expect(replacedRoot.find('em').textContent).toBe('replacement');
+		} finally {
+			restore();
+			replacedRoot?.unmount();
+		}
+	});
+
+	it('renders Date() text and preserves object children from a shadowed Date', () => {
+		const source = `export function Converted() @{ <p>{String(new Date(0))}</p> }
+		export function Clock() @{ <p>{Date()}</p> }
+		export function ObjectChild() @{ <p>{new Date(0)}</p> }`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'date-child.tsrx',
+			mode: 'client',
+			compileOptions,
+		});
+		const server = loadCompiledFixtureSource(source, {
+			id: 'date-child.tsrx',
+			mode: 'server',
+			compileOptions,
+		});
+		const converted = mount(client.Converted);
+		try {
+			expect(converted.find('p').textContent).toBe(String(new Date(0)));
+			expect(ServerRT.renderToString(server.Converted).html).toContain(String(new Date(0)));
+		} finally {
+			converted.unmount();
+		}
+		const clock = mount(client.Clock);
+		try {
+			// Date() returns a display string, whereas new Date() is an object child.
+			expect(Number.isFinite(Date.parse(clock.find('p').textContent!))).toBe(true);
+			expect(ServerRT.renderToString(server.Clock).html).toContain('GMT');
+		} finally {
+			clock.unmount();
+		}
+		expect(() => mount(client.ObjectChild)).toThrow(
+			/Objects are not valid|Minified Octane error #3/,
+		);
+		expect(() => ServerRT.renderToString(server.ObjectChild)).toThrow(
+			/Objects are not valid|Minified Octane error #3/,
+		);
+		const shadowed = loadCompiledFixtureSource(
+			`export function Shadowed(props) @{
+				const Date = props.render;
+				<p>{Date()}</p>
+			}`,
+			{ id: 'shadowed-date.tsrx', mode: 'client', compileOptions },
+		);
+		const root = mount(shadowed.Shadowed, {
+			render: () => createElement('i', null, 'an element'),
+		});
+		try {
+			expect(root.find('i').textContent).toBe('an element');
 		} finally {
 			root.unmount();
 		}

--- a/packages/octane/tests/typescript-text-holes.test.ts
+++ b/packages/octane/tests/typescript-text-holes.test.ts
@@ -192,6 +192,11 @@ describe.each([false, true])('inferred text hydration (development diagnostics: 
 		);
 		expect(stringChildren(fixture.source, fixture.facts!)).not.toContain('props.maybe');
 		expect(stringChildren(fixture.source, fixture.facts!)).not.toContain('props.child');
+		expect(
+			(fixture.facts!.primitiveTextChildRanges ?? []).map(([start, end]) =>
+				fixture.source.slice(start, end),
+			),
+		).toContain('count');
 		const props = { label: 'First & <label>', maybe: null, child: 'plain' };
 		const { html } = await ServerRuntime.renderToString(fixture.server.TextScene, props);
 		const container = document.createElement('div');
@@ -199,6 +204,12 @@ describe.each([false, true])('inferred text hydration (development diagnostics: 
 		document.body.appendChild(container);
 		const member = container.querySelector('#text-member')!;
 		const memberText = member.firstChild;
+		const typedCount = container.querySelector('#text-typed-count')!;
+		const typedCountText = typedCount.firstChild;
+		const numberSibling = [...container.querySelector('#text-number-siblings')!.childNodes].find(
+			(node) => node.nodeType === Node.TEXT_NODE && node.nodeValue === '0',
+		);
+		expect(numberSibling).toBeDefined();
 		const before = container.querySelector('#text-before');
 		const after = container.querySelector('#text-after');
 		const siblingText = [...container.querySelector('#text-siblings')!.childNodes].find(
@@ -212,11 +223,16 @@ describe.each([false, true])('inferred text hydration (development diagnostics: 
 			flushSync(() => {});
 			expect(container.querySelector('#text-member')).toBe(member);
 			expect(member.firstChild).toBe(memberText);
+			expect(typedCount.firstChild).toBe(typedCountText);
+			expect(numberSibling!.parentNode).toBe(container.querySelector('#text-number-siblings'));
 			expect(container.querySelector('#text-before')).toBe(before);
 			expect(container.querySelector('#text-after')).toBe(after);
 			expect(siblingText!.parentNode).toBe(container.querySelector('#text-siblings'));
 			flushSync(() => (container.querySelector('#text-bump') as HTMLButtonElement).click());
 			expect(container.querySelector('#text-count')!.textContent).toBe('1');
+			expect(typedCount.firstChild).toBe(typedCountText);
+			expect(typedCountText!.nodeValue).toBe('1');
+			expect(numberSibling!.nodeValue).toBe('1');
 			flushSync(() =>
 				root!.render(fixture.client.TextScene, {
 					label: 'Second',

--- a/packages/octane/tests/vite-text-types.test.ts
+++ b/packages/octane/tests/vite-text-types.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, hydrateRoot, type Root } from '../src/index.js';
+import { renderToString } from 'octane/server';
+import { octane } from 'octane/compiler/vite';
+import type { Plugin } from 'vite';
+import { evaluateCompiledFixtureCode } from './_server-fixture.js';
+import { createTextTypeFixture } from './_text-type-project.js';
+
+describe('Vite TypeScript text compilation', () => {
+	let root: Root | null = null;
+	let container: HTMLElement | null = null;
+	afterEach(() => {
+		root?.unmount();
+		root = null;
+		container?.remove();
+		container = null;
+	});
+
+	it('hydrates and updates typed imported text across production targets', async () => {
+		const source = `import type { Label } from './model';
+export function App(props: { label: Label }) @{
+		<p><i>before</i>{props.label}<i>after</i></p>
+}`;
+		const fixture = createTextTypeFixture({
+			'App.tsrx': source,
+			'model.ts': 'export type Label = string;',
+		});
+		const plugin: Plugin = octane({ hmr: false, textTypes: { tsconfig: fixture.tsconfig } });
+		const file = fixture.file('App.tsrx');
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await (plugin.config as any)({ root: fixture.directory }, { command: 'build' });
+			await (plugin.configResolved as any)({
+				root: fixture.directory,
+				command: 'build',
+				build: {},
+				define: {},
+			});
+			const client = (await (plugin.transform as any).call({}, source, file, { ssr: false }))?.code;
+			await (plugin.closeBundle as any)?.();
+			const server = (await (plugin.transform as any).call({}, source, file, { ssr: true }))?.code;
+			expect(typeof client).toBe('string');
+			expect(typeof server).toBe('string');
+			const clientApp = evaluateCompiledFixtureCode(client, file, 'client', undefined).App;
+			const serverApp = evaluateCompiledFixtureCode(server, file, 'server', undefined).App;
+			const { html } = await renderToString(serverApp, { label: 'first' });
+			container = document.createElement('div');
+			container.innerHTML = html;
+			document.body.appendChild(container);
+			const p = container.querySelector('p')!;
+			const text = [...p.childNodes].find(
+				(node) => node.nodeType === Node.TEXT_NODE && node.nodeValue === 'first',
+			);
+			expect(text).toBeDefined();
+			root = hydrateRoot(container, clientApp, { label: 'first' });
+			flushSync(() => {});
+			flushSync(() => root!.render(clientApp, { label: 'second' }));
+			expect(container.querySelector('p')).toBe(p);
+			expect(text?.parentNode).toBe(p);
+			expect(text?.nodeValue).toBe('second');
+			expect(p.textContent).toBe('beforesecondafter');
+			expect(error.mock.calls.flat().map(String).join('\n')).not.toMatch(/hydration.*mismatch/i);
+		} finally {
+			await (plugin.closeBundle as any)?.();
+			fixture.dispose();
+			error.mockRestore();
+		}
+	});
+});

--- a/packages/rsbuild-plugin-octane/src/index.js
+++ b/packages/rsbuild-plugin-octane/src/index.js
@@ -235,6 +235,7 @@ function assertRootPublicPaths(config, clientEnvironment) {
  *   hmr?: boolean,
  *   parallel?: boolean | { maxWorkers?: number },
  *   cssModuleConstants?: import('@octanejs/rspack-plugin').OctaneRspackPluginOptions['cssModuleConstants'],
+ *   textTypes?: import('@octanejs/rspack-plugin').OctaneRspackPluginOptions['textTypes'],
  *   profile?: boolean,
  *   strong?: boolean,
  *   exclude?: string[],
@@ -555,6 +556,9 @@ export function pluginOctane(inlineOptions = {}) {
 						...(inlineOptions.cssModuleConstants === undefined
 							? null
 							: { cssModuleConstants: inlineOptions.cssModuleConstants }),
+						...(inlineOptions.textTypes === undefined
+							? null
+							: { textTypes: inlineOptions.textTypes }),
 						...(strong === undefined ? null : { strong }),
 						...(inlineOptions.hmr === undefined ? null : { hmr: inlineOptions.hmr }),
 						...(inlineOptions.profile === undefined

--- a/packages/rsbuild-plugin-octane/tests/renderer-config.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/renderer-config.test.ts
@@ -189,6 +189,24 @@ describe('Rsbuild renderer configuration', () => {
 		for (const plugin of plugins) expect(plugin.options.parallel).toEqual(parallel);
 	});
 
+	it('shares an explicit text type project with browser and server compilers', async () => {
+		writeProject(root, true);
+		const instance = await createRsbuild({
+			cwd: root,
+			rsbuildConfig: {
+				plugins: [pluginOctane({ textTypes: { tsconfig: 'tsconfig.json' } })],
+			},
+		});
+		const plugins = (await instance.initConfigs({ action: 'build' }))
+			.flatMap((config) => config.plugins ?? [])
+			.filter((plugin): plugin is OctaneRspackPlugin => plugin instanceof OctaneRspackPlugin);
+
+		expect(plugins).toHaveLength(2);
+		for (const plugin of plugins) {
+			expect(plugin.options.textTypes).toEqual({ tsconfig: 'tsconfig.json' });
+		}
+	});
+
 	it('enables Strong mode for compiler-only projects without an app config', async () => {
 		writeProject(root, false);
 		rmSync(join(root, 'octane.config.ts'));

--- a/packages/rsbuild-plugin-octane/types/index.d.ts
+++ b/packages/rsbuild-plugin-octane/types/index.d.ts
@@ -11,6 +11,13 @@ export {
 
 export interface OctaneRsbuildPluginOptions {
 	/**
+	 * @experimental TypeScript text proofs in one-shot production browser and
+	 * server builds. Relative tsconfig paths resolve from the project root.
+	 * Watch/HMR and development builds retain syntax-only classification.
+	 * Requires the optional TypeScript peer; see the Rspack option for caching.
+	 */
+	textTypes?: OctaneRspackPluginOptions['textTypes'];
+	/**
 	 * @experimental Fold authenticated JavaScript CSS-module exports in one-shot
 	 * production builds. Uses the Rspack plugin's exact-source provider contract;
 	 * native `css/module` remains unchanged. Disabled by default.

--- a/packages/rspack-plugin-octane/src/loader.js
+++ b/packages/rspack-plugin-octane/src/loader.js
@@ -1,7 +1,8 @@
-import { realpathSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import remapping from '@jridgewell/remapping';
 import { canonicalModuleId, cleanModuleId, createOctaneCompiler } from 'octane/compiler/bundler';
+import { resolveRendererForFile } from 'octane/compiler/renderers';
 import {
 	clearCssModuleBuildInfo,
 	CSS_MODULE_CONTEXT_KEY,
@@ -14,6 +15,7 @@ import {
 	selectLayerCompilerOptions,
 } from './shared.js';
 import { loadDescriptorChildrenImports } from './descriptor-children.js';
+import { textTypeFactsForLoader } from './text-types.js';
 
 function realRoot(path) {
 	try {
@@ -134,6 +136,41 @@ export default function octaneLoader(source, inputSourceMap) {
 		});
 		const id = realModuleId(this.resource ?? this.resourcePath);
 		const authoredSource = String(source);
+		const textTypeCandidate =
+			options.textTypes !== undefined && this.mode === 'production' && !dev && this.hot !== true;
+		let textTypeFilename;
+		if (textTypeCandidate) {
+			const file = cleanModuleId(id);
+			if (
+				/(?:\.tsrx|\.tsx)$/i.test(file) &&
+				existsSync(file) &&
+				compiler._isProjectOwnedSource(file)
+			) {
+				const canonical = compiler._canonicalModuleId(file);
+				const pragmaOwned =
+					file.endsWith('.tsx') && compiler._pragmaClaimsOwnership(authoredSource);
+				if (compiler._passesOwnershipGate(file, canonical, pragmaOwned)) {
+					const renderer = resolveRendererForFile(compiler.renderers, canonical);
+					if (
+						renderer.target === 'dom' &&
+						!(environment === 'server' && renderer.server === 'client-only')
+					) {
+						textTypeFilename = canonical;
+					}
+				}
+			}
+		}
+		if (textTypeFilename !== undefined) {
+			// An imported type can change while this module's source stays the same.
+			// Rspack's persistent module cache has no dependency edges to every TS
+			// Program input. Production watches stay syntax-only but must not persist
+			// their generic output for a later one-shot typed build either.
+			this.cacheable?.(false);
+		}
+		const textTypes =
+			textTypeFilename !== undefined &&
+			this._compiler?.watchMode !== true &&
+			this._compiler?.options?.watch !== true;
 		const cssModuleConstants =
 			this[CSS_MODULE_CONTEXT_KEY]?.enabled === true
 				? prepareCssModuleConstants(this, compiler, authoredSource, id, {
@@ -142,7 +179,7 @@ export default function octaneLoader(source, inputSourceMap) {
 						dev,
 					})
 				: null;
-		const finish = (clientOnlyImports, isDescriptorChildrenImport, callback) => {
+		const finish = (clientOnlyImports, isDescriptorChildrenImport, textTypeFacts, callback) => {
 			try {
 				const result = compiler.transform(authoredSource, id, {
 					environment,
@@ -151,6 +188,7 @@ export default function octaneLoader(source, inputSourceMap) {
 					profile,
 					...(clientOnlyImports.length > 0 ? { clientOnlyImports } : null),
 					...(isDescriptorChildrenImport === null ? null : { isDescriptorChildrenImport }),
+					...(textTypeFacts === undefined ? null : { textTypeFacts }),
 					...cssModuleConstants?.transformOptions,
 				});
 
@@ -205,18 +243,33 @@ export default function octaneLoader(source, inputSourceMap) {
 			/\.(?:tsrx|tsx)$/.test(cleanModuleId(id)) &&
 			/<\s*[A-Z_$]/.test(authoredSource) &&
 			authoredSource.includes('import');
-		if (requests.length > 0 || mayUseDescriptorImports) {
+		if (requests.length > 0 || mayUseDescriptorImports || textTypes) {
 			const asyncCallback = this.async?.() ?? callback;
 			Promise.all([
 				requests.length > 0 ? resolveClientOnlyImports(this, compiler, authoredSource, id) : [],
 				mayUseDescriptorImports ? loadDescriptorChildrenImports(this, authoredSource, id) : null,
+				textTypes
+					? textTypeFactsForLoader(
+							this._compiler,
+							options.textTypes.tsconfig,
+							compilerOptions.renderers,
+							cleanModuleId(id),
+							authoredSource,
+						).then((facts) => ({
+							...facts,
+							// The neutral compiler uses a project-relative module identity;
+							// the checker necessarily reads the real filesystem filename.
+							filename: textTypeFilename,
+						}))
+					: undefined,
 			]).then(
-				([imports, descriptorImport]) => finish(imports, descriptorImport, asyncCallback),
+				([imports, descriptorImport, textTypeFacts]) =>
+					finish(imports, descriptorImport, textTypeFacts, asyncCallback),
 				(error) => asyncCallback(error instanceof Error ? error : new Error(String(error))),
 			);
 			return;
 		}
-		finish([], null, callback);
+		finish([], null, undefined, callback);
 	} catch (error) {
 		this.callback(error instanceof Error ? error : new Error(String(error)));
 	}

--- a/packages/rspack-plugin-octane/src/plugin.js
+++ b/packages/rspack-plugin-octane/src/plugin.js
@@ -14,6 +14,11 @@ import {
 	inferRspackEnvironment,
 	normalizePluginOptions,
 } from './shared.js';
+import {
+	disposeTextTypeCompiler,
+	invalidateTextTypeCompiler,
+	registerTextTypeCompiler,
+} from './text-types.js';
 
 const PLUGIN_NAME = 'OctaneRspackPlugin';
 const PROFILE_DEFINE = '__OCTANE_PROFILE_ENABLED__';
@@ -359,6 +364,16 @@ export class OctaneRspackPlugin {
 			compiler.options.mode === 'production' &&
 			!dev &&
 			!hotModuleReplacement;
+		// Loader worker pools cannot share one TypeScript Program. Watch and HMR
+		// use syntax-only compilation, including production-mode watch builds.
+		const textTypes =
+			this.options.textTypes !== undefined &&
+			compiler.options.mode === 'production' &&
+			!dev &&
+			!hotModuleReplacement;
+		const tsconfig = textTypes
+			? realRoot(resolve(root, this.options.textTypes.tsconfig))
+			: undefined;
 		assertProfilingDefineAvailable(compiler, profile);
 		saltPersistentCacheVersion(compiler, {
 			root,
@@ -377,7 +392,14 @@ export class OctaneRspackPlugin {
 			requireDirective: this.options.requireDirective === true,
 			transpile: this.options.transpile !== false,
 			cssModuleConstants,
+			textTypes: tsconfig,
 		});
+		if (tsconfig !== undefined) {
+			registerTextTypeCompiler(compiler, tsconfig, root);
+			compiler.hooks.run?.tap(PLUGIN_NAME, () => invalidateTextTypeCompiler(compiler));
+			compiler.hooks.watchRun?.tap(PLUGIN_NAME, () => invalidateTextTypeCompiler(compiler));
+			compiler.hooks.shutdown?.tap(PLUGIN_NAME, () => disposeTextTypeCompiler(compiler));
+		}
 		installProfilingDefine(compiler, profile);
 		if (cssModuleConstants) {
 			installCssModuleConstants(compiler, {
@@ -420,13 +442,14 @@ export class OctaneRspackPlugin {
 			...(this.options.requireDirective === undefined
 				? null
 				: { requireDirective: this.options.requireDirective }),
+			...(tsconfig === undefined ? null : { textTypes: { tsconfig } }),
 		};
 		compiler.options.module.rules.push({
 			test: OCTANE_RULE,
 			type: 'javascript/auto',
 			enforce: 'pre',
 			use:
-				this.options.parallel === false
+				this.options.parallel === false || textTypes
 					? [{ loader: loaderPath, options: loaderOptions }]
 					: [
 							{ loader: finalizeLoaderPath, options: loaderOptions },

--- a/packages/rspack-plugin-octane/src/shared.js
+++ b/packages/rspack-plugin-octane/src/shared.js
@@ -46,6 +46,7 @@ const LOADER_OPTION_KEYS = new Set([
 	'requireDirective',
 	'universalRuntime',
 	'layerSpecializations',
+	'textTypes',
 ]);
 const PLUGIN_OPTION_KEYS = new Set([
 	...LOADER_OPTION_KEYS,
@@ -216,6 +217,21 @@ function normalizeOptions(value, plugin) {
 		throw new TypeError('@octanejs/rspack-plugin: `exclude` must be an array of path strings.');
 	}
 	if (plugin) assertBooleanOption(options, 'transpile');
+	if (options.textTypes !== undefined) {
+		if (
+			options.textTypes === null ||
+			typeof options.textTypes !== 'object' ||
+			Array.isArray(options.textTypes) ||
+			Object.keys(options.textTypes).some((key) => key !== 'tsconfig') ||
+			typeof options.textTypes.tsconfig !== 'string' ||
+			options.textTypes.tsconfig.trim() !== options.textTypes.tsconfig ||
+			!options.textTypes.tsconfig
+		) {
+			throw new TypeError(
+				'@octanejs/rspack-plugin: `textTypes` must be an object with a non-empty `tsconfig` path.',
+			);
+		}
+	}
 	if (
 		plugin &&
 		options.cssModuleConstants !== undefined &&
@@ -246,6 +262,9 @@ function normalizeOptions(value, plugin) {
 		...(options.requireDirective === undefined
 			? null
 			: { requireDirective: options.requireDirective }),
+		...(options.textTypes === undefined
+			? null
+			: { textTypes: Object.freeze({ tsconfig: options.textTypes.tsconfig }) }),
 		...(plugin && parallel !== undefined ? { parallel } : null),
 		...(plugin && options.transpile !== undefined ? { transpile: options.transpile } : null),
 		...(plugin && options.runtime !== undefined ? { runtime: options.runtime } : null),

--- a/packages/rspack-plugin-octane/src/text-types.js
+++ b/packages/rspack-plugin-octane/src/text-types.js
@@ -1,0 +1,50 @@
+/**
+ * Type analysis is an opt-in production build concern. Keep TypeScript out of
+ * the ordinary loader's module graph and retain one project per compiler and
+ * renderer configuration, rather than one TypeScript Program per module.
+ */
+const projectsByCompiler = new WeakMap();
+
+export function registerTextTypeCompiler(compiler, tsconfig, root) {
+	if (projectsByCompiler.has(compiler)) {
+		throw new Error('@octanejs/rspack-plugin: only one text type project may own a compiler.');
+	}
+	projectsByCompiler.set(compiler, { tsconfig, root, projects: new Map(), closed: false });
+}
+
+export function invalidateTextTypeCompiler(compiler) {
+	const state = projectsByCompiler.get(compiler);
+	if (!state || state.closed) return;
+	for (const project of state.projects.values()) project.invalidate();
+}
+
+export function disposeTextTypeCompiler(compiler) {
+	const state = projectsByCompiler.get(compiler);
+	if (!state) return;
+	state.closed = true;
+	for (const project of state.projects.values()) project.dispose();
+	state.projects.clear();
+	projectsByCompiler.delete(compiler);
+}
+
+export async function textTypeFactsForLoader(compiler, tsconfig, renderers, filename, source) {
+	const state = projectsByCompiler.get(compiler);
+	if (!state || state.tsconfig !== tsconfig || state.closed) {
+		throw new Error(
+			'@octanejs/rspack-plugin: `textTypes` requires the OctaneRspackPlugin on the same compiler.',
+		);
+	}
+	// The optional TypeScript peer and Volar adapter are loaded only by an opted-in
+	// production compiler. import() also shares its module initialization across
+	// concurrently built modules without retaining a checker in loader options.
+	const { createTextTypeProject } = await import('octane/compiler/typescript');
+	if (state.closed)
+		throw new Error('@octanejs/rspack-plugin: compiler closed during type analysis.');
+	const key = renderers?.signature ?? 'dom';
+	let project = state.projects.get(key);
+	if (!project) {
+		project = createTextTypeProject({ tsconfig, root: state.root, renderers });
+		state.projects.set(key, project);
+	}
+	return project.snapshot(filename, source);
+}

--- a/packages/rspack-plugin-octane/src/text-types.js
+++ b/packages/rspack-plugin-octane/src/text-types.js
@@ -3,32 +3,44 @@
  * the ordinary loader's module graph and retain one project per compiler and
  * renderer configuration, rather than one TypeScript Program per module.
  */
-const projectsByCompiler = new WeakMap();
+// Rspack loads the plugin from its application's module graph and the loader
+// through its loader runner. Those can instantiate this ESM module separately
+// (for example under Vitest), even though both receive the same compiler.
+// Keep the project on that compiler under a process-wide symbol instead of in
+// module-local state. Typed builds use the main-thread loader.
+const COMPILER_TEXT_TYPES = Symbol.for('@octanejs/rspack-plugin/text-types/v1');
+
+function compilerState(compiler) {
+	return compiler?.[COMPILER_TEXT_TYPES];
+}
 
 export function registerTextTypeCompiler(compiler, tsconfig, root) {
-	if (projectsByCompiler.has(compiler)) {
+	if (compilerState(compiler)) {
 		throw new Error('@octanejs/rspack-plugin: only one text type project may own a compiler.');
 	}
-	projectsByCompiler.set(compiler, { tsconfig, root, projects: new Map(), closed: false });
+	Object.defineProperty(compiler, COMPILER_TEXT_TYPES, {
+		value: { tsconfig, root, projects: new Map(), closed: false },
+		configurable: true,
+	});
 }
 
 export function invalidateTextTypeCompiler(compiler) {
-	const state = projectsByCompiler.get(compiler);
+	const state = compilerState(compiler);
 	if (!state || state.closed) return;
 	for (const project of state.projects.values()) project.invalidate();
 }
 
 export function disposeTextTypeCompiler(compiler) {
-	const state = projectsByCompiler.get(compiler);
+	const state = compilerState(compiler);
 	if (!state) return;
 	state.closed = true;
 	for (const project of state.projects.values()) project.dispose();
 	state.projects.clear();
-	projectsByCompiler.delete(compiler);
+	delete compiler[COMPILER_TEXT_TYPES];
 }
 
 export async function textTypeFactsForLoader(compiler, tsconfig, renderers, filename, source) {
-	const state = projectsByCompiler.get(compiler);
+	const state = compilerState(compiler);
 	if (!state || state.tsconfig !== tsconfig || state.closed) {
 		throw new Error(
 			'@octanejs/rspack-plugin: `textTypes` requires the OctaneRspackPlugin on the same compiler.',

--- a/packages/rspack-plugin-octane/tests/loader.integration.test.ts
+++ b/packages/rspack-plugin-octane/tests/loader.integration.test.ts
@@ -26,6 +26,7 @@ function transform({
 	source,
 	target = 'web',
 	hot = false,
+	watch = false,
 	mode = 'development',
 	options = {},
 }: {
@@ -34,12 +35,14 @@ function transform({
 	source: string;
 	target?: unknown;
 	hot?: boolean;
+	watch?: boolean;
 	mode?: string;
 	options?: Record<string, unknown>;
 }) {
 	const dependencies: string[] = [];
 	const missingDependencies: string[] = [];
 	const warnings: Error[] = [];
+	const cacheable: boolean[] = [];
 	const module = { buildInfo: {} as Record<string, unknown> };
 	let output: LoaderOutput | undefined;
 	octaneLoader.call(
@@ -49,10 +52,11 @@ function transform({
 			resourcePath,
 			target,
 			hot,
+			...(watch ? { _compiler: { watchMode: true, options: { watch: true } } } : null),
 			mode,
 			sourceMap: true,
 			_module: module,
-			cacheable() {},
+			cacheable: (value: boolean) => cacheable.push(value),
 			getOptions: () => options,
 			addDependency: (dependency: string) => dependencies.push(dependency),
 			addMissingDependency: (dependency: string) => missingDependencies.push(dependency),
@@ -65,7 +69,7 @@ function transform({
 	);
 	if (!output) throw new Error('Octane loader did not invoke its callback.');
 	if (output.error) throw output.error;
-	return { ...output, dependencies, missingDependencies, warnings, module };
+	return { ...output, dependencies, missingDependencies, warnings, cacheable, module };
 }
 
 describe('loader with the neutral compiler', () => {
@@ -416,6 +420,43 @@ describe('loader with the neutral compiler', () => {
 
 		expect(result.content).toBe(source);
 		expect(result.dependencies).not.toContain(join(root, 'src/Main.tsrx'));
+	});
+
+	it('keeps production watch builds syntax-only and out of the persistent module cache', () => {
+		const source = 'export function Watch(props: { label: string }) @{ <p>{props.label}</p> }\n';
+		const resourcePath = write(root, 'src/Watch.tsrx', source);
+		const result = transform({
+			root,
+			resourcePath,
+			source,
+			mode: 'production',
+			watch: true,
+			// A watch transform must not initialize a checker or read a tsconfig.
+			options: { textTypes: { tsconfig: join(root, 'missing-tsconfig.json') } },
+		});
+
+		expect(getOctaneRspackBuildInfo(result.module)?.transformKind).toBe('compile');
+		expect(result.cacheable).toContain(false);
+	});
+
+	it('keeps installed Octane sources outside the application type project', () => {
+		write(
+			root,
+			'node_modules/@fixture/raw/package.json',
+			JSON.stringify({ name: '@fixture/raw', dependencies: { octane: '*' } }),
+		);
+		const source = 'export function Raw() { return <span>ready</span>; }\n';
+		const resourcePath = write(root, 'node_modules/@fixture/raw/index.tsx', source);
+		const result = transform({
+			root,
+			resourcePath,
+			source,
+			mode: 'production',
+			options: { textTypes: { tsconfig: join(root, 'missing-tsconfig.json') } },
+		});
+
+		expect(getOctaneRspackBuildInfo(result.module)?.transformKind).toBe('compile');
+		expect(result.cacheable).not.toContain(false);
 	});
 
 	it('watches a manual-slot manifest that changes a plain TypeScript decision', () => {

--- a/packages/rspack-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspack-plugin-octane/tests/plugin.test.ts
@@ -162,6 +162,34 @@ describe('OctaneRspackPlugin', () => {
 		]);
 	});
 
+	it('uses a main-thread, non-worker loader only for opted-in production text analysis', () => {
+		const production = createCompiler('web');
+		(production.options as any).mode = 'production';
+		(production.options as any).cache = { type: 'persistent', version: 'user-cache' };
+		applyPlugin(new OctaneRspackPlugin({ textTypes: { tsconfig: 'tsconfig.json' } }), production);
+		expect(production.options.module.rules[0].use).toEqual([
+			{
+				loader: expect.any(String),
+				options: expect.objectContaining({
+					textTypes: { tsconfig: '/project/tsconfig.json' },
+				}),
+			},
+		]);
+		const ordinary = createCompiler('web');
+		(ordinary.options as any).mode = 'production';
+		(ordinary.options as any).cache = { type: 'persistent', version: 'user-cache' };
+		applyPlugin(new OctaneRspackPlugin(), ordinary);
+		expect((ordinary.options as any).cache.version).not.toBe(
+			(production.options as any).cache.version,
+		);
+		const development = createCompiler('web');
+		(development.options as any).mode = 'development';
+		applyPlugin(new OctaneRspackPlugin({ textTypes: { tsconfig: 'tsconfig.json' } }), development);
+		expect(development.options.module.rules[0].use).toHaveLength(2);
+		expect(development.options.module.rules[0].use[1].parallel).toEqual({ maxWorkers: 4 });
+		expect(development.options.module.rules[0].use[1].options).not.toHaveProperty('textTypes');
+	});
+
 	it('honors explicit client mode and serializable loader options', () => {
 		const existingHostPath = process.execPath;
 		const compiler = createCompiler('node');

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -48,10 +48,16 @@ module.exports = new Proxy({}, {
 `;
 }
 
-async function compile(config: Record<string, unknown>) {
+async function compile(config: Record<string, unknown>, capture?: (stats: any) => unknown) {
 	const compiler = rspack(config as any) as any;
 	return new Promise<any>((resolve, reject) => {
 		compiler.run((error: Error | null, stats: any) => {
+			let captured: unknown;
+			try {
+				if (!error && stats && !stats.hasErrors()) captured = capture?.(stats);
+			} catch (captureError) {
+				error = captureError instanceof Error ? captureError : new Error(String(captureError));
+			}
 			compiler.close((closeError: Error | null) => {
 				if (error || closeError) {
 					reject(error ?? closeError);
@@ -66,7 +72,7 @@ async function compile(config: Record<string, unknown>) {
 					reject(new Error(errors.map((entry: any) => entry.message ?? String(entry)).join('\n')));
 					return;
 				}
-				resolve(stats);
+				resolve(capture ? captured : stats);
 			});
 		});
 	});
@@ -1023,47 +1029,73 @@ export function Typed(props: { label: Label }) { return <p>before{props.label}af
 `,
 		);
 		const cacheDirectory = join(root, '.rspack-text-types-cache');
-		const build = async (index: number) => {
-			const stats = await compile({
-				name: 'text-type-import-cache',
-				context: root,
-				mode: 'production',
-				target: 'node',
-				entry: './src/text-entry.js',
-				optimization: { minimize: false },
-				output: { path: join(root, `dist-text-types-${index}`), filename: 'bundle.js' },
-				cache: {
-					type: 'persistent',
-					version: 'user-cache-v1',
-					storage: { type: 'filesystem', directory: cacheDirectory },
+		const build = async () => {
+			const { code, transformKind, builtTyped, builtEntry } = await compile(
+				{
+					name: 'text-type-import-cache',
+					context: root,
+					mode: 'production',
+					target: 'node',
+					entry: './src/text-entry.js',
+					optimization: { minimize: false },
+					output: { path: join(root, 'dist-text-types'), filename: 'bundle.js' },
+					cache: {
+						type: 'persistent',
+						version: 'user-cache-v1',
+						storage: { type: 'filesystem', directory: cacheDirectory },
+					},
+					plugins: [new OctaneRspackPlugin({ textTypes: { tsconfig } })],
 				},
-				plugins: [new OctaneRspackPlugin({ textTypes: { tsconfig } })],
-			});
-			const module = [...stats.compilation.modules].find(
-				(item: any) => item.resource === component,
-			) as any;
-			expect(getOctaneRspackBuildInfo(module)?.transformKind).toBe('compile');
-			const code = module.originalSource()?.source();
+				(stats) => {
+					const module = [...stats.compilation.modules].find(
+						(item: any) =>
+							item.resource === component ||
+							item.nameForCondition?.() === component ||
+							item.identifier?.().includes(component),
+					) as any;
+				const entry = [...stats.compilation.modules].find(
+					(item: any) => item.nameForCondition?.() === join(root, 'src/text-entry.js'),
+				) as any;
+				const built = new Set(
+					[...stats.compilation.builtModules].map((item: any) => item.identifier()),
+				);
+				return {
+					transformKind: getOctaneRspackBuildInfo(module)?.transformKind,
+					code: module.originalSource()?.source(),
+					builtTyped: built.has(module.identifier()),
+					builtEntry: entry && built.has(entry.identifier()),
+				};
+				},
+			);
+			expect(transformKind).toBe('compile');
 			expect(code).toBeTypeOf('string');
-			return evaluateCompiledFixtureCode(String(code), component, 'server', undefined).Typed;
+			return {
+				Typed: evaluateCompiledFixtureCode(String(code), component, 'server', undefined).Typed,
+				builtTyped,
+				builtEntry,
+			};
 		};
 
-		const first = await build(1);
-		const initialHtml = (await renderToString(first, { label: 'first' })).html.replace(
+		const first = await build();
+		expect(first.builtTyped).toBe(true);
+		expect(first.builtEntry).toBe(true);
+		const initialHtml = (await renderToString(first.Typed, { label: 'first' })).html.replace(
 			/<!--.*?-->/g,
 			'',
 		);
 		expect(initialHtml).toContain('beforefirstafter');
 		// Exercise the boundary of the first build's static string proof to
 		// distinguish it from a syntax-only build before checking invalidation.
-		const { html: oldTypedHtml } = await renderToString(first, { label: true });
+		const { html: oldTypedHtml } = await renderToString(first.Typed, { label: true });
 		expect(oldTypedHtml.replace(/<!--.*?-->/g, '')).toContain('beforetrueafter');
 		// The component source is unchanged and its type-only import is absent
 		// from the emitted module graph. A persistent cached text binding would
 		// incorrectly stringify the newly valid boolean child.
 		write(root, 'src/model.ts', 'export type Label = boolean;\n');
-		const second = await build(2);
-		const { html: rendered } = await renderToString(second, { label: true });
+		const second = await build();
+		expect(second.builtTyped).toBe(true);
+		expect(second.builtEntry).toBe(false);
+		const { html: rendered } = await renderToString(second.Typed, { label: true });
 		const html = rendered.replace(/<!--.*?-->/g, '');
 		expect(html).toContain('beforeafter');
 		expect(html).not.toContain('true');

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -998,6 +998,7 @@ export function Typed(props: { label: Label }) { return <p>before{props.label}af
 		);
 		write(root, 'src/model.ts', 'export type Label = string;\n');
 		write(root, 'src/text-entry.js', `export { Typed } from './Typed.tsx';\n`);
+		write(root, 'src/stable-entry.js', `export const stable = 'unchanged';\n`);
 		const tsconfig = write(
 			root,
 			'tsconfig.json',
@@ -1030,15 +1031,15 @@ export function Typed(props: { label: Label }) { return <p>before{props.label}af
 		);
 		const cacheDirectory = join(root, '.rspack-text-types-cache');
 		const build = async () => {
-			const { code, transformKind, builtTyped, builtEntry } = await compile(
+			const { code, transformKind, builtTyped, builtStable } = await compile(
 				{
 					name: 'text-type-import-cache',
 					context: root,
 					mode: 'production',
 					target: 'node',
-					entry: './src/text-entry.js',
+					entry: { typed: './src/text-entry.js', stable: './src/stable-entry.js' },
 					optimization: { minimize: false },
-					output: { path: join(root, 'dist-text-types'), filename: 'bundle.js' },
+					output: { path: join(root, 'dist-text-types'), filename: '[name].js' },
 					cache: {
 						type: 'persistent',
 						version: 'user-cache-v1',
@@ -1053,18 +1054,19 @@ export function Typed(props: { label: Label }) { return <p>before{props.label}af
 							item.nameForCondition?.() === component ||
 							item.identifier?.().includes(component),
 					) as any;
-				const entry = [...stats.compilation.modules].find(
-					(item: any) => item.nameForCondition?.() === join(root, 'src/text-entry.js'),
-				) as any;
-				const built = new Set(
-					[...stats.compilation.builtModules].map((item: any) => item.identifier()),
-				);
-				return {
-					transformKind: getOctaneRspackBuildInfo(module)?.transformKind,
-					code: module.originalSource()?.source(),
-					builtTyped: built.has(module.identifier()),
-					builtEntry: entry && built.has(entry.identifier()),
-				};
+					const stableModules = [...stats.compilation.modules].filter(
+						(item: any) =>
+							item.nameForCondition?.() === realpathSync(join(root, 'src/stable-entry.js')),
+					) as any[];
+					const built = new Set(
+						[...stats.compilation.builtModules].map((item: any) => item.identifier()),
+					);
+					return {
+						transformKind: getOctaneRspackBuildInfo(module)?.transformKind,
+						code: module.originalSource()?.source(),
+						builtTyped: built.has(module.identifier()),
+						builtStable: stableModules.some((item) => built.has(item.identifier())),
+					};
 				},
 			);
 			expect(transformKind).toBe('compile');
@@ -1072,13 +1074,13 @@ export function Typed(props: { label: Label }) { return <p>before{props.label}af
 			return {
 				Typed: evaluateCompiledFixtureCode(String(code), component, 'server', undefined).Typed,
 				builtTyped,
-				builtEntry,
+				builtStable,
 			};
 		};
 
 		const first = await build();
 		expect(first.builtTyped).toBe(true);
-		expect(first.builtEntry).toBe(true);
+		expect(first.builtStable).toBe(true);
 		const initialHtml = (await renderToString(first.Typed, { label: 'first' })).html.replace(
 			/<!--.*?-->/g,
 			'',
@@ -1094,7 +1096,7 @@ export function Typed(props: { label: Label }) { return <p>before{props.label}af
 		write(root, 'src/model.ts', 'export type Label = boolean;\n');
 		const second = await build();
 		expect(second.builtTyped).toBe(true);
-		expect(second.builtEntry).toBe(false);
+		expect(second.builtStable).toBe(false);
 		const { html: rendered } = await renderToString(second.Typed, { label: true });
 		const html = rendered.replace(/<!--.*?-->/g, '');
 		expect(html).toContain('beforeafter');

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -15,7 +15,9 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import rspack from '@rspack/core';
 import { JSDOM } from 'jsdom';
 import { compile as compileOctane } from 'octane/compiler';
+import { renderToString } from 'octane/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { evaluateCompiledFixtureCode } from '../../octane/tests/_server-fixture.js';
 import { getOctaneRspackBuildInfo, OctaneRspackPlugin } from '../src/index.js';
 
 const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
@@ -978,6 +980,94 @@ globalThis.__octane_descriptor_result__ = renderToString(App, {}).html;
 		expect(profiled).toContain('/src/App.tsrx#App');
 		expect(normalAgain).not.toContain('/src/App.tsrx#App');
 	}, 30_000);
+
+	it('recompiles an unchanged component after an imported text type changes', async () => {
+		const component = write(
+			root,
+			'src/Typed.tsx',
+			`/** @jsxImportSource octane */
+import type { Label } from './model';
+export function Typed(props: { label: Label }) { return <p>before{props.label}after</p>; }
+`,
+		);
+		write(root, 'src/model.ts', 'export type Label = string;\n');
+		write(root, 'src/text-entry.js', `export { Typed } from './Typed.tsx';\n`);
+		const tsconfig = write(
+			root,
+			'tsconfig.json',
+			JSON.stringify({
+				compilerOptions: {
+					strict: true,
+					target: 'ESNext',
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+					jsx: 'react-jsx',
+					jsxImportSource: 'octane',
+					skipLibCheck: true,
+					types: [],
+				},
+				include: ['src/**/*'],
+			}),
+		);
+		const packageFile = join(root, 'node_modules/octane/package.json');
+		const packageManifest = JSON.parse(readFileSync(packageFile, 'utf8'));
+		packageManifest.exports['./jsx-runtime'] = './jsx-runtime.d.ts';
+		writeFileSync(packageFile, JSON.stringify(packageManifest));
+		write(
+			root,
+			'node_modules/octane/jsx-runtime.d.ts',
+			`export namespace JSX {
+	interface Element { readonly __element: unique symbol }
+	interface IntrinsicElements { [name: string]: any }
+}
+`,
+		);
+		const cacheDirectory = join(root, '.rspack-text-types-cache');
+		const build = async (index: number) => {
+			const stats = await compile({
+				name: 'text-type-import-cache',
+				context: root,
+				mode: 'production',
+				target: 'node',
+				entry: './src/text-entry.js',
+				optimization: { minimize: false },
+				output: { path: join(root, `dist-text-types-${index}`), filename: 'bundle.js' },
+				cache: {
+					type: 'persistent',
+					version: 'user-cache-v1',
+					storage: { type: 'filesystem', directory: cacheDirectory },
+				},
+				plugins: [new OctaneRspackPlugin({ textTypes: { tsconfig } })],
+			});
+			const module = [...stats.compilation.modules].find(
+				(item: any) => item.resource === component,
+			) as any;
+			expect(getOctaneRspackBuildInfo(module)?.transformKind).toBe('compile');
+			const code = module.originalSource()?.source();
+			expect(code).toBeTypeOf('string');
+			return evaluateCompiledFixtureCode(String(code), component, 'server', undefined).Typed;
+		};
+
+		const first = await build(1);
+		const initialHtml = (await renderToString(first, { label: 'first' })).html.replace(
+			/<!--.*?-->/g,
+			'',
+		);
+		expect(initialHtml).toContain('beforefirstafter');
+		// Exercise the boundary of the first build's static string proof to
+		// distinguish it from a syntax-only build before checking invalidation.
+		const { html: oldTypedHtml } = await renderToString(first, { label: true });
+		expect(oldTypedHtml.replace(/<!--.*?-->/g, '')).toContain('beforetrueafter');
+		// The component source is unchanged and its type-only import is absent
+		// from the emitted module graph. A persistent cached text binding would
+		// incorrectly stringify the newly valid boolean child.
+		write(root, 'src/model.ts', 'export type Label = boolean;\n');
+		const second = await build(2);
+		const { html: rendered } = await renderToString(second, { label: true });
+		const html = rendered.replace(/<!--.*?-->/g, '');
+		expect(html).toContain('beforeafter');
+		expect(html).not.toContain('true');
+	}, 60_000);
 
 	it.each(['before', 'after'] as const)(
 		'rejects a conflicting reserved define applied %s the Octane plugin',

--- a/packages/rspack-plugin-octane/tests/shared.test.ts
+++ b/packages/rspack-plugin-octane/tests/shared.test.ts
@@ -195,6 +195,9 @@ describe('declarative options', () => {
 			/thread/,
 		],
 		[{ runtime: '' }, /runtime/],
+		[{ textTypes: true }, /textTypes/],
+		[{ textTypes: { tsconfig: '' } }, /textTypes/],
+		[{ textTypes: { tsconfig: 'tsconfig.json', unknown: true } }, /textTypes/],
 		[{ transform: () => {} }, /unknown option/],
 	] as const)('rejects invalid options %#', (value, message) => {
 		expect(() => normalizePluginOptions(value)).toThrow(message);

--- a/packages/rspack-plugin-octane/types/index.d.ts
+++ b/packages/rspack-plugin-octane/types/index.d.ts
@@ -176,6 +176,17 @@ export interface OctaneRspackLoaderOptions {
 
 export interface OctaneRspackPluginOptions extends OctaneRspackLoaderOptions {
 	/**
+	 * @experimental Prove primitive DOM text children from the TypeScript project
+	 * in one-shot production builds. Relative paths resolve from the plugin root.
+	 * Requires the optional TypeScript peer. Uses one main-thread checker per
+	 * compiler, and typed modules bypass Rspack's persistent module cache so
+	 * imported type edits are observed on the next build. Watch/HMR and
+	 * development builds retain syntax-only classification. Configure the same
+	 * tsconfig and renderers for browser and server compilation.
+	 * @default undefined
+	 */
+	textTypes?: { tsconfig: string };
+	/**
 	 * @experimental Fold proven CSS-module strings in one-shot production builds.
 	 * `true` accepts only pure, initialized named ESM string exports. A provider
 	 * may additionally authenticate immutable exports against the exact completed

--- a/packages/vite-plugin-octane/src/index.js
+++ b/packages/vite-plugin-octane/src/index.js
@@ -221,7 +221,7 @@ function collect_hydrate_module_paths(config) {
  * it). An explicit `profile` (true or false) always takes precedence over
  * `devtools`.
  *
- * @param {{ hmr?: boolean, profile?: boolean, devtools?: boolean, strong?: boolean, exclude?: string[], requireDirective?: boolean, renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions, cssModuleConstants?: import('octane/compiler/vite').OctaneVitePluginOptions['cssModuleConstants'] }} [inlineOptions]
+ * @param {{ hmr?: boolean, profile?: boolean, devtools?: boolean, strong?: boolean, textTypes?: import('octane/compiler/vite').OctaneVitePluginOptions['textTypes'], exclude?: string[], requireDirective?: boolean, renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions, cssModuleConstants?: import('octane/compiler/vite').OctaneVitePluginOptions['cssModuleConstants'] }} [inlineOptions]
  * @returns {Plugin[]}
  */
 export function octane(inlineOptions = {}) {
@@ -881,6 +881,7 @@ export function octane(inlineOptions = {}) {
 	 *   hmr?: boolean,
 	 *   profile?: boolean | 'auto',
 	 *   strong?: boolean,
+	 *   textTypes?: import('octane/compiler/vite').OctaneVitePluginOptions['textTypes'],
 	 *   exclude?: string[],
 	 *   requireDirective?: boolean,
 	 *   renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions,
@@ -894,6 +895,7 @@ export function octane(inlineOptions = {}) {
 	if (inlineOptions.profile !== undefined) compilerOptions.profile = inlineOptions.profile;
 	else if (inlineOptions.devtools === true) compilerOptions.profile = 'auto';
 	if (inlineOptions.strong !== undefined) compilerOptions.strong = inlineOptions.strong;
+	if (inlineOptions.textTypes !== undefined) compilerOptions.textTypes = inlineOptions.textTypes;
 	if (inlineOptions.exclude !== undefined) compilerOptions.exclude = inlineOptions.exclude;
 	if (inlineOptions.requireDirective !== undefined) {
 		compilerOptions.requireDirective = inlineOptions.requireDirective;

--- a/packages/vite-plugin-octane/tests/plugin.test.ts
+++ b/packages/vite-plugin-octane/tests/plugin.test.ts
@@ -183,6 +183,12 @@ describe('isViteOwnedUrl', () => {
 });
 
 describe('octane() plugin factory', () => {
+	it('forwards the typed-text project option to the compiler', () => {
+		expect(() => octane({ textTypes: { tsconfig: ' tsconfig.json ' } })).toThrow(
+			'`textTypes` requires { tsconfig: string }.',
+		);
+	});
+
 	it('types components with the live props-first ABI', () => {
 		const Component: Component<{ value: string }> = (props) => props.value;
 		expect(Component({ value: 'props-first' }, undefined)).toBe('props-first');

--- a/packages/vite-plugin-octane/types/index.d.ts
+++ b/packages/vite-plugin-octane/types/index.d.ts
@@ -17,6 +17,8 @@ export interface OctanePluginOptions {
 	profile?: boolean;
 	/** Assert Strong mode's pure immutable-snapshot render contract for app code. */
 	strong?: boolean;
+	/** TypeScript-backed child-text inference in one-shot production builds. */
+	textTypes?: OctaneVitePluginOptions['textTypes'];
 	/**
 	 * Path fragments the compiler's plain `.ts`/`.js` hook-slotting pass must
 	 * skip. Prefer package manifest `octane.hookSlots.manual` declarations.


### PR DESCRIPTION
## Summary
- Infer primitive DOM text children from safe local syntax, including `Number()`, `BigInt()`, `Date()`, numeric operators, and `typeof`.
- Add optional TypeScript project proofs for primitive string, number, bigint, and their unions during one-shot production builds with Vite, Rspack, and Rsbuild.
- Preserve explicit `as string` text behavior and client/server hydration layout; keep watch/HMR syntax-only.

## Why
Direct primitive DOM children can use Octane's text binding without requiring casts or `String()` calls. The optional checker can prove typed member reads and imported aliases that syntax alone cannot resolve. Numeric proofs stay distinct from string proofs so they do not change concatenation inference.

## Changes
- Source-bound, serializable primitive text ranges in the TypeScript adapter, plus a project root for renderer rule identities.
- Vite and Rspack/Rsbuild opt-in wiring with project lifetime and cache guards; Rspack skips persistent module caching for eligible typed modules.
- Client, server, hydration, option, imported-type invalidation, and watch fallback coverage; compiler guidance and patch changesets.

## Validation
- [x] `pnpm install --frozen-lockfile --registry=https://registry.npmjs.org/` (explicitly authorized), `pnpm sync`, and scoped `pnpm format:files:check`.
- [x] Owning package typechecks and scoped `pnpm typecheck:files` for changed compiler, Vite, Rspack, and Rsbuild files.
- [x] Focused Vitest: 117 core text cases, 77 nearby hydration/compiler cases, 73 Vite cases (four Chromium cases rerun with local browser permission), 86 Rspack cases, and 16 Rsbuild cases.
- [x] `node benchmarks/bench.mjs --quick --ratios text-type-roots`: warm snapshot ratio guard passed; 34-root 0.0016 ms, 20,002-root 0.0018 ms.
- [x] `node --check` on changed JavaScript and `git diff --check`.
- [ ] Full repository `pnpm format:check`, `pnpm typecheck`, and `pnpm test` were not run locally; targeted package gates above cover the changed paths.
- [x] [Current-head CI run 34278249317](https://github.com/octanejs/octane/actions/runs/34278249317) passed on `91bc9a49dfe8bff2b42021185f27445b9e3b7e81` after rerunning a transient Chromium-backed parity worker failure on the same head.
## Risk / follow-ups
- The existing `as string` classification already works on the base; the new test preserves that behavior. Numeric literal static baking is excluded because root static text already has a separate client/server inconsistency.
- Independently configured Rspack browser/server compilers do not have a shared atomic filesystem snapshot if imported types change while both builds run. Use the same tsconfig and stable source tree for both builds.
- The TypeScript warm-snapshot ratio guard passes. No controlled before/after DOM timing was collected, so this PR does not claim a measured speedup.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791492178&installation_model_id=432790&pr_number=1003&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1003&signature=b9eaa5c955e149e28ff7a98d620a85b50698fb4681de4102c98ec84d0288ba8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how DOM children are classified for SSR and hydration; mismatched client/server facts or stale Rspack cache would cause subtle layout bugs, though the PR adds guards and invalidation for the new production path.
> 
> **Overview**
> Extends DOM child **text binding** beyond strings to locally provable **numbers and bigints** (literals, numeric operators, `Number`/`BigInt`/`Date()`/`typeof`, and related syntax), while keeping explicit **`as string`** behavior and separate string vs primitive TypeScript proofs so numeric evidence does not affect string concatenation inference.
> 
> The compiler threads optional **`textTypeFacts`** (now including **`primitiveTextChildRanges`**) through client/server emission and hydration adjacency so both sides agree on text holes vs renderable children.
> 
> **Vite, Rspack, and Rsbuild** gain an opt-in **`textTypes: { tsconfig }`** for **one-shot production** builds: a shared TypeScript project supplies facts to the compiler; dev/HMR/watch stay syntax-only. Vite fails closed if proofs drift between client and server in the same build. Rspack disables parallel compilation and **persistent module caching** for typed Octane modules so imported type changes cannot reuse stale output.
> 
> Docs and types describe the broader primitive domains, safety boundaries (booleans/objects stay renderable), and optional **`root`** on the TS project adapter for renderer rule alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91bc9a49dfe8bff2b42021185f27445b9e3b7e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

