### PR TITLE
perf: seed raw HTML and deopt DOM expandos

### DIFF
--- a/.changeset/seed-dom-expandos.md
+++ b/.changeset/seed-dom-expandos.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Seed frequently polled DOM expando keys on native prototypes, including raw HTML ownership, de-opt descriptors, and uncontrolled value baselines.

--- a/benchmarks/dom-expando/README.md
+++ b/benchmarks/dom-expando/README.md
@@ -1,0 +1,41 @@
+# DOM expando misses
+
+This production Node/jsdom probe measures the property reads behind the
+unseeded DOM expando finding in [octanejs/octane#981](https://github.com/octanejs/octane/issues/981).
+It runs each built client runtime in its own process with a fresh DOM. The
+fixture mounts 128 keyed descriptor components, activates raw HTML once, then
+measures missing expando reads on ordinary host elements, text nodes, and inputs.
+The `defaultChecked` marker is excluded: the runtime only tests whether that
+symbol is present, and seeding it would require an own-property test on every
+initial `defaultChecked` write.
+It also times a complete descriptor update, an unseeded symbol miss, and a
+present `nodeType` lookup as controls. Five untimed rounds precede the samples;
+target order alternates.
+
+Build Octane on each revision and freeze both `packages/octane/dist` directories.
+The frozen directories must retain their relative imports and an enclosing
+`package.json` with `"type": "module"`. Supply both to compare them, or one
+for a standalone run:
+
+```bash
+BENCH_BASELINE_DIST_DIR=/absolute/baseline/packages/octane/dist \
+BENCH_CANDIDATE_DIST_DIR=/absolute/candidate/packages/octane/dist \
+BENCH_JSON=/tmp/dom-expando.json node benchmarks/dom-expando/run.mjs 13
+
+BENCH_DIST_DIR=/absolute/frozen/packages/octane/dist \
+node benchmarks/dom-expando/run.mjs 13
+```
+
+When this worktree has no local dependencies, set `BENCH_DEPENDENCIES_DIR` to a
+same-lockfile Octane checkout that has `jsdom` installed. Compare B–C–C–B
+process order as well as the paired run above before interpreting small timing
+differences. The runner requires the same semantic hash for every target on
+both versions, validates retained keyed DOM nodes and updated text, and checks
+live `defaultValue` and first `defaultChecked` behavior. Its untimed diagnostics
+show whether each formerly missing key was seeded on the right DOM prototype;
+they do not assert internal layout as a correctness contract.
+
+These numbers isolate JavaScript property lookups in jsdom. They cannot measure
+Blink DOM lookup speed, layout, paint, browser memory, or an application-wide
+improvement. The complete descriptor update includes much more work and can
+remain inside measurement noise even when the lookup mechanism changes.

--- a/benchmarks/dom-expando/run.mjs
+++ b/benchmarks/dom-expando/run.mjs
@@ -1,0 +1,352 @@
+// Node-only production probe for octanejs/octane#981's DOM expando reads.
+// Each dist runs in its own process so one runtime cannot seed the other's DOM.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const HERE = fileURLToPath(import.meta.url);
+const iterations = Number(process.argv[2] ?? 9);
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new TypeError('Pass a positive integer number of samples.');
+}
+
+const hash = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+const runtimeUrl = (dist) => pathToFileURL(path.join(path.resolve(dist), 'runtime.js')).href;
+const baseline = process.env.BENCH_BASELINE_DIST_DIR;
+const candidate = process.env.BENCH_CANDIDATE_DIST_DIR;
+const single = process.env.BENCH_DIST_DIR;
+if ((baseline || candidate) && (!baseline || !candidate || single)) {
+	throw new Error(
+		'Set both BENCH_BASELINE_DIST_DIR and BENCH_CANDIDATE_DIST_DIR, or BENCH_DIST_DIR alone.',
+	);
+}
+if (!baseline && !single) {
+	throw new Error('Build octane first and set BENCH_DIST_DIR or both BENCH_*_DIST_DIR paths.');
+}
+
+let payload;
+try {
+	if (process.env.BENCH_EXPANDO_WORKER === undefined) {
+		const variants = baseline
+			? [
+					['baseline', baseline],
+					['candidate', candidate],
+				]
+			: [['single', single]];
+		const results = [];
+		for (const [name, dist] of variants) {
+			const child = spawnSync(process.execPath, [HERE, String(iterations)], {
+				cwd: REPO,
+				encoding: 'utf8',
+				env: {
+					...process.env,
+					BENCH_EXPANDO_WORKER: '1',
+					BENCH_EXPANDO_RUNTIME_URL: runtimeUrl(dist),
+					BENCH_EXPANDO_VARIANT: name,
+				},
+			});
+			if (child.status !== 0) {
+				throw new Error(`${name}: ${child.stderr || child.stdout}`);
+			}
+			results.push(JSON.parse(child.stdout));
+		}
+		if (results.length === 2) {
+			for (const target of results[0].targets) {
+				const other = results[1].targets.find((entry) => entry.name === target.name);
+				assert.ok(other, `${target.name}: missing candidate result`);
+				assert.equal(
+					other.meta.outputHash,
+					target.meta.outputHash,
+					`${target.name}: semantic drift`,
+				);
+			}
+		}
+		payload = { suite: 'dom-expando', iterations, variants: results };
+		console.log('| target | ' + results.map((item) => item.variant).join(' | ') + ' |');
+		console.log('| --- | ' + results.map(() => '---:').join(' | ') + ' |');
+		for (const target of results[0].targets) {
+			console.log(
+				`| ${target.name} | ${results
+					.map((item) =>
+						item.targets
+							.find((entry) => entry.name === target.name)
+							.ops.per_item_us.score.toFixed(4),
+					)
+					.join(' | ')} |`,
+			);
+		}
+		for (const item of results) console.log(`${item.variant}: ${JSON.stringify(item.diagnostics)}`);
+	} else {
+		const dependencyRoot = path.resolve(process.env.BENCH_DEPENDENCIES_DIR || REPO);
+		const requireDependency = createRequire(path.join(dependencyRoot, 'package.json'));
+		const { JSDOM } = requireDependency('jsdom');
+		const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+			url: 'http://localhost/',
+		});
+		for (const key of [
+			'window',
+			'document',
+			'Node',
+			'Element',
+			'CharacterData',
+			'HTMLElement',
+			'HTMLInputElement',
+			'HTMLTextAreaElement',
+			'Event',
+			'MutationObserver',
+		]) {
+			Object.defineProperty(globalThis, key, {
+				configurable: true,
+				value: key === 'window' ? dom.window : dom.window[key],
+			});
+		}
+		const runtime = await import(process.env.BENCH_EXPANDO_RUNTIME_URL);
+		const {
+			createRoot,
+			createElement,
+			flushSync,
+			setDangerouslySetInnerHTML,
+			setDefaultValueUncontrolled,
+			setDefaultChecked,
+		} = runtime;
+
+		const count = 128;
+		function Row({ id, version }) {
+			return createElement('span', { 'data-row': id }, `row-${id}:${version}`);
+		}
+		function Scene({ version }) {
+			return createElement(
+				'section',
+				{ id: 'rows' },
+				Array.from({ length: count }, (_, id) => createElement(Row, { id, version, key: id })),
+			);
+		}
+		const container = document.createElement('div');
+		document.body.append(container);
+		const root = createRoot(container);
+		root.render(Scene, { version: 0 });
+		const rendered = [...container.querySelectorAll('span[data-row]')];
+		assert.equal(rendered.length, count);
+		const stamped = rendered[0];
+		const descriptor = Object.getOwnPropertySymbols(stamped).find(
+			(symbol) => symbol.description === 'octane.deoptDesc',
+		);
+		assert.ok(descriptor, 'Scene must render real de-opt host descriptors');
+		assert.ok(stamped[descriptor], 'rendered host must retain its descriptor');
+		const plain = Array.from({ length: 1_024 }, () => document.createElement('span'));
+		const text = Array.from({ length: 1_024 }, () => document.createTextNode('plain'));
+		const inputs = Array.from({ length: 1_024 }, () => document.createElement('input'));
+		const baselineInput = document.createElement('input');
+		setDefaultValueUncontrolled(baselineInput, 'initial');
+		const valueSymbol = Object.getOwnPropertySymbols(baselineInput).find(
+			(symbol) => symbol.description === 'octane.defaultValue',
+		);
+		assert.ok(valueSymbol);
+		baselineInput.value = 'user edit';
+		setDefaultValueUncontrolled(baselineInput, 'reset');
+		assert.equal(baselineInput.value, 'user edit');
+		assert.equal(baselineInput.defaultValue, 'reset');
+		const checked = document.createElement('input');
+		checked.type = 'checkbox';
+		checked.checked = false; // mark the browser's live checkedness dirty
+		setDefaultChecked(checked, true);
+		assert.equal(
+			checked.checked,
+			true,
+			'first authored defaultChecked initializes live checkedness',
+		);
+		assert.equal(checked.defaultChecked, true);
+		const raw = document.createElement('div');
+		setDangerouslySetInnerHTML(raw, { __html: '<b>raw</b>' });
+		assert.equal(raw.innerHTML, '<b>raw</b>');
+		setDangerouslySetInnerHTML(raw, null);
+		assert.equal(raw.innerHTML, '');
+
+		const hasOwn = Object.prototype.hasOwnProperty;
+		for (const host of [plain[0], text[0], inputs[0]]) {
+			assert.equal(hasOwn.call(host, descriptor), false);
+			assert.equal(host[descriptor], undefined);
+		}
+		assert.equal(hasOwn.call(plain[0], '__oct_dangerHTML'), false);
+		assert.equal(plain[0].__oct_dangerHTML, undefined);
+		assert.equal(hasOwn.call(inputs[0], valueSymbol), false);
+		assert.equal(inputs[0][valueSymbol], undefined);
+
+		const diagnostics = {
+			'danger-inherited': '__oct_dangerHTML' in Element.prototype,
+			'danger-static-inherited': '__oct_dangerChild' in Element.prototype,
+			'danger-spread-inherited': '__oct_dangerSpreadChild' in Element.prototype,
+			'danger-enumerable': Object.prototype.propertyIsEnumerable.call(
+				Element.prototype,
+				'__oct_dangerHTML',
+			),
+			'deopt-element-inherited': descriptor in Element.prototype,
+			'deopt-text-inherited': descriptor in CharacterData.prototype,
+			'default-value-inherited': valueSymbol in Element.prototype,
+		};
+		const scenarios = [];
+		function add(name, items, repeats, work, verify) {
+			scenarios.push({
+				name,
+				operations: items * repeats,
+				work,
+				verify,
+				samples: [],
+				outputHash: null,
+			});
+		}
+		function sum(nodes, reader, repeats) {
+			let total = 0;
+			for (let repeat = 0; repeat < repeats; repeat++) {
+				for (let index = 0; index < nodes.length; index++) total += reader(nodes[index]);
+			}
+			return total;
+		}
+		const emptyRead = (value) => (value === undefined ? 1 : 0);
+		const controlSymbol = Symbol('unseeded-control');
+		add(
+			'unseeded-control-miss',
+			plain.length,
+			64,
+			() => sum(plain, (node) => emptyRead(node[controlSymbol]), 64),
+			(result) => {
+				assert.equal(result, plain.length * 64);
+				return hash(result);
+			},
+		);
+		add(
+			'node-type-control',
+			plain.length,
+			64,
+			() => sum(plain, (node) => node.nodeType, 64),
+			(result) => {
+				assert.equal(result, plain.length * 64);
+				return hash(result);
+			},
+		);
+		add(
+			'danger-active-miss',
+			plain.length,
+			64,
+			() => sum(plain, (node) => emptyRead(node.__oct_dangerHTML), 64),
+			(result) => {
+				assert.equal(result, plain.length * 64);
+				return hash(result);
+			},
+		);
+		add(
+			'danger-child-misses',
+			plain.length,
+			64,
+			() =>
+				sum(
+					plain,
+					(node) => emptyRead(node.__oct_dangerChild) + emptyRead(node.__oct_dangerSpreadChild),
+					64,
+				),
+			(result) => {
+				assert.equal(result, plain.length * 64 * 2);
+				return hash(result);
+			},
+		);
+		add(
+			'deopt-element-miss',
+			plain.length,
+			64,
+			() => sum(plain, (node) => emptyRead(node[descriptor]), 64),
+			(result) => {
+				assert.equal(result, plain.length * 64);
+				return hash(result);
+			},
+		);
+		add(
+			'deopt-text-miss',
+			text.length,
+			64,
+			() => sum(text, (node) => emptyRead(node[descriptor]), 64),
+			(result) => {
+				assert.equal(result, text.length * 64);
+				return hash(result);
+			},
+		);
+		add(
+			'default-value-miss',
+			inputs.length,
+			64,
+			() => sum(inputs, (node) => emptyRead(node[valueSymbol]), 64),
+			(result) => {
+				assert.equal(result, inputs.length * 64);
+				return hash(result);
+			},
+		);
+		let version = 1;
+		add(
+			'deopt-host-update',
+			count,
+			1,
+			() => {
+				const next = version++;
+				flushSync(() => root.render(Scene, { version: next }));
+				return next;
+			},
+			(next) => {
+				const spans = [...container.querySelectorAll('span[data-row]')];
+				assert.equal(spans.length, count);
+				for (let id = 0; id < count; id++) {
+					assert.equal(spans[id], rendered[id], `${id}: retained keyed row`);
+					assert.equal(spans[id].textContent, `row-${id}:${next}`);
+				}
+				return hash(['retained de-opt rows', count]);
+			},
+		);
+
+		const warmup = 5;
+		for (let round = 0; round < warmup + iterations; round++) {
+			for (const scenario of round % 2 === 0 ? scenarios : [...scenarios].reverse()) {
+				const begin = performance.now();
+				const result = scenario.work();
+				const elapsed = ((performance.now() - begin) * 1_000) / scenario.operations;
+				const observed = scenario.verify(result);
+				if (scenario.outputHash !== null) assert.equal(observed, scenario.outputHash);
+				scenario.outputHash = observed;
+				if (round >= warmup) scenario.samples.push(elapsed);
+			}
+		}
+		const targets = scenarios.map((scenario) => ({
+			name: scenario.name,
+			ops: {
+				per_item_us: timingStatForJson(summarizeSamples(scenario.samples, { scoreMode: 'mean' })),
+			},
+			meta: {
+				outputHash: scenario.outputHash,
+				operationsPerSample: scenario.operations,
+				nodeVersion: process.version,
+			},
+		}));
+		root.unmount();
+		container.remove();
+		dom.window.close();
+		process.stdout.write(
+			JSON.stringify({ variant: process.env.BENCH_EXPANDO_VARIANT, targets, diagnostics }),
+		);
+	}
+} catch (error) {
+	const message = error instanceof Error ? error.stack || error.message : String(error);
+	console.error(message);
+	process.exitCode = 1;
+	if (process.env.BENCH_EXPANDO_WORKER === undefined)
+		payload = { suite: 'dom-expando', failed: message };
+}
+
+if (payload && process.env.BENCH_JSON)
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, 2)}\n`);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -13600,8 +13600,10 @@ function getNextSibling(node: Node): Node | null {
 }
 
 /** Pre-seed one expando key on a prototype (see bootstrap comment, trick 2). */
-function seedExpando(proto: object, key: string): void {
-	if (!(key in proto)) (proto as any)[key] = undefined;
+function seedExpando(proto: object, key: PropertyKey, enumerable = true): void {
+	if (key in proto) return;
+	if (enumerable) (proto as any)[key] = undefined;
+	else Object.defineProperty(proto, key, { value: undefined, writable: true, configurable: true });
 }
 
 let domOperationsReady = false;
@@ -13630,6 +13632,14 @@ function initDomOperations(): void {
 		// clone()/drainFrag() fragment-wrapper discriminants.
 		seedExpando(elementProto, '__oct_frag');
 		seedExpando(elementProto, '__oct_vfrag');
+		// Raw HTML ownership is polled by dynamic child slots after the first raw host.
+		// New private keys must not appear in for...in walks over DOM elements.
+		seedExpando(elementProto, DANGER_HTML_ACTIVE, false);
+		seedExpando(elementProto, DANGER_HTML_STATIC_CHILD, false);
+		seedExpando(elementProto, DANGER_HTML_SPREAD_CHILD, false);
+		// De-opt child scans and uncontrolled form baselines also read absent symbols.
+		seedExpando(elementProto, DEOPT_DESC, false);
+		seedExpando(elementProto, DEFAULT_VALUE_BASELINE, false);
 		if (process.env.NODE_ENV !== 'production') {
 			seedExpando(elementProto, '__oct_loc');
 		}
@@ -13639,6 +13649,7 @@ function initDomOperations(): void {
 	if (typeof CharacterData !== 'undefined' && Object.isExtensible(CharacterData.prototype)) {
 		seedExpando(CharacterData.prototype, '$$portalEnd');
 		seedExpando(CharacterData.prototype, '$$deoptKey');
+		seedExpando(CharacterData.prototype, DEOPT_DESC, false);
 	}
 }
 

--- a/packages/octane/tests/conformance/controlled-input.test.ts
+++ b/packages/octane/tests/conformance/controlled-input.test.ts
@@ -319,6 +319,20 @@ describe('conformance: defaultValue / defaultChecked (uncontrolled)', () => {
 		r.unmount();
 	});
 
+	it('changing a pristine checkbox default keeps its mounted live selection', () => {
+		const r = mount(DefaultsCheckbox, { dc: true });
+		try {
+			const el = r.find('#dci') as HTMLInputElement;
+			expect(el.checked).toBe(true);
+			r.update(DefaultsCheckbox, { dc: false });
+			expect(r.find('#dci')).toBe(el);
+			expect(el.checked).toBe(true);
+			expect(el.defaultChecked).toBe(false);
+		} finally {
+			r.unmount();
+		}
+	});
+
 	it('a reused descriptor input keeps its selection when a default is added later', () => {
 		const Input = (props: { defaultChecked?: boolean }) =>
 			createElement('input', { type: 'checkbox', ...props });

--- a/packages/octane/tests/danger-html.test.ts
+++ b/packages/octane/tests/danger-html.test.ts
@@ -1,5 +1,5 @@
 import { it, expect } from 'vitest';
-import { flushSync } from '../src/index.js';
+import { createElement, flushSync } from '../src/index.js';
 import { mount } from './_helpers';
 import {
 	DangerHtml,
@@ -79,4 +79,51 @@ it('accepts a nullish coexisting child and keeps the raw HTML', () => {
 	// Filling the hole on a LATER render is rejected just the same.
 	expect(() => flushSync(() => setDangerChild('kid'))).toThrow(/dangerouslySetInnerHTML/);
 	r.unmount();
+});
+
+function MixedRawAndDeoptHosts(props: { raw: boolean; value: string }) {
+	return createElement(
+		'section',
+		null,
+		createElement(
+			'div',
+			{
+				id: 'raw-host',
+				dangerouslySetInnerHTML: props.raw ? { __html: '<b>raw</b>' } : null,
+			},
+			props.raw ? null : 'ordinary',
+		),
+		createElement('p', { id: 'mixed-host' }, [
+			createElement('em', { key: 'left' }, 'left'),
+			props.value,
+			createElement('strong', { key: 'right' }, 'right'),
+		]),
+	);
+}
+
+it('keeps foreign text and owned mixed children beside a raw HTML host', () => {
+	const r = mount(MixedRawAndDeoptHosts, { raw: true, value: 'first' });
+	try {
+		const raw = r.find('#raw-host');
+		const mixed = r.find('#mixed-host');
+		const foreign = document.createTextNode('foreign:');
+		mixed.insertBefore(foreign, mixed.firstChild);
+		expect(raw.innerHTML).toBe('<b>raw</b>');
+		expect(mixed.textContent).toBe('foreign:leftfirstright');
+
+		r.update(MixedRawAndDeoptHosts, { raw: false, value: 'second' });
+		expect(r.find('#raw-host')).toBe(raw);
+		expect(raw.textContent).toBe('ordinary');
+		expect(raw.querySelector('b')).toBeNull();
+		expect(r.find('#mixed-host')).toBe(mixed);
+		expect(mixed.firstChild).toBe(foreign);
+		expect(mixed.textContent).toBe('foreign:leftsecondright');
+
+		r.update(MixedRawAndDeoptHosts, { raw: true, value: 'third' });
+		expect(raw.innerHTML).toBe('<b>raw</b>');
+		expect(mixed.firstChild).toBe(foreign);
+		expect(mixed.textContent).toBe('foreign:leftthirdright');
+	} finally {
+		r.unmount();
+	}
 });


### PR DESCRIPTION
## Summary

- Seed the raw HTML ownership keys and de-opt descriptor symbol on native DOM prototypes, plus the uncontrolled `defaultValue` baseline symbol.
- Define the new keys as nonenumerable so DOM `for...in` walks do not expose them.
- Add behavioral regressions for checkbox reset baselines and mixed raw HTML/de-opt hosts, and a production Node/jsdom miss probe.

## Why

#981 identified repeated absent-property reads on ordinary DOM nodes after raw HTML ownership is activated and during de-opt child scans. Bootstrap now turns those misses into inherited `undefined` reads. The `defaultChecked` initialized symbol is deliberately **not** seeded: its only runtime read is a presence test, and seeding it would force an own-property check on every first defaultChecked write.

## Validation

- [ ] `pnpm format:check` (repository-wide check not run)
- [ ] `pnpm typecheck` (repository-wide check not run)
- [ ] `pnpm test` (repository-wide prechecks and browser projects not run locally)
- [x] `pnpm sync` (no generated changes)
- [x] `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] 228 focused tests across 16 development/production project runs, covering controlled forms, raw HTML, de-opt reconciliation, portals, and hydration.
- [x] The broader `octane`/`octane-prod` run passed 17,475 tests with one 5-second timeout under concurrent build load; that test passed in isolation in both projects (6/6 tests).
- [x] A deliberately broken checkbox membership guard failed the new regression in both modes; deliberately retained stale raw HTML failed the other new regression in both modes; both passed after restoration.
- [x] Frozen production baseline/candidate matched all eight semantic hashes in the paired benchmark. All six intended prototype locations report inherited hits on the candidate and misses on baseline; the raw HTML keys remain nonenumerable. The B–C–C–B lookup timings track control variation, so no throughput improvement is claimed.

## Risk / follow-ups

The native DOM prototype initialization runs once per client realm. The local probe uses jsdom and does not measure browser DOM throughput; current-head CI will cover browser behavior. #981 remains open for other findings.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791551842&installation_model_id=432790&pr_number=1015&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1015&signature=d4724ccb9b16c54c28648d9985454543c1a724508a400dda02f440afdfc92efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> One-time mutation of native DOM prototypes affects all elements in a realm; behavior is covered by new tests but real browser impact is indirect (lookup path only).
> 
> **Overview**
> **Seeds hot DOM expando lookups on native prototypes** so absent-property reads become inherited `undefined` hits after the first raw-HTML host or during de-opt child scans (#981).
> 
> `initDomOperations` now pre-seeds raw HTML ownership keys (`__oct_dangerHTML` and related child markers), the de-opt descriptor symbol, and the uncontrolled `defaultValue` baseline on `Element` / `CharacterData` prototypes. `seedExpando` accepts `PropertyKey` and can define **non-enumerable** slots so new keys do not show up in `for...in` over elements. `defaultChecked` is intentionally **not** seeded.
> 
> Adds a Node/jsdom **dom-expando** benchmark (baseline vs candidate, semantic hash checks) and regressions for pristine checkbox `defaultChecked` updates and mixed raw HTML + de-opt sibling reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0336258c8a2c680deb2d0700f404b449f351caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->