### PR TITLE
perf: reuse universal codec resource-handle factory

### DIFF
--- a/.changeset/reuse-universal-codec-handle.md
+++ b/.changeset/reuse-universal-codec-handle.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reuse a root-bound resource handle factory across universal host prop codec calls.

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -7077,6 +7077,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 	private readonly passiveTasks: (() => void)[] = [];
 	private hostAttachments: UniversalHostAttachmentState | null = null;
 	private collapsedTemplates: Set<LogicalRecord> | null = null;
+	private codecResourceHandle: ((id: string | number) => UniversalResourceHandle) | null = null;
 
 	constructor(
 		private readonly container: Container,
@@ -7853,25 +7854,24 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			// value contract even when the renderer did not install a custom codec.
 			return this.transport === null ? value : cloneSerializableValue(value);
 		}
+		const createResourceHandle = (this.codecResourceHandle ??= (id) => {
+			if ((typeof id !== 'string' && typeof id !== 'number') || String(id).length === 0) {
+				throw new TypeError('A universal resource handle ID must be a non-empty string or number.');
+			}
+			return Object.freeze({
+				$$kind: 'octane.universal.resource' as const,
+				renderer: this.renderer,
+				root: this.resourceRoot,
+				id,
+			});
+		});
 		const result = codec.encode({
 			container: this.container,
 			renderer: this.renderer,
 			hostType,
 			name,
 			value,
-			createResourceHandle: (id) => {
-				if ((typeof id !== 'string' && typeof id !== 'number') || String(id).length === 0) {
-					throw new TypeError(
-						'A universal resource handle ID must be a non-empty string or number.',
-					);
-				}
-				return Object.freeze({
-					$$kind: 'octane.universal.resource' as const,
-					renderer: this.renderer,
-					root: this.resourceRoot,
-					id,
-				});
-			},
+			createResourceHandle,
 		});
 		if (result === null || typeof result !== 'object') {
 			throw new TypeError(

--- a/packages/octane/tests/universal-transport.test.ts
+++ b/packages/octane/tests/universal-transport.test.ts
@@ -7,6 +7,9 @@ import {
 	type UniversalAsyncCommitTransport,
 	type UniversalHostBatch,
 	type UniversalHostDriver,
+	type UniversalHostPropCodec,
+	type UniversalHostPropCodecContext,
+	type UniversalResourceHandle,
 	type UniversalSerializableValue,
 	type UniversalTransportAcknowledgement,
 	type UniversalTransportCommitMessage,
@@ -471,14 +474,17 @@ function createLoopback(container: TransportContainer) {
 	return api;
 }
 
-function transportRoot(withCodec = true) {
+function transportRoot(
+	withCodec = true,
+	driver?: UniversalHostDriver<TransportContainer, PublicHandle>,
+) {
 	const container: TransportContainer = {
 		renderer: RENDERER,
 		host: createObjectContainer(RENDERER),
 		publicInstances: new Map(),
 	};
 	const loopback = createLoopback(container);
-	const root = createUniversalRoot(container, createTransportDriver(withCodec), {
+	const root = createUniversalRoot(container, driver ?? createTransportDriver(withCodec), {
 		transport: loopback.transport,
 	});
 	loopback.bindRoot(root);
@@ -839,6 +845,122 @@ describe('universal asynchronous transport', () => {
 		);
 		expect(loopback.sentBatches).toEqual([]);
 		await root.unmountAsync();
+	});
+
+	it('keeps codec context snapshots and borrowed resource handles scoped to their root', async () => {
+		const contexts: UniversalHostPropCodecContext<TransportContainer>[] = [];
+		const codec: UniversalHostPropCodec<TransportContainer> = {
+			encode(context) {
+				contexts.push(context);
+				if (context.name === 'resource') {
+					const value = context.value as { id: string } | UniversalResourceHandle;
+					return {
+						kind: 'resource',
+						handle: '$$kind' in value ? value : context.createResourceHandle(value.id),
+					};
+				}
+				return { kind: 'value', value: context.value as UniversalSerializableValue };
+			},
+		};
+		const driver = {
+			...createTransportDriver(false),
+			props: undefined as UniversalHostPropCodec<TransportContainer> | undefined,
+		};
+		const { container, root } = transportRoot(false, driver);
+		// Drivers may make a codec available after constructing their root.
+		driver.props = codec;
+		const plan = universalPlan(RENDERER, {
+			kind: 'host',
+			type: 'card',
+			propsSlot: 0,
+			children: [{ kind: 'host', type: 'badge', propsSlot: 1 }],
+		});
+		const Scene = defineUniversalComponent(
+			RENDERER,
+			(props: {
+				resource: { id: string } | UniversalResourceHandle;
+				badge: { id: string };
+				label: string;
+			}) =>
+				universalValue(plan, [
+					universalProps([
+						['set', 'resource', props.resource],
+						['set', 'label', props.label],
+					]),
+					universalProps([['set', 'resource', props.badge]]),
+				]),
+		);
+		const firstResource = { id: 'texture-1' };
+		await root.renderAsync(Scene, {
+			resource: firstResource,
+			badge: { id: 'badge-1' },
+			label: 'first',
+		});
+		const initialContexts = contexts.slice();
+		expect(new Set(initialContexts.map((context) => context.createResourceHandle)).size).toBe(1);
+		const cardResource = initialContexts.find(
+			(context) => context.hostType === 'card' && context.name === 'resource',
+		)!;
+		const cardLabel = initialContexts.find(
+			(context) => context.hostType === 'card' && context.name === 'label',
+		)!;
+		const badgeResource = initialContexts.find(
+			(context) => context.hostType === 'badge' && context.name === 'resource',
+		)!;
+		expect(cardResource.value).toBe(firstResource);
+		expect(cardLabel.value).toBe('first');
+		expect(badgeResource.value).toEqual({ id: 'badge-1' });
+
+		const createLaterHandle = cardResource.createResourceHandle;
+		const laterHandle = createLaterHandle('texture-later');
+		await root.renderAsync(Scene, {
+			resource: laterHandle,
+			badge: { id: 'badge-2' },
+			label: 'second',
+		});
+		const updatedContexts = contexts.slice(initialContexts.length);
+		for (const context of updatedContexts) {
+			expect(context.createResourceHandle).toBe(createLaterHandle);
+		}
+		expect(updatedContexts).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ hostType: 'card', name: 'resource', value: laterHandle }),
+				expect.objectContaining({ hostType: 'card', name: 'label', value: 'second' }),
+				expect.objectContaining({
+					hostType: 'badge',
+					name: 'resource',
+					value: { id: 'badge-2' },
+				}),
+			]),
+		);
+		expect(cardResource.value).toBe(firstResource);
+		expect(cardLabel.value).toBe('first');
+		expect(badgeResource.value).toEqual({ id: 'badge-1' });
+		expect(container.host.children[0].props.resource).toMatchObject({
+			id: 'texture-later',
+		});
+
+		const other = transportRoot(false, driver);
+		await expect(
+			other.root.renderAsync(Scene, {
+				resource: laterHandle,
+				badge: { id: 'foreign-badge' },
+				label: 'foreign',
+			}),
+		).rejects.toThrow(/does not belong to renderer .* and this root/);
+		expect(other.container.host.children).toEqual([]);
+		expect(other.loopback.sentBatches).toEqual([]);
+		await other.root.renderAsync(Scene, {
+			resource: { id: 'own-texture' },
+			badge: { id: 'own-badge' },
+			label: 'recovered',
+		});
+		expect(other.container.host.children[0].props.resource).toMatchObject({
+			id: 'own-texture',
+		});
+		expect(contexts.at(-1)!.createResourceHandle).not.toBe(createLaterHandle);
+		await root.unmountAsync();
+		await other.root.unmountAsync();
 	});
 
 	it.each([false, true])(


### PR DESCRIPTION
## Summary

Reuse one root-bound resource-handle factory across universal host prop codec calls. A codec installed after root creation still works, and each call receives a fresh, retainable context snapshot. This is the callback portion of #981's universal transport allocation item.

## Why

The transport encoder created a new resource-handle closure for every coded host prop, even though its only captured state belongs to the root. A codec may retain its context or borrow the factory after the encode call, so the factory must remain bound to the originating root.

## Changes

- Create the factory lazily at the first codec call and reuse it for that root's subsequent props and renders.
- Cover late codec installation, shared factory identity, stable retained contexts, borrowed handles, foreign-root rejection, and recovery in the transport regression.
- Add an `octane` patch changeset.

## Validation

- [ ] `pnpm format:check` (not run; changed-file check below)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (not run; targeted suites below)
- [x] targeted tests: `pnpm exec vitest run packages/octane/tests/universal-transport.test.ts packages/octane/tests/universal-renderer.test.ts --reporter=dot` (268/268 in development and production); transport-only rerun after the factory identity assertions (54/54)
- [x] `pnpm format:files:check packages/octane/src/universal-core.ts packages/octane/tests/universal-transport.test.ts .changeset/reuse-universal-codec-handle.md`; `git diff --check`; `pnpm sync`

On the same production source-bundle harness, 256 coded props produced 256 distinct factories per prepare on merged `main` and one on this branch (one across two prepares). No-codec controls produced zero in both; wire hashes, frozen resource handles, and root stamps matched across five workloads. The full production bundle changed by +68 bytes (797,033 to 797,101). Nine rounds of 400 public `root.prepare()` calls in both bundle orders gave conflicting timing directions, including in no-codec controls, so no end-to-end throughput gain is claimed.

## Risk / follow-ups

This adds one cached callback per codec-using root. The public codec context object remains fresh per prop because codecs may retain its value, host type, and name. Reusing that object would require a separate observable-contract decision; the #981 checklist item stays open.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791498512&installation_model_id=432790&pr_number=1005&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1005&signature=0675b3d4e1e159dd884cf963180a35f0ffcca4f20086d309795f911618e498ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral contract is unchanged aside from stable factory identity per root; validation and wire encoding paths are covered by expanded transport regression tests.
> 
> **Overview**
> **Reuses one root-bound `createResourceHandle` factory** for universal host prop codec encoding instead of allocating a new closure on every coded prop.
> 
> On first `encodeHostProp` with a custom codec, the root lazily caches the factory (`codecResourceHandle`); later encodes pass that same function while each codec call still gets a **fresh context snapshot** (value, host type, name). That keeps late-installed codecs and codecs that retain context or borrow the factory after encode aligned with the originating root.
> 
> Transport tests now cover shared factory identity across props/re-renders, stable retained contexts, borrowed handles, rejection of handles from another root, and recovery on a foreign root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ec99caa31b70e61243a7b549e5ce85f5d63593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->