### PR TITLE
perf: avoid cycle set for primitive transport props

### DIFF
--- a/.changeset/lazy-transport-cycle-tracking.md
+++ b/.changeset/lazy-transport-cycle-tracking.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip cycle-tracking allocation for primitive universal host values crossing a transport.

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -6884,7 +6884,7 @@ function runOwnedCommit(owner: UniversalOwnerRecord | null, work: () => void): v
 
 function cloneSerializableValue(
 	value: unknown,
-	seen: WeakSet<object> = new WeakSet(),
+	seen?: WeakSet<object>,
 ): UniversalSerializableValue {
 	if (
 		value === null ||
@@ -6902,6 +6902,7 @@ function cloneSerializableValue(
 	if ((value as Partial<UniversalResourceHandle>).$$kind === 'octane.universal.resource') {
 		throw new TypeError('A resource handle must use the resource encoding branch.');
 	}
+	seen ??= new WeakSet();
 	if (seen.has(value)) throw new TypeError('Serializable host values cannot contain cycles.');
 	seen.add(value);
 	try {

--- a/packages/octane/tests/universal-transport.test.ts
+++ b/packages/octane/tests/universal-transport.test.ts
@@ -841,6 +841,62 @@ describe('universal asynchronous transport', () => {
 		await root.unmountAsync();
 	});
 
+	it.each([false, true])(
+		'transports ordinary values with shared nesting and rejects cycles (codec: %s)',
+		async (withCodec) => {
+			const { container, root } = transportRoot(withCodec);
+			const plan = universalPlan(RENDERER, { kind: 'host', type: 'node', propsSlot: 0 });
+			const Scene = defineUniversalComponent(RENDERER, (props: { payload: unknown }) =>
+				universalValue(plan, [
+					universalProps([
+						['set', 'empty', null],
+						['set', 'missing', undefined],
+						['set', 'label', 'ready'],
+						['set', 'count', 42],
+						['set', 'large', 17n],
+						['set', 'enabled', true],
+						['set', 'disabled', false],
+						['set', 'payload', props.payload],
+					]),
+				]),
+			);
+			const shared = { label: 'shared', values: [1, null] };
+			const payload = {
+				first: shared,
+				repeated: [shared, shared.values],
+				nested: { value: shared },
+			};
+			await root.renderAsync(Scene, { payload });
+			shared.label = 'changed';
+			shared.values[0] = 99;
+
+			const expectedPayload = {
+				first: { label: 'shared', values: [1, null] },
+				repeated: [{ label: 'shared', values: [1, null] }, [1, null]],
+				nested: { value: { label: 'shared', values: [1, null] } },
+			};
+			expect(container.host.children[0].props).toEqual({
+				empty: null,
+				missing: undefined,
+				label: 'ready',
+				count: 42,
+				large: 17n,
+				enabled: true,
+				disabled: false,
+				payload: expectedPayload,
+			});
+			expect(container.host.children[0].props.payload).not.toBe(payload);
+
+			const cycle: Record<string, unknown> = {};
+			cycle.self = cycle;
+			await expect(root.renderAsync(Scene, { payload: cycle })).rejects.toThrow(
+				'Serializable host values cannot contain cycles.',
+			);
+			expect(container.host.children[0].props.payload).toEqual(expectedPayload);
+			await root.unmountAsync();
+		},
+	);
+
 	it('clones plain object props built in another realm across the wire', async () => {
 		// A transported renderer can be handed values whose Object.prototype
 		// belongs to another realm (an engine main thread hosted in an iframe, an


### PR DESCRIPTION
## Summary

- Allocate cycle-tracking state only when a transported host value is an object; primitive props now return before the `WeakSet` is created.
- Cover both the codec and plain transport paths with mixed primitive props, nested shared values, clone isolation, and cycle rejection.

## Why

The universal renderer clones every transported host prop. The default argument to `cloneSerializableValue` allocated a `WeakSet` even when a value was `null`, `undefined`, a string, number, bigint, or boolean. This is the primitive-allocation part of [#981](https://github.com/octanejs/octane/issues/981).

## Changes

- Make the cycle set optional at entry and initialize it after object and resource checks. Recursive object visits share the same set, and the existing `finally` still removes each visited object.
- Add a consumer-level transport regression across both codec modes. Deliberately retaining visited objects makes all four new development/production cases fail when a repeated shared object is encountered; restoring the implementation makes them pass.
- Add an `octane` patch changeset.

## Validation

- [x] `pnpm format:files:check packages/octane/src/universal-core.ts packages/octane/tests/universal-transport.test.ts .changeset/lazy-transport-cycle-tracking.md`
- [x] `pnpm typecheck` (passed locally)
- [ ] `pnpm test` (full suite left to CI)
- [x] `pnpm exec vitest run packages/octane/tests/universal-transport.test.ts packages/octane/tests/universal-renderer.test.ts --reporter=dot` — 266 passed across development and production projects.
- [x] `pnpm typecheck:files packages/octane/src/universal-core.ts`; `pnpm sync`; `git diff --check`.

Production source-bundle ABBA probe on Node 26.4.0/V8 (baseline `ab3236409`, same build inputs): an exact-source serializer probe over 15 rounds × 250,000 primitive calls measured median 0.01773 → 0.00882 µs/call, with nonoverlapping observed ranges. The object-valued control ranges overlapped. Instrumentation counted 256 → 0 `WeakSet` allocations for a 256-primitive-prop transported prepare; object props remained 256 → 256 and local props 0 → 0. Across nine paired public-renderer runs × 700 prepares, the 256-primitive-prop median was 0.06491 → 0.06122 ms, but ranges overlapped, so the end-to-end timing is inconclusive. Command SHA-256 hashes matched for all three workloads; nested clones remained distinct and frozen.

[Current-head CI](https://github.com/octanejs/octane/actions/runs/34282521679) passed all 26 jobs on attempt 2 at `da4c63803985b09be7e26b21e94601a88e958b92`, including parity, package validation, browser integration, and provenance. Attempt 1 could not run a Base UI drawer test file in the broad parity shard; that file passed all 16 tests in a focused adapted-project run, and the same-head parity shard passed on retry. Cursor Bugbot passed without comments.

## Risk / follow-ups

The change only affects transported serialization. Object cycle and sharing semantics remain protected by the same recursion set; the test covers both codec modes and rejected updates. The [#981](https://github.com/octanejs/octane/issues/981) item also calls out the codec context object and closure per prop; that part remains for a separate measured change.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791495928&installation_model_id=432790&pr_number=1004&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1004&signature=bc96e41bc917bce19492a1043f847125fd5e57333f7d3d1a49d7f0944f396a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Serialization behavior for objects is unchanged; only avoids allocations on the primitive fast path, with new transport tests covering both codec modes.
> 
> **Overview**
> **Lazy cycle tracking** for universal host values sent across a transport: `cloneSerializableValue` no longer creates a `WeakSet` on every call—primitives (`null`, `undefined`, strings, numbers, bigints, booleans) return immediately, and the set is created only when cloning object graphs (same sharing/cycle rules as before).
> 
> Adds a transport test (codec on/off) that exercises mixed primitives, nested shared references, frozen clone isolation, and cycle rejection. Includes an `octane` patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4c63803985b09be7e26b21e94601a88e958b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->