### PR TITLE
perf: keep scoped JSX descriptors on fast shapes

### DIFF
--- a/.changeset/stable-scoped-descriptor-shapes.md
+++ b/.changeset/stable-scoped-descriptor-shapes.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Keep scoped JSX element and value descriptors on stable property shapes while preserving deferred children, cloning, and server rendering behavior.
+Expose the scoped descriptor benchmark in the MCP suite catalog.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,7 +87,7 @@ runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
 **universal-object-teardown**,
 **universal-template-events**, **universal-native-hover**, **universal-owner-drafts**,
-**universal-draft-lookup**,
+**universal-draft-lookup**, **scoped-descriptor-shapes**,
 **universal-external-store**,
 **lynx-render**, **lynx-bundle-size**, **tsrx-renderer-validation-ranges**, and
 **tsrx-local-component-name-catalog** are Node-only,
@@ -284,6 +284,7 @@ internally, get their own baseline and guard namespace.
 | `universal-native-hover` | universal-native-hover | none (Node-only) | compiled production native universal selection in 20 and 80 keyed rows, each with four component/view layers; 2,000 real hover updates per sample, host and prop identity checks, teardown, a same-run scaling ratio, and optional local V8 cumulative allocation profile |
 | `universal-owner-drafts` | universal-owner-drafts | none (Node-only) | retained object-driver roots with 0, 1, 128, and 1,024 changed-prop child owners; output, render, host identity, and structural-command controls |
 | `universal-draft-lookup` | universal-draft-lookup | none (Node-only) | root-owned ref lookups from 0, 1, 128, and 1,024 changing child owners, with own-ref and plain-object controls and host, state, and structural-command checks |
+| `scoped-descriptor-shapes` | scoped-descriptor-shapes | none (Node-only) | production client/server scoped element and value descriptor creation, reads, enumeration, cloning, Children.map and SSR, with plain-element controls and deferred-child/key/order checks |
 | `universal-external-store` | universal-external-store | none (Node-only) | 128 native universal store subscribers, getter/subscribe identity controls, notification bursts, and deterministic subscription-lifetime and state-projection guards |
 | `lynx-render` | lynx-render | none (Node-only) | dual-thread Lynx render CPU: empty startup, create 1,000 and 10,000 keyed rows through the real background root, transport, and main receiver over a cheap fake Element PAPI, plus a gate that a native tap reaches its background handler via the engine `publishEvent` receiver |
 | `lynx-table` | lynx-table | none (Node-only; separate Chromium harness) | deterministic per-operation wire cost of the cross-framework krausest table (command counts and serialized commit bytes vs a changed-rows floor) through the real dual-thread path and real tap tokens |

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -888,6 +888,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Production client and server scoped descriptors: creation, field
+		// reads, enumeration, cloning, Children.map, and SSR with plain controls.
+		name: 'scoped-descriptor-shapes',
+		cwd: 'scoped-descriptor-shapes',
+		servers: [],
+		iter: { normal: 7, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Native universal external-store hooks: stable subscription lifetimes and
 		// bounded state-projection work across parent renders and notification bursts.
 		name: 'universal-external-store',

--- a/benchmarks/scoped-descriptor-shapes/README.md
+++ b/benchmarks/scoped-descriptor-shapes/README.md
@@ -1,0 +1,71 @@
+# Scoped descriptor shapes
+
+This Node-only production benchmark covers the client and server forms of
+compiler-created scoped JSX element and value descriptors. It calls
+`createScopedElement` and `createScopedValue` through the compiled runtime and
+checks public descriptor properties, deferred child reads, clones, and
+`Children.map` key replacement. It uses 128 and 1,024 elements with the same
+authored prop shape; a plain `createElement` descriptor is the no-deferred
+control. At 1,024 elements it separately measures named field reads and
+`for...in` enumeration. The server also renders a 128-row descriptor tree to
+HTML with identical plain and scoped trees.
+
+Each creation, clone, and `Children.map` sample verifies that child resolvers
+did not run before inspection. After timing, every element is checked for its
+key, title, enumerable descriptor and props keys in order, accessor ownership,
+and equal `descriptor.children`/`props.children`. A stable SHA-256 semantic hash
+is emitted for each target. Server HTML and CSS are compared to an explicit
+expected string. An untimed preflight also clones and maps a scoped value whose
+resolved element has scoped children; it checks both receivers retain deferred
+access after the copy. Five untimed warmups precede the timed samples, and target
+order reverses every round. Client and server samples run in separate Node
+processes so their distinct shared accessor functions cannot affect each
+other's V8 hidden classes. Timings are microseconds per processed element.
+
+```bash
+node benchmarks/scoped-descriptor-shapes/run.mjs 7
+node benchmarks/bench.mjs --quick scoped-descriptor-shapes
+```
+
+For a frozen baseline, set **both** `BENCH_CLIENT_RUNTIME_URL` and
+`BENCH_SERVER_RUNTIME_URL` to absolute `file:` URLs for production `runtime.js`
+and `runtime.server.js`. When unset, the script builds the current Octane
+package. Set `BENCH_JSON` to write benchmark-schema results for interleaved
+baseline/candidate comparisons. Compare hashes before comparing timings.
+
+The production Node run isolates descriptor allocation and property access. It
+does not measure browser layout, hydration, GC pause distributions, or the
+compiler's generated call overhead. The SSR target includes other renderer work,
+so a small SSR timing change inside observed variance is inconclusive. Scope
+freshness and the semantics of replacing children receive behavioral tests in
+the Octane package rather than being inferred from these timings.
+
+## Paired production measurement
+
+Against frozen `main`, the final candidate was measured in B–C–C–B order, with
+13 timed samples and five untimed warmups per run on Node 26/macOS arm64.
+Each row below is the candidate/baseline ratio of the paired mean at 1,024
+elements. “Adjusted” divides that ratio by the matched plain-element control's
+ratio to account for run-to-run drift. Values below 1 are faster. All 48 target
+hashes matched across all four runs.
+
+| Operation | Client raw | Client adjusted | Server raw | Server adjusted |
+| --- | ---: | ---: | ---: | ---: |
+| Scoped element create | 0.85× | 0.94× | 0.89× | 0.81× |
+| Scoped element field reads | 0.39× | 0.84× | 0.29× | 0.64× |
+| Scoped element `for...in` | 0.06× | 0.09× | 0.06× | 0.08× |
+| Scoped element clone | 0.66× | 0.76× | 0.73× | 0.77× |
+| Scoped element `Children.map` | 0.69× | 0.73× | 0.82× | 0.78× |
+| Scoped value create | 0.92× | 1.02× | 1.14× | 1.04× |
+| Scoped value field reads | 0.51× | 1.08× | 0.38× | 0.85× |
+| Scoped value `for...in` | 0.12× | 0.18× | 0.13× | 0.17× |
+
+Scoped-value creation was 1.02–1.04× its matched control after adjustment, so
+these runs show no clear gain or regression. Scoped-value field reads also
+overlap the plain-read control after adjustment. The server's full scoped SSR
+target was 0.93× baseline, while the plain SSR control was 1.00×; its small
+relative improvement is inconclusive. Client scoped-element construction shows
+only a small relative difference. The strongest evidence is the fast-property
+transition and the consistent enumeration gain. Client and server ran in
+separate Node isolates so their distinct shared accessor functions did not
+contaminate each other's maps.

--- a/benchmarks/scoped-descriptor-shapes/run.mjs
+++ b/benchmarks/scoped-descriptor-shapes/run.mjs
@@ -1,0 +1,385 @@
+// Production Node-only descriptor-shape workload for octanejs/octane#981.
+// Run a frozen baseline through BENCH_CLIENT_RUNTIME_URL and
+// BENCH_SERVER_RUNTIME_URL; the default builds and imports this worktree.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const iterations = Number(process.argv[2] ?? 7);
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new TypeError('Pass a positive integer sample count.');
+}
+if (!process.env.BENCH_CLIENT_RUNTIME_URL && !process.env.BENCH_SERVER_RUNTIME_URL) {
+	const build = spawnSync('pnpm', ['--filter', 'octane', 'build'], {
+		cwd: REPO,
+		stdio: 'inherit',
+	});
+	if (build.status !== 0) throw new Error('The production octane build failed.');
+} else if (!process.env.BENCH_CLIENT_RUNTIME_URL || !process.env.BENCH_SERVER_RUNTIME_URL) {
+	throw new Error('Specify both BENCH_CLIENT_RUNTIME_URL and BENCH_SERVER_RUNTIME_URL.');
+}
+
+const dist = path.join(REPO, 'packages/octane/dist');
+const clientUrl =
+	process.env.BENCH_CLIENT_RUNTIME_URL ?? pathToFileURL(path.join(dist, 'runtime.js')).href;
+const serverUrl =
+	process.env.BENCH_SERVER_RUNTIME_URL ?? pathToFileURL(path.join(dist, 'runtime.server.js')).href;
+
+const hash = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+let payload;
+
+if (process.env.BENCH_SCOPE === undefined) {
+	// The client and server runtime use different shared getter functions for
+	// otherwise identically shaped records. Loading both in one V8 isolate makes
+	// the second runtime dictionary-mode even when its real deployment is fast.
+	const childResults = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-scoped-shapes-'));
+	try {
+		const targets = [];
+		for (const scope of ['client', 'server']) {
+			const output = path.join(childResults, `${scope}.json`);
+			const child = spawnSync(
+				process.execPath,
+				[fileURLToPath(import.meta.url), String(iterations)],
+				{
+					cwd: REPO,
+					encoding: 'utf8',
+					env: {
+						...process.env,
+						BENCH_SCOPE: scope,
+						BENCH_JSON: output,
+						BENCH_CLIENT_RUNTIME_URL: clientUrl,
+						BENCH_SERVER_RUNTIME_URL: serverUrl,
+					},
+				},
+			);
+			if (child.status !== 0) throw new Error(`${scope}: ${child.stderr || child.stdout}`);
+			const result = JSON.parse(fs.readFileSync(output, 'utf8'));
+			if (result.failed) throw new Error(`${scope}: ${result.failed}`);
+			targets.push(...result.targets);
+			process.stdout.write(child.stdout);
+		}
+		payload = { suite: 'scoped-descriptor-shapes', iterations, targets };
+	} catch (error) {
+		const message = error instanceof Error ? error.stack || error.message : String(error);
+		payload = { suite: 'scoped-descriptor-shapes', iterations, targets: [], failed: message };
+		console.error(message);
+		process.exitCode = 1;
+	} finally {
+		fs.rmSync(childResults, { recursive: true, force: true });
+	}
+} else {
+	if (process.env.BENCH_SCOPE !== 'client' && process.env.BENCH_SCOPE !== 'server') {
+		throw new Error('BENCH_SCOPE must be client or server.');
+	}
+	try {
+		const scope = process.env.BENCH_SCOPE;
+		const modules = [[scope, await import(scope === 'client' ? clientUrl : serverUrl)]];
+		const scenarios = [];
+		const warmupSamples = 5;
+
+		for (const [environment, runtime] of modules) {
+			const { Children, cloneElement, createElement, createScopedElement, createScopedValue } =
+				runtime;
+			let nestedChildrenReads = 0;
+			const nestedValue = createScopedValue(() =>
+				createScopedElement('span', { key: 'nested', id: 'nested' }, () => {
+					nestedChildrenReads++;
+					return 'nested-child';
+				}),
+			);
+			const nestedClone = cloneElement(nestedValue, { title: 'copied' });
+			const nestedMapped = Children.map([nestedValue], (element) => element)[0];
+			assert.equal(
+				nestedChildrenReads,
+				0,
+				`${environment}: nested children resolved before inspection`,
+			);
+			assert.equal(nestedClone.key, 'nested');
+			assert.equal(nestedClone.props.id, 'nested');
+			assert.equal(nestedClone.props.title, 'copied');
+			assert.equal(nestedClone.children, 'nested-child');
+			assert.equal(nestedClone.props.children, 'nested-child');
+			assert.equal(nestedMapped.key, '.$nested');
+			assert.equal(nestedMapped.children, 'nested-child');
+			assert.equal(nestedMapped.props.children, 'nested-child');
+			assert.equal(nestedChildrenReads, 1);
+			for (const size of [128, 1_024]) {
+				const rows = Array.from({ length: size }, (_, index) => ({
+					key: `row-${index}`,
+					id: `row-${index}`,
+					title: `label-${index}`,
+					child: `value-${index}`,
+				}));
+				const configs = rows.map((row) => ({
+					key: row.key,
+					id: row.id,
+					title: row.title,
+					'data-kind': 'entry',
+				}));
+				const cloneConfigs = rows.map((row) => ({ title: `copy-${row.id}` }));
+				const readCounts = new Int32Array(size);
+				const readers = rows.map((row, index) => () => {
+					readCounts[index]++;
+					return row.child;
+				});
+				const plain = rows.map((row, index) => createElement('span', configs[index], row.child));
+				const plainReaders = plain.map((element, index) => () => {
+					readCounts[index]++;
+					return element;
+				});
+				const scoped = rows.map((_, index) =>
+					createScopedElement('span', configs[index], readers[index]),
+				);
+				const values = rows.map((_, index) => createScopedValue(plainReaders[index]));
+
+				function inspect(element, row, kind, key = row.key, title = row.title) {
+					assert.equal(element.type, 'span');
+					assert.equal(element.key, key);
+					assert.equal(element.ref, null);
+					assert.equal(element.props.id, row.id);
+					assert.equal(element.props.title, title);
+					assert.equal(element.props['data-kind'], 'entry');
+					assert.deepEqual(Object.keys(element), [
+						'$$kind',
+						'type',
+						'props',
+						'key',
+						'ref',
+						'children',
+					]);
+					assert.deepEqual(Object.keys(element.props), ['id', 'title', 'data-kind', 'children']);
+					const deferred = Object.getOwnPropertyDescriptor(element, 'children');
+					const propsDeferred = Object.getOwnPropertyDescriptor(element.props, 'children');
+					assert.equal(deferred.enumerable, true);
+					assert.equal(propsDeferred.enumerable, true);
+					assert.equal(typeof deferred.get === 'function', kind !== 'plain');
+					assert.equal(typeof propsDeferred.get === 'function', kind === 'scoped');
+					assert.equal(element.children, row.child);
+					assert.equal(element.props.children, row.child);
+					return [key, title, element.children, element.props.children];
+				}
+
+				function add(name, operations, work, verify, shouldStayDeferred = false) {
+					scenarios.push({
+						name: `${environment}-${name}-${size}`,
+						environment,
+						size,
+						operations,
+						work,
+						verify,
+						deferredReadCounts: shouldStayDeferred ? readCounts : null,
+						samples: [],
+						outputHash: null,
+					});
+				}
+
+				function createBatch(factory) {
+					const result = new Array(size);
+					for (let index = 0; index < size; index++) result[index] = factory(index);
+					return result;
+				}
+				function verifyBatch(
+					result,
+					kind,
+					keyFor = (row) => row.key,
+					titleFor = (row) => row.title,
+				) {
+					assert.equal(result.length, size);
+					return hash(
+						result.map((item, index) =>
+							inspect(item, rows[index], kind, keyFor(rows[index]), titleFor(rows[index])),
+						),
+					);
+				}
+				function expectedSum(items, work) {
+					let total = 0;
+					for (const item of items) total += work(item);
+					return total;
+				}
+				function readFields(item) {
+					return (
+						item.type.length +
+						item.props.id.length +
+						item.key.length +
+						(item.ref === null ? 1 : 0) +
+						item.children.length +
+						item.props.children.length
+					);
+				}
+				function readKeys(item) {
+					let count = 0;
+					for (const key in item) count += key.length;
+					for (const key in item.props) count += key.length;
+					return count;
+				}
+				function readBatch(items, read, repetitions) {
+					let total = 0;
+					for (let repeat = 0; repeat < repetitions; repeat++) {
+						for (let index = 0; index < size; index++) total += read(items[index]);
+					}
+					return total;
+				}
+
+				for (const [kind, factory, items] of [
+					[
+						'scoped-element',
+						(index) => createScopedElement('span', configs[index], readers[index]),
+						scoped,
+					],
+					['scoped-value', (index) => createScopedValue(plainReaders[index]), values],
+					['plain', (index) => createElement('span', configs[index], rows[index].child), plain],
+				]) {
+					const descriptorKind =
+						kind === 'scoped-element' ? 'scoped' : kind === 'plain' ? 'plain' : 'value';
+					add(
+						`${kind}-create`,
+						size,
+						() => createBatch(factory),
+						(result) => verifyBatch(result, descriptorKind),
+						kind !== 'plain',
+					);
+					const fieldsSum = expectedSum(items, readFields);
+					add(
+						`${kind}-read`,
+						size * 32,
+						() => readBatch(items, readFields, 32),
+						(result) => {
+							assert.equal(result, fieldsSum * 32);
+							return hash(result);
+						},
+					);
+					if (size === 1_024) {
+						const keysSum = expectedSum(items, readKeys);
+						add(
+							`${kind}-enumerate`,
+							size * 8,
+							() => readBatch(items, readKeys, 8),
+							(result) => {
+								assert.equal(result, keysSum * 8);
+								return hash(result);
+							},
+						);
+					}
+				}
+
+				for (const [kind, items] of [
+					['scoped-element', scoped],
+					['plain', plain],
+				]) {
+					const descriptorKind = kind === 'plain' ? 'plain' : 'scoped';
+					add(
+						`${kind}-clone`,
+						size,
+						() => createBatch((index) => cloneElement(items[index], cloneConfigs[index])),
+						(result) =>
+							verifyBatch(
+								result,
+								descriptorKind,
+								(row) => row.key,
+								(row) => `copy-${row.id}`,
+							),
+						kind !== 'plain',
+					);
+					add(
+						`${kind}-children-map`,
+						size,
+						() => Children.map(items, (element) => element),
+						(result) => verifyBatch(result, descriptorKind, (row) => `.$${row.key}`),
+						kind !== 'plain',
+					);
+				}
+
+				if (environment === 'server' && size === 128) {
+					for (const [kind, children] of [
+						['scoped-element', scoped],
+						['plain', plain],
+					]) {
+						const root = createElement('ul', { id: 'rows' }, children);
+						const expectedHtml = `<!--[--><ul id="rows">${rows
+							.map(
+								(row) =>
+									`<span id="${row.id}" title="${row.title}" data-kind="entry">${row.child}</span>`,
+							)
+							.join('')}</ul><!--]-->`;
+						add(
+							`${kind}-ssr`,
+							size,
+							() => runtime.renderToString(root),
+							({ html, css }) => {
+								assert.equal(html, expectedHtml);
+								assert.equal(css, '');
+								return hash([html, css]);
+							},
+						);
+					}
+				}
+			}
+		}
+
+		function takeSample(scenario, measured) {
+			const previousDeferredReads = scenario.deferredReadCounts?.reduce(
+				(sum, count) => sum + count,
+				0,
+			);
+			const start = performance.now();
+			const result = scenario.work();
+			const elapsedUsPerItem = ((performance.now() - start) * 1_000) / scenario.operations;
+			if (scenario.deferredReadCounts !== null) {
+				assert.equal(
+					scenario.deferredReadCounts.reduce((sum, count) => sum + count, 0),
+					previousDeferredReads,
+					`${scenario.name}: deferred resolver ran during creation or cloning`,
+				);
+			}
+			const outputHash = scenario.verify(result);
+			if (scenario.outputHash !== null) assert.equal(outputHash, scenario.outputHash);
+			scenario.outputHash = outputHash;
+			if (measured) scenario.samples.push(elapsedUsPerItem);
+		}
+		for (let round = 0; round < warmupSamples + iterations; round++) {
+			const ordered = round % 2 === 0 ? scenarios : [...scenarios].reverse();
+			for (const scenario of ordered) takeSample(scenario, round >= warmupSamples);
+		}
+		const targets = scenarios.map((scenario) => {
+			const timing = summarizeSamples(scenario.samples, { scoreMode: 'mean' });
+			return {
+				name: scenario.name,
+				ops: { per_item_us: timingStatForJson(timing) },
+				meta: {
+					environment: scenario.environment,
+					items: scenario.size,
+					operationsPerSample: scenario.operations,
+					outputHash: scenario.outputHash,
+					nodeVersion: process.version,
+					platform: process.platform,
+					architecture: process.arch,
+				},
+			};
+		});
+		payload = { suite: 'scoped-descriptor-shapes', iterations, targets };
+		console.log('| target | µs per item |');
+		console.log('| --- | ---: |');
+		for (const target of targets) {
+			console.log(`| ${target.name} | ${target.ops.per_item_us.score.toFixed(3)} |`);
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.stack || error.message : String(error);
+		payload = { suite: 'scoped-descriptor-shapes', iterations, targets: [], failed: message };
+		console.error(message);
+		process.exitCode = 1;
+	}
+}
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -111,6 +111,7 @@ export const BENCHMARK_SUITES = [
 	'universal-native-hover',
 	'universal-owner-drafts',
 	'universal-draft-lookup',
+	'scoped-descriptor-shapes',
 	'universal-external-store',
 	'lynx-render',
 	'lynx-table',

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -709,6 +709,161 @@ interface ElementDescriptor {
 // evaluation. The component serializer must pass these props through intact:
 // spreading them would invoke the child accessor before entering the component.
 const SCOPED_ELEMENT_PROPS = new WeakSet<object>();
+const SCOPED_CHILDREN_RESOLVER = Symbol('octane.scopedChildrenResolver');
+const SCOPED_VALUE_RESOLVER = Symbol('octane.scopedValueResolver');
+
+type DeferredChildren = { [SCOPED_CHILDREN_RESOLVER]: () => unknown };
+type DeferredValue = ElementDescriptor & { [SCOPED_VALUE_RESOLVER]: () => ElementDescriptor };
+
+function getScopedChildren(this: DeferredChildren): unknown {
+	return this[SCOPED_CHILDREN_RESOLVER]();
+}
+
+const SCOPED_CHILDREN_PROPERTY = { configurable: true, enumerable: true, get: getScopedChildren };
+
+function setScopedChildrenResolver(target: object, resolve: () => unknown): void {
+	Object.defineProperty(target, SCOPED_CHILDREN_RESOLVER, { value: resolve });
+}
+
+// Each deferred record keeps its resolver while sharing accessor identities.
+const SCOPED_VALUE_PROPERTIES: PropertyDescriptorMap = {
+	type: {
+		configurable: true,
+		enumerable: true,
+		get(this: DeferredValue) {
+			return this[SCOPED_VALUE_RESOLVER]().type;
+		},
+	},
+	props: {
+		configurable: true,
+		enumerable: true,
+		get(this: DeferredValue) {
+			return this[SCOPED_VALUE_RESOLVER]().props;
+		},
+	},
+	key: {
+		configurable: true,
+		enumerable: true,
+		get(this: DeferredValue) {
+			return this[SCOPED_VALUE_RESOLVER]().key;
+		},
+	},
+	ref: {
+		configurable: true,
+		enumerable: true,
+		get(this: DeferredValue) {
+			return this[SCOPED_VALUE_RESOLVER]().ref;
+		},
+	},
+	children: {
+		configurable: true,
+		enumerable: true,
+		get(this: DeferredValue) {
+			return this[SCOPED_VALUE_RESOLVER]().children;
+		},
+	},
+};
+
+function restoreWritableScopedChildren(props: any, name: string, value: unknown): boolean {
+	const inherited = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(props), name);
+	if (inherited?.get === undefined && inherited?.set === undefined) return false;
+	// An inherited accessor can write children before deferred children replace it.
+	Object.defineProperty(props, 'children', {
+		configurable: true,
+		enumerable: true,
+		writable: true,
+		value,
+	});
+	return true;
+}
+
+/** Copy a scoped element's config and defaults without eagerly reading its children. */
+function copyScopedElementConfig(type: any, config: any): any {
+	// A copied __proto__ can intercept later assignments. Keep the original
+	// copying/defaulting order before installing deferred children in that case.
+	if (
+		(config != null && hasOwnProp.call(config, '__proto__')) ||
+		hasOwnProp.call(Object.prototype, 'children')
+	) {
+		const props = copyElementConfig(config);
+		applyElementDefaultProps(type, props);
+		Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+		return props;
+	}
+	const props: any = {};
+	let copiedChildren: unknown;
+	let hasChildren = false;
+	let childrenAreWritable = false;
+	if (config != null) {
+		for (const name in config) {
+			if (name === 'key' || !hasOwnProp.call(config, name)) continue;
+			if (name === 'children') {
+				// Copying the config reads its getter once. Defining the accessor in
+				// this position also preserves Object.keys order for spread children.
+				copiedChildren = config[name];
+				Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+				hasChildren = true;
+			} else {
+				const value = config[name];
+				if (
+					hasChildren &&
+					!childrenAreWritable &&
+					!hasOwnProp.call(props, name) &&
+					restoreWritableScopedChildren(props, name, copiedChildren)
+				) {
+					childrenAreWritable = true;
+				}
+				props[name] = value;
+			}
+		}
+	}
+	const defaults = type?.defaultProps;
+	if (defaults != null) {
+		for (const name in defaults) {
+			if (name === 'children') {
+				// The ordinary defaulting pass reads this property only when its
+				// copied value is undefined. Keep that observable getter read without
+				// evaluating the deferred children in our replacement accessor.
+				if (
+					(childrenAreWritable ? props.children : hasChildren ? copiedChildren : props.children) ===
+					undefined
+				) {
+					const defaultChildren = defaults[name];
+					copiedChildren = defaultChildren;
+					if (childrenAreWritable) {
+						props.children = defaultChildren;
+					} else if (!hasChildren) {
+						// A caller-provided __proto__ (or modified Object.prototype)
+						// can intercept the original assignment. Keep that rare path's
+						// setter/throw and insert the accessor at the end afterward.
+						if (
+							Object.getPrototypeOf(props) !== Object.prototype ||
+							Object.getOwnPropertyDescriptor(Object.prototype, 'children') !== undefined
+						) {
+							props.children = defaultChildren;
+						} else {
+							Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+							hasChildren = true;
+						}
+					}
+				}
+			} else {
+				if (
+					hasChildren &&
+					!childrenAreWritable &&
+					!hasOwnProp.call(props, name) &&
+					restoreWritableScopedChildren(props, name, copiedChildren)
+				) {
+					childrenAreWritable = true;
+				}
+				if (props[name] === undefined) props[name] = defaults[name];
+			}
+		}
+	}
+	if (childrenAreWritable || !hasChildren)
+		Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+	return props;
+}
 
 function hasElementConfigKey(config: any): boolean {
 	if (config == null || (typeof config !== 'object' && typeof config !== 'function')) return false;
@@ -809,24 +964,16 @@ export function nativeCreateScopedValue(readElement: () => ElementDescriptor): E
 }
 
 function scopedValueDescriptor(resolve: () => ElementDescriptor): ElementDescriptor {
-	const descriptor: ElementDescriptor = {
-		$$kind: ELEMENT_TAG,
-		get type() {
-			return resolve().type;
-		},
-		get props() {
-			return resolve().props;
-		},
-		get key() {
-			return resolve().key;
-		},
-		get ref() {
-			return resolve().ref;
-		},
-		get children() {
-			return resolve().children;
-		},
-	};
+	const descriptor = { $$kind: ELEMENT_TAG } as ElementDescriptor;
+	// The client and server runtimes may share a realm. Seed this module's own
+	// resolver before the public accessor transitions so their distinct getters
+	// do not compete for the same initial V8 map.
+	Object.defineProperty(descriptor, SCOPED_VALUE_RESOLVER, { value: resolve });
+	Object.defineProperty(descriptor, 'type', SCOPED_VALUE_PROPERTIES.type);
+	Object.defineProperty(descriptor, 'props', SCOPED_VALUE_PROPERTIES.props);
+	Object.defineProperty(descriptor, 'key', SCOPED_VALUE_PROPERTIES.key);
+	Object.defineProperty(descriptor, 'ref', SCOPED_VALUE_PROPERTIES.ref);
+	Object.defineProperty(descriptor, 'children', SCOPED_VALUE_PROPERTIES.children);
 	if (process.env.NODE_ENV !== 'production') Object.freeze(descriptor);
 	return descriptor;
 }
@@ -839,8 +986,7 @@ export function createScopedElement(
 ): ElementDescriptor {
 	const src = (props ?? null) as any;
 	const key = hasElementConfigKey(src) ? '' + src.key : null;
-	const copiedProps = copyElementConfig(src);
-	applyElementDefaultProps(type, copiedProps);
+	const copiedProps = copyScopedElementConfig(type, src);
 
 	let resolved = false;
 	let resolvedScope: SSRScope | null = null;
@@ -866,8 +1012,7 @@ export function nativeCreateScopedElement(
 ): ElementDescriptor {
 	const src = (props ?? null) as any;
 	const key = hasElementConfigKey(src) ? '' + src.key : null;
-	const copiedProps = copyElementConfig(src);
-	applyElementDefaultProps(type, copiedProps);
+	const copiedProps = copyScopedElementConfig(type, src);
 	return scopedElementDescriptor(
 		type,
 		copiedProps,
@@ -882,8 +1027,7 @@ function scopedElementDescriptor(
 	key: string | null,
 	children: () => unknown,
 ): ElementDescriptor {
-	const childProperty = { configurable: true, enumerable: true, get: children };
-	Object.defineProperty(copiedProps, 'children', childProperty);
+	setScopedChildrenResolver(copiedProps, children);
 	SCOPED_ELEMENT_PROPS.add(copiedProps);
 	const descriptor: ElementDescriptor = {
 		$$kind: ELEMENT_TAG,
@@ -891,9 +1035,9 @@ function scopedElementDescriptor(
 		props: copiedProps,
 		key,
 		ref: copiedProps.ref !== undefined ? copiedProps.ref : null,
-		children: null,
-	};
-	Object.defineProperty(descriptor, 'children', childProperty);
+	} as ElementDescriptor;
+	Object.defineProperty(descriptor, 'children', SCOPED_CHILDREN_PROPERTY);
+	setScopedChildrenResolver(descriptor, children);
 	return finalizeElementDescriptor(descriptor);
 }
 
@@ -1117,9 +1261,17 @@ export function cloneElement(
 	}
 	// Preserve deferred children until their represented component owns the read.
 	let scopedChildren: (() => unknown) | undefined;
+	let scopedResolver: (() => unknown) | undefined;
 	let props: any;
 	if (SCOPED_ELEMENT_PROPS.has(element.props)) {
 		scopedChildren = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		if (scopedChildren === getScopedChildren) {
+			scopedResolver = (element as ElementDescriptor & DeferredChildren)[SCOPED_CHILDREN_RESOLVER];
+		} else if (scopedChildren === SCOPED_VALUE_PROPERTIES.children.get) {
+			// A scoped value wrapping a scoped element reads its own resolver.
+			const get = scopedChildren;
+			scopedChildren = () => get!.call(element);
+		}
 		props = {};
 		for (const name in element.props) {
 			if (name !== 'key' && name !== 'children' && hasOwnProp.call(element.props, name)) {
@@ -1144,47 +1296,95 @@ export function cloneElement(
 	}
 	const n = children.length;
 	let kids: any;
-	let childProperty: PropertyDescriptor | undefined;
+	let preserveScopedChildren = false;
 	if (n === 1) {
 		kids = children[0];
 	} else if (n > 1) {
 		kids = children;
 	} else if (scopedChildren !== undefined && !replacedChildren) {
-		childProperty = { configurable: true, enumerable: true, get: scopedChildren };
-		Object.defineProperty(props, 'children', childProperty);
+		Object.defineProperty(
+			props,
+			'children',
+			scopedResolver === undefined
+				? { configurable: true, enumerable: true, get: scopedChildren }
+				: SCOPED_CHILDREN_PROPERTY,
+		);
+		if (scopedResolver !== undefined) setScopedChildrenResolver(props, scopedResolver);
 		SCOPED_ELEMENT_PROPS.add(props);
+		preserveScopedChildren = true;
 		kids = null;
 	} else {
 		// No new children: reuse `config.children` (now merged into props) or the original.
 		kids = 'children' in props ? props.children : element.children;
 	}
 	if (n > 0) props.children = kids;
-	const descriptor: ElementDescriptor = {
-		$$kind: ELEMENT_TAG,
-		type: element.type,
-		props,
-		key,
-		ref: props.ref !== undefined ? props.ref : null,
-		children: kids ?? null,
-	};
-	if (childProperty !== undefined) Object.defineProperty(descriptor, 'children', childProperty);
+	let descriptor: ElementDescriptor;
+	if (preserveScopedChildren) {
+		descriptor = {
+			$$kind: ELEMENT_TAG,
+			type: element.type,
+			props,
+			key,
+			ref: props.ref !== undefined ? props.ref : null,
+		} as ElementDescriptor;
+		Object.defineProperty(
+			descriptor,
+			'children',
+			scopedResolver === undefined
+				? { configurable: true, enumerable: true, get: scopedChildren }
+				: SCOPED_CHILDREN_PROPERTY,
+		);
+		if (scopedResolver !== undefined) setScopedChildrenResolver(descriptor, scopedResolver);
+	} else {
+		descriptor = {
+			$$kind: ELEMENT_TAG,
+			type: element.type,
+			props,
+			key,
+			ref: props.ref !== undefined ? props.ref : null,
+			children: kids ?? null,
+		};
+	}
 	return finalizeElementDescriptor(descriptor);
 }
 
 function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): ElementDescriptor {
 	// Traversal changes only the key, never the scope that resolves its children.
 	const scopedChildren = SCOPED_ELEMENT_PROPS.has(element.props);
-	const descriptor: ElementDescriptor = {
-		$$kind: ELEMENT_TAG,
-		type: element.type,
-		props: element.props,
-		key,
-		ref: element.ref,
-		children: scopedChildren ? null : element.children,
-	};
+	let descriptor: ElementDescriptor;
 	if (scopedChildren) {
 		const get = Object.getOwnPropertyDescriptor(element, 'children')!.get;
-		Object.defineProperty(descriptor, 'children', { configurable: true, enumerable: true, get });
+		const copiedGetter =
+			get === SCOPED_VALUE_PROPERTIES.children.get ? () => get!.call(element) : get;
+		descriptor = {
+			$$kind: ELEMENT_TAG,
+			type: element.type,
+			props: element.props,
+			key,
+			ref: element.ref,
+		} as ElementDescriptor;
+		Object.defineProperty(
+			descriptor,
+			'children',
+			get === getScopedChildren
+				? SCOPED_CHILDREN_PROPERTY
+				: { configurable: true, enumerable: true, get: copiedGetter },
+		);
+		if (get === getScopedChildren) {
+			setScopedChildrenResolver(
+				descriptor,
+				(element as ElementDescriptor & DeferredChildren)[SCOPED_CHILDREN_RESOLVER],
+			);
+		}
+	} else {
+		descriptor = {
+			$$kind: ELEMENT_TAG,
+			type: element.type,
+			props: element.props,
+			key,
+			ref: element.ref,
+			children: element.children,
+		};
 	}
 	return finalizeElementDescriptor(descriptor);
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -21170,6 +21170,14 @@ const ELEMENTS_MISSING_LIST_KEY = new WeakSet<object>();
 // collection. Ordinary createElement calls retain their exact public shape and
 // allocation path.
 const SCOPED_ELEMENT_PROPS = new WeakSet<object>();
+const SCOPED_CHILDREN_RESOLVER: unique symbol = Symbol('octane.scopedChildren');
+const SCOPED_CHILDREN_PROPERTY: PropertyDescriptor = {
+	configurable: true,
+	enumerable: true,
+	get: function (this: { [SCOPED_CHILDREN_RESOLVER]: () => unknown }) {
+		return this[SCOPED_CHILDREN_RESOLVER]();
+	},
+};
 export interface ElementDescriptor<P = any> {
 	$$kind: typeof ELEMENT_TAG;
 	// A compiled ComponentBody (the fast/common case, e.g. `root.render(<App/>)`)
@@ -21222,6 +21230,121 @@ function copyElementConfig(config: any): any {
 	return props;
 }
 
+function restoreWritableScopedChildren(props: any, name: string, value: unknown): boolean {
+	const inherited = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(props), name);
+	if (inherited?.get === undefined && inherited?.set === undefined) return false;
+	// An inherited accessor can write children during the next assignment (or
+	// default lookup). Keep the original writable value until copying finishes.
+	Object.defineProperty(props, 'children', {
+		configurable: true,
+		enumerable: true,
+		writable: true,
+		value,
+	});
+	return true;
+}
+
+// A scoped child replaces any copied/default children value. Install the shared
+// accessor at the same enumeration position without first adding a data field;
+// keep the overwritten value only for defaultProps' undefined check.
+function copyScopedElementConfig(type: any, config: any, resolve: () => unknown): any {
+	// An own __proto__ can change where later assignments land (including an
+	// inherited children setter). Preserve the full copy/default sequence before
+	// replacing children in this uncommon case. The same applies if a caller has
+	// explicitly installed children on Object.prototype.
+	if (
+		(config != null && hasOwnProp.call(config, '__proto__')) ||
+		hasOwnProp.call(Object.prototype, 'children')
+	) {
+		const props = copyElementConfig(config);
+		applyElementDefaultProps(type, props);
+		Object.defineProperty(props, SCOPED_CHILDREN_RESOLVER, { value: resolve });
+		Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+		SCOPED_ELEMENT_PROPS.add(props);
+		return props;
+	}
+	const props: any = {};
+	Object.defineProperty(props, SCOPED_CHILDREN_RESOLVER, { value: resolve });
+	let copiedChildren: any;
+	let hasCopiedChildren = false;
+	let childrenAreWritable = false;
+	if (config != null) {
+		for (const name in config) {
+			if (name === 'key' || !hasOwnProp.call(config, name)) continue;
+			if (name === 'children') {
+				copiedChildren = config[name];
+				Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+				hasCopiedChildren = true;
+			} else {
+				const value = config[name];
+				if (
+					hasCopiedChildren &&
+					!childrenAreWritable &&
+					!hasOwnProp.call(props, name) &&
+					restoreWritableScopedChildren(props, name, copiedChildren)
+				) {
+					childrenAreWritable = true;
+				}
+				props[name] = value;
+			}
+		}
+	}
+	const defaults = type?.defaultProps;
+	if (defaults != null) {
+		for (const name in defaults) {
+			if (name === 'children') {
+				if (
+					(childrenAreWritable
+						? props.children
+						: hasCopiedChildren
+							? copiedChildren
+							: props.children) === undefined
+				) {
+					copiedChildren = defaults[name];
+					if (childrenAreWritable) {
+						props.children = copiedChildren;
+					} else if (!hasCopiedChildren) {
+						if ('children' in props) {
+							// Preserve an inherited setter/throw before replacing the value.
+							props.children = copiedChildren;
+						} else {
+							Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+							hasCopiedChildren = true;
+						}
+					}
+				}
+			} else {
+				if (
+					hasCopiedChildren &&
+					!childrenAreWritable &&
+					!hasOwnProp.call(props, name) &&
+					restoreWritableScopedChildren(props, name, copiedChildren)
+				) {
+					childrenAreWritable = true;
+				}
+				if (props[name] === undefined) props[name] = defaults[name];
+			}
+		}
+	}
+	if (childrenAreWritable || !hasCopiedChildren)
+		Object.defineProperty(props, 'children', SCOPED_CHILDREN_PROPERTY);
+	SCOPED_ELEMENT_PROPS.add(props);
+	return props;
+}
+
+function scopedElementRecord<P>(
+	type: ElementDescriptor<P>['type'],
+	props: P,
+	key: any,
+	ref: any,
+	resolve: () => unknown,
+): ElementDescriptor<P> {
+	const descriptor = { $$kind: ELEMENT_TAG, type, props, key, ref } as ElementDescriptor<P>;
+	Object.defineProperty(descriptor, SCOPED_CHILDREN_RESOLVER, { value: resolve });
+	Object.defineProperty(descriptor, 'children', SCOPED_CHILDREN_PROPERTY);
+	return descriptor;
+}
+
 function finalizeElementDescriptor<P>(descriptor: ElementDescriptor<P>): ElementDescriptor<P> {
 	if (process.env.NODE_ENV !== 'production') {
 		Object.freeze(descriptor.props);
@@ -21234,6 +21357,34 @@ const SCOPED_VALUE_RECORD: unique symbol = Symbol('octane.scopedValue');
 
 type ScopedValueDescriptor<P> = ElementDescriptor<P> & {
 	readonly [SCOPED_VALUE_RECORD]?: () => ElementDescriptor<P>;
+};
+
+function scopedValueType(this: ScopedValueDescriptor<any>): ElementDescriptor['type'] {
+	return this[SCOPED_VALUE_RECORD]!().type;
+}
+function scopedValueProps(this: ScopedValueDescriptor<any>): any {
+	return this[SCOPED_VALUE_RECORD]!().props;
+}
+function scopedValueKey(this: ScopedValueDescriptor<any>): any {
+	const next = this[SCOPED_VALUE_RECORD]!();
+	const key = next.key;
+	if (key === null && KEYED_ELEMENT_DESCRIPTORS.has(next)) {
+		KEYED_ELEMENT_DESCRIPTORS.add(this);
+	}
+	return key;
+}
+function scopedValueRef(this: ScopedValueDescriptor<any>): any {
+	return this[SCOPED_VALUE_RECORD]!().ref;
+}
+function scopedValueChildren(this: ScopedValueDescriptor<any>): any {
+	return this[SCOPED_VALUE_RECORD]!().children;
+}
+const SCOPED_VALUE_PROPERTIES: PropertyDescriptorMap = {
+	type: { configurable: true, enumerable: true, get: scopedValueType },
+	props: { configurable: true, enumerable: true, get: scopedValueProps },
+	key: { configurable: true, enumerable: true, get: scopedValueKey },
+	ref: { configurable: true, enumerable: true, get: scopedValueRef },
+	children: { configurable: true, enumerable: true, get: scopedValueChildren },
 };
 
 /**
@@ -21260,30 +21411,15 @@ export function nativeCreateScopedValue<P>(
 }
 
 function scopedValueDescriptor<P>(resolve: () => ElementDescriptor<P>): ElementDescriptor<P> {
-	const descriptor: ElementDescriptor<P> = {
-		$$kind: ELEMENT_TAG,
-		get type() {
-			return resolve().type;
-		},
-		get props() {
-			return resolve().props;
-		},
-		get key() {
-			const next = resolve();
-			const key = next.key;
-			if (key === null && KEYED_ELEMENT_DESCRIPTORS.has(next)) {
-				KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
-			}
-			return key;
-		},
-		get ref() {
-			return resolve().ref;
-		},
-		get children() {
-			return resolve().children;
-		},
-	};
+	const descriptor = { $$kind: ELEMENT_TAG } as ElementDescriptor<P>;
 	Object.defineProperty(descriptor, SCOPED_VALUE_RECORD, { value: resolve });
+	// Different renderer copies can share the initial { $$kind } V8 map. Seed
+	// this module's symbol before accessor transitions to keep their maps apart.
+	Object.defineProperty(descriptor, 'type', SCOPED_VALUE_PROPERTIES.type);
+	Object.defineProperty(descriptor, 'props', SCOPED_VALUE_PROPERTIES.props);
+	Object.defineProperty(descriptor, 'key', SCOPED_VALUE_PROPERTIES.key);
+	Object.defineProperty(descriptor, 'ref', SCOPED_VALUE_PROPERTIES.ref);
+	Object.defineProperty(descriptor, 'children', SCOPED_VALUE_PROPERTIES.children);
 	if (process.env.NODE_ENV !== 'production') Object.freeze(descriptor);
 	return descriptor;
 }
@@ -21323,22 +21459,14 @@ function scopedElementDescriptor<P>(
 	const src = (props ?? null) as any;
 	const hasKey = hasElementConfigKey(src);
 	const key = hasKey ? '' + src.key : null;
-	const copiedProps = copyElementConfig(src);
-	applyElementDefaultProps(type, copiedProps);
-
-	const childProperty = { configurable: true, enumerable: true, get: children };
-	Object.defineProperty(copiedProps, 'children', childProperty);
-	SCOPED_ELEMENT_PROPS.add(copiedProps);
-
-	const descriptor: ElementDescriptor<P> = {
-		$$kind: ELEMENT_TAG,
+	const copiedProps = copyScopedElementConfig(type, src, children);
+	const descriptor = scopedElementRecord(
 		type,
-		props: copiedProps as P,
+		copiedProps as P,
 		key,
-		ref: copiedProps.ref !== undefined ? copiedProps.ref : null,
-		children: null,
-	};
-	Object.defineProperty(descriptor, 'children', childProperty);
+		copiedProps.ref !== undefined ? copiedProps.ref : null,
+		children,
+	);
 	if (
 		key === null &&
 		src != null &&
@@ -21459,10 +21587,19 @@ export function cloneElement<P>(
 		throw new Error(formatClientError(4));
 	}
 	let scopedChildren: (() => unknown) | undefined;
+	let copiedGetter: (() => unknown) | undefined;
 	let props: any;
 	if (SCOPED_ELEMENT_PROPS.has(element.props as object)) {
 		// Copy a scoped descriptor's child accessor without evaluating it in the caller's scope.
-		scopedChildren = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		const get = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		if (get === SCOPED_CHILDREN_PROPERTY.get) {
+			scopedChildren = (element as any)[SCOPED_CHILDREN_RESOLVER];
+		} else {
+			// A complete scoped value can wrap a scoped element. Its shared getter
+			// reads a resolver from its receiver, so bind that one to the source.
+			// A user-replaced getter still receives the clone as before.
+			copiedGetter = get === SCOPED_VALUE_PROPERTIES.children.get ? () => get!.call(element) : get;
+		}
 		props = {};
 		for (const name in element.props) {
 			if (name !== 'key' && name !== 'children' && hasOwnProp.call(element.props, name)) {
@@ -21491,31 +21628,54 @@ export function cloneElement<P>(
 	}
 	const n = children.length;
 	let kids: any;
-	let childProperty: PropertyDescriptor | undefined;
+	let keepsScopedChildren = false;
 	if (n === 1) {
 		kids = children[0];
 	} else if (n > 1) {
 		POSITIONAL_CHILDREN.add(children);
 		kids = children;
-	} else if (scopedChildren !== undefined && !replacedChildren) {
-		childProperty = { configurable: true, enumerable: true, get: scopedChildren };
-		Object.defineProperty(props, 'children', childProperty);
+	} else if ((scopedChildren !== undefined || copiedGetter !== undefined) && !replacedChildren) {
+		if (copiedGetter === undefined) {
+			Object.defineProperty(props, SCOPED_CHILDREN_RESOLVER, { value: scopedChildren });
+		}
+		Object.defineProperty(
+			props,
+			'children',
+			copiedGetter === undefined
+				? SCOPED_CHILDREN_PROPERTY
+				: { configurable: true, enumerable: true, get: copiedGetter },
+		);
 		SCOPED_ELEMENT_PROPS.add(props);
+		keepsScopedChildren = true;
 		kids = null;
 	} else {
 		// No new children: reuse `config.children` (now merged into props) or the original.
 		kids = 'children' in props ? props.children : element.children;
 	}
 	if (n > 0) props.children = kids;
-	const descriptor: ElementDescriptor<P> = {
-		$$kind: ELEMENT_TAG,
-		type: element.type,
-		props,
-		key,
-		ref: props.ref !== undefined ? props.ref : null,
-		children: kids ?? null,
-	};
-	if (childProperty !== undefined) Object.defineProperty(descriptor, 'children', childProperty);
+	const ref = props.ref !== undefined ? props.ref : null;
+	let descriptor: ElementDescriptor<P>;
+	if (keepsScopedChildren && copiedGetter === undefined) {
+		descriptor = scopedElementRecord(element.type, props, key, ref, scopedChildren!);
+	} else {
+		descriptor = {
+			$$kind: ELEMENT_TAG,
+			type: element.type,
+			props,
+			key,
+			ref,
+			children: kids ?? null,
+		};
+		if (keepsScopedChildren) {
+			// A production caller may replace the accessor. Copy its receiver-sensitive
+			// getter unchanged on this cold path.
+			Object.defineProperty(descriptor, 'children', {
+				configurable: true,
+				enumerable: true,
+				get: copiedGetter,
+			});
+		}
+	}
 	// Only a nullish result key needs the out-of-band record (see createElement).
 	if (
 		key === null &&
@@ -21534,20 +21694,43 @@ export function cloneElement<P>(
 
 function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): ElementDescriptor {
 	const scoped = SCOPED_ELEMENT_PROPS.has(element.props);
-	const descriptor: ElementDescriptor = {
-		$$kind: ELEMENT_TAG,
-		type: element.type,
-		props: element.props,
-		key,
-		ref: element.ref,
-		children: scoped ? null : element.children,
-	};
+	let descriptor: ElementDescriptor;
 	if (scoped) {
-		Object.defineProperty(descriptor, 'children', {
-			configurable: true,
-			enumerable: true,
-			get: Object.getOwnPropertyDescriptor(element, 'children')!.get!,
-		});
+		const get = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		if (get === SCOPED_CHILDREN_PROPERTY.get) {
+			descriptor = scopedElementRecord(
+				element.type,
+				element.props,
+				key,
+				element.ref,
+				(element as any)[SCOPED_CHILDREN_RESOLVER],
+			);
+		} else {
+			const copiedGetter =
+				get === SCOPED_VALUE_PROPERTIES.children.get ? () => get!.call(element) : get;
+			descriptor = {
+				$$kind: ELEMENT_TAG,
+				type: element.type,
+				props: element.props,
+				key,
+				ref: element.ref,
+				children: null,
+			};
+			Object.defineProperty(descriptor, 'children', {
+				configurable: true,
+				enumerable: true,
+				get: copiedGetter,
+			});
+		}
+	} else {
+		descriptor = {
+			$$kind: ELEMENT_TAG,
+			type: element.type,
+			props: element.props,
+			key,
+			ref: element.ref,
+			children: element.children,
+		};
 	}
 	// `key` is a real (non-null) string here, so presence is already implied.
 	if (ELEMENTS_MISSING_LIST_KEY.has(element)) ELEMENTS_MISSING_LIST_KEY.add(descriptor);

--- a/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
+++ b/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
@@ -83,6 +83,28 @@ function InspectContextAttribute(props: { child: OctaneNode }) {
 	);
 }
 
+function InspectDeferredChild(props: { child: OctaneNode; name: string }) {
+	const child = Children.only(props.child) as ElementDescriptor;
+	return (
+		<section
+			data-inspected-child={props.name}
+			data-prop-keys={Object.keys(child.props).join(',')}
+			data-observed-child={String(child.props.children)}
+		>
+			{child}
+		</section>
+	);
+}
+
+function DefaultChildren(props: { children?: OctaneNode; sequence?: string }) {
+	return (
+		<strong data-default-child="yes" data-seq={props.sequence}>
+			{props.children}
+		</strong>
+	);
+}
+(DefaultChildren as any).defaultProps = { children: 'default' };
+
 function InspectChildrenThenProvide(props: { child: OctaneNode }) {
 	const child = Children.only(props.child) as ElementDescriptor;
 	const inspected = String(child.props.children);
@@ -212,6 +234,56 @@ export function RootInspectedAttributeContext() {
 	return (
 		<ValueContext.Provider value="inner">
 			<InspectContextAttribute child={content} />
+		</ValueContext.Provider>
+	);
+}
+
+export function IndependentDeferredChildren(props: {
+	first: string;
+	second: string;
+	value: string;
+}) {
+	const first = (
+		<span data-sibling="first" data-order="one">
+			{props.first + ':' + getterValue.current}
+		</span>
+	);
+	const second = (
+		<span data-sibling="second" data-order="two">
+			{props.second + ':' + getterValue.current}
+		</span>
+	);
+	const flattened = Children.toArray(first)[0];
+	const mapped = Children.map(second, (child) =>
+		cloneElement(child as ElementDescriptor, { key: 'replacement', 'data-copy': 'yes' }),
+	)![0];
+	return (
+		<ValueContext.Provider value={props.value}>
+			<div data-outlet="independent-children">
+				<InspectDeferredChild child={flattened} name="first" />
+				<InspectDeferredChild child={mapped} name="second" />
+			</div>
+		</ValueContext.Provider>
+	);
+}
+
+export function DeferredChildrenSources(props: { value: string }) {
+	const spread = {
+		get children() {
+			return 'spread';
+		},
+		'data-seq': 'spread',
+	};
+	const fromSpread = <span {...spread}>{getterValue.current}</span>;
+	const fromDefaults = <DefaultChildren>{getterValue.current}</DefaultChildren>;
+	const defaultOnly = <DefaultChildren sequence={getterValue.current} />;
+	return (
+		<ValueContext.Provider value={props.value}>
+			<div data-outlet="children-sources">
+				<InspectDeferredChild child={fromSpread} name="spread" />
+				<InspectDeferredChild child={fromDefaults} name="defaults" />
+				<InspectDeferredChild child={defaultOnly} name="default-only" />
+			</div>
 		</ValueContext.Provider>
 	);
 }

--- a/packages/octane/tests/scoped-jsx-values.test.ts
+++ b/packages/octane/tests/scoped-jsx-values.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 
-import { flushSync, hydrateRoot, type ComponentBody } from '../src/index.js';
+import {
+	Children,
+	cloneElement,
+	createScopedElement,
+	createScopedValue,
+	flushSync,
+	hydrateRoot,
+	type ComponentBody,
+	type ElementDescriptor,
+} from '../src/index.js';
 import { act, mount } from './_helpers.js';
 import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
 import * as tsx from './_fixtures/scoped-jsx-values.tsx';
@@ -82,6 +91,22 @@ function InspectContextAttribute(props: { child: OctaneNode }) @{
 		{cloned}
 	</section>
 }
+
+function InspectDeferredChild(props: { child: OctaneNode; name: string }) @{
+	const child = Children.only(props.child) as ElementDescriptor;
+	<section
+		data-inspected-child={props.name}
+		data-prop-keys={Object.keys(child.props).join(',')}
+		data-observed-child={String(child.props.children)}
+	>
+		{child}
+	</section>
+}
+
+function DefaultChildren(props: { children?: OctaneNode; sequence?: string }) @{
+	<strong data-default-child="yes" data-seq={props.sequence}>{props.children}</strong>
+}
+(DefaultChildren as any).defaultProps = { children: 'default' };
 
 function InspectChildrenThenProvide(props: { child: OctaneNode }) @{
 	const child = Children.only(props.child) as ElementDescriptor;
@@ -189,6 +214,40 @@ export function RootInspectedAttributeContext() @{
 	</span>;
 	<ValueContext.Provider value="inner">
 		<InspectContextAttribute child={content} />
+	</ValueContext.Provider>
+}
+
+export function IndependentDeferredChildren(props: { first: string; second: string; value: string }) @{
+	const first = <span data-sibling="first" data-order="one">{(props.first + ':' + getterValue.current) as string}</span>;
+	const second = <span data-sibling="second" data-order="two">{(props.second + ':' + getterValue.current) as string}</span>;
+	const flattened = Children.toArray(first)[0];
+	const mapped = Children.map(second, (child) =>
+		cloneElement(child as ElementDescriptor, { key: 'replacement', 'data-copy': 'yes' }),
+	)![0];
+	<ValueContext.Provider value={props.value}>
+		<div data-outlet="independent-children">
+			<InspectDeferredChild child={flattened} name="first" />
+			<InspectDeferredChild child={mapped} name="second" />
+		</div>
+	</ValueContext.Provider>
+}
+
+export function DeferredChildrenSources(props: { value: string }) @{
+	const spread = {
+		get children() {
+			return 'spread';
+		},
+		'data-seq': 'spread',
+	};
+	const fromSpread = <span {...spread}>{getterValue.current as string}</span>;
+	const fromDefaults = <DefaultChildren>{getterValue.current as string}</DefaultChildren>;
+	const defaultOnly = <DefaultChildren sequence={getterValue.current} />;
+	<ValueContext.Provider value={props.value}>
+		<div data-outlet="children-sources">
+			<InspectDeferredChild child={fromSpread} name="spread" />
+			<InspectDeferredChild child={fromDefaults} name="defaults" />
+			<InspectDeferredChild child={defaultOnly} name="default-only" />
+		</div>
 	</ValueContext.Provider>
 }
 
@@ -787,6 +846,66 @@ for (const fixture of fixtures) {
 			container.remove();
 		});
 
+		it('keeps mapped and cloned siblings bound to their own deferred children', () => {
+			const result = mount(fixture.client.IndependentDeferredChildren, {
+				first: 'one',
+				second: 'two',
+				value: 'inner',
+			});
+			const assertChildren = (first: string, second: string) => {
+				const parent = result.find('[data-outlet="independent-children"]');
+				const observed = parent.querySelectorAll('[data-inspected-child]');
+				expect(Array.from(observed, (node) => node.getAttribute('data-observed-child'))).toEqual([
+					first,
+					second,
+				]);
+				expect(Array.from(observed, (node) => node.textContent)).toEqual([first, second]);
+				expect(Array.from(observed, (node) => node.getAttribute('data-prop-keys'))).toEqual([
+					'data-sibling,data-order,children',
+					'data-sibling,data-order,data-copy,children',
+				]);
+				expect(parent.querySelector('[data-sibling="second"]')?.getAttribute('data-copy')).toBe(
+					'yes',
+				);
+			};
+			assertChildren('one:inner', 'two:inner');
+
+			result.update(fixture.client.IndependentDeferredChildren, {
+				first: 'new-one',
+				second: 'new-two',
+				value: 'next',
+			});
+			assertChildren('new-one:next', 'new-two:next');
+			result.unmount();
+		});
+
+		it('preserves spread and default children precedence and property order', () => {
+			const result = mount(fixture.client.DeferredChildrenSources, { value: 'inner' });
+			const assertChildren = (value: string) => {
+				const parent = result.find('[data-outlet="children-sources"]');
+				const observed = parent.querySelectorAll('[data-inspected-child]');
+				expect(Array.from(observed, (node) => node.getAttribute('data-observed-child'))).toEqual([
+					value,
+					value,
+					'default',
+				]);
+				expect(Array.from(observed, (node) => node.textContent)).toEqual([value, value, 'default']);
+				expect(Array.from(observed, (node) => node.getAttribute('data-prop-keys'))).toEqual([
+					'children,data-seq',
+					'children',
+					'sequence,children',
+				]);
+				const defaulted = parent.querySelector('[data-inspected-child="default-only"]');
+				const content = defaulted?.querySelector('[data-default-child="yes"]');
+				expect(content?.textContent).toBe('default');
+				expect(content?.getAttribute('data-seq')).toBe(value);
+			};
+			assertChildren('inner');
+			result.update(fixture.client.DeferredChildrenSources, { value: 'next' });
+			assertChildren('next');
+			result.unmount();
+		});
+
 		it('evaluates fragment-nested host attributes inside their represented provider', () => {
 			const result = mount(fixture.client.FragmentNestedAttributeContext);
 			expect(
@@ -1054,6 +1173,136 @@ for (const fixture of fixtures) {
 		});
 	});
 }
+
+if (process.env.OCTANE_TEST_COMPILE_MODE === 'prod') {
+	it('preserves a caller-defined children getter on mapped and cloned elements', () => {
+		vi.stubEnv('NODE_ENV', 'production');
+		try {
+			const original = createScopedElement('span', { 'data-kind': 'original' }, () => 'scoped');
+			Object.defineProperty(original, 'children', {
+				configurable: true,
+				enumerable: true,
+				get(this: ElementDescriptor<{ 'data-kind': string }>) {
+					return `${this.props['data-kind']}:${this.key}`;
+				},
+			});
+
+			const cloned = cloneElement(original, { 'data-kind': 'clone', key: 'new-key' });
+			const mapped = Children.map([original], (child) =>
+				cloneElement(child as ElementDescriptor, { 'data-kind': 'mapped' }),
+			)![0] as ElementDescriptor;
+			const flattened = Children.toArray([original])[0] as ElementDescriptor;
+			expect(original.children).toBe('original:null');
+			expect(cloned.children).toBe('clone:new-key');
+			expect(mapped.children).toBe(`mapped:${mapped.key}`);
+			expect(flattened.children).toBe(`original:${flattened.key}`);
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+}
+
+it('clones and maps scoped values whose resolved elements defer children', () => {
+	const reads: string[] = [];
+	const first = createScopedValue(() =>
+		createScopedElement('span', { key: 'a' }, () => {
+			reads.push('a');
+			return 'alpha';
+		}),
+	);
+	const second = createScopedValue(() =>
+		createScopedElement('em', { key: 'b' }, () => {
+			reads.push('b');
+			return 'beta';
+		}),
+	);
+	const clone = cloneElement(first, { title: 'copy' });
+	const mapped = Children.map([first, second], (child) => child)!;
+	const flattened = Children.toArray([first, second]);
+	expect(reads).toEqual([]);
+	expect(clone.children).toBe('alpha');
+	expect(mapped[0].children).toBe('alpha');
+	expect(mapped[1].children).toBe('beta');
+	expect(flattened[0].children).toBe('alpha');
+	expect(flattened[1].children).toBe('beta');
+	expect(cloneElement(mapped[1] as ElementDescriptor).children).toBe('beta');
+	expect(reads).toContain('a');
+	expect(reads).toContain('b');
+});
+
+it('preserves inherited children setters and default prop order in scoped elements', () => {
+	function DefaultedChild() {
+		return null;
+	}
+	(DefaultedChild as any).defaultProps = { children: 'default', 'data-after': 'after' };
+	const assigned: unknown[] = [];
+	const inherited = {
+		get children() {
+			return undefined;
+		},
+		set children(value: unknown) {
+			assigned.push(value);
+		},
+	};
+	const config = Object.create(null) as Record<string, unknown>;
+	Object.defineProperty(config, '__proto__', {
+		configurable: true,
+		enumerable: true,
+		value: inherited,
+	});
+	config['data-before'] = 'before';
+	const descriptor = createScopedElement(DefaultedChild, config, () => 'scoped');
+
+	expect(assigned).toEqual(['default']);
+	expect(Object.keys(descriptor.props)).toEqual(['data-before', 'data-after', 'children']);
+	expect(descriptor.props.children).toBe('scoped');
+	expect(descriptor.children).toBe('scoped');
+});
+
+it('copies inherited children assignments before replacing them with scoped accessors', () => {
+	const assigned: unknown[] = [];
+	const inherited = {
+		set children(value: unknown) {
+			assigned.push(value);
+		},
+		set touch(value: unknown) {
+			assigned.push(`touch:${String(value)}`);
+			(this as { children?: unknown }).children = 'from touch';
+		},
+	};
+	const config = Object.create(null) as Record<string, unknown>;
+	Object.defineProperty(config, '__proto__', { enumerable: true, value: inherited });
+	config.children = 'provided';
+	config.touch = 1;
+	const descriptor = createScopedElement('span', config, () => 'deferred');
+	// The original copy invokes both setters before installing deferred children.
+	expect(assigned).toEqual(['provided', 'touch:1', 'from touch']);
+	expect(Object.keys(descriptor.props)).toEqual(['children']);
+	expect(descriptor.props.children).toBe('deferred');
+});
+
+it('allows later inherited setters to write copied children before deferral', () => {
+	const property = '__octaneScopedTouchTest__';
+	const observed: unknown[] = [];
+	Object.defineProperty(Object.prototype, property, {
+		configurable: true,
+		set(this: { children?: unknown }, value: unknown) {
+			observed.push(value);
+			this.children = 'from inherited setter';
+		},
+	});
+	try {
+		const descriptor = createScopedElement(
+			'span',
+			{ children: 'provided', [property]: 'trigger' },
+			() => 'deferred',
+		);
+		expect(observed).toEqual(['trigger']);
+		expect(descriptor.props.children).toBe('deferred');
+	} finally {
+		delete (Object.prototype as Record<string, unknown>)[property];
+	}
+});
 
 describe('TSRX directives nested in JSX values', () => {
 	it('retains the provider inside an active directive arm', () => {

--- a/packages/octane/tests/ssr-element-utils.test.ts
+++ b/packages/octane/tests/ssr-element-utils.test.ts
@@ -14,6 +14,8 @@ const {
 	isValidElement,
 	Children,
 	createPortal,
+	createScopedElement,
+	createScopedValue,
 	renderToStaticMarkup,
 } = Server as any;
 
@@ -110,6 +112,190 @@ describe('octane/server element utilities', () => {
 		const App = () => clone;
 		const { html } = renderToStaticMarkup(App);
 		expect(html).toBe('<span class="tick tick-big">v</span>');
+	});
+
+	it('keeps each deferred element child with its original scope through cloning and mapping', () => {
+		const reads: string[] = [];
+		const first = createScopedElement('span', { key: 'first', 'data-row': 'first' }, () => {
+			reads.push('first');
+			return 'alpha';
+		});
+		const second = createScopedElement('span', { key: 'second', 'data-row': 'second' }, () => {
+			reads.push('second');
+			return 'beta';
+		});
+		const clone = cloneElement(first, { 'data-cloned': 'yes' });
+		const mapped = Children.map([first, second], (child: unknown) => child);
+		const replaced = cloneElement(first, { children: 'replacement' });
+		expect(reads).toEqual([]);
+		expect(Object.keys(first)).toEqual(['$$kind', 'type', 'props', 'key', 'ref', 'children']);
+		expect(Object.getOwnPropertyDescriptor(first, 'children')).toMatchObject({
+			configurable: false,
+			enumerable: true,
+		});
+		expect(first.props.children).toBe('alpha');
+		expect(second.children).toBe('beta');
+		expect(clone.props.children).toBe('alpha');
+		expect(mapped[0].children).toBe('alpha');
+		expect(mapped[1].children).toBe('beta');
+		expect(replaced.props.children).toBe('replacement');
+		const html = renderToStaticMarkup(() => [clone, mapped[1], replaced]).html;
+		expect(html).toContain('<span data-row="first" data-cloned="yes">alpha</span>');
+		expect(html).toContain('<span data-row="second">beta</span>');
+		expect(html).toContain('<span data-row="first">replacement</span>');
+		expect(reads).toContain('first');
+		expect(reads).toContain('second');
+	});
+
+	it('preserves spread and default children observations while deferring their replacement', () => {
+		let sourceReads = 0;
+		let defaultReads = 0;
+		const Label = Object.assign(
+			(props: { children?: unknown; id?: string }) =>
+				createElement('span', { id: props.id }, props.children),
+			{
+				defaultProps: {
+					role: 'label',
+					get children() {
+						defaultReads++;
+						return 'unused default';
+					},
+					'data-after': 'suffix',
+				},
+			},
+		);
+		const spread = createScopedElement(
+			Label,
+			{
+				id: 'spread',
+				get children() {
+					sourceReads++;
+					return undefined;
+				},
+				title: 'provided',
+			},
+			() => 'deferred spread',
+		);
+		const defaulted = createScopedElement(Label, { id: 'defaulted' }, () => 'deferred default');
+		expect(sourceReads).toBe(1);
+		expect(defaultReads).toBe(2);
+		expect(Object.keys(spread.props)).toEqual(['id', 'children', 'title', 'role', 'data-after']);
+		expect(Object.keys(defaulted.props)).toEqual(['id', 'role', 'children', 'data-after']);
+		expect(spread.props.children).toBe('deferred spread');
+		expect(defaulted.props.children).toBe('deferred default');
+		const html = renderToStaticMarkup(() => [spread, defaulted]).html;
+		expect(html).toContain('<span id="spread">deferred spread</span>');
+		expect(html).toContain('<span id="defaulted">deferred default</span>');
+	});
+
+	it('respects inherited children when default props are applied', () => {
+		const assigned: unknown[] = [];
+		const prototype = {
+			get children() {
+				return undefined;
+			},
+			set children(value: unknown) {
+				assigned.push(value);
+			},
+		};
+		const source = Object.create(null);
+		Object.defineProperty(source, '__proto__', { enumerable: true, value: prototype });
+		source.id = 'inherited';
+		const Label = Object.assign(
+			(props: { children?: unknown }) => createElement('span', null, props.children),
+			{ defaultProps: { role: 'status', children: 'default', title: 'end' } },
+		);
+		const element = createScopedElement(Label, source, () => 'deferred');
+		expect(assigned).toEqual(['default']);
+		expect(Object.keys(element.props)).toEqual(['id', 'role', 'title', 'children']);
+		expect(element.props.children).toBe('deferred');
+		expect(renderToStaticMarkup(() => element).html).toContain('<span>deferred</span>');
+	});
+
+	it('runs inherited config setters before installing deferred children', () => {
+		const assigned: unknown[] = [];
+		const inherited = {
+			set children(value: unknown) {
+				assigned.push(value);
+			},
+			set touch(value: unknown) {
+				assigned.push(`touch:${String(value)}`);
+				(this as { children?: unknown }).children = 'from touch';
+			},
+		};
+		const config = Object.create(null) as Record<string, unknown>;
+		Object.defineProperty(config, '__proto__', { enumerable: true, value: inherited });
+		config.children = 'provided';
+		config.touch = 1;
+		const element = createScopedElement('span', config, () => 'deferred');
+		expect(assigned).toEqual(['provided', 'touch:1', 'from touch']);
+		expect(Object.keys(element.props)).toEqual(['children']);
+		expect(element.props.children).toBe('deferred');
+	});
+
+	it('allows a later inherited setter to write copied children', () => {
+		const property = '__octaneScopedTouchTest__';
+		const observed: unknown[] = [];
+		Object.defineProperty(Object.prototype, property, {
+			configurable: true,
+			set(this: { children?: unknown }, value: unknown) {
+				observed.push(value);
+				this.children = 'from inherited setter';
+			},
+		});
+		try {
+			const element = createScopedElement(
+				'span',
+				{ children: 'provided', [property]: 'trigger' },
+				() => 'deferred',
+			);
+			expect(observed).toEqual(['trigger']);
+			expect(element.props.children).toBe('deferred');
+		} finally {
+			delete (Object.prototype as Record<string, unknown>)[property];
+		}
+	});
+
+	it('keeps complete deferred records independent when inspected', () => {
+		const first = createScopedValue(() => createScopedElement('strong', { key: 'a' }, () => 'one'));
+		const second = createScopedValue(() => createScopedElement('em', { key: 'b' }, () => 'two'));
+		expect(Object.keys(first)).toEqual(['$$kind', 'type', 'props', 'key', 'ref', 'children']);
+		expect(first.type).toBe('strong');
+		expect(first.key).toBe('a');
+		expect(first.children).toBe('one');
+		expect(second.type).toBe('em');
+		expect(second.key).toBe('b');
+		expect(second.props.children).toBe('two');
+		expect(renderToStaticMarkup(() => [first, second]).html).toContain('<strong>one</strong>');
+		expect(renderToStaticMarkup(() => [first, second]).html).toContain('<em>two</em>');
+	});
+
+	it('clones and maps scoped values wrapping deferred scoped elements', () => {
+		const reads: string[] = [];
+		const first = createScopedValue(() =>
+			createScopedElement('span', { key: 'a' }, () => {
+				reads.push('a');
+				return 'alpha';
+			}),
+		);
+		const second = createScopedValue(() =>
+			createScopedElement('em', { key: 'b' }, () => {
+				reads.push('b');
+				return 'beta';
+			}),
+		);
+		const clone = cloneElement(first, { title: 'copy' });
+		const mapped = Children.map([first, second], (child: unknown) => child);
+		const flattened = Children.toArray([first, second]);
+		expect(reads).toEqual([]);
+		expect(clone.children).toBe('alpha');
+		expect(mapped[0].children).toBe('alpha');
+		expect(mapped[1].children).toBe('beta');
+		expect(flattened[0].children).toBe('alpha');
+		expect(flattened[1].children).toBe('beta');
+		expect(cloneElement(mapped[1]).children).toBe('beta');
+		expect(reads).toContain('a');
+		expect(reads).toContain('b');
 	});
 
 	it('throws on a non-element, like the client entry', () => {


### PR DESCRIPTION
## Summary

Address the scoped JSX descriptor and props dictionary-mode finding in #981 on the client and server runtimes.

## Why

A new `children` getter per scoped element changes V8's accessor transition on later instances; overwriting the descriptor's `children: null` field also normalizes its shape. Complete scoped-value records create a fresh set of five getters on every instance. These descriptors occur in compiled value-position JSX, including lists with dynamic children.

## Changes

- Share scoped-element and scoped-value accessor identities, with a per-instance private resolver. Construct scoped descriptors without a temporary `children` data field and keep source/default `children` reads and enumerable key order intact.
- Preserve deferred children through `cloneElement`, `Children.map`, and `Children.toArray`, including nested scoped values, custom production getters, inherited setters, and SSR.
- Add public client/server/TSRX/TSX regressions, a production benchmark with plain-element controls and semantic hashes, MCP benchmark registration, and patch changesets for `octane` and `@octanejs/mcp-server`.

## Validation

- [x] `pnpm sync`; no generated changes.
- [x] Direct Prettier check on changed files, `git diff --check`, `tsgo --noEmit -p packages/octane/tsconfig.json`, and standalone TSX fixture typecheck.
- [x] Scoped JSX, clone, signals, SSR, and hydration tests: 1,019/1,019 in 19 Vitest project runs; added nested-value clone tests: 4/4 in dev/prod.
- [x] Direct `node scripts/check-changesets.js && node scripts/check-release-plan.mjs`; production Octane build; `node benchmarks/bench.mjs --quick scoped-descriptor-shapes` (48 targets).
- [x] Frozen production baseline vs candidate, B–C–C–B with 13 samples per run, five warmups, client/server in separate processes: 48/48 public semantic hashes match; a nested scoped-value clone/map preflight reproduces the earlier regression on the previous build and passes the final build. V8 `%HasFastProperties` reports fast for four of four scoped elements, props objects, and value descriptors in both runtimes.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34348121052) passed 26/26 jobs at `547a369`, including formatting, typecheck, Node 24 tests, React parity, browser integration, and package validation. The repository-wide commands were not separately run locally; direct scoped equivalents passed. A pnpm dependency-status preflight attempted an install through an unavailable internal registry for the final local formatter and changeset commands, so their direct equivalents were run.

## Risk / follow-ups

At 1,024 elements, matched-control-adjusted scoped-element enumeration is 0.09× client / 0.08× server and scoped-value enumeration is 0.18× / 0.17×. Scoped-value creation is 1.02× / 1.04× and field reads are 1.08× / 0.85×, within observed run drift; full SSR throughput is inconclusive. The benchmark measures Node property access rather than browser layout, GC pauses, or full application throughput. Exceptional prototype/setter paths preserve ordinary copy semantics and may remain dictionary-mode. The #981 issue remains open for its other findings.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JSX descriptor creation, cloning, and SSR serialization paths used by compiler value-position JSX; behavior is heavily tested but edge cases around prototypes and accessor identity remain sensitive.
> 
> **Overview**
> Refactors **scoped element and scoped value** JSX descriptors on client and server so V8 can keep **fast object shapes**: shared `children` / field getters backed by per-instance symbol resolvers, construction without a transient `children` data field, and **`copyScopedElementConfig`** so spread props, `defaultProps`, and rare inherited `children` setters still match prior observable behavior while deferring evaluation.
> 
> **`cloneElement`**, **`Children.map`**, and key replacement keep each element’s deferred child resolver (including scoped values wrapping scoped elements and production custom getters) without resolving children early; SSR paths use the same rules.
> 
> Adds a Node-only **`scoped-descriptor-shapes`** benchmark (plain `createElement` controls, semantic hashes, client/server in separate processes), wires it into **`bench.mjs`**, docs, and the MCP suite list, plus client/server/TSRX regressions and patch changesets for `octane` and `@octanejs/mcp-server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547a36939249465c164252f7ccc38e477d4af220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791546828&installation_model_id=432790&pr_number=1013&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1013&signature=2b1f5bbf8fcda0b7177a037a5b52c0ca3539bd820edbb1e287358486239fe0ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
