### PR TITLE
perf: keep memo wrappers on stable shapes

### DIFF
--- a/.changeset/stable-memo-wrapper-shapes.md
+++ b/.changeset/stable-memo-wrapper-shapes.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Keep distinct client and server `memo()` wrappers on stable property shapes while preserving live defaults and static-hoisting behavior.
+Expose the memo wrapper shape benchmark in the MCP suite catalog.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,7 +87,7 @@ runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
 **universal-object-teardown**,
 **universal-template-events**, **universal-native-hover**, **universal-owner-drafts**,
-**universal-draft-lookup**, **scoped-descriptor-shapes**,
+**universal-draft-lookup**, **scoped-descriptor-shapes**, **memo-wrapper-shapes**,
 **universal-external-store**,
 **lynx-render**, **lynx-bundle-size**, **tsrx-renderer-validation-ranges**, and
 **tsrx-local-component-name-catalog** are Node-only,
@@ -285,6 +285,7 @@ internally, get their own baseline and guard namespace.
 | `universal-owner-drafts` | universal-owner-drafts | none (Node-only) | retained object-driver roots with 0, 1, 128, and 1,024 changed-prop child owners; output, render, host identity, and structural-command controls |
 | `universal-draft-lookup` | universal-draft-lookup | none (Node-only) | root-owned ref lookups from 0, 1, 128, and 1,024 changing child owners, with own-ref and plain-object controls and host, state, and structural-command checks |
 | `scoped-descriptor-shapes` | scoped-descriptor-shapes | none (Node-only) | production client/server scoped element and value descriptor creation, reads, enumeration, cloning, Children.map and SSR, with plain-element controls and deferred-child/key/order checks |
+| `memo-wrapper-shapes` | memo-wrapper-shapes | none (Node-only) | production client/server creation and metadata reads across 128 and 1,024 distinct memo wrappers, with plain-function/data-only controls, live defaults, static-hoisting checks, and untimed V8 shape diagnostics |
 | `universal-external-store` | universal-external-store | none (Node-only) | 128 native universal store subscribers, getter/subscribe identity controls, notification bursts, and deterministic subscription-lifetime and state-projection guards |
 | `lynx-render` | lynx-render | none (Node-only) | dual-thread Lynx render CPU: empty startup, create 1,000 and 10,000 keyed rows through the real background root, transport, and main receiver over a cheap fake Element PAPI, plus a gate that a native tap reaches its background handler via the engine `publishEvent` receiver |
 | `lynx-table` | lynx-table | none (Node-only; separate Chromium harness) | deterministic per-operation wire cost of the cross-framework krausest table (command counts and serialized commit bytes vs a changed-rows floor) through the real dual-thread path and real tap tokens |

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -897,6 +897,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Distinct production client/server memo wrappers: creation and metadata
+		// reads, with plain-function and data-only controls in isolated processes.
+		name: 'memo-wrapper-shapes',
+		cwd: 'memo-wrapper-shapes',
+		servers: [],
+		iter: { normal: 7, quick: 3 },
+		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+	},
+	{
 		// Native universal external-store hooks: stable subscription lifetimes and
 		// bounded state-projection work across parent renders and notification bursts.
 		name: 'universal-external-store',

--- a/benchmarks/memo-wrapper-shapes/README.md
+++ b/benchmarks/memo-wrapper-shapes/README.md
@@ -1,0 +1,45 @@
+# Memo wrapper shapes
+
+This Node-only production benchmark measures the creation and named-property
+reads of 128 and 1,024 distinct `memo()` wrappers. It runs the client and server
+runtime in separate V8 isolates; mixing their accessor identities in one
+process would change the hidden classes being measured. A plain nested-function
+factory and plain-function read are timing-drift controls. A synthetic data-only
+function has the same readable statics but no accessors, isolating the lookup
+and descriptor overhead; it is a performance control, not a replacement for
+the live `defaultProps` contract. The client uses an
+optional comparator on every eighth wrapper; the server has no comparator
+argument. Multiple wrapper shapes matter here: `memo-wall` exercises memo
+bailouts but does not make many distinct wrappers at one property-read site.
+
+Before each measurement the harness verifies the public `type`, `displayName`,
+`defaultProps`, `__memo`, optional `__compare`, direct invocation, and enumerable
+keys. It copies all non-enumerable statics into a HOC and checks that the copy
+does not gain memo behavior, while its defaults stay live. It also checks both
+directions of default-prop updates and a writable display name. Each sample's
+result has a stable semantic hash; V8 `%HasFastProperties` records the untimed
+fast-property count on the retained read fixtures, without making hidden class
+details a correctness gate. Five warmups precede the timed samples, and scenario
+order alternates. Results are microseconds per wrapper created or read.
+
+```bash
+node benchmarks/memo-wrapper-shapes/run.mjs 7
+BENCH_DIST_DIR=/absolute/frozen/dist BENCH_JSON=/tmp/memo-wrapper-baseline.json \
+  node benchmarks/memo-wrapper-shapes/run.mjs 13
+BENCH_JSON=/tmp/memo-wrapper-candidate.json \
+  node benchmarks/memo-wrapper-shapes/run.mjs 13
+```
+
+For paired comparisons, use `BENCH_DIST_DIR` for an already built production
+distribution, or set both `BENCH_CLIENT_RUNTIME_URL` and
+`BENCH_SERVER_RUNTIME_URL` to absolute `file:` URLs. If no override is set, the
+harness builds the current Octane package. Interleave frozen baseline and
+candidate runs (for example, B–C–C–B), compare all semantic hashes, and compare
+memo creation/read against both the data-only and plain-function controls. Keep Node,
+dependencies, sample count, and process isolation the same on both heads.
+
+The shape count is a V8 diagnostic, not an application throughput claim. The
+timing does not measure DOM rendering, SSR page throughput, hydration, GC pause
+distribution, or bundle size. The source changes may move work from creation
+to metadata reads, so compare both operations and the plain controls before
+claiming a speedup.

--- a/benchmarks/memo-wrapper-shapes/run.mjs
+++ b/benchmarks/memo-wrapper-shapes/run.mjs
@@ -1,0 +1,357 @@
+// Production Node/V8 probe for octanejs/octane#981's memo wrapper shapes.
+// Run client and server in separate isolates: their accessor identities are
+// independent, and loading both into one isolate would change the map sample.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const iterations = Number(process.argv[2] ?? 7);
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new TypeError('Pass a positive integer sample count.');
+}
+
+const suppliedDist = process.env.BENCH_DIST_DIR;
+const suppliedClient = process.env.BENCH_CLIENT_RUNTIME_URL;
+const suppliedServer = process.env.BENCH_SERVER_RUNTIME_URL;
+if (suppliedDist && (suppliedClient || suppliedServer)) {
+	throw new Error('Use BENCH_DIST_DIR or the two runtime URLs, not both.');
+}
+if (!suppliedDist && !suppliedClient && !suppliedServer) {
+	const build = spawnSync('pnpm', ['--filter', 'octane', 'build'], {
+		cwd: REPO,
+		stdio: 'inherit',
+	});
+	if (build.status !== 0) throw new Error('The production octane build failed.');
+} else if (!suppliedDist && (!suppliedClient || !suppliedServer)) {
+	throw new Error('Specify both BENCH_CLIENT_RUNTIME_URL and BENCH_SERVER_RUNTIME_URL.');
+}
+
+const dist = suppliedDist ? path.resolve(suppliedDist) : path.join(REPO, 'packages/octane/dist');
+const clientUrl = suppliedClient ?? pathToFileURL(path.join(dist, 'runtime.js')).href;
+const serverUrl = suppliedServer ?? pathToFileURL(path.join(dist, 'runtime.server.js')).href;
+const hash = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+const script = fileURLToPath(import.meta.url);
+let payload;
+
+if (process.env.BENCH_SCOPE === undefined) {
+	const childResults = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-memo-wrapper-shapes-'));
+	try {
+		const targets = [];
+		for (const scope of ['client', 'server']) {
+			const output = path.join(childResults, `${scope}.json`);
+			const child = spawnSync(
+				process.execPath,
+				['--allow-natives-syntax', script, String(iterations)],
+				{
+					cwd: REPO,
+					encoding: 'utf8',
+					env: {
+						...process.env,
+						BENCH_SCOPE: scope,
+						BENCH_JSON: output,
+						BENCH_CLIENT_RUNTIME_URL: clientUrl,
+						BENCH_SERVER_RUNTIME_URL: serverUrl,
+						BENCH_DIST_DIR: '',
+					},
+				},
+			);
+			if (child.status !== 0) throw new Error(`${scope}: ${child.stderr || child.stdout}`);
+			const result = JSON.parse(fs.readFileSync(output, 'utf8'));
+			if (result.failed) throw new Error(`${scope}: ${result.failed}`);
+			targets.push(...result.targets);
+			process.stdout.write(child.stdout);
+		}
+		payload = { suite: 'memo-wrapper-shapes', iterations, targets };
+	} catch (error) {
+		const message = error instanceof Error ? error.stack || error.message : String(error);
+		payload = { suite: 'memo-wrapper-shapes', iterations, targets: [], failed: message };
+		console.error(message);
+		process.exitCode = 1;
+	} finally {
+		fs.rmSync(childResults, { recursive: true, force: true });
+	}
+} else {
+	try {
+		const scope = process.env.BENCH_SCOPE;
+		if (scope !== 'client' && scope !== 'server') throw new Error('Invalid BENCH_SCOPE.');
+		const { memo } = await import(scope === 'client' ? clientUrl : serverUrl);
+		const hasFastProperties = new Function('value', 'return %HasFastProperties(value);');
+		const scenarios = [];
+		const warmups = 5;
+
+		for (const size of [128, 1_024]) {
+			const components = Array.from({ length: size }, (_, index) => {
+				function Component(props) {
+					return props.value + index;
+				}
+				Component.defaultProps = { value: index };
+				return Component;
+			});
+			const compare = (oldProps, newProps) => oldProps.value === newProps.value;
+			const hasCompare = scope === 'client';
+			const makeMemo = (component, index) =>
+				hasCompare && index % 8 === 0 ? memo(component, compare) : memo(component);
+			const makePlain = (component) => {
+				function Plain(props) {
+					return component(props);
+				}
+				return Plain;
+			};
+			const makeData = (component, index) => {
+				function Data(props) {
+					return component(props);
+				}
+				Object.defineProperty(Data, 'type', { value: component });
+				Object.defineProperty(Data, 'displayName', {
+					configurable: true,
+					writable: true,
+					value: 'Component',
+				});
+				Object.defineProperty(Data, '__memo', { value: true });
+				Object.defineProperty(Data, 'defaultProps', {
+					configurable: true,
+					value: component.defaultProps,
+				});
+				if (hasCompare && index % 8 === 0) {
+					Object.defineProperty(Data, '__compare', { value: compare });
+				}
+				return Data;
+			};
+			const makeBatch = (factory) => {
+				const wrappers = new Array(size);
+				for (let index = 0; index < size; index++) {
+					wrappers[index] = factory(components[index], index);
+				}
+				return wrappers;
+			};
+			const memoWrappers = makeBatch(makeMemo);
+			const plainWrappers = makeBatch(makePlain);
+			const dataWrappers = makeBatch(makeData);
+
+			function checkStatics(wrappers) {
+				const results = [];
+				for (let index = 0; index < size; index++) {
+					const wrapper = wrappers[index];
+					const component = components[index];
+					assert.equal(wrapper.type, component);
+					assert.equal(wrapper.displayName, 'Component');
+					assert.equal(wrapper.__memo, true);
+					assert.equal(wrapper.defaultProps, component.defaultProps);
+					assert.equal(wrapper({ value: 3 }), index + 3);
+					assert.deepEqual(Object.keys(wrapper), []);
+					assert.equal(Object.getOwnPropertyDescriptor(wrapper, '__memo')?.enumerable, false);
+					assert.equal(wrapper.__compare, hasCompare && index % 8 === 0 ? compare : undefined);
+					results.push([index, wrapper.displayName, wrapper.defaultProps.value, wrapper.__memo]);
+				}
+				return hash(results);
+			}
+
+			function checkPlain(wrappers) {
+				const results = [];
+				for (let index = 0; index < size; index++) {
+					assert.equal(wrappers[index]({ value: 3 }), index + 3);
+					results.push([index, wrappers[index].name]);
+				}
+				return hash(results);
+			}
+
+			checkStatics(memoWrappers);
+			checkStatics(dataWrappers);
+			checkPlain(plainWrappers);
+			// These are untimed contract checks. A static-hoisting HOC copies even
+			// non-enumerable keys and must not become a memo boundary itself.
+			const first = memoWrappers[0];
+			const original = components[0];
+			const before = original.defaultProps;
+			function Hoisted() {}
+			for (const key of Reflect.ownKeys(first)) {
+				if (!['name', 'length', 'prototype', 'arguments', 'caller'].includes(key)) {
+					Object.defineProperty(Hoisted, key, Object.getOwnPropertyDescriptor(first, key));
+				}
+			}
+			assert.equal(Hoisted.__memo, false);
+			assert.equal(Hoisted.defaultProps, before);
+			const replacement = { value: 9001 };
+			first.defaultProps = replacement;
+			assert.equal(original.defaultProps, replacement);
+			assert.equal(Hoisted.defaultProps, replacement);
+			original.defaultProps = before;
+			assert.equal(first.defaultProps, before);
+			first.displayName = 'Renamed';
+			assert.equal(first.displayName, 'Renamed');
+			first.displayName = 'Component';
+
+			const batches = Math.max(4, Math.ceil(16_384 / size));
+			const add = (name, operations, work, verify, wrappers = null) => {
+				scenarios.push({
+					name: `${scope}-${name}-${size}`,
+					size,
+					operations,
+					work,
+					verify,
+					wrappers,
+					samples: [],
+					outputHash: null,
+				});
+			};
+			for (const [kind, factory, verify] of [
+				['memo', makeMemo, checkStatics],
+				['data', makeData, checkStatics],
+				['plain', makePlain, checkPlain],
+			]) {
+				add(
+					`${kind}-create`,
+					size * batches,
+					() => {
+						let latest;
+						for (let batch = 0; batch < batches; batch++) latest = makeBatch(factory);
+						return latest;
+					},
+					verify,
+				);
+			}
+
+			const readMemo = (wrappers) => {
+				let total = 0;
+				for (let repeat = 0; repeat < 128; repeat++) {
+					for (let index = 0; index < size; index++) {
+						const wrapped = wrappers[index];
+						if (wrapped.__memo) total++;
+						total += wrapped.defaultProps.value;
+						total += wrapped.type.name.length + wrapped.displayName.length;
+					}
+				}
+				return total;
+			};
+			const expectedMemo = readMemo(memoWrappers);
+			add(
+				'memo-read',
+				size * 128,
+				() => readMemo(memoWrappers),
+				(value) => {
+					assert.equal(value, expectedMemo);
+					return hash(value);
+				},
+				memoWrappers,
+			);
+			const expectedData = readMemo(dataWrappers);
+			assert.equal(expectedData, expectedMemo);
+			add(
+				'data-read',
+				size * 128,
+				() => readMemo(dataWrappers),
+				(value) => {
+					assert.equal(value, expectedData);
+					return hash(value);
+				},
+				dataWrappers,
+			);
+
+			// Plain wrapper reads track CPU drift without memo metadata lookups.
+			const readPlain = (wrappers) => {
+				let total = 0;
+				for (let repeat = 0; repeat < 128; repeat++) {
+					for (let index = 0; index < size; index++) total += wrappers[index].name.length;
+				}
+				return total;
+			};
+			const expectedPlain = readPlain(plainWrappers);
+			add(
+				'plain-read',
+				size * 128,
+				() => readPlain(plainWrappers),
+				(value) => {
+					assert.equal(value, expectedPlain);
+					return hash(value);
+				},
+				plainWrappers,
+			);
+		}
+
+		for (let round = 0; round < warmups + iterations; round++) {
+			const order = round % 2 === 0 ? scenarios : [...scenarios].reverse();
+			for (const scenario of order) {
+				const start = performance.now();
+				const result = scenario.work();
+				const perItemUs = ((performance.now() - start) * 1_000) / scenario.operations;
+				const outputHash = scenario.verify(result);
+				if (scenario.outputHash !== null) assert.equal(outputHash, scenario.outputHash);
+				scenario.outputHash = outputHash;
+				if (round >= warmups) scenario.samples.push(perItemUs);
+			}
+		}
+
+		const targets = scenarios.map((scenario) => {
+			const stat = summarizeSamples(scenario.samples, { scoreMode: 'mean' });
+			const shapes = scenario.wrappers
+				? scenario.wrappers.reduce(
+						(count, wrapper) => count + Number(hasFastProperties(wrapper)),
+						0,
+					)
+				: null;
+			return {
+				name: scenario.name,
+				ops: { per_item_us: timingStatForJson(stat) },
+				meta: {
+					items: scenario.size,
+					operationsPerSample: scenario.operations,
+					outputHash: scenario.outputHash,
+					fastPropertyObjects: shapes,
+					shapeSampleObjects: scenario.wrappers?.length ?? 0,
+					nodeVersion: process.version,
+					platform: process.platform,
+					architecture: process.arch,
+				},
+			};
+		});
+		const memoShapes = new Map();
+		for (const size of [128, 1_024]) {
+			const scenario = scenarios.find((entry) => entry.name === `${scope}-memo-read-${size}`);
+			memoShapes.set(size, {
+				fast: scenario.wrappers.reduce(
+					(sum, wrapper) => sum + Number(hasFastProperties(wrapper)),
+					0,
+				),
+				count: size,
+			});
+		}
+		for (const target of targets) {
+			if (target.name.includes('memo-create')) {
+				target.meta.memoWrapperShapes = memoShapes.get(target.meta.items);
+			}
+		}
+		payload = { suite: 'memo-wrapper-shapes', iterations, targets };
+		console.log('| target | µs per item | fast sampled wrappers |');
+		console.log('| --- | ---: | ---: |');
+		for (const target of targets) {
+			const shapes = target.meta.memoWrapperShapes;
+			const shapeCount = shapes
+				? `${shapes.fast}/${shapes.count}`
+				: target.meta.shapeSampleObjects
+					? `${target.meta.fastPropertyObjects}/${target.meta.shapeSampleObjects}`
+					: '—';
+			console.log(
+				`| ${target.name} | ${target.ops.per_item_us.score.toFixed(3)} | ${shapeCount} |`,
+			);
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.stack || error.message : String(error);
+		payload = { suite: 'memo-wrapper-shapes', iterations, targets: [], failed: message };
+		console.error(message);
+		process.exitCode = 1;
+	}
+}
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -112,6 +112,7 @@ export const BENCHMARK_SUITES = [
 	'universal-owner-drafts',
 	'universal-draft-lookup',
 	'scoped-descriptor-shapes',
+	'memo-wrapper-shapes',
 	'universal-external-store',
 	'lynx-render',
 	'lynx-table',

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -6150,29 +6150,36 @@ export function useOptimistic<S, V = S>(state: S): [S, (value: V) => void] {
 	return [state, NOOP];
 }
 
+const MEMO_OWNER = Symbol('memoOwner');
+const MEMO_MARKER_DESCRIPTOR: PropertyDescriptor = {
+	get(this: Function) {
+		return this === (this as any)[MEMO_OWNER];
+	},
+};
+const MEMO_DEFAULT_PROPS_DESCRIPTOR: PropertyDescriptor = {
+	configurable: true,
+	// Static hoisters must copy `type` along with this accessor.
+	get(this: { type: (...args: any[]) => any }) {
+		return (this.type as any).defaultProps;
+	},
+	set(this: { type: (...args: any[]) => any }, value: unknown) {
+		(this.type as any).defaultProps = value;
+	},
+};
 export function memo<C extends (...args: any[]) => any>(
 	component: C,
 ): C & { readonly type: C; displayName?: string } {
 	const memoWrapper = (props: any, scope: SSRScope, extra?: any): unknown =>
 		component(props, scope, extra);
+	Object.defineProperty(memoWrapper, MEMO_OWNER, { value: memoWrapper });
 	Object.defineProperty(memoWrapper, 'type', { value: component });
 	Object.defineProperty(memoWrapper, 'displayName', {
 		configurable: true,
 		writable: true,
 		value: (component as any).displayName || component.name || 'Memo',
 	});
-	Object.defineProperty(memoWrapper, '__memo', {
-		get() {
-			return this === memoWrapper;
-		},
-	});
-	Object.defineProperty(memoWrapper, 'defaultProps', {
-		configurable: true,
-		get: () => (component as any).defaultProps,
-		set: (value) => {
-			(component as any).defaultProps = value;
-		},
-	});
+	Object.defineProperty(memoWrapper, '__memo', MEMO_MARKER_DESCRIPTOR);
+	Object.defineProperty(memoWrapper, 'defaultProps', MEMO_DEFAULT_PROPS_DESCRIPTOR);
 	return memoWrapper as unknown as C & { readonly type: C; displayName?: string };
 }
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -26744,6 +26744,23 @@ function shallowEqualPropsExact(a: any, b: any): boolean {
 	return true;
 }
 
+const MEMO_OWNER = Symbol('memoOwner');
+const MEMO_MARKER_DESCRIPTOR: PropertyDescriptor = {
+	get(this: ComponentBody<any>) {
+		return this === (this as any)[MEMO_OWNER];
+	},
+};
+const MEMO_DEFAULT_PROPS_DESCRIPTOR: PropertyDescriptor = {
+	configurable: true,
+	// Static hoisters must copy `type` along with this accessor.
+	get(this: { type: ComponentBody<any> }) {
+		return (this.type as any).defaultProps;
+	},
+	set(this: { type: ComponentBody<any> }, value: unknown) {
+		(this.type as any).defaultProps = value;
+	},
+};
+
 /**
  * `memo(Component)` — React-shape HOC. Returns a wrapper component that
  * skips its body when the incoming props are shallow-equal to the committed
@@ -26779,29 +26796,21 @@ export function memo<P>(
 		return component(props, scope, extra);
 	}
 	// Static-hoisting HOCs copy even non-enumerable descriptors. Keep the marker
-	// bound to its owner so copying it cannot memoize an unrelated wrapper.
+	// bound to its owner so copying it cannot memoize an unrelated wrapper. Define
+	// the owner before shared accessors to keep every wrapper on the same shape.
+	Object.defineProperty(memoWrapper, MEMO_OWNER, { value: memoWrapper });
 	Object.defineProperty(memoWrapper, 'type', { value: component });
 	Object.defineProperty(memoWrapper, 'displayName', {
 		configurable: true,
 		writable: true,
 		value: (component as any).displayName || component.name || 'Memo',
 	});
-	Object.defineProperty(memoWrapper, '__memo', {
-		get() {
-			return this === memoWrapper;
-		},
-	});
+	Object.defineProperty(memoWrapper, '__memo', MEMO_MARKER_DESCRIPTOR);
 	// `createElement(memo(Component), …)` and `lazy(() => ({default:
 	// memo(Component)}))` resolve defaults at the public wrapper boundary. Keep the
 	// property live so a component that updates its defaultProps between renders
 	// has the same observable behavior through memo as it does directly.
-	Object.defineProperty(memoWrapper, 'defaultProps', {
-		configurable: true,
-		get: () => (component as any).defaultProps,
-		set: (value) => {
-			(component as any).defaultProps = value;
-		},
-	});
+	Object.defineProperty(memoWrapper, 'defaultProps', MEMO_DEFAULT_PROPS_DESCRIPTOR);
 	if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 		__profileComponentSource(memoWrapper, component);
 	if (arePropsEqual) Object.defineProperty(memoWrapper, '__compare', { value: arePropsEqual });

--- a/packages/octane/tests/audit-hook-behavior.test.ts
+++ b/packages/octane/tests/audit-hook-behavior.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createElement, createRoot, HMR, hmr, lazy, memo, startTransition } from '../src/index.js';
+import {
+	createContext,
+	createElement,
+	createRoot,
+	HMR,
+	hmr,
+	lazy,
+	memo,
+	startTransition,
+	useContext,
+} from '../src/index.js';
 import { act, flushEffects, mount } from './_helpers';
 import { compile } from '../src/compiler/compile.js';
 import {
@@ -134,6 +144,85 @@ describe('state, component identity, and lifecycle contracts', () => {
 		try {
 			root.update(HoistedMemo, { value: 'new' });
 			expect(root.find('section').textContent).toBe('newold');
+		} finally {
+			root.unmount();
+		}
+	});
+	it('renders distinct memo components across prop and context changes', () => {
+		const Theme = createContext('light');
+		const rows = Array.from({ length: 8 }, (_, index) =>
+			memo(function Row(props: { label: string }) {
+				const theme = useContext(Theme);
+				return createElement('span', { 'data-row': String(index) }, `${theme}:${props.label}`);
+			}),
+		);
+		function Host(props: { theme: string; label: string }) {
+			return createElement(Theme.Provider, {
+				value: props.theme,
+				children: rows.map((Row, index) => createElement(Row, { key: index, label: props.label })),
+			});
+		}
+		const root = mount(Host, { theme: 'light', label: 'initial' });
+		const labels = () =>
+			Array.from(root.container.querySelectorAll('span'), (span) => span.textContent);
+		try {
+			expect(labels()).toEqual(Array(8).fill('light:initial'));
+			root.update(Host, { theme: 'dark', label: 'initial' });
+			expect(labels()).toEqual(Array(8).fill('dark:initial'));
+			root.update(Host, { theme: 'dark', label: 'updated' });
+			expect(labels()).toEqual(Array(8).fill('dark:updated'));
+		} finally {
+			root.unmount();
+		}
+	});
+	it('keeps nested memo defaults live and copied HOC behavior independent', () => {
+		const Body = Object.assign(
+			function Body(props: { label?: string | null }) {
+				return createElement('span', null, String(props.label));
+			},
+			{ defaultProps: { label: 'first' } },
+		);
+		const First = memo(Body);
+		const Second = memo(Body);
+		const Nested = memo(Second);
+		const HoistedSource = memo(Body, () => true);
+		function Hoc(props: { label?: string | null }) {
+			return createElement('strong', null, String(props.label));
+		}
+		for (const key of Reflect.ownKeys(HoistedSource)) {
+			if (
+				key !== 'name' &&
+				key !== 'length' &&
+				key !== 'prototype' &&
+				key !== 'caller' &&
+				key !== 'arguments'
+			) {
+				Object.defineProperty(Hoc, key, Object.getOwnPropertyDescriptor(HoistedSource, key)!);
+			}
+		}
+		function Host(props: { hocLabel?: string; revision: number }) {
+			return createElement('section', null, [
+				createElement(First, { key: 'first', label: undefined }),
+				createElement(Second, { key: 'second', label: undefined }),
+				createElement(Nested, { key: 'nested', label: null }),
+				createElement(Hoc, { key: 'hoc', label: props.hocLabel }),
+			]);
+		}
+		const root = mount(Host, { hocLabel: 'explicit', revision: 0 });
+		const content = () =>
+			Array.from(root.container.querySelectorAll('span, strong'), (node) => node.textContent);
+		try {
+			expect(content()).toEqual(['first', 'first', 'null', 'explicit']);
+			root.update(Host, { hocLabel: 'changed', revision: 1 });
+			expect(content()).toEqual(['first', 'first', 'null', 'changed']);
+			Body.defaultProps = { label: 'second' };
+			root.update(Host, { revision: 2 });
+			expect(content()).toEqual(['second', 'second', 'null', 'second']);
+			(First as typeof First & { defaultProps: { label: string } }).defaultProps = {
+				label: 'third',
+			};
+			root.update(Host, { revision: 3 });
+			expect(content()).toEqual(['third', 'third', 'null', 'third']);
 		} finally {
 			root.unmount();
 		}

--- a/packages/octane/tests/ssr-element-utils.test.ts
+++ b/packages/octane/tests/ssr-element-utils.test.ts
@@ -16,6 +16,7 @@ const {
 	createPortal,
 	createScopedElement,
 	createScopedValue,
+	memo,
 	renderToStaticMarkup,
 } = Server as any;
 
@@ -29,6 +30,54 @@ function captureThrown(run: () => unknown): unknown {
 }
 
 describe('octane/server element utilities', () => {
+	it('renders distinct and nested memo wrappers with live defaults after static hoisting', () => {
+		const bodies = Array.from({ length: 6 }, (_, index) =>
+			Object.assign(
+				function Body(props: { label?: string }) {
+					return createElement('span', null, `${index}:${props.label}`);
+				},
+				{ defaultProps: { label: `initial-${index}` } },
+			),
+		);
+		const rows = bodies.map((Body) => memo(Body));
+		const Nested = memo(rows[2]);
+		const HoistedSource = memo(bodies[0]);
+		function Hoc(props: { label?: string }) {
+			return createElement('strong', null, `hoc:${props.label}`);
+		}
+		for (const key of Reflect.ownKeys(HoistedSource)) {
+			if (
+				key !== 'name' &&
+				key !== 'length' &&
+				key !== 'prototype' &&
+				key !== 'caller' &&
+				key !== 'arguments'
+			) {
+				Object.defineProperty(Hoc, key, Object.getOwnPropertyDescriptor(HoistedSource, key)!);
+			}
+		}
+		function View() {
+			return createElement('div', null, [
+				...rows.map((Row: any, index: number) =>
+					createElement(Row, { key: index, label: undefined }),
+				),
+				createElement(Nested, { key: 'nested' }),
+				createElement(Hoc, { key: 'hoc' }),
+			]);
+		}
+		const html = () => renderToStaticMarkup(View).html;
+		expect(html()).toBe(
+			'<div><span>0:initial-0</span><span>1:initial-1</span><span>2:initial-2</span><span>3:initial-3</span><span>4:initial-4</span><span>5:initial-5</span><span>2:initial-2</span><strong>hoc:initial-0</strong></div>',
+		);
+		bodies[0].defaultProps = { label: 'changed' };
+		bodies[2].defaultProps = { label: 'nested changed' };
+		rows[1].defaultProps = { label: 'set through wrapper' };
+		expect(html()).toBe(
+			'<div><span>0:changed</span><span>1:set through wrapper</span><span>2:nested changed</span><span>3:initial-3</span><span>4:initial-4</span><span>5:initial-5</span><span>2:nested changed</span><strong>hoc:changed</strong></div>',
+		);
+		expect(Server.renderToString(View).html).toContain('<strong>hoc:changed</strong>');
+	});
+
 	it.each(['renderToString', 'renderToStaticMarkup'] as const)(
 		'%s preserves omitted children when a component forwards merged props',
 		(renderMethod) => {


### PR DESCRIPTION
## Summary

- Keep distinct client and server `memo()` wrapper functions on stable V8 property shapes with shared metadata accessors and a private owner marker.
- Preserve live `defaultProps`, nested wrappers, comparator behavior, and protection against a full static-hoisting HOC accidentally becoming a memo boundary. Add client/server regressions and a registered production benchmark.
- Follow up on #981's `memo()` wrapper finding.

## Why

On merged `main` (`1c28da5`), V8 reports fast properties for only the first `memo()` wrapper; later wrappers enter dictionary mode because each getter/setter is a fresh function. The production baseline reproduces this in both runtimes. The new benchmark samples 128 and 1,024 distinct wrappers rather than the single wrapper in `memo-wall`.

## Validation

- [x] `pnpm format:files:check` for all changed files; `git diff --check`
- [x] `pnpm typecheck`
- [x] `pnpm sync`; changeset validation
- [x] Targeted client/server tests in development and production projects: 164/164; new tests deliberately failed under broken default forwarding and copied marker behavior, then passed after restoration.
- [x] MCP benchmark catalog tests: 15/15; `node benchmarks/bench.mjs --quick memo-wrapper-shapes`
- [x] Frozen production baseline and candidate: 24/24 semantic hashes match in paired runs. V8 fast-property samples change from 1/128 and 0/1,024 to 128/128 and 1,024/1,024 on both runtimes.
- [ ] `pnpm test`: the repository-wide run was stopped after unrelated browser suites failed; an isolated Aria case confirmed Chromium exits at launch with macOS Mach port `Permission denied (1100)`, before executing the test. [Current-head CI passed all 26 jobs](https://github.com/octanejs/octane/actions/runs/34353017248), including browser integration and React parity; Cursor Bugbot passed without findings.

## Risk / follow-ups

- Timing controls drifted several-fold across B–C–C–B and B–C–B–C pairs, so these measurements do not establish a throughput improvement. The benchmark records the shape change and matched behavior; application-level timing is still open.
- A consumer copying only a `defaultProps` accessor descriptor to an unrelated function must also copy `type` for live forwarding. Full static hoisting remains covered by regressions; an isolated descriptor copy used to retain the original component through a per-wrapper closure.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791549966&installation_model_id=432790&pr_number=1014&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1014&signature=5cf041a17feb013cde8bf569dad0efe07202beafe33f087d245e6351f574afcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `memo()` metadata on both runtimes; behavior is heavily regression-tested, but incorrect descriptor sharing could break memo detection, defaultProps forwarding, or HOC static copying.
> 
> **Overview**
> **Client and server `memo()`** no longer attach fresh getter/setter closures on every wrapper. Each wrapper gets a private **`MEMO_OWNER`** marker, then reuses shared descriptors for **`__memo`** (owner-bound marker) and **`defaultProps`** (live read/write via **`type`**), so many distinct wrappers stay on the same hidden-class shape while static hoisting still cannot turn an copied HOC into a memo boundary.
> 
> Adds the Node-only **`memo-wrapper-shapes`** benchmark (128/1,024 wrappers, client/server isolates, semantic hashes, V8 fast-property diagnostics) and wires it into **`bench.mjs`**, benchmark docs, and the MCP suite catalog. **Client audit** and **SSR element** tests cover distinct/nested memos, live defaults, and hoisted statics.
> 
> Patch changeset for **`octane`** and **`@octanejs/mcp-server`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa172b585f6b1ceeab57b8794d058ddd210a3912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
