### PR TITLE
perf: index cross-owner universal draft lookups

### DIFF
--- a/.changeset/lazy-universal-draft-lookup.md
+++ b/.changeset/lazy-universal-draft-lookup.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Index universal owner drafts only when a render reads an earlier owner's hook or ref, preserving fast reads of the newest draft and the latest draft after retries.
+Expose the new universal draft lookup benchmark in the MCP suite catalog.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,6 +87,7 @@ runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
 **universal-object-teardown**,
 **universal-template-events**, **universal-native-hover**, **universal-owner-drafts**,
+**universal-draft-lookup**,
 **universal-external-store**,
 **lynx-render**, **lynx-bundle-size**, **tsrx-renderer-validation-ranges**, and
 **tsrx-local-component-name-catalog** are Node-only,
@@ -282,6 +283,7 @@ internally, get their own baseline and guard namespace.
 | `universal-template-events` | universal-template-events | none (Node-only) | shape-stable handler updates across 128 and 1,024 retained native event sites through ordinary hosts and the fallback collapsed-template host capability, with host identity, stable listener IDs, latest-handler dispatch, and redundant-command controls |
 | `universal-native-hover` | universal-native-hover | none (Node-only) | compiled production native universal selection in 20 and 80 keyed rows, each with four component/view layers; 2,000 real hover updates per sample, host and prop identity checks, teardown, a same-run scaling ratio, and optional local V8 cumulative allocation profile |
 | `universal-owner-drafts` | universal-owner-drafts | none (Node-only) | retained object-driver roots with 0, 1, 128, and 1,024 changed-prop child owners; output, render, host identity, and structural-command controls |
+| `universal-draft-lookup` | universal-draft-lookup | none (Node-only) | root-owned ref lookups from 0, 1, 128, and 1,024 changing child owners, with own-ref and plain-object controls and host, state, and structural-command checks |
 | `universal-external-store` | universal-external-store | none (Node-only) | 128 native universal store subscribers, getter/subscribe identity controls, notification bursts, and deterministic subscription-lifetime and state-projection guards |
 | `lynx-render` | lynx-render | none (Node-only) | dual-thread Lynx render CPU: empty startup, create 1,000 and 10,000 keyed rows through the real background root, transport, and main receiver over a cheap fake Element PAPI, plus a gate that a native tap reaches its background handler via the engine `publishEvent` receiver |
 | `lynx-table` | lynx-table | none (Node-only; separate Chromium harness) | deterministic per-operation wire cost of the cross-framework krausest table (command counts and serialized commit bytes vs a changed-rows floor) through the real dual-thread path and real tap tokens |

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -879,6 +879,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Universal draft lookup (Node-only): ancestor-owned refs read across
+		// 128 and 1,024 child owners, with own-ref and plain-property controls.
+		name: 'universal-draft-lookup',
+		cwd: 'universal-draft-lookup',
+		servers: [],
+		iter: { normal: 7, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Native universal external-store hooks: stable subscription lifetimes and
 		// bounded state-projection work across parent renders and notification bursts.
 		name: 'universal-external-store',

--- a/benchmarks/universal-draft-lookup/README.md
+++ b/benchmarks/universal-draft-lookup/README.md
@@ -1,0 +1,28 @@
+# Universal draft lookup
+
+This Node-only benchmark uses public universal object roots with 0, 1, 128,
+or 1,024 keyed child owners. Every accepted update changes each child's
+`version` prop, so unchanged-owner retention cannot skip the measured work.
+The scene creates a ref. Each child reads and writes that earlier owner's
+`ref.current`, which places the requested owner farther from the end of the
+draft list as siblings render.
+
+The `own-ref` control reads and writes each child's own ref, whose draft is the
+most recently appended owner. The `plain-property` control performs the same
+sequenced reads and writes on an ordinary object without a hook. A zero-child
+scene measures root-only work. `single-ancestor-read` makes only the last child
+of the wide tree read the ancestor once per update; it measures the cost of
+building an index for an isolated lookup. Each mode checks the version sequence,
+accepted commits, host identities, ref identity and values, structural commands,
+and unmount cleanup. Renderables for each sampled update are built before timing.
+
+```bash
+node benchmarks/universal-draft-lookup/run.mjs 7
+```
+
+Set `BENCH_RUNTIME_URL` to an absolute `file:` URL for a previously built
+production `dist/universal.js` to compare the same frozen baseline against a
+candidate without rebuilding it. `BENCH_JSON` writes benchmark-schema results
+for paired comparisons. Times include component execution, reconciliation and
+the object driver; controls identify shared work. The harness does not measure
+browser, native-device, paint, or full-application throughput.

--- a/benchmarks/universal-draft-lookup/run.mjs
+++ b/benchmarks/universal-draft-lookup/run.mjs
@@ -1,0 +1,270 @@
+// Public object-root updates with changed child props. The ancestor-ref target
+// reads and writes the root owner's ref from each child, so lookup distance
+// grows across the sibling list. Own-ref and plain-property targets control for
+// unrelated owner/driver work. Child renderables are built outside timed work.
+process.env.NODE_ENV = 'production';
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const rawIterations = process.argv[2] ?? '7';
+const iterations = Number(rawIterations);
+if (!Number.isSafeInteger(iterations) || iterations <= 0) {
+	throw new TypeError(`iterations must be a positive safe integer, received ${rawIterations}.`);
+}
+
+if (process.env.BENCH_RUNTIME_URL === undefined) {
+	const build = spawnSync('pnpm', ['--filter', 'octane', 'build'], {
+		cwd: REPO,
+		stdio: 'inherit',
+	});
+	if ((build.status ?? 1) !== 0) throw new Error('The octane package build failed.');
+}
+
+const runtimeUrl =
+	process.env.BENCH_RUNTIME_URL ??
+	pathToFileURL(path.join(REPO, 'packages/octane/dist/universal.js')).href;
+let payload;
+
+try {
+	const {
+		createObjectContainer,
+		createObjectDriver,
+		createUniversalRoot,
+		defineUniversalComponent,
+		universalComponent,
+		universalPlan,
+		universalValue,
+		useRef,
+	} = await import(runtimeUrl);
+
+	const scenePlan = universalPlan('object', {
+		kind: 'host',
+		type: 'scene',
+		bindings: [['version', 0]],
+		children: [{ kind: 'slot', slot: 1 }],
+	});
+	const cellPlan = universalPlan('object', {
+		kind: 'host',
+		type: 'cell',
+		bindings: [['id', 0]],
+	});
+	const sizes = [0, 1, 128, 1_024];
+	const modes = ['ancestor-ref', 'single-ancestor-read', 'own-ref', 'plain-property'];
+	const warmupUpdates = 8;
+	const updatesPerSample = 8;
+	const fixtures = new Map();
+	const failures = [];
+
+	for (const mode of modes) {
+		for (const size of sizes) {
+			const name = `${mode}-${size}`;
+			const observedVersions = Array(size).fill(-1);
+			const childRenders = Array(size).fill(0);
+			const ownRefs = Array(size).fill(null);
+			const sharedProperty = { current: -1 };
+			let ancestorRef = null;
+			const Child = defineUniversalComponent('object', ({ id, version }) => {
+				if (mode === 'single-ancestor-read') {
+					if (id === size - 1 && ancestorRef?.current !== -1) {
+						throw new Error(`${name}: far child could not read the ancestor ref`);
+					}
+				} else {
+					const ref =
+						mode === 'ancestor-ref'
+							? ancestorRef
+							: mode === 'own-ref'
+								? useRef(-1, 'own-accumulator')
+								: sharedProperty;
+					if (ref === null) throw new Error(`${name}: child rendered without its ancestor ref`);
+					if (mode === 'own-ref') {
+						if (ownRefs[id] !== null && ownRefs[id] !== ref) {
+							throw new Error(`${name}: child ${id} changed its ref identity`);
+						}
+						ownRefs[id] = ref;
+					}
+					const previous = mode === 'own-ref' ? version - 1 : version * size + id - 1;
+					if (ref.current !== previous) {
+						throw new Error(`${name}: child ${id} saw ${ref.current} instead of ${previous}`);
+					}
+					const next = mode === 'own-ref' ? version : version * size + id;
+					ref.current = next;
+					if (ref.current !== next) throw new Error(`${name}: child ${id} lost its ref write`);
+				}
+				observedVersions[id] = version;
+				childRenders[id]++;
+				return universalValue(cellPlan, [id]);
+			});
+			const Scene = defineUniversalComponent('object', ({ version, children }) => {
+				if (mode === 'ancestor-ref' || mode === 'single-ancestor-read') {
+					const ref = useRef(-1, 'root-accumulator');
+					if (ancestorRef !== null && ancestorRef !== ref) {
+						throw new Error(`${name}: ancestor ref identity changed`);
+					}
+					ancestorRef = ref;
+				}
+				return universalValue(scenePlan, [version, children]);
+			});
+			const nextProps = (version) => ({
+				version,
+				children: Array.from({ length: size }, (_, id) =>
+					universalComponent('object', Child, { id, version }, id),
+				),
+			});
+			const container = createObjectContainer('object');
+			const root = createUniversalRoot(container, createObjectDriver('object'));
+			root.render(Scene, nextProps(0));
+			const retainedScene = container.children[0];
+			const retainedCells = [...retainedScene.children];
+			for (let version = 1; version <= warmupUpdates; version++) {
+				root.render(Scene, nextProps(version));
+			}
+			container.commits.length = 0;
+			fixtures.set(name, {
+				name,
+				mode,
+				size,
+				container,
+				root,
+				Scene,
+				nextProps,
+				version: warmupUpdates + 1,
+				observedVersions,
+				childRenders,
+				ownRefs,
+				sharedRef: () =>
+					mode === 'ancestor-ref' || mode === 'single-ancestor-read' ? ancestorRef : sharedProperty,
+				retainedScene,
+				retainedCells,
+				structuralCommands: 0,
+				acceptedCommits: 0,
+				samples: [],
+			});
+		}
+	}
+
+	for (let iteration = 0; iteration < iterations; iteration++) {
+		const order = iteration % 2 === 0 ? [...fixtures.values()] : [...fixtures.values()].reverse();
+		for (const fixture of order) {
+			const versions = Array.from({ length: updatesPerSample }, () =>
+				fixture.nextProps(fixture.version++),
+			);
+			const start = performance.now();
+			for (const props of versions) fixture.root.render(fixture.Scene, props);
+			fixture.samples.push((performance.now() - start) / updatesPerSample);
+			fixture.acceptedCommits += fixture.container.commits.length;
+			fixture.structuralCommands += fixture.container.commits.reduce(
+				(total, batch) =>
+					total +
+					batch.commands.filter((command) =>
+						['create', 'destroy', 'insert', 'remove'].includes(command.op),
+					).length,
+				0,
+			);
+			fixture.container.commits.length = 0;
+		}
+	}
+
+	const targets = [];
+	for (const fixture of fixtures.values()) {
+		const { name, mode, size } = fixture;
+		const latestVersion = fixture.version - 1;
+		const scene = fixture.container.children[0];
+		if (scene !== fixture.retainedScene || scene?.props.version !== latestVersion) {
+			failures.push(`${name}: scene identity or latest version changed`);
+		}
+		if (fixture.container.instanceCount !== size + 1 || scene?.children.length !== size) {
+			failures.push(`${name}: expected ${size} retained child hosts`);
+		}
+		for (let id = 0; id < size; id++) {
+			if (
+				scene?.children[id] !== fixture.retainedCells[id] ||
+				scene.children[id].props.id !== id ||
+				fixture.observedVersions[id] !== latestVersion ||
+				fixture.childRenders[id] !== 1 + warmupUpdates + iterations * updatesPerSample ||
+				(mode === 'own-ref' && fixture.ownRefs[id]?.current !== latestVersion)
+			) {
+				failures.push(`${name}: child ${id} lost identity, state, or changed-prop render`);
+				break;
+			}
+		}
+		const sharedValue = fixture.sharedRef()?.current ?? -1;
+		const expectedShared =
+			size === 0 || mode === 'single-ancestor-read' ? -1 : (latestVersion + 1) * size - 1;
+		if (mode !== 'own-ref' && sharedValue !== expectedShared) {
+			failures.push(`${name}: shared value ${sharedValue} != ${expectedShared}`);
+		}
+		if (
+			fixture.structuralCommands !== 0 ||
+			fixture.acceptedCommits !== iterations * updatesPerSample
+		) {
+			failures.push(`${name}: unexpected commands or unaccepted updates`);
+		}
+		const outputHash = createHash('sha256')
+			.update(
+				JSON.stringify({
+					mode,
+					version: scene?.props.version,
+					cells: scene?.children.map((child) => child.props.id),
+					sharedValue: mode === 'own-ref' ? null : sharedValue,
+					ownRefValues: mode === 'own-ref' ? fixture.ownRefs.map((ref) => ref.current) : null,
+				}),
+			)
+			.digest('hex');
+		const stats = summarizeSamples(fixture.samples);
+		targets.push({
+			name,
+			ops: { update_ms: timingStatForJson(stats) },
+			meta: {
+				nodeVersion: process.version,
+				platform: process.platform,
+				architecture: process.arch,
+				mode,
+				childOwners: size,
+				hostInstances: fixture.container.instanceCount,
+				latestVersion,
+				acceptedCommits: fixture.acceptedCommits,
+				structuralCommands: fixture.structuralCommands,
+				outputHash,
+			},
+		});
+		fixture.root.unmount();
+		if (fixture.container.instanceCount !== 0 || fixture.container.children.length !== 0) {
+			failures.push(`${name}: unmount did not release every host`);
+		}
+	}
+
+	payload = {
+		suite: 'universal-draft-lookup',
+		iterations,
+		targets,
+		...(failures.length === 0 ? null : { failed: failures.join(' | ') }),
+	};
+	console.log('| target | child owners | ms per accepted update |');
+	console.log('| --- | ---: | ---: |');
+	for (const target of targets) {
+		console.log(
+			`| ${target.name} | ${target.meta.childOwners} | ${target.ops.update_ms.score.toFixed(3)} |`,
+		);
+	}
+	if (failures.length !== 0) {
+		console.error(failures.join('\n'));
+		process.exitCode = 1;
+	}
+} catch (error) {
+	const message = error instanceof Error ? error.stack || error.message : String(error);
+	payload = { suite: 'universal-draft-lookup', iterations, targets: [], failed: message };
+	console.error(message);
+	process.exitCode = 1;
+}
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -110,6 +110,7 @@ export const BENCHMARK_SUITES = [
 	'universal-template-events',
 	'universal-native-hover',
 	'universal-owner-drafts',
+	'universal-draft-lookup',
 	'universal-external-store',
 	'lynx-render',
 	'lynx-table',

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -1143,6 +1143,9 @@ interface RenderAttempt {
 	owner: DraftOwner;
 	scope: UniversalOwnerRecord | null;
 	owners: DraftOwner[];
+	// Indexed on demand for reads of another owner's draft. Claims append to
+	// owners, and the last draft for a record must win after a retained retry.
+	draftLookup: { indexed: number; byRecord: Map<UniversalOwnerRecord, DraftOwner> } | null;
 	treeFeatures: number;
 	replayEntries: readonly SuspendedMemoEntry[];
 	retryThenables: Set<PromiseLike<unknown>>;
@@ -5167,10 +5170,20 @@ function currentDraftOwner(): DraftOwner {
 function findDraftOwner(record: UniversalOwnerRecord): DraftOwner | null {
 	const attempt = CURRENT_ATTEMPT;
 	if (attempt === null) return null;
-	for (let index = attempt.owners.length - 1; index >= 0; index--) {
-		if (attempt.owners[index].record === record) return attempt.owners[index];
+	const owners = attempt.owners;
+	const last = owners[owners.length - 1];
+	if (last !== undefined && last.record === record) return last;
+	let lookup = attempt.draftLookup;
+	if (lookup === null) {
+		lookup = { indexed: 0, byRecord: new Map() };
+		attempt.draftLookup = lookup;
 	}
-	return null;
+	for (let index = lookup.indexed; index < owners.length; index++) {
+		const owner = owners[index];
+		lookup.byRecord.set(owner.record, owner);
+	}
+	lookup.indexed = owners.length;
+	return lookup.byRecord.get(record) ?? null;
 }
 
 function applyUniversalHookUpdateQueue<T>(
@@ -8785,6 +8798,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			owner,
 			scope: target,
 			owners: [owner],
+			draftLookup: null,
 			treeFeatures: 0,
 			replayEntries: [],
 			retryThenables: new Set(),
@@ -9095,6 +9109,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			owner,
 			scope: null,
 			owners: [owner],
+			draftLookup: null,
 			treeFeatures: 0,
 			replayEntries,
 			retryThenables: new Set(),

--- a/packages/octane/tests/universal-state-updates.test.ts
+++ b/packages/octane/tests/universal-state-updates.test.ts
@@ -12,6 +12,7 @@ import {
 	universalProps,
 	universalValue,
 	useLayoutEffect,
+	useRef,
 	useState,
 } from '../src/universal-native.js';
 
@@ -160,6 +161,169 @@ describe('universal queued state values', () => {
 		state.root.render(state.Scene, {});
 		expect(state.container.children[0].props.value).toBe(10);
 		state.root.unmount();
+	});
+
+	it('keeps ancestor ref writes local across keyed siblings, nested preparations, and a retry', () => {
+		const ids = Array.from({ length: 32 }, (_, index) => `item-${index}`);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const nestedContainer = createObjectContainer();
+		const nestedRoot = createUniversalRoot(nestedContainer, createObjectDriver());
+		const rowPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'ref-row',
+			bindings: [
+				['id', 0],
+				['before', 1],
+				['after', 2],
+				['predecessor', 3],
+			],
+		});
+		const nestedPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'nested-ref-result',
+			bindings: [['value', 0]],
+		});
+		const lifecycle: string[] = [];
+		const nestedReads: Array<{ outer: string; ownBefore: string; ownAfter: string }> = [];
+		const resumedReads: string[] = [];
+		const rowRefs = new Map<string, { current: string }>();
+		let sharedRef!: { current: string };
+		let nestedRef!: { current: string };
+		const Nested = defineUniversalComponent(
+			'object',
+			({ outer, version }: { outer: { current: string }; version: string }) => {
+				const own = useRef('nested:seed', 'nested-ref');
+				nestedRef = own;
+				const outerValue = outer.current;
+				const ownBefore = own.current;
+				own.current = `nested:${version}`;
+				nestedReads.push({ outer: outerValue, ownBefore, ownAfter: own.current });
+				return universalValue(nestedPlan, [outerValue]);
+			},
+		);
+		const Row = defineUniversalComponent(
+			'object',
+			({
+				id,
+				version,
+				shared,
+				nested,
+				previousId,
+			}: {
+				id: string;
+				version: string;
+				shared: { current: string };
+				nested: boolean;
+				previousId: string | null;
+			}) => {
+				const own = useRef('row:seed', 'row-ref');
+				rowRefs.set(id, own);
+				const predecessor = previousId === null ? null : rowRefs.get(previousId)!.current;
+				own.current = `${version}:${id}`;
+				useLayoutEffect(
+					() => {
+						lifecycle.push(`mount:${id}`);
+						return () => lifecycle.push(`cleanup:${id}`);
+					},
+					[],
+					'row-effect',
+				);
+				const before = shared.current;
+				shared.current = `${version}:${id}`;
+				if (nested) {
+					const prepared = nestedRoot.prepare(Nested, { outer: shared, version: 'prepared' });
+					prepared.abort();
+					resumedReads.push(shared.current);
+				}
+				return universalValue(rowPlan, [id, before, shared.current, predecessor]);
+			},
+		);
+		const Scene = defineUniversalComponent(
+			'object',
+			({
+				order,
+				version,
+				retry = false,
+			}: {
+				order: string[];
+				version: string;
+				retry?: boolean;
+			}) => {
+				const [pass, setPass] = useState(0, 'scene-pass');
+				if (retry && pass === 0) setPass(1);
+				const shared = useRef('seed', 'shared-ref');
+				sharedRef = shared;
+				return universalFor(
+					order,
+					(id) => id,
+					(id, index) =>
+						universalComponent('object', Row, {
+							id,
+							version: `${version}:${pass}`,
+							shared,
+							nested: version === 'prepared' && id === 'item-16',
+							previousId: index === 0 ? null : order[index - 1],
+						}),
+				);
+			},
+		);
+
+		root.render(Scene, { order: ids, version: 'initial' });
+		const committedRef = sharedRef;
+		const originalRows = new Map(container.children.map((row) => [row.props.id, row]));
+		expect(container.children.map((row) => row.props.before)).toEqual([
+			'seed',
+			...ids.slice(0, -1).map((id) => `initial:0:${id}`),
+		]);
+		expect(sharedRef.current).toBe(`initial:0:${ids.at(-1)}`);
+		expect(container.children.map((row) => row.props.predecessor)).toEqual([
+			null,
+			...ids.slice(0, -1).map((id) => `initial:0:${id}`),
+		]);
+		expect(lifecycle.toSorted()).toEqual(ids.map((id) => `mount:${id}`).toSorted());
+		nestedRoot.render(Nested, { outer: sharedRef, version: 'initial' });
+		const nestedHost = nestedContainer.children[0];
+		expect(nestedHost.props.value).toBe(`initial:0:${ids.at(-1)}`);
+		expect(nestedRef.current).toBe('nested:initial');
+
+		const prepared = root.prepare(Scene, { order: ids, version: 'prepared' });
+		expect(prepared.status).toBe('prepared');
+		expect(nestedReads.at(-1)).toEqual({
+			outer: `initial:0:${ids.at(-1)}`,
+			ownBefore: 'nested:initial',
+			ownAfter: 'nested:prepared',
+		});
+		expect(resumedReads).toEqual(['prepared:0:item-16']);
+		prepared.abort();
+		expect(sharedRef).toBe(committedRef);
+		expect(sharedRef.current).toBe(`initial:0:${ids.at(-1)}`);
+		expect(nestedRef.current).toBe('nested:initial');
+		expect(nestedContainer.children[0]).toBe(nestedHost);
+		expect(nestedHost.props.value).toBe(`initial:0:${ids.at(-1)}`);
+		expect(container.children.map((row) => row.props.after)).toEqual(
+			ids.map((id) => `initial:0:${id}`),
+		);
+		expect(lifecycle).toHaveLength(ids.length);
+
+		const reversed = [...ids].reverse();
+		root.render(Scene, { order: reversed, version: 'retry', retry: true });
+		expect(sharedRef).toBe(committedRef);
+		expect(sharedRef.current).toBe(`retry:1:${reversed.at(-1)}`);
+		expect(container.children.map((row) => row.props.after)).toEqual(
+			reversed.map((id) => `retry:1:${id}`),
+		);
+		expect(container.children.map((row) => row.props.predecessor)).toEqual([
+			null,
+			...reversed.slice(0, -1).map((id) => `retry:1:${id}`),
+		]);
+		for (const row of container.children) expect(row).toBe(originalRows.get(row.props.id));
+		expect(lifecycle).toHaveLength(ids.length);
+		root.unmount();
+		nestedRoot.unmount();
+		expect(lifecycle.toSorted()).toEqual(
+			ids.flatMap((id) => [`mount:${id}`, `cleanup:${id}`]).toSorted(),
+		);
 	});
 
 	it('retries a keyed render without publishing abandoned children or effects', () => {


### PR DESCRIPTION
## Summary

- Index draft owners lazily within a universal render attempt when a hook or ref reads another owner's draft. The newest draft remains an allocation-free direct lookup.
- Preserve last-draft-wins behavior after a render-phase retry and keep the lookup isolated across nested preparations and aborts.
- Add a public object-root regression and a registered production benchmark for ancestor, own-ref, single distant-read, and plain-property workloads.

## Why

Part of #981: each sibling reading or writing a ref owned by an earlier ancestor otherwise scans the growing draft-owner list. Repeated ancestor-ref access becomes quadratic across a wide sibling tree.

## Changes

- Add an attempt-local lazy `Map` that catches up with appended draft owners in order; duplicate records overwrite earlier drafts. Reads of the latest owner use the direct tail check.
- Exercise chained ancestor and predecessor ref reads across keyed siblings, nested prepare/abort, retries, reordering, retained hosts, effects, and cleanup.
- Register `universal-draft-lookup` in the benchmark runner and MCP catalog; add patch changesets for `octane` and `@octanejs/mcp-server`.

## Validation

- [x] `pnpm sync` and `git diff --check`
- [x] `pnpm format:files:check` for all eight changed files
- [x] `pnpm typecheck:files packages/octane/src/universal-core.ts packages/octane/tests/universal-state-updates.test.ts`
- [x] Targeted universal development/production tests and MCP suite-list test: 37 files, 733 tests passed
- [x] Deliberate missing non-tail lookup and first-draft-wins mutants made the new regression fail in development and production; both restored, final suite green
- [x] `node benchmarks/bench.mjs --quick universal-draft-lookup` (16 targets, output and identity checks)
- [ ] Full `pnpm test`, repository-wide `pnpm typecheck` and `pnpm format:check` locally; current-head CI will run these gates

Production Node 26.4.0 object-driver B–C–C–B comparison (13 samples per run, eight accepted updates per sample): at 1,024 child owners, repeated ancestor-ref reads took 2.019/1.882 ms per update on the frozen baseline and 1.238/1.080 ms on the candidate (about 41% lower paired mean). The 128-owner result was inconclusive. Single distant reads, own-ref reads, and plain-property controls showed mixed small differences within run variability. All 16 targets matched output hashes across runs with stable hosts, 104 accepted commits and zero structural commands.

## Risk / follow-ups

- A single non-tail lookup now builds an index for that attempt; the isolated-read control did not show a reliable win. The optimization targets repeated cross-owner reads. The index is attempt-local and append-aware so retries keep the newest draft.
- #981 has other independent open findings. Leave this checklist entry open until this PR merges.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791542973&installation_model_id=432790&pr_number=1011&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1011&signature=6bbd1401ac84c40a7ccf5314e9be6ff3a77f829f03bc11ccd41ee6b976b1ea8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches universal render-attempt hook/ref resolution in `universal-core.ts`; incorrect indexing could corrupt ref/state across siblings, preparations, or retries, though new tests and the benchmark gate correctness.
> 
> **Overview**
> **Cross-owner hook/ref reads** no longer scan the full draft-owner list on every lookup. `findDraftOwner` keeps an allocation-free tail check for the newest owner and builds an attempt-local `Map` only when a render needs an earlier owner's draft; later appends extend the index and overwrites keep **last-draft-wins** after retries.
> 
> Adds a Node **`universal-draft-lookup`** benchmark (ancestor ref, own-ref, single distant read, plain-object controls at 0–1,024 child owners) plus runner/MCP registration, patch changesets, and a regression test for shared ancestor refs across keyed siblings, nested prepare/abort, and render-phase retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3942da5104ebeb08b34357cc40a9af5022b35939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->