### PR TITLE
perf: avoid repeated delegated event paths

### DIFF
--- a/.changeset/octane-delegated-path-once.md
+++ b/.changeset/octane-delegated-path-once.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid constructing a native event path during the capture observer when a single root has no portals, and reuse the path across the capture and emulated bubble queues of nonbubbling events.

--- a/benchmarks/event-delegation/README.md
+++ b/benchmarks/event-delegation/README.md
@@ -21,6 +21,25 @@ It also requires the 128 capture traversals to reuse one path array. Native
 capture and bubbling, framework capture, event targets, all 128 controlled
 inputs, and their corresponding output text must remain correct.
 
+The gate also builds `event-work-no-capture.html` in a separate browser context.
+Its own compiled 512-field form has the same controlled input, validation, and
+output work but no authored input-capture handler. Importing the main form and
+passing an empty capture handler would still register capture at module load, so
+the second page uses a separate entry. An observer around the browser's native
+`Event.prototype.composedPath` counts only calls for the 128 dispatched input
+events and is restored before leaving each fixture. On the no-capture path the
+gate requires one path construction per event; the original capture
+fixture retains its capture and portal checks. These observers never run in the
+ordinary timing application. The unoptimized no-capture baseline constructs
+two paths per input event (256 for 128 events).
+
+The isolated page also dispatches one nonbubbling native `play` event on a
+`<video>`. Compiled form capture, video bubble, and form bubble handlers must
+run in that order with their own `currentTarget` and the video as `target`.
+Native document capture and video target listeners must fire, while a native
+document bubble listener must not. The shared delegated capture/bubble callback
+must call `composedPath()` once for the event (three calls before the change).
+
 Before those inputs, a separate work-only fixture mounts and unmounts two compiled
 JSX portals sharing `document.body` three times. Portal capture, target and bubble
 handlers and ref cleanup must all run; detached buttons must stop receiving
@@ -38,5 +57,5 @@ node benchmarks/event-delegation/work.mjs
 node benchmarks/bench.mjs --quick event-delegation
 ```
 
-Set `EVENT_URL` to an existing production `event-work.html` preview instead of
-building one.
+Set `EVENT_URL` to an existing production `event-work.html` preview that also
+serves `event-work-no-capture.html` instead of building one.

--- a/benchmarks/event-delegation/work.mjs
+++ b/benchmarks/event-delegation/work.mjs
@@ -18,6 +18,7 @@ const failures = [];
 let browser;
 let productionServer;
 let observed;
+let noCaptureObserved;
 try {
 	let target = process.env.EVENT_URL;
 	if (!target) {
@@ -30,7 +31,10 @@ try {
 				emptyOutDir: true,
 				minify: 'esbuild',
 				rollupOptions: {
-					input: path.join(appDirectory, 'event-work.html'),
+					input: [
+						path.join(appDirectory, 'event-work.html'),
+						path.join(appDirectory, 'event-work-no-capture.html'),
+					],
 					output: {
 						chunkFileNames: 'assets/[name]-[hash].js',
 						entryFileNames: 'assets/[name]-[hash].js',
@@ -79,6 +83,7 @@ try {
 
 			const originalDefineProperty = Object.defineProperty;
 			const originalPush = Array.prototype.push;
+			const originalComposedPath = Event.prototype.composedPath;
 			const originalPreviousSibling = Object.getOwnPropertyDescriptor(
 				Node.prototype,
 				'previousSibling',
@@ -100,6 +105,7 @@ try {
 			let invalidCurrentTargets = 0;
 			let previousSiblingReads = 0;
 			let documentPositionComparisons = 0;
+			let inputComposedPaths = 0;
 			const capture = () => nativeCaptures++;
 			const bubble = () => nativeBubbles++;
 
@@ -129,6 +135,10 @@ try {
 				}
 				return originalPush.apply(this, values);
 			};
+			Event.prototype.composedPath = function () {
+				if (currentInput !== null && this.target === currentInput) inputComposedPaths++;
+				return originalComposedPath.call(this);
+			};
 			Object.defineProperty(Node.prototype, 'previousSibling', {
 				...originalPreviousSibling,
 				get() {
@@ -154,6 +164,7 @@ try {
 				currentInput = null;
 				Object.defineProperty = originalDefineProperty;
 				Array.prototype.push = originalPush;
+				Event.prototype.composedPath = originalComposedPath;
 				Object.defineProperty(Node.prototype, 'previousSibling', originalPreviousSibling);
 				Node.prototype.compareDocumentPosition = originalComparePosition;
 				document.removeEventListener('input', capture, true);
@@ -186,11 +197,129 @@ try {
 				descriptors: descriptors.size,
 				getters: getters.size,
 				capturePaths: capturePaths.size,
+				inputComposedPaths,
 				previousSiblingReads,
 				documentPositionComparisons,
 			};
 		},
 		{ events: EVENTS, fields: FIELDS, portalCycles: PORTAL_CYCLES },
+	);
+	// A second browser context loads only the controlled-input module. Importing
+	// the ordinary App here would register onInputCapture for this runtime copy
+	// before any event is dispatched, even if its handler value were undefined.
+	const noCapturePage = await browser.newPage();
+	await noCapturePage.goto(new URL('event-work-no-capture.html', target).href, {
+		waitUntil: 'load',
+	});
+	await noCapturePage.waitForFunction(() => globalThis.__runtimeStress?.ready === true, null, {
+		timeout: 10_000,
+	});
+	noCaptureObserved = await noCapturePage.evaluate(
+		({ events, fields }) => {
+			const form = document.querySelector('#stress-form');
+			const media = document.querySelector('#event-work-media');
+			if (form === null || document.querySelectorAll('input[data-field-index]').length !== fields) {
+				throw new Error('Missing controlled no-capture benchmark form');
+			}
+			if (media === null) throw new Error('Missing nonbubbling media event target');
+			const setInputValue = Object.getOwnPropertyDescriptor(
+				HTMLInputElement.prototype,
+				'value',
+			).set;
+			const originalComposedPath = Event.prototype.composedPath;
+			let currentInput = null;
+			let currentMedia = null;
+			let inputComposedPaths = 0;
+			let mediaComposedPaths = 0;
+			let nativeCaptures = 0;
+			let nativeBubbles = 0;
+			let nativeMediaCaptures = 0;
+			let nativeMediaTargets = 0;
+			let nativeMediaBubbles = 0;
+			let unexpectedFrameworkCaptures = 0;
+			let invalidMediaCurrentTargets = 0;
+			const mediaOrder = [];
+			const capture = () => nativeCaptures++;
+			const bubble = () => nativeBubbles++;
+			const mediaCapture = () => nativeMediaCaptures++;
+			const mediaTarget = () => nativeMediaTargets++;
+			const mediaBubble = () => nativeMediaBubbles++;
+			document.addEventListener('input', capture, true);
+			document.addEventListener('input', bubble);
+			document.addEventListener('play', mediaCapture, true);
+			media.addEventListener('play', mediaTarget);
+			document.addEventListener('play', mediaBubble);
+			globalThis.__octaneDelegatedInputCapture = () => unexpectedFrameworkCaptures++;
+			globalThis.__eventWorkMedia = (phase, event) => {
+				mediaOrder.push(phase);
+				const expected = phase === 'target-bubble' ? media : form;
+				if (event.target !== media || event.currentTarget !== expected) {
+					invalidMediaCurrentTargets++;
+				}
+			};
+			Event.prototype.composedPath = function () {
+				if (currentInput !== null && this.target === currentInput) inputComposedPaths++;
+				if (currentMedia !== null && this.type === 'play' && this.target === currentMedia)
+					mediaComposedPaths++;
+				return originalComposedPath.call(this);
+			};
+			try {
+				for (let index = 0; index < events; index++) {
+					currentInput = document.querySelector(`input[data-field-index="${index}"]`);
+					setInputValue.call(currentInput, `event-${index}`);
+					currentInput.dispatchEvent(
+						new InputEvent('input', { bubbles: true, data: String(index) }),
+					);
+					currentInput = null;
+				}
+				currentMedia = media;
+				media.dispatchEvent(new Event('play', { bubbles: false }));
+				currentMedia = null;
+			} finally {
+				currentInput = null;
+				currentMedia = null;
+				Event.prototype.composedPath = originalComposedPath;
+				document.removeEventListener('input', capture, true);
+				document.removeEventListener('input', bubble);
+				document.removeEventListener('play', mediaCapture, true);
+				media.removeEventListener('play', mediaTarget);
+				document.removeEventListener('play', mediaBubble);
+				delete globalThis.__octaneDelegatedInputCapture;
+				delete globalThis.__eventWorkMedia;
+			}
+			let updatedFields = 0;
+			let updatedOutputs = 0;
+			for (let index = 0; index < events; index++) {
+				const expected = `event-${index}`;
+				if (document.querySelector(`input[data-field-index="${index}"]`)?.value === expected) {
+					updatedFields++;
+				}
+				if (document.querySelector(`[data-field-output="${index}"]`)?.textContent === expected) {
+					updatedOutputs++;
+				}
+			}
+			return {
+				eventHosts: document.querySelectorAll('input[data-field-index]').length,
+				events,
+				inputComposedPaths,
+				mediaComposedPaths,
+				nativeCaptures,
+				nativeBubbles,
+				nativeMediaCaptures,
+				nativeMediaTargets,
+				nativeMediaBubbles,
+				unexpectedFrameworkCaptures,
+				frameworkBubbles: globalThis.__runtimeStress.stats.form.validationRequests,
+				updatedFields,
+				updatedOutputs,
+				mediaHandlers: mediaOrder.length,
+				mediaOrderCorrect: Number(
+					mediaOrder.join(',') === 'form-capture,target-bubble,form-bubble',
+				),
+				invalidMediaCurrentTargets,
+			};
+		},
+		{ events: EVENTS, fields: FIELDS },
 	);
 } finally {
 	try {
@@ -213,6 +342,9 @@ if (observed.eventHosts !== FIELDS)
 	failures.push(`eventHosts: ${observed.eventHosts} is not ${FIELDS}`);
 if (observed.invalidCurrentTargets !== 0) {
 	failures.push(`invalidCurrentTargets: ${observed.invalidCurrentTargets} is not zero`);
+}
+if (observed.inputComposedPaths > EVENTS * 2) {
+	failures.push(`inputComposedPaths: ${observed.inputComposedPaths} exceeds ${EVENTS * 2}`);
 }
 if (observed.definitions !== EVENTS * 2) {
 	failures.push(`definitions: ${observed.definitions} is not ${EVENTS * 2}`);
@@ -239,9 +371,48 @@ for (const key of [
 	if (observed[key] !== 0)
 		failures.push(`${key}: ${observed[key]} is not zero after portal cleanup`);
 }
+for (const key of [
+	'nativeCaptures',
+	'nativeBubbles',
+	'frameworkBubbles',
+	'updatedFields',
+	'updatedOutputs',
+]) {
+	if (noCaptureObserved[key] !== EVENTS)
+		failures.push(`no capture ${key}: ${noCaptureObserved[key]} is not ${EVENTS}`);
+}
+if (noCaptureObserved.eventHosts !== FIELDS) {
+	failures.push(`no capture eventHosts: ${noCaptureObserved.eventHosts} is not ${FIELDS}`);
+}
+if (noCaptureObserved.unexpectedFrameworkCaptures !== 0) {
+	failures.push(
+		`no capture unexpectedFrameworkCaptures: ${noCaptureObserved.unexpectedFrameworkCaptures} is not zero`,
+	);
+}
+if (noCaptureObserved.inputComposedPaths !== EVENTS) {
+	failures.push(
+		`no capture inputComposedPaths: ${noCaptureObserved.inputComposedPaths} is not ${EVENTS}`,
+	);
+}
+for (const key of ['nativeMediaCaptures', 'nativeMediaTargets', 'mediaOrderCorrect']) {
+	if (noCaptureObserved[key] !== 1)
+		failures.push(`no capture ${key}: ${noCaptureObserved[key]} is not 1`);
+}
+if (noCaptureObserved.mediaHandlers !== 3) {
+	failures.push(`no capture mediaHandlers: ${noCaptureObserved.mediaHandlers} is not 3`);
+}
+for (const key of ['nativeMediaBubbles', 'invalidMediaCurrentTargets']) {
+	if (noCaptureObserved[key] !== 0)
+		failures.push(`no capture ${key}: ${noCaptureObserved[key]} is not zero`);
+}
+if (noCaptureObserved.mediaComposedPaths !== 1) {
+	failures.push(`no capture mediaComposedPaths: ${noCaptureObserved.mediaComposedPaths} is not 1`);
+}
 
 console.log('Production delegated-event work:');
 console.table(observed);
+console.log('Production delegated-event work without authored capture:');
+console.table(noCaptureObserved);
 if (process.env.BENCH_JSON) {
 	const stat = (value) => ({ median: value, min: value, samples: 1 });
 	fs.writeFileSync(
@@ -254,6 +425,13 @@ if (process.env.BENCH_JSON) {
 						name: 'octane-tsrx-work',
 						ops: Object.fromEntries(
 							Object.entries(observed).map(([name, value]) => [name, stat(value)]),
+						),
+						meta: { gate: failures.length === 0 ? 'passed' : 'failed' },
+					},
+					{
+						name: 'octane-tsrx-no-capture-work',
+						ops: Object.fromEntries(
+							Object.entries(noCaptureObserved).map(([name, value]) => [name, stat(value)]),
 						),
 						meta: { gate: failures.length === 0 ? 'passed' : 'failed' },
 					},

--- a/benchmarks/news/octane-tsrx/event-work-no-capture.html
+++ b/benchmarks/news/octane-tsrx/event-work-no-capture.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Octane delegated-event work without authored capture</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/runtime-stress/event-work-no-capture.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/octane-tsrx/src/runtime-stress/EventWorkNoCapture.tsrx
+++ b/benchmarks/news/octane-tsrx/src/runtime-stress/EventWorkNoCapture.tsrx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'octane';
+import {
+	FORM_FIELDS,
+	markFieldRender,
+	recordValidation,
+} from '../../../../runtime-stress/shared.js';
+
+function FormField(props: { index: number }) @{
+	const [value, setValue] = useState('');
+	useEffect(() => {
+		setValue('');
+	}, []);
+	markFieldRender(props.index);
+	const onInput = (event: Event) => {
+		const next = (event.currentTarget as HTMLInputElement).value;
+		setValue(next);
+		recordValidation(next);
+	};
+
+	<label>
+		<input
+			name={'field-' + props.index}
+			data-field-index={String(props.index)}
+			value={value}
+			onInput={onInput}
+		/>
+		<output data-field-output={String(props.index)}>{value as string}</output>
+	</label>
+}
+
+function reportMediaEvent(phase: string, event: Event) {
+	const benchmark = globalThis as
+		typeof globalThis & {
+			__eventWorkMedia?: (phase: string, event: Event) => void;
+		};
+	benchmark.__eventWorkMedia?.(phase, event);
+}
+
+// This separate module never registers an authored input-capture listener.
+// The normal stress App does so at module load even if its handler is unset.
+export function EventWorkNoCapture() @{
+	<form
+		id="stress-form"
+		onPlayCapture={(event: Event) => reportMediaEvent('form-capture', event)}
+		onPlay={(event: Event) => reportMediaEvent('form-bubble', event)}
+	>
+		@for (const index of FORM_FIELDS; key index) {
+			<FormField index={index} />
+		}
+		<video
+			id="event-work-media"
+			onPlay={(event: Event) => reportMediaEvent('target-bubble', event)}
+		/>
+	</form>
+}

--- a/benchmarks/news/octane-tsrx/src/runtime-stress/event-work-no-capture.ts
+++ b/benchmarks/news/octane-tsrx/src/runtime-stress/event-work-no-capture.ts
@@ -1,0 +1,12 @@
+import { createRoot, flushSync } from 'octane';
+import { installRuntimeStress } from '../../../../runtime-stress/shared.js';
+import { EventWorkNoCapture } from './EventWorkNoCapture.tsrx';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing delegated-event benchmark root');
+
+const stress = installRuntimeStress();
+const root = createRoot(container);
+root.render(EventWorkNoCapture, {});
+flushSync(() => {});
+stress.ready = true;

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -17949,11 +17949,17 @@ function isEventRoot(node: Node, epoch: number): boolean {
 	return membership !== undefined && membership.count > 0;
 }
 
-function prepareDelegatedEvent(event: Event, listener: Node): EventTarget[] {
-	const path = event.composedPath();
+function prepareDelegatedEvent(event: Event, listener: Node): EventTarget[] | undefined {
 	// Every delegated type has a root capture observer, even without an authored
 	// capture handler. The outermost observer starts a fresh native delivery, so
 	// synchronously redispatching the same Event never inherits an old root epoch.
+	// One public root without portals needs only the epoch; its bubble listener
+	// can build the path once, after native target listeners have run.
+	if (_delegationTargets.size === 1 && portalEventTargetCount === 0) {
+		(event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
+		return;
+	}
+	const path = event.composedPath();
 	if (_delegationTargets.size === 1) {
 		(event as any)[EVENT_ROOT_EPOCH] = eventRootEpoch;
 		if (portalEventTargetCount !== 0) {
@@ -18818,7 +18824,8 @@ function finishCaptureDispatch(event: Event): void {
 }
 
 function dispatchDelegated(this: Node, event: Event): void {
-	if (delegatedCapture(event.type)) prepareDelegatedEvent(event, this);
+	const nativeCapture = delegatedCapture(event.type);
+	let path = nativeCapture ? prepareDelegatedEvent(event, this) : undefined;
 	(event as any)[DELEGATED_BUBBLE_VERSION] = ((event as any)[DELEGATED_BUBBLE_VERSION] || 0) + 1;
 	maybeEnqueueRestore(event);
 	const key = '$$' + event.type;
@@ -18842,12 +18849,10 @@ function dispatchDelegated(this: Node, event: Event): void {
 		// Non-bubbling families share one native capture callback. Run the logical
 		// capture queue first, independent of module registration order, and honor
 		// a stop within that phase before starting the emulated bubble queue.
-		if (
-			delegatedCapture(event.type) &&
-			_delegatedCapture.has(event.type) &&
-			dispatchDelegatedCapture.call(this, event)
-		)
-			return;
+		if (nativeCapture && _delegatedCapture.has(event.type)) {
+			path ??= event.composedPath();
+			if (dispatchDelegatedCapture.call(this, event, path)) return;
+		}
 		if (!_delegated.has(event.type)) return;
 		// Custom elements receive known nonbubbling events through authored
 		// capture handlers only. They do not install the native target listener
@@ -18858,7 +18863,7 @@ function dispatchDelegated(this: Node, event: Event): void {
 			(event.type === 'invalid' || EMULATED_BUBBLING_EVENTS.includes(event.type))
 		)
 			return;
-		buildDelegatedPath(event, this);
+		buildDelegatedPath(event, this, path);
 		snapshotDelegatedSlots(pathBase, key, event);
 		stop = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
 		propagationStarted = true;
@@ -18909,9 +18914,10 @@ function dispatchDelegated(this: Node, event: Event): void {
 // Capture runs only this native listener's segment, in reverse path order.
 // Returning whether this queue stopped native propagation lets the shared
 // non-bubbling listener decide whether it may start its emulated bubble queue.
-function dispatchDelegatedCapture(this: Node, event: Event): boolean {
-	const path = prepareDelegatedEvent(event, this);
+function dispatchDelegatedCapture(this: Node, event: Event, path?: EventTarget[]): boolean {
+	path ??= prepareDelegatedEvent(event, this);
 	if (!_delegatedCapture.has(event.type)) return false;
+	path ??= event.composedPath();
 	if (!event.bubbles || !_delegated.has(event.type)) maybeEnqueueRestore(event);
 	const key = CAPTURE_PREFIX + event.type;
 	const pathBase = CAPTURE_PATH.length;

--- a/packages/octane/tests/audit-events-portals.test.ts
+++ b/packages/octane/tests/audit-events-portals.test.ts
@@ -257,6 +257,45 @@ export function App({report, label, read}) @{
 		}
 	});
 
+	it('reads the latest handlers after a nonbubbling capture updates the tree', () => {
+		const { App } = fixture(`
+export function App({label, capture, log}) @{
+	<section onPlayCapture={(event) => capture(event, label)} onPlay={(event) => log('parent', label, event.currentTarget)}>
+		<video onPlay={(event) => log('target', label, event.currentTarget)} />
+	</section>
+}`);
+		const calls: Array<[string, string, EventTarget | null]> = [];
+		let r: ReturnType<typeof mount>;
+		const log = (name: string, label: string, currentTarget: EventTarget | null) => {
+			calls.push([name, label, currentTarget]);
+		};
+		const capture = (event: Event, label: string) => {
+			log('capture', label, event.currentTarget);
+			if (label === 'old') r.update(App, { label: 'new', capture, log });
+		};
+		r = mount(App, { label: 'old', capture, log });
+		try {
+			const video = r.find('video');
+			const parent = r.find('section');
+			const play = () => video.dispatchEvent(new Event('play', { bubbles: false }));
+			play();
+			expect(calls).toEqual([
+				['capture', 'old', parent],
+				['target', 'new', video],
+				['parent', 'new', parent],
+			]);
+			calls.length = 0;
+			play();
+			expect(calls).toEqual([
+				['capture', 'new', parent],
+				['target', 'new', video],
+				['parent', 'new', parent],
+			]);
+		} finally {
+			r.unmount();
+		}
+	});
+
 	it('captures a form action before submit handlers synchronously replace it', () => {
 		const calls: string[] = [];
 		let r: ReturnType<typeof mount>;
@@ -388,6 +427,42 @@ export function App({report, label, read}) @{
 			}
 		}
 		expect(run(false)).toEqual(run(true));
+	});
+
+	it('bubbles through nested roots without capture handlers after remount', () => {
+		const calls: string[] = [];
+		const container = document.createElement('div');
+		document.body.append(container);
+		const handler = (name: string) => () => calls.push(name);
+		const outer = createRoot(container);
+		outer.render(
+			h(
+				'section',
+				{ onAuditPathOnly: handler('outer') },
+				h('div', { id: 'inner-root', onAuditPathOnly: handler('container') }),
+			),
+		);
+		const host = container.querySelector('#inner-root')!;
+		let inner = createRoot(host);
+		const mountInner = () => inner.render(h('button', { onAuditPathOnly: handler('inner') }, 'go'));
+		const dispatch = () =>
+			container
+				.querySelector('button')!
+				.dispatchEvent(new Event('auditpathonly', { bubbles: true }));
+		try {
+			mountInner();
+			dispatch();
+			expect(calls).toEqual(['inner', 'container', 'outer']);
+			inner.unmount();
+			inner = createRoot(host);
+			mountInner();
+			dispatch();
+			expect(calls).toEqual(['inner', 'container', 'outer', 'inner', 'container', 'outer']);
+		} finally {
+			inner.unmount();
+			outer.unmount();
+			container.remove();
+		}
 	});
 
 	it('preserves portal child state for string and number keys across reorder', () => {


### PR DESCRIPTION
## Summary

- Skip `composedPath()` in the root capture observer when one public root has no portals and no authored capture path is needed; retain the root epoch stamp.
- Reuse a local native path across the capture and emulated bubble queues of a nonbubbling event. Separate native capture/bubble callbacks, nested roots, and portals still prepare their own paths.
- Add behavioral regressions for synchronous nonbubbling capture updates and nested-root remounts, plus a production Chromium work gate with an isolated no-capture input form and a nonbubbling `play` event.

Addresses the delegated `composedPath()` finding in #981. Keep the issue open for its remaining checklist items.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm format:files:check` on all changed files; `pnpm sync` generated no tracked changes
- [x] Targeted event/portal/focus/capture suites: 62/62 across development and production projects
- [x] `node benchmarks/event-delegation/work.mjs` in Chromium: no-authored-capture inputs 256 → 128 path calls for 128 events; nonbubbling `play` 3 → 1. Authored input capture remains 256/128 events, with portal, handler order, controlled output, and native propagation controls passing on both main and candidate.
- [x] `node benchmarks/bench.mjs --quick event-delegation` before and after: captured-input timing 14.4 ms → 8.4 ms in two-sample quick runs; other framework timings moved too, so no throughput gain is claimed.
- [ ] `pnpm test`: attempted locally on Node 26; the long multi-project run reported unrelated timeouts and Node 26 localStorage failures, then exhausted its 4 GB V8 heap. Isolated Jotai utils passed 10/10 and compiler/Volar passed 26/26 on supported Node 22. The email preview watcher test fails identically with the unmodified main runtime on this host. Current-head CI on Node 24 is the full-suite gate.

## Risk / follow-ups

- The path remains local to one nonbubbling native listener; no Event path is retained across callbacks. A portal or multiple active roots still requires the eager composed path and ownership checks.
- The usual captured-input timing fixture cannot measure the no-capture improvement. The deterministic work gate covers that path; wall-clock timings there were not collected.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554979&installation_model_id=432790&pr_number=1016&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1016&signature=7e70df3855c3c73730dec537a20712dc8fb2ac1277d4871559f655c70538dff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core delegated event propagation in the runtime; behavior is constrained to single-root/no-portal and path-reuse paths but incorrect path timing could break capture/bubble ordering or nested roots.
> 
> **Overview**
> **Reduces how often Octane calls `Event.prototype.composedPath()` during delegated event delivery**, which was a hotspot for simple apps with one root and no portals.
> 
> In `prepareDelegatedEvent`, when there is a **single delegation root and no portals**, the root capture observer now only stamps the root epoch and **returns without building a path**; bubble handling can construct the path once after native target listeners run. For **nonbubbling** events that share one native capture callback, **`dispatchDelegated` passes the same path** into capture and emulated bubble (`buildDelegatedPath`) instead of calling `composedPath()` again. Multi-root, portal, and authored-capture cases still prepare paths eagerly when needed.
> 
> **Benchmark and test coverage** adds a separate `event-work-no-capture` production fixture (no authored input capture at module load), extends `work.mjs` to assert **one `composedPath` per input** on that path and **one per nonbubbling `play` event** with correct handler order, and adds regressions for **capture-time remounts** on `play` and **nested-root bubbling after inner remount**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937fc5272ddd23f20958d0248bf54e9a071b97ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->