### PR TITLE
perf: cut universal native hover allocation with lazy replay identities

### DIFF
--- a/.changeset/lazy-universal-owner-replay.md
+++ b/.changeset/lazy-universal-owner-replay.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Build universal owner replay identities only when pending memos need them. Ordinary native renderer updates no longer allocate identity indexes and replay paths for every nested component.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -86,7 +86,7 @@ the three runtime-stress suites vite-build and time each target themselves (the
 runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
 **universal-object-teardown**,
-**universal-template-events**, **universal-external-store**,
+**universal-template-events**, **universal-native-hover**, **universal-external-store**,
 **lynx-render**, **lynx-bundle-size**, **tsrx-renderer-validation-ranges**, and
 **tsrx-local-component-name-catalog** are Node-only,
 **ssr-http** and **tanstack-start** boot (and kill) their own production HTTP
@@ -279,6 +279,7 @@ internally, get their own baseline and guard namespace.
 | `universal-leaf-update` | universal-leaf-update | none (Node-only) | universal update locality beside 0–4,000 unrelated component siblings through the compiler and native object driver: plain leaf `setState`, keyed `@for` item state, a leaf under an idle `@try`, a structural (insert/remove) update, and compact-row list selection |
 | `universal-object-teardown` | universal-object-teardown | none (Node-only) | transactional object-driver unmount scaling at 2, 4,096, and 16,384 flat siblings, with exact remove/destroy and empty-driver controls |
 | `universal-template-events` | universal-template-events | none (Node-only) | shape-stable handler updates across 128 and 1,024 retained native event sites through ordinary hosts and the fallback collapsed-template host capability, with host identity, stable listener IDs, latest-handler dispatch, and redundant-command controls |
+| `universal-native-hover` | universal-native-hover | none (Node-only) | compiled production native universal selection in 20 and 80 keyed rows, each with four component/view layers; 2,000 real hover updates per sample, host and prop identity checks, teardown, a same-run scaling ratio, and optional local V8 cumulative allocation profile |
 | `universal-external-store` | universal-external-store | none (Node-only) | 128 native universal store subscribers, getter/subscribe identity controls, notification bursts, and deterministic subscription-lifetime and state-projection guards |
 | `lynx-render` | lynx-render | none (Node-only) | dual-thread Lynx render CPU: empty startup, create 1,000 and 10,000 keyed rows through the real background root, transport, and main receiver over a cheap fake Element PAPI, plus a gate that a native tap reaches its background handler via the engine `publishEvent` receiver |
 | `lynx-table` | lynx-table | none (Node-only; separate Chromium harness) | deterministic per-operation wire cost of the cross-framework krausest table (command counts and serialized commit bytes vs a changed-rows floor) through the real dual-thread path and real tap tokens |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -400,6 +400,14 @@
     "note": "Eight times as many retained fallback collapsed-template event sites should take no more than 1.5 times linear growth. The optimized node-local cursor measures about 7-8x; the former whole-template search measures about 26x on the same fixture."
   },
   {
+    "suite": "universal-native-hover",
+    "op": "hover_update_ms",
+    "target": "rows-80",
+    "reference": "rows-20",
+    "maxRatio": 8,
+    "note": "Issue #1007's four-layer native universal hover-selection tree grows fourfold in row count and host count (101 to 401), while each event still changes two row props and retains every host. The baseline measured about 4.3x; the 8x ceiling allows noisy same-run timing while rejecting superlinear materialization. The harness separately asserts exact host updates and teardown; V8 allocation profiles are local diagnostics."
+  },
+  {
     "suite": "universal-external-store",
     "op": "lifetime_subscribe_calls",
     "target": "stable-getter",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -861,6 +861,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Issue #1007: compiled native universal row selection with four
+		// component/view layers and real event-driven state updates.
+		name: 'universal-native-hover',
+		cwd: 'universal-native-hover',
+		servers: [],
+		iter: { normal: 7, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Native universal external-store hooks: stable subscription lifetimes and
 		// bounded state-projection work across parent renders and notification bursts.
 		name: 'universal-external-store',

--- a/benchmarks/universal-native-hover/README.md
+++ b/benchmarks/universal-native-hover/README.md
@@ -1,0 +1,49 @@
+# Native universal hover updates
+
+This Node-only suite follows issue #1007's small native renderer workload:
+20 rows, four component and `view` layers around each row, and 2,000 hover
+events that select successive rows. It compiles JSX in production mode for the
+public `octane/universal/native` renderer and uses the public object host driver.
+An 80-row variant checks the cost of increasing the same component depth and
+number of hosts fourfold.
+
+Each sample keeps the tree mounted, dispatches 2,000 native host events, and
+flushes the resulting state update. The harness verifies the original 101 or
+401 host identities, four view layers per row, correct selected props, exactly
+two changed row props on a separate event, and complete host teardown. It
+clears the object driver's diagnostic `commits` history after every event;
+otherwise that history retains every accepted host batch and can look like a
+renderer memory leak. Mount, validation, and teardown are outside timed samples.
+
+```bash
+node benchmarks/universal-native-hover/run.mjs 7
+node benchmarks/bench.mjs --quick --ratios universal-native-hover
+```
+
+To compare immutable production builds without rebuilding the current source,
+copy the complete `packages/octane/dist` directory into a package root that
+provides the same `package.json` imports, parser source, and `node_modules`,
+then supply its path:
+
+```bash
+BENCH_OCTANE_DIST=/absolute/path/to/old-package/dist node benchmarks/universal-native-hover/run.mjs 7
+```
+
+For a local **cumulative allocation diagnostic**, write a V8 Inspector
+sampling profile. The 2 KiB sampler includes objects collected by both minor
+and major GC, so its sum estimates allocated bytes during the first warmed
+20-row, 2,000-hover sample. It also prints the largest allocation stacks. A
+profiled timing sample is distorted by instrumentation; compare normal runs
+for latency, and use the same Node version, sampling options, and host for
+allocation comparisons. The profile is local and may be large.
+
+```bash
+BENCH_ALLOCATION_JSON=/private/tmp/native-hover-allocation.json \
+  node benchmarks/universal-native-hover/run.mjs 1
+```
+
+The ratio guard permits at most twice linear growth from 20 to 80 rows. This
+checks scaling on the same machine and run; it cannot prove a reduction in
+constant cost. The object driver's transactional simulation is part of the
+measured public host path. Node/V8 sampling cannot reproduce Hermes's exact
+garbage collector, allocation accounting, native GPU work, or event transport.

--- a/benchmarks/universal-native-hover/run.mjs
+++ b/benchmarks/universal-native-hover/run.mjs
@@ -1,0 +1,292 @@
+// Issue #1007: a compiled native universal tree with four view layers per row.
+// Mount, validation, and teardown stay outside the update timing samples.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { Session } from 'node:inspector';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const ROOT = import.meta.dirname;
+const REPO = path.resolve(ROOT, '../..');
+const rawIterations = process.argv[2] ?? '7';
+const iterations = Number(rawIterations);
+assert.ok(Number.isSafeInteger(iterations) && iterations > 0, 'Expected positive iterations');
+const allocationProfilePath = process.env.BENCH_ALLOCATION_JSON;
+const profileAllocations = allocationProfilePath !== undefined;
+
+const DIST = path.resolve(process.env.BENCH_OCTANE_DIST ?? path.join(REPO, 'packages/octane/dist'));
+if (!process.env.BENCH_OCTANE_DIST) {
+	const build = spawnSync('pnpm', ['--filter', 'octane', 'build'], {
+		cwd: REPO,
+		stdio: 'inherit',
+	});
+	assert.equal(build.status, 0, 'The octane package build failed');
+}
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-universal-native-hover-'));
+let payload;
+
+const appSource = `
+import { useState } from 'octane';
+
+function Fourth({ id, selected, onHover }) {
+  return <view depth={4}><row id={id} selected={selected} onHover={onHover} /></view>;
+}
+function Third({ id, selected, onHover }) {
+  return <view depth={3}><Fourth id={id} selected={selected} onHover={onHover} /></view>;
+}
+function Second({ id, selected, onHover }) {
+  return <view depth={2}><Third id={id} selected={selected} onHover={onHover} /></view>;
+}
+function First({ id, selected, onHover }) {
+  return <view depth={1}><Second id={id} selected={selected} onHover={onHover} /></view>;
+}
+export default function App({ size }) {
+  const [active, setActive] = useState(-1);
+  return <scene>{Array.from({ length: size }, (_, id) =>
+    <First key={id} id={id} selected={active === id} onHover={() => setActive(id)} />
+  )}</scene>;
+}
+`;
+
+try {
+	const { compile } = await import(pathToFileURL(path.join(DIST, 'compiler/index.js')).href);
+	const runtimeUrl = pathToFileURL(path.join(DIST, 'universal-native.js')).href;
+	fs.writeFileSync(
+		path.join(temporary, 'runtime.mjs'),
+		`export * from ${JSON.stringify(runtimeUrl)};\n`,
+	);
+	const compiled = compile(appSource, 'native-hover.jsx', {
+		mode: 'client',
+		dev: false,
+		hmr: false,
+		renderer: {
+			id: 'object',
+			module: './runtime.mjs',
+			target: 'universal',
+			server: 'unsupported',
+			text: 'host',
+			capabilities: [],
+		},
+	});
+	assert.deepEqual(compiled.diagnostics ?? [], [], 'The production fixture must compile');
+	fs.writeFileSync(path.join(temporary, 'app.mjs'), compiled.code);
+	const { createObjectContainer, createObjectDriver, createUniversalRoot, flushUniversalSync } =
+		await import(runtimeUrl);
+	const { default: App } = await import(pathToFileURL(path.join(temporary, 'app.mjs')).href);
+	const eventPayload = Object.freeze({});
+	const sizes = [20, 80];
+	const warmupEvents = 100;
+	const eventsPerSample = 2_000;
+	const fixtures = new Map();
+	const failures = [];
+	let allocationProfile = null;
+	const inspector = profileAllocations ? new Session() : null;
+	const post = (method, params = {}) =>
+		new Promise((resolve, reject) =>
+			inspector.post(method, params, (error, result) => (error ? reject(error) : resolve(result))),
+		);
+
+	function check(condition, message) {
+		if (!condition) failures.push(message);
+	}
+
+	function hostRows(scene) {
+		return scene.children.map((first) => first.children[0].children[0].children[0].children[0]);
+	}
+
+	function verify(fixture, stage) {
+		const { container, scene, rows, size, selected } = fixture;
+		check(container.children[0] === scene, `${stage}: scene lost identity`);
+		check(container.instanceCount === 1 + size * 5, `${stage}: host count changed`);
+		check(scene.children.length === size, `${stage}: row count changed`);
+		for (let index = 0; index < size; index++) {
+			let view = scene.children[index];
+			for (let depth = 1; depth <= 4; depth++) {
+				check(
+					view.type === 'view' && view.props.depth === depth,
+					`${stage}: view ${index}/${depth} changed`,
+				);
+				check(
+					view === fixture.views[index][depth - 1],
+					`${stage}: view ${index}/${depth} lost identity`,
+				);
+				view = view.children[0];
+			}
+			check(view === rows[index], `${stage}: row ${index} lost identity`);
+			check(view.type === 'row' && view.props.id === index, `${stage}: row ${index} changed`);
+			check(
+				view.props.selected === (index === selected),
+				`${stage}: row ${index} selection is wrong`,
+			);
+		}
+	}
+
+	function press(fixture, index, retainCommit = false) {
+		flushUniversalSync(() =>
+			fixture.container.dispatchEvent(fixture.rows[index], 'hover', eventPayload),
+		);
+		fixture.selected = index;
+		// The object driver's public diagnostic ledger holds complete historical batches.
+		// A native host does not retain them, so release each one during the workload.
+		if (!retainCommit) fixture.container.commits.length = 0;
+	}
+
+	for (const size of sizes) {
+		const container = createObjectContainer('object');
+		const root = createUniversalRoot(container, createObjectDriver('object'));
+		flushUniversalSync(() => root.render(App, { size }));
+		const scene = container.children[0];
+		assert.equal(scene?.type, 'scene', 'Expected the compiled scene host');
+		const views = scene.children.map((first) => {
+			const chain = [];
+			let view = first;
+			for (let depth = 0; depth < 4; depth++) {
+				chain.push(view);
+				view = view.children[0];
+			}
+			return chain;
+		});
+		const fixture = {
+			container,
+			root,
+			scene,
+			views,
+			rows: hostRows(scene),
+			size,
+			selected: -1,
+			samples: [],
+		};
+		verify(fixture, `mount-${size}`);
+		for (let index = 0; index < warmupEvents; index++) press(fixture, index % size);
+		verify(fixture, `warmup-${size}`);
+		fixtures.set(size, fixture);
+	}
+
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		for (const size of iteration % 2 === 0 ? sizes : [...sizes].reverse()) {
+			const fixture = fixtures.get(size);
+			if (profileAllocations && iteration === 0 && size === 20) {
+				inspector.connect();
+				await post('HeapProfiler.enable');
+				await post('HeapProfiler.startSampling', {
+					samplingInterval: 2_048,
+					includeObjectsCollectedByMajorGC: true,
+					includeObjectsCollectedByMinorGC: true,
+				});
+			}
+			const start = performance.now();
+			for (let event = 0; event < eventsPerSample; event++) {
+				press(fixture, (event + iteration) % size);
+			}
+			fixture.samples.push((performance.now() - start) / eventsPerSample);
+			if (profileAllocations && iteration === 0 && size === 20) {
+				allocationProfile = (await post('HeapProfiler.stopSampling')).profile;
+				inspector.disconnect();
+			}
+			verify(fixture, `sample-${size}-${iteration}`);
+		}
+	}
+
+	const targets = [];
+	for (const size of sizes) {
+		const fixture = fixtures.get(size);
+		const previouslySelected = fixture.selected;
+		const nextSelected = (previouslySelected + 1) % size;
+		press(fixture, nextSelected, true);
+		const lastBatch = fixture.container.commits.at(-1);
+		const commands = lastBatch?.commands ?? [];
+		const updates = commands.filter((command) => command.op === 'update');
+		const selectedWrites = updates.filter((command) => 'selected' in command.props);
+		const structuralCommands = commands.filter((command) =>
+			['create', 'recreate', 'insert', 'move', 'remove', 'destroy'].includes(command.op),
+		);
+		check(fixture.container.commits.length === 1, `probe-${size}: expected one accepted commit`);
+		check(structuralCommands.length === 0, `probe-${size}: hover changed the host structure`);
+		check(
+			updates.length === 2 && selectedWrites.length === 2,
+			`probe-${size}: hover should update only the old and new selected rows`,
+		);
+		check(
+			fixture.rows[previouslySelected].props.selected === false &&
+				fixture.rows[nextSelected].props.selected === true,
+			`probe-${size}: old/new row props were not updated`,
+		);
+		verify(fixture, `probe-${size}`);
+		fixture.container.commits.length = 0;
+		const stats = summarizeSamples(fixture.samples);
+		targets.push({
+			name: `rows-${size}`,
+			ops: { hover_update_ms: timingStatForJson(stats) },
+			meta: {
+				rows: size,
+				viewsPerRow: 4,
+				hostInstances: fixture.container.instanceCount,
+				retainedRows: fixture.rows.length,
+				selected: fixture.selected,
+				events: warmupEvents + iterations * eventsPerSample + 1,
+				hoverUpdateCommands: updates.length,
+				selectedPropWrites: selectedWrites.length,
+				structuralCommands: structuralCommands.length,
+				commitsRetained: fixture.container.commits.length,
+			},
+		});
+		fixture.root.unmount();
+		check(fixture.container.children.length === 0, `unmount-${size}: visible hosts remain`);
+		check(fixture.container.instanceCount === 0, `unmount-${size}: host instances remain`);
+		check(
+			fixture.container.commits.at(-1)?.commands.filter((command) => command.op === 'destroy')
+				.length ===
+				1 + size * 5,
+			`unmount-${size}: missing host destroy commands`,
+		);
+	}
+
+	payload = {
+		suite: 'universal-native-hover',
+		iterations,
+		targets,
+		...(failures.length ? { failed: failures.join(' | ') } : null),
+	};
+	if (allocationProfile !== null) {
+		fs.writeFileSync(allocationProfilePath, `${JSON.stringify(allocationProfile)}\n`);
+		const hot = [];
+		function visit(node, stack) {
+			const name = node.callFrame.functionName || '(anonymous)';
+			const next = [...stack, name];
+			if (node.selfSize) hot.push({ bytes: node.selfSize, stack: next.join(' > ') });
+			for (const child of node.children) visit(child, next);
+		}
+		visit(allocationProfile.head, []);
+		hot.sort((a, b) => b.bytes - a.bytes);
+		console.log('Top sampled allocation stacks (estimated bytes):');
+		for (const item of hot.slice(0, 12)) console.log(`${item.bytes}\t${item.stack}`);
+	}
+	console.log('| target | hosts | ms per hover |');
+	console.log('| --- | ---: | ---: |');
+	for (const target of targets) {
+		console.log(
+			`| ${target.name} | ${target.meta.hostInstances} | ${target.ops.hover_update_ms.score.toFixed(3)} |`,
+		);
+	}
+	if (failures.length) {
+		console.error(failures.join('\n'));
+		process.exitCode = 1;
+	}
+} catch (error) {
+	const message = error instanceof Error ? error.stack || error.message : String(error);
+	payload = { suite: 'universal-native-hover', iterations, targets: [], failed: message };
+	console.error(message);
+	process.exitCode = 1;
+} finally {
+	fs.rmSync(temporary, { recursive: true, force: true });
+}
+
+if (process.env.BENCH_JSON)
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, 2)}\n`);

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -108,6 +108,7 @@ export const BENCHMARK_SUITES = [
 	'universal-leaf-update',
 	'universal-object-teardown',
 	'universal-template-events',
+	'universal-native-hover',
 	'universal-external-store',
 	'lynx-render',
 	'lynx-table',

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -1176,7 +1176,11 @@ interface DraftOwner {
 	componentProps: any;
 	componentRevision: number;
 	parent: DraftOwner | null;
-	replayPath: readonly SuspendedOwnerSegment[];
+	// Built only when a pending memo needs to be matched across a replay.
+	replayPath: readonly SuspendedOwnerSegment[] | null;
+	// The claim chain survives a render-phase retry or a held boundary replacing
+	// parent.children, so unkeyed sibling ordinals remain the same on replay.
+	priorClaimedSibling: DraftOwner | null;
 	hooks: Map<unknown, UniversalHook>;
 	clonedHooks: Set<unknown>;
 	seenEffects: EffectHook[];
@@ -1193,7 +1197,6 @@ interface DraftOwner {
 	sequentialClaimCursor: number;
 	childOwnerBuckets: OwnerIdentityIndex<UniversalOwnerRecord[]> | null;
 	childClaimCursors: OwnerIdentityIndex<number> | null;
-	childReplayOrdinals: OwnerIdentityIndex<number> | null;
 	contextValues: Map<UniversalContext<any>, unknown> | null;
 	appliedUpdates: Map<unknown, AppliedUniversalHookUpdates>;
 	needsRender: boolean;
@@ -2236,7 +2239,7 @@ function createOwnerRecord(
 function draftOwner(
 	record: UniversalOwnerRecord,
 	parent: DraftOwner | null,
-	replayPath: readonly SuspendedOwnerSegment[],
+	replayPath: readonly SuspendedOwnerSegment[] | null,
 ): DraftOwner {
 	return {
 		record,
@@ -2244,6 +2247,7 @@ function draftOwner(
 		componentRevision: record.componentRevision,
 		parent,
 		replayPath,
+		priorClaimedSibling: parent?.children[parent.children.length - 1] ?? null,
 		hooks: new Map(record.hooks),
 		clonedHooks: new Set(),
 		seenEffects: [],
@@ -2253,7 +2257,6 @@ function draftOwner(
 		sequentialClaimCursor: 0,
 		childOwnerBuckets: null,
 		childClaimCursors: null,
-		childReplayOrdinals: null,
 		contextValues: record.contextValues === null ? null : new Map(record.contextValues),
 		appliedUpdates: new Map(),
 		needsRender: false,
@@ -2268,16 +2271,35 @@ function draftOwner(
 	};
 }
 
-function childReplayPath(
-	parent: DraftOwner,
-	component: UniversalComponent<any> | null,
-	identityPath: readonly unknown[],
-	key: unknown,
-): readonly SuspendedOwnerSegment[] {
-	const ordinals = (parent.childReplayOrdinals ??= createOwnerIdentityIndex());
-	const ordinal = readOwnerIdentity(ordinals, component, identityPath, key) ?? 0;
-	writeOwnerIdentity(ordinals, component, identityPath, key, ordinal + 1);
-	return [...parent.replayPath, { component, identityPath, key, ordinal }];
+function ownerReplayPath(owner: DraftOwner): readonly SuspendedOwnerSegment[] {
+	if (owner.replayPath !== null) return owner.replayPath;
+	const record = owner.record;
+	let ordinal = 0;
+	// Claims of the same component at the same site may be unkeyed. Their
+	// encounter order distinguishes pending memos during a Suspense replay.
+	for (
+		let sibling = owner.priorClaimedSibling;
+		sibling !== null;
+		sibling = sibling.priorClaimedSibling
+	) {
+		const previous = sibling.record;
+		if (
+			previous.component === record.component &&
+			Object.is(previous.key, record.key) &&
+			identityPathsEqual(previous.identityPath, record.identityPath)
+		) {
+			ordinal++;
+		}
+	}
+	return (owner.replayPath = [
+		...ownerReplayPath(owner.parent!),
+		{
+			component: record.component,
+			identityPath: record.identityPath,
+			key: record.key,
+			ordinal,
+		},
+	]);
 }
 
 function childOwnerBucket(
@@ -2358,7 +2380,7 @@ function adoptChildOwner(
 ): DraftOwner {
 	const attempt = currentAttempt();
 	parent.claimedChildren.add(record);
-	const draft = draftOwner(record, parent, childReplayPath(parent, component, identityPath, key));
+	const draft = draftOwner(record, parent, null);
 	parent.children.push(draft);
 	attempt.owners.push(draft);
 	return draft;
@@ -2490,7 +2512,6 @@ function executeOwner(
 		owner.claimedChildren = new Set();
 		owner.sequentialClaimCursor = 0;
 		owner.childClaimCursors = null;
-		owner.childReplayOrdinals = null;
 		owner.contextStable = null;
 		owner.needsRender = false;
 		owner.implicitSlot = 0;
@@ -2735,7 +2756,6 @@ function resetDraftChildren(owner: DraftOwner): void {
 	owner.claimedChildren = new Set();
 	owner.sequentialClaimCursor = 0;
 	owner.childClaimCursors = null;
-	owner.childReplayOrdinals = null;
 }
 
 function retainCommittedOwnerTree(owner: DraftOwner): void {
@@ -2748,13 +2768,8 @@ function retainCommittedOwnerTree(owner: DraftOwner): void {
 	owner.claimedChildren = new Set(owner.record.children);
 	owner.sequentialClaimCursor = 0;
 	owner.childClaimCursors = null;
-	owner.childReplayOrdinals = null;
 	for (const childRecord of owner.record.children) {
-		const child = draftOwner(
-			childRecord,
-			owner,
-			childReplayPath(owner, childRecord.component, childRecord.identityPath, childRecord.key),
-		);
+		const child = draftOwner(childRecord, owner, null);
 		owner.children.push(child);
 		currentAttempt().owners.push(child);
 		retainCommittedOwnerTree(child);
@@ -2844,11 +2859,7 @@ function retainCommittedTryArm(owner: DraftOwner): BlueprintNode[] | null {
 	const range = findLogicalRange(owner.record.root.rootRecordForRetention(), childRecord.rangeKey);
 	if (range === null) return null;
 	resetDraftChildren(owner);
-	const child = draftOwner(
-		childRecord,
-		owner,
-		childReplayPath(owner, childRecord.component, childRecord.identityPath, childRecord.key),
-	);
+	const child = draftOwner(childRecord, owner, null);
 	owner.children.push(child);
 	owner.claimedChildren.add(childRecord);
 	currentAttempt().owners.push(child);
@@ -2875,6 +2886,7 @@ function retainCommittedActivity(owner: DraftOwner): BlueprintNode[] {
 		: null;
 	resetDraftChildren(owner);
 	const retained = draftOwner(record, parent, owner.replayPath);
+	retained.priorClaimedSibling = owner.priorClaimedSibling;
 	retained.visibility = owner.visibility;
 	retained.canHandleSuspense = owner.canHandleSuspense;
 	retained.boundaryThenable = owner.boundaryThenable;
@@ -4796,7 +4808,7 @@ function findSuspendedMemo(
 		if (
 			Object.is(entry.slot, slot) &&
 			depsEqual(entry.deps, deps) &&
-			suspendedOwnerPathEqual(entry.ownerPath, owner.replayPath)
+			suspendedOwnerPathEqual(entry.ownerPath, ownerReplayPath(owner))
 		) {
 			return entry;
 		}
@@ -4821,13 +4833,13 @@ function collectSuspendedMemos(attempt: RenderAttempt): readonly SuspendedMemoEn
 				entries.some(
 					(entry) =>
 						Object.is(entry.slot, slot) &&
-						suspendedOwnerPathEqual(entry.ownerPath, owner.replayPath),
+						suspendedOwnerPathEqual(entry.ownerPath, ownerReplayPath(owner)),
 				)
 			) {
 				continue;
 			}
 			entries.push({
-				ownerPath: owner.replayPath,
+				ownerPath: ownerReplayPath(owner),
 				slot,
 				deps: hook.deps,
 				value: hook.value,

--- a/packages/octane/tests/universal-semantics-regressions.test.ts
+++ b/packages/octane/tests/universal-semantics-regressions.test.ts
@@ -6,10 +6,14 @@ import {
 	createUniversalRoot,
 	defineUniversalComponent,
 	rendererRegion,
+	universalComponent,
 	universalFor,
 	universalKey,
 	universalPlan,
+	universalTry,
 	universalValue,
+	use as useUniversal,
+	useMemo as useUniversalMemo,
 	useState as useUniversalState,
 	type ObjectHostInstance,
 	type RendererRegion,
@@ -439,6 +443,74 @@ describe('universal runtime semantic regressions', () => {
 		expect(instances(container, 'keyed-result').map((child) => child.props.value)).toEqual([
 			'value-a',
 			'value-b',
+		]);
+		root.unmount();
+	});
+
+	it('replays pending memos for distinct nested siblings after a render-phase retry', async () => {
+		const { container, root } = objectRoot();
+		const requests = new Map<string, ReturnType<typeof deferred<string>>[]>();
+		const load = vi.fn((id: string) => {
+			const request = deferred<string>();
+			const entries = requests.get(id) ?? [];
+			entries.push(request);
+			requests.set(id, entries);
+			return request.promise;
+		});
+		const resultPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'sibling-result',
+			bindings: [
+				['id', 0],
+				['value', 1],
+			],
+		});
+		const pendingPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'sibling-pending',
+			bindings: [['id', 0]],
+		});
+		const scenePlan = universalPlan('object', {
+			kind: 'host',
+			type: 'sibling-scene',
+			children: [
+				{ kind: 'slot', slot: 0 },
+				{ kind: 'slot', slot: 1 },
+			],
+		});
+		const Sibling = defineUniversalComponent('object', ({ id }: { id: string }) => {
+			const request = useUniversalMemo(() => load(id), [], 'shared-request');
+			return universalValue(resultPlan, [id, useUniversal(request)]);
+		});
+		const Scene = defineUniversalComponent('object', () => {
+			const [pass, setPass] = useUniversalState(0, 'pass');
+			if (pass === 0) setPass(1);
+			const child = (id: string) =>
+				universalTry(
+					() => universalComponent('object', Sibling, { id }),
+					() => universalValue(pendingPlan, [id]),
+				);
+			return universalValue(scenePlan, [child('a'), child('b')]);
+		});
+
+		root.render(Scene, undefined);
+		expect(instances(container, 'sibling-pending').map((child) => child.props.id)).toEqual([
+			'a',
+			'b',
+		]);
+		const initialRequests = load.mock.calls.length;
+		expect(requests.get('a')?.length).toBeGreaterThan(0);
+		expect(requests.get('b')?.length).toBeGreaterThan(0);
+		for (const [id, entries] of requests) {
+			for (const [index, request] of entries.entries()) request.resolve(`${id}:${index}`);
+		}
+		await flushMicrotasks();
+
+		expect(load).toHaveBeenCalledTimes(initialRequests);
+		expect(instances(container, 'sibling-pending')).toHaveLength(0);
+		expect(instances(container, 'sibling-result').map((child) => child.props.value)).toEqual([
+			`a:${requests.get('a')!.length - 1}`,
+			`b:${requests.get('b')!.length - 1}`,
 		]);
 		root.unmount();
 	});


### PR DESCRIPTION
## Summary

- Defer universal owner replay identity construction until a suspended memo needs matching. Ordinary native updates no longer allocate an identity index and a path array for every nested component.
- Preserve unkeyed sibling encounter ordinals across render-phase retries and retained boundary owners; add a public object-driver regression for distinct nested pending memos.
- Add a compiled native hover benchmark with 20 and 80 rows, four view layers per row, 2,000 real events per sample, host identity and prop checks, teardown checks, and a scaling guard. Register the suite in the MCP server's benchmark list.

## Why

Issue #1007 reports 3.88 GB cumulative JavaScript allocation and heavy Hermes GC in a 20-row native hover workload. The renderer was eagerly building replay identities for every owner on every update even when no memo suspended. That work is now paid only by pending memo replay.

## Performance evidence

On Node 26.4.0/V8, macOS arm64, in the same public compiled object-driver workload and with the same 2 KiB Inspector allocation sampler (including objects collected by GC), a warmed 20-row, 2,000-hover sample allocated an estimated **2,334,311,200 → 1,495,282,392 bytes** (−839,028,808 bytes; **−35.9%**). These were separate immutable production builds from `f86fb48c` and the original lazy-replay diff, before #1009 merged. Both runs verified stable host structure, correct selection, and teardown. The 80/20 same-run hover timing ratio on this branch was 4.97 against an 8.0 guard; concurrent local tests made absolute timings noisy. Built `universal-core.js` changed by +50 raw bytes and +63 gzip bytes. After merging #1009, both production benchmark suites passed their semantic controls; the hover 80/20 timing ratio was 4.24 against the 8.0 guard.

## Validation

- [x] `pnpm sync` — no generated changes, including after merging current `main` (`0ba4016c`).
- [x] `pnpm format:files:check` on changed files.
- [x] `./node_modules/.bin/vitest run packages/octane/tests/universal*.test.ts --reporter=dot` — 714/714 tests in dev and production after the final runtime edit.
- [x] `./node_modules/.bin/vitest run packages/octane-mcp-server/src/index.test.js --reporter=dot` — 15/15 tests after adding the suite list entry.
- [x] Post-merge `./node_modules/.bin/vitest run packages/octane/tests/universal*.test.ts packages/octane-mcp-server/src/index.test.js --reporter=dot` — 731/731 tests across 37 files.
- [x] `pnpm --filter octane exec tsrx-tsc --noEmit --project tsconfig.json`.
- [x] `BENCH_OCTANE_DIST=<production dist> BENCH_ALLOCATION_JSON=<profile> node benchmarks/universal-native-hover/run.mjs 1` — both pinned builds passed semantic checks and yielded the profiles above.
- [x] `pnpm format:check`.
- [x] `pnpm typecheck`.
- [ ] `pnpm test` — full local run encounters macOS Chromium sandbox launch failures (`MachPortRendezvousServer` permission denied); targeted native suite and CI are the relevant gates. The run also exposed the benchmark list omission, now fixed and retested.

## Risk / follow-ups

- The issue's standalone Hermes harness is unavailable. V8 allocation estimates are not Hermes GC evidence. The candidate still allocates about 1.50 GB in this diagnostic workload, so this PR is a measured reduction rather than parity with Solid; #1007 should remain open for further owner/materialization work and a Hermes rerun.
- Fresh callback props in the row fixture require all 20 row components to render on each hover under current semantics. The separate draft collection optimization merged in #1009 and is included through the merge commit; this PR diff remains focused on lazy replay identities.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791534720&installation_model_id=432790&pr_number=1010&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1010&signature=8761feeb295d07b59cf366b0190bd52807e76a82974c6292f2022640ffdca484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes universal-core Suspense memo replay identity construction; incorrect ordinals or lazy paths could mis-associate pending memos across siblings or retries, though new and existing universal tests target this.
> 
> **Overview**
> Defers building universal **owner replay paths** until Suspense needs to match a pending memo (`findSuspendedMemo` / `collectSuspendedMemos` call `ownerReplayPath`). Ordinary native updates no longer eagerly maintain `childReplayOrdinals` or a replay segment for every nested owner claim.
> 
> **Unkeyed sibling ordinals** for replay matching now come from a `priorClaimedSibling` claim chain (including retained Activity owners), replacing per-render identity-index updates. A semantics regression covers **distinct nested pending memos** after a render-phase retry.
> 
> Adds the **`universal-native-hover`** Node benchmark (issue #1007): compiled 20/80-row, four-layer hover selection with correctness probes, an 80/20 timing ratio guard, and runner/MCP registration. Patch changeset documents the allocation win.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf1ed36d2a55dcb80bd90be6b9d44079b6a8e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


