### PR TITLE
perf: skip unused delegated capture fallback tasks

### DIFF
--- a/.changeset/captured-event-restore-fallback.md
+++ b/.changeset/captured-event-restore-fallback.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid scheduling a capture fallback task for ordinary delegated discrete events when no controlled form restoration is pending. Preserve the fallback for a controlled edit whose native bubble is stopped below the root, including controls armed after capture and restores queued by nested events.

--- a/benchmarks/event-delegation/README.md
+++ b/benchmarks/event-delegation/README.md
@@ -40,6 +40,17 @@ Native document capture and video target listeners must fire, while a native
 document bubble listener must not. The shared delegated capture/bubble callback
 must call `composedPath()` once for the event (three calls before the change).
 
+The same isolated page also mounts an idle button under a form with authored
+`onClickCapture`, button `onClick`, and form `onClick`. Playwright clicks the
+button 16 times, producing trusted native events. A temporary `setTimeout`
+observer counts zero-delay tasks only between a document capture listener
+(before Octane's root capture) and a document bubble listener (after Octane's
+root bubble). The gate checks native and framework handler order, trusted event
+identity and `currentTarget`, and zero timers for each click that reaches the
+bubble listener. This fixture registers capture only for `click`; the input
+gate above still exercises its own event type unchanged. The baseline scheduled
+one unnecessary fallback timer per click (16 total).
+
 Before those inputs, a separate work-only fixture mounts and unmounts two compiled
 JSX portals sharing `document.body` three times. Portal capture, target and bubble
 handlers and ref cleanup must all run; detached buttons must stop receiving

--- a/benchmarks/event-delegation/work.mjs
+++ b/benchmarks/event-delegation/work.mjs
@@ -13,12 +13,14 @@ const appDirectory = fileURLToPath(new URL('../news/octane-tsrx/', import.meta.u
 const EVENTS = 128;
 const FIELDS = 512;
 const PORTAL_CYCLES = 3;
+const TRUSTED_CLICKS = 16;
 const failures = [];
 
 let browser;
 let productionServer;
 let observed;
 let noCaptureObserved;
+let trustedClickObserved;
 try {
 	let target = process.env.EVENT_URL;
 	if (!target) {
@@ -321,6 +323,107 @@ try {
 		},
 		{ events: EVENTS, fields: FIELDS },
 	);
+	// A native document capture listener opens the observation window before
+	// Octane's root capture listener. Document bubble closes it after the root
+	// bubble listener, so timers outside the click's delivery cannot enter it.
+	await noCapturePage.evaluate(() => {
+		const form = document.querySelector('#stress-form');
+		const button = document.querySelector('#event-work-trusted-click');
+		if (form === null || button === null) throw new Error('Missing trusted-click work target');
+		const originalSetTimeout = window.setTimeout;
+		const result = {
+			nativeCaptures: 0,
+			nativeBubbles: 0,
+			frameworkCaptures: 0,
+			buttonBubbles: 0,
+			formBubbles: 0,
+			invalidEvents: 0,
+			timersByClick: [],
+			order: [],
+		};
+		let activeClick = null;
+		const capture = (event) => {
+			if (event.target !== button) return;
+			result.nativeCaptures++;
+			if (activeClick !== null || !event.isTrusted) result.invalidEvents++;
+			activeClick = event;
+			result.order.push('document-capture');
+			result.timersByClick.push(0);
+		};
+		const bubble = (event) => {
+			if (event.target !== button) return;
+			result.nativeBubbles++;
+			if (activeClick !== event) result.invalidEvents++;
+			result.order.push('document-bubble');
+			activeClick = null;
+		};
+		document.addEventListener('click', capture, true);
+		document.addEventListener('click', bubble);
+		window.setTimeout = function (...args) {
+			if (activeClick !== null && args[1] === 0) {
+				result.timersByClick[result.timersByClick.length - 1]++;
+			}
+			return Reflect.apply(originalSetTimeout, window, args);
+		};
+		globalThis.__eventWorkClick = (phase, event) => {
+			if (phase === 'form-capture') result.frameworkCaptures++;
+			else if (phase === 'button-bubble') result.buttonBubbles++;
+			else if (phase === 'form-bubble') result.formBubbles++;
+			if (
+				event !== activeClick ||
+				!event.isTrusted ||
+				event.target !== button ||
+				event.currentTarget !== (phase === 'button-bubble' ? button : form)
+			) {
+				result.invalidEvents++;
+			}
+			result.order.push(phase);
+		};
+		globalThis.__trustedClickWork = {
+			result,
+			restore() {
+				window.setTimeout = originalSetTimeout;
+				document.removeEventListener('click', capture, true);
+				document.removeEventListener('click', bubble);
+				delete globalThis.__eventWorkClick;
+				delete globalThis.__trustedClickWork;
+			},
+		};
+	});
+	try {
+		const clickTarget = noCapturePage.locator('#event-work-trusted-click');
+		for (let index = 0; index < TRUSTED_CLICKS; index++) await clickTarget.click();
+		trustedClickObserved = await noCapturePage.evaluate((clicks) => {
+			const result = globalThis.__trustedClickWork.result;
+			const expectedOrder = [
+				'document-capture',
+				'form-capture',
+				'button-bubble',
+				'form-bubble',
+				'document-bubble',
+			];
+			return {
+				clicks,
+				nativeCaptures: result.nativeCaptures,
+				nativeBubbles: result.nativeBubbles,
+				frameworkCaptures: result.frameworkCaptures,
+				buttonBubbles: result.buttonBubbles,
+				formBubbles: result.formBubbles,
+				invalidEvents: result.invalidEvents,
+				orderCorrect: Number(
+					result.order.length === clicks * expectedOrder.length &&
+						result.order.every(
+							(phase, index) => phase === expectedOrder[index % expectedOrder.length],
+						),
+				),
+				zeroDelayTimers: result.timersByClick.reduce((sum, count) => sum + count, 0),
+				minTimersPerClick: Math.min(...result.timersByClick),
+				maxTimersPerClick: Math.max(...result.timersByClick),
+			};
+		}, TRUSTED_CLICKS);
+	} finally {
+		await noCapturePage.evaluate(() => globalThis.__trustedClickWork?.restore());
+	}
 } finally {
 	try {
 		await browser?.close();
@@ -408,11 +511,42 @@ for (const key of ['nativeMediaBubbles', 'invalidMediaCurrentTargets']) {
 if (noCaptureObserved.mediaComposedPaths !== 1) {
 	failures.push(`no capture mediaComposedPaths: ${noCaptureObserved.mediaComposedPaths} is not 1`);
 }
+for (const key of [
+	'nativeCaptures',
+	'nativeBubbles',
+	'frameworkCaptures',
+	'buttonBubbles',
+	'formBubbles',
+]) {
+	if (trustedClickObserved[key] !== TRUSTED_CLICKS) {
+		failures.push(`trusted click ${key}: ${trustedClickObserved[key]} is not ${TRUSTED_CLICKS}`);
+	}
+}
+if (trustedClickObserved.invalidEvents !== 0) {
+	failures.push(`trusted click invalidEvents: ${trustedClickObserved.invalidEvents} is not zero`);
+}
+if (trustedClickObserved.orderCorrect !== 1) {
+	failures.push('trusted click handler and native listener order is incorrect');
+}
+// Every click reaches the delegated root bubble, which closes its capture
+// boundary. A post-dispatch fallback task would have no remaining work.
+if (trustedClickObserved.zeroDelayTimers !== 0) {
+	failures.push(
+		`trusted click zeroDelayTimers: ${trustedClickObserved.zeroDelayTimers} is not zero`,
+	);
+}
+for (const key of ['minTimersPerClick', 'maxTimersPerClick']) {
+	if (trustedClickObserved[key] !== 0) {
+		failures.push(`trusted click ${key}: ${trustedClickObserved[key]} is not zero`);
+	}
+}
 
 console.log('Production delegated-event work:');
 console.table(observed);
 console.log('Production delegated-event work without authored capture:');
 console.table(noCaptureObserved);
+console.log('Production trusted captured-click work:');
+console.table(trustedClickObserved);
 if (process.env.BENCH_JSON) {
 	const stat = (value) => ({ median: value, min: value, samples: 1 });
 	fs.writeFileSync(
@@ -432,6 +566,13 @@ if (process.env.BENCH_JSON) {
 						name: 'octane-tsrx-no-capture-work',
 						ops: Object.fromEntries(
 							Object.entries(noCaptureObserved).map(([name, value]) => [name, stat(value)]),
+						),
+						meta: { gate: failures.length === 0 ? 'passed' : 'failed' },
+					},
+					{
+						name: 'octane-tsrx-trusted-click-work',
+						ops: Object.fromEntries(
+							Object.entries(trustedClickObserved).map(([name, value]) => [name, stat(value)]),
 						),
 						meta: { gate: failures.length === 0 ? 'passed' : 'failed' },
 					},

--- a/benchmarks/news/octane-tsrx/src/runtime-stress/EventWorkNoCapture.tsrx
+++ b/benchmarks/news/octane-tsrx/src/runtime-stress/EventWorkNoCapture.tsrx
@@ -36,6 +36,14 @@ function reportMediaEvent(phase: string, event: Event) {
 	benchmark.__eventWorkMedia?.(phase, event);
 }
 
+function reportClickEvent(phase: string, event: Event) {
+	const benchmark = globalThis as
+		typeof globalThis & {
+			__eventWorkClick?: (phase: string, event: Event) => void;
+		};
+	benchmark.__eventWorkClick?.(phase, event);
+}
+
 // This separate module never registers an authored input-capture listener.
 // The normal stress App does so at module load even if its handler is unset.
 export function EventWorkNoCapture() @{
@@ -43,6 +51,8 @@ export function EventWorkNoCapture() @{
 		id="stress-form"
 		onPlayCapture={(event: Event) => reportMediaEvent('form-capture', event)}
 		onPlay={(event: Event) => reportMediaEvent('form-bubble', event)}
+		onClickCapture={(event: Event) => reportClickEvent('form-capture', event)}
+		onClick={(event: Event) => reportClickEvent('form-bubble', event)}
 	>
 		@for (const index of FORM_FIELDS; key index) {
 			<FormField index={index} />
@@ -51,5 +61,10 @@ export function EventWorkNoCapture() @{
 			id="event-work-media"
 			onPlay={(event: Event) => reportMediaEvent('target-bubble', event)}
 		/>
+		<button
+			id="event-work-trusted-click"
+			type="button"
+			onClick={(event: Event) => reportClickEvent('button-bubble', event)}
+		>{'Click work target'}</button>
 	</form>
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -18796,6 +18796,15 @@ function finishCaptureDispatch(event: Event): void {
 		return;
 	}
 	if (!DISCRETE_EVENTS.has(type)) return;
+	// A missed bubble can leave a restore queued by a nested event in capture.
+	// The target itself may also become controlled in a native listener below
+	// this root, so retain the fallback for form controls even when $$ctrl is
+	// not armed yet. Other events have no controlled work to finish here.
+	if (pendingRestores.length === 0) {
+		if (!RESTORE_EVENTS.has(type)) return;
+		const tag = (event.target as Element | null)?.localName;
+		if (tag !== 'input' && tag !== 'textarea' && tag !== 'select') return;
+	}
 	const bubbleVersion = (event as any)[DELEGATED_BUBBLE_VERSION];
 	const fallback = () => {
 		// A delivered bubble segment closes the capture segment's commit boundary

--- a/packages/octane/tests/_fixtures/dispatch-commit-timing.tsrx
+++ b/packages/octane/tests/_fixtures/dispatch-commit-timing.tsrx
@@ -31,7 +31,7 @@ export function NestedSubmit() @{
 			type="button"
 			onClick={(e) => {
 				setStatus('submitting');
-				e.currentTarget.form.requestSubmit();
+				e.currentTarget.form!.requestSubmit();
 			}}
 		>
 			go
@@ -53,6 +53,21 @@ export function ControlledInput() @{
 export function RejectedInput() @{
 	const [value] = useState('fixed');
 	<input id="rejected" value={value} />
+}
+
+export function CapturedNestedInput(props: { onCapture: () => void }) @{
+	<div>
+		<button id="captured-button" type="button" onClickCapture={props.onCapture}>press</button>
+		<input id="nested-input" value="fixed" />
+	</div>
+}
+
+export function LateControlledInput(props: { value?: string; onCapture: () => void }) @{
+	<input
+		id="late-controlled"
+		{...(props.value === undefined ? {} : { value: props.value })}
+		onInputCapture={props.onCapture}
+	/>
 }
 
 // Controlled input beside a reset button whose click ALSO clears the state. A

--- a/packages/octane/tests/discrete-dispatch-commit-timing.test.ts
+++ b/packages/octane/tests/discrete-dispatch-commit-timing.test.ts
@@ -19,6 +19,8 @@ import {
 	NestedSubmit,
 	ControlledInput,
 	RejectedInput,
+	CapturedNestedInput,
+	LateControlledInput,
 	ResetForm,
 	SubmitCompletedInput,
 } from './_fixtures/dispatch-commit-timing.tsrx';
@@ -134,6 +136,50 @@ describe('discrete dispatch commit timing (React batchedUpdates parity)', () => 
 		input.dispatchEvent(new Event('input', { bubbles: true }));
 		expect(input.value).toBe('fixed');
 		r.unmount();
+	});
+
+	it('restores a nested controlled edit when the outer click stops before its bubble handler', async () => {
+		let input: HTMLInputElement;
+		const r = mount(CapturedNestedInput, {
+			onCapture() {
+				setNativeValue(input, 'edited');
+				input.dispatchEvent(new Event('input', { bubbles: true }));
+			},
+		});
+		try {
+			input = r.find('#nested-input') as HTMLInputElement;
+			const button = r.find('#captured-button') as HTMLButtonElement;
+			button.addEventListener('click', (event) => event.stopPropagation());
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			// The input's own dispatch ran inside the click capture handler. Its
+			// restoration waits for the outer event's boundary even without bubble.
+			expect(input.value).toBe('edited');
+			await Promise.resolve();
+			expect(input.value).toBe('fixed');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('restores an input first controlled by a native target listener after capture', async () => {
+		const onCapture = () => {};
+		const r = mount(LateControlledInput, { onCapture });
+		try {
+			const input = r.find('#late-controlled') as HTMLInputElement;
+			input.addEventListener('input', (event) => {
+				r.update(LateControlledInput, { value: 'fixed', onCapture });
+				setNativeValue(input, 'edited');
+				event.stopPropagation();
+			});
+			setNativeValue(input, 'typed');
+			input.dispatchEvent(new Event('input', { bubbles: true }));
+			expect(r.find('#late-controlled')).toBe(input);
+			expect(input.value).toBe('edited');
+			await Promise.resolve();
+			expect(input.value).toBe('fixed');
+		} finally {
+			r.unmount();
+		}
 	});
 
 	it('a reset-button click that also clears controlled state leaves the control dirty, like React', async () => {


### PR DESCRIPTION
## Summary

- Skip the discrete capture fallback closure and task when no controlled restore is pending and the event cannot target a controlled form element.
- Preserve the fallback for nested controlled edits and a form control armed by a native target listener after root capture.
- Add a production Chromium work gate for trusted captured clicks and two behavioral regressions. Refs #981.

## Why

An authored capture handler makes `finishCaptureDispatch` schedule `setTimeout(..., 0)` for every trusted discrete event even when ordinary root bubbling closes the dispatch boundary. The timer then observes that bubble already ran and does no work.

## Changes

- Keep the fallback if a nested dispatch already queued a restore, or if `input`/`change`/`click` targets a native input, textarea, or select that could become controlled before its bubble is stopped. Other captured discrete events skip it.
- Extend the existing event-delegation production gate with 16 trusted button clicks, native/framework capture and bubble order, event identity, and zero-delay timer counts. The same gate measured 16 tasks for 16 clicks on the unmodified runtime and 0 for 16 on this head, with all handler and existing input/portal/media controls passing.
- Check nested restore and late control arming in development and production tests; each test was observed failing under a deliberately broken guard.

## Validation

- [ ] `pnpm format:check` (scoped `pnpm format:files:check` passed for all changed files)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (current-head CI will run the full suite)
- [x] targeted tests: `discrete-dispatch-commit-timing.test.ts` in `octane` and `octane-prod` (28/28), adjacent capture/dedup/controlled-restore suites in both modes (34/34), real Chromium `event-boundaries.test.ts` (28/28)
- [x] `node benchmarks/event-delegation/work.mjs` (production Chromium, all deterministic work gates passed)
- [x] `pnpm sync`, staged `git diff --check`

## Risk / follow-ups

Captured form-control edit events retain the conservative fallback even when the target was uncontrolled at capture, because a native listener can arm it before stopping propagation. No change to native event routing or the separate signal event batch fallback.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556880&installation_model_id=432790&pr_number=1017&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1017&signature=0812fd09d681eb8fd0144c867ea8c366146565b7ccd1e836a062b52057afb000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes discrete-event dispatch-boundary timing for controlled form restores; behavior is narrowed with conservative form-control guards but still affects core event delegation.
> 
> **Overview**
> **Stops scheduling no-op `setTimeout(0)` capture fallback tasks** for ordinary bubbling discrete events when authored capture is registered but nothing needs a post-dispatch controlled restore.
> 
> `finishCaptureDispatch` now returns early unless a restore is already queued from a nested dispatch, or the event is a restore-capable type (`input`/`change`/`click`) whose target is `input`, `textarea`, or `select` (so a native listener can still arm control and stop propagation before bubble). Clicks that complete delegation without that work no longer enqueue a timer that only discovers the bubble already ran.
> 
> **Validation added:** a Chromium work gate runs 16 trusted button clicks with capture/bubble order checks and asserts **zero** zero-delay timers during each click’s delivery (baseline was 16). Two dispatch-commit tests cover nested input restore when an outer click stops bubbling, and restore when an input becomes controlled after capture via a native target listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22be2fa7cad131f9a672f4d187f049ff9218ed10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->