### PR TITLE
perf: skip context-only parallel use batches

### DIFF
--- a/.changeset/context-only-use-batches.md
+++ b/.changeset/context-only-use-batches.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid emitting a parallel `useBatch` for proven module-level context-only reads in TSRX and plain TypeScript. Mixed promise reads and child warming continue to batch as before.

--- a/benchmarks/recursive-context/README.md
+++ b/benchmarks/recursive-context/README.md
@@ -148,14 +148,33 @@ Octane dialect timing rows also have order-balanced aliases: the primary
 TSRX→TSX pass is repeated TSX→TSRX, and the two fully-warmed sample sets are
 combined for TSX/TSRX ratio guards.
 
-`work.mjs` observes the emitted production bundles rather than adding source
-probes that could change compiler purity. A jitless Chromium precise-coverage
-pass caps blocks, generic slots, descriptors, keyed survivor work, and teardown
-scopes at their current levels while permitting reductions. Full/all-slot
-aggregates allow a generic slot to become a cheaper specialized slot without
-allowing duplicate dispatch. Every row requires live production-bundle coverage,
-and the root and partial updates must still execute exactly 1024 and 32 `setText`
-calls.
+`work.mjs` observes emitted production bundles rather than adding source probes
+that could change compiler purity. The unified runner first times the normal
+minified builds; then the untimed work pass rebuilds the two Octane fixtures with
+`vite build --minify false` so Chromium can attribute precise calls to named
+functions. Run `bench:work` with both Octane preview servers running; it also
+performs the diagnostic rebuild. A jitless Chromium precise-coverage pass caps
+blocks, generic slots, descriptors, keyed survivor work, and teardown scopes at
+their current levels while permitting reductions. Full/all-slot aggregates
+allow a generic slot to become a cheaper specialized slot without allowing
+duplicate dispatch. Every row requires live production-bundle coverage, and
+root and partial updates must still execute exactly 1024 and 32 `setText` calls.
+
+The TSRX leaf reads two local `createContext` values and no promises. Before
+removing its redundant context-only `useBatch`, the 1024-leaf mount and root
+update each called `useBatch` 3072 times; the 32-leaf partial update and
+remount each called it 94 times. Exact gates now require 2048 and 62 calls,
+respectively: the remaining calls register the independent child warm plans
+with `useBatch([], warmThunk)`. The JSX twin emits no `useBatch` calls for this
+fixture. The normal DOM checks in `run.mjs` still verify all 1024 leaf paths,
+both context values, the isolated 32-leaf provider update, and remount identity.
+
+The same work pass also compiles a plain TypeScript custom hook with two reads
+from a directly initialized module context in both client and server modes. Its
+codegen-size gate permits no growth beyond the authored source, preserves both
+`use()` calls, and requires zero generated `useBatch`/`puBatch` imports or calls.
+A separate mixed context/promise hook must still generate one batch call in each
+mode, confirming that the analyzer detects the helper when batching is needed.
 
 Default: 10 warmups + 20 iters. Pass an integer to `bench` to override iters
 (`bench:long` runs 40).

--- a/benchmarks/recursive-context/work.mjs
+++ b/benchmarks/recursive-context/work.mjs
@@ -1,9 +1,13 @@
 // Deterministic, untimed production-work gate for Octane's TSRX/TSX twins.
 // Source counters would change the compiler's purity analysis, so this observes
-// the unminified production bundles through Chromium precise call coverage.
+// unminified production diagnostic builds through Chromium precise call coverage.
 
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
+import ts from 'typescript';
+import { slotHooks } from '../../packages/octane/src/compiler/slot-hooks.js';
 import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
 import { collectPreciseCalls } from '../lib/precise-work.mjs';
 
@@ -11,6 +15,17 @@ const TARGETS = [
 	{ name: 'octane-tsrx', url: 'http://localhost:5185/' },
 	{ name: 'octane-jsx', url: 'http://localhost:5188/' },
 ];
+
+// The unified runner finishes its timed pass against normally minified assets
+// before invoking this untimed gate. Build the same production fixtures without
+// minification here so Chromium can attribute calls to the original function
+// names; the existing preview servers serve the refreshed assets.
+for (const target of TARGETS) {
+	execFileSync('pnpm', ['exec', 'vite', 'build', '--minify', 'false'], {
+		cwd: fileURLToPath(new URL(`${target.name}/`, import.meta.url)),
+		stdio: 'inherit',
+	});
+}
 
 const METRICS = [
 	'renderBlock',
@@ -24,6 +39,7 @@ const METRICS = [
 	'reconcileKeyed',
 	'updateSurvivor',
 	'setText',
+	'useBatch',
 	'unmountBlock',
 	'unmountScope',
 ];
@@ -40,6 +56,78 @@ const OPS = [
 	},
 	{ name: 'unmount', before: ['__mount'], operation: '__unmount' },
 ];
+
+// Plain .ts custom hooks use a separate compiler pass from the TSRX fixture.
+// The mixed source proves the AST reader still detects generated batch calls.
+const PLAIN_CONTEXT_HOOK = `import { createContext, use } from 'octane';
+const Ctx = createContext(0);
+export function usePair(): number {
+  const first = use(Ctx);
+  const second = use(Ctx);
+  return first + second;
+}`;
+const PLAIN_MIXED_HOOK = `import { createContext, use } from 'octane';
+const Ctx = createContext(0);
+export function useMixed(promise: Promise<number>): number {
+  const value = use(promise);
+  const local = use(Ctx);
+  return value + local;
+}`;
+
+function countImportedCalls(ast, importedName) {
+	const locals = new Set();
+	for (const statement of ast.statements) {
+		if (!ts.isImportDeclaration(statement)) continue;
+		const bindings = statement.importClause?.namedBindings;
+		if (!bindings || !ts.isNamedImports(bindings)) continue;
+		for (const specifier of bindings.elements) {
+			if ((specifier.propertyName?.text ?? specifier.name.text) === importedName) {
+				locals.add(specifier.name.text);
+			}
+		}
+	}
+	let calls = 0;
+	function visit(node) {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isIdentifier(node.expression) &&
+			locals.has(node.expression.text)
+		) {
+			calls++;
+		}
+		ts.forEachChild(node, visit);
+	}
+	visit(ast);
+	return { imports: locals.size, calls };
+}
+
+function measurePlainHook(source, environment) {
+	const code =
+		slotHooks(source, 'recursive-context-custom-hook.ts', {
+			environment,
+			dev: false,
+			hmr: false,
+		})?.code ?? source;
+	const ast = ts.createSourceFile('compiled-custom-hook.ts', code, ts.ScriptTarget.Latest, true);
+	if (ast.parseDiagnostics.length > 0) {
+		throw new Error(`Plain ${environment} hook output contains invalid TypeScript`);
+	}
+	return {
+		bytes: Buffer.byteLength(code),
+		batch: countImportedCalls(ast, environment === 'server' ? 'puBatch' : 'useBatch'),
+		use: countImportedCalls(ast, 'use'),
+	};
+}
+
+const PLAIN_HOOKS = Object.fromEntries(
+	['client', 'server'].map((environment) => [
+		environment,
+		{
+			context: measurePlainHook(PLAIN_CONTEXT_HOOK, environment),
+			mixed: measurePlainHook(PLAIN_MIXED_HOOK, environment),
+		},
+	]),
+);
 
 // Scaffolding is bounded above so later direct-return lowering can reduce it
 // without rebaselining this gate. The visible update cardinality is exact.
@@ -58,6 +146,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
+			exact: { useBatch: 2048 },
 		},
 		update_root: {
 			maxFullSlotCalls: 1027,
@@ -72,7 +161,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
-			exact: { setText: 1024 },
+			exact: { setText: 1024, useBatch: 2048 },
 		},
 		update_partial: {
 			maxFullSlotCalls: 33,
@@ -87,7 +176,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
-			exact: { setText: 32 },
+			exact: { setText: 32, useBatch: 62 },
 		},
 		partial_unmount: {
 			maxFullSlotCalls: 0,
@@ -118,6 +207,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
+			exact: { useBatch: 62 },
 		},
 		unmount: {
 			maxFullSlotCalls: 0,
@@ -278,6 +368,22 @@ const browser = await chromium.launch({
 });
 const results = {};
 const failures = [];
+for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
+	if (context.batch.imports !== 0 || context.batch.calls !== 0) {
+		failures.push(`${environment}.plain_context: unexpected batch helper or call`);
+	}
+	if (context.use.calls !== 2) {
+		failures.push(`${environment}.plain_context: ${context.use.calls} context reads, expected 2`);
+	}
+	if (context.bytes > Buffer.byteLength(PLAIN_CONTEXT_HOOK)) {
+		failures.push(
+			`${environment}.plain_context: generated ${context.bytes} bytes exceeds authored size`,
+		);
+	}
+	if (mixed.batch.imports !== 1 || mixed.batch.calls !== 1) {
+		failures.push(`${environment}.plain_mixed: expected one imported batch call`);
+	}
+}
 try {
 	for (const target of TARGETS) {
 		results[target.name] = {};
@@ -297,38 +403,68 @@ try {
 }
 
 console.log(
-	'Operation                 | render | full | void | lite | child | descriptors | host/deopt/keyed/survivors | text | unmount block/scope',
+	'Operation                 | render | full | void | lite | child | descriptors | host/deopt/keyed/survivors | text | batch | unmount block/scope',
 );
 console.log(
-	'--------------------------+--------+------+------+------+-------+-------------+----------------------------+------+--------------------',
+	'--------------------------+--------+------+------+------+-------+-------------+----------------------------+------+-------+--------------------',
 );
 for (const target of TARGETS) {
 	for (const op of OPS) {
 		const c = results[target.name][op.name];
 		console.log(
-			`${`${target.name}.${op.name}`.padEnd(25)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${c.hostElementBody}/${c.deoptItemBody}/${c.reconcileKeyed}/${c.updateSurvivor} | ${String(c.setText).padStart(4)} | ${c.unmountBlock}/${c.unmountScope}`,
+			`${`${target.name}.${op.name}`.padEnd(25)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${c.hostElementBody}/${c.deoptItemBody}/${c.reconcileKeyed}/${c.updateSurvivor} | ${String(c.setText).padStart(4)} | ${String(c.useBatch).padStart(5)} | ${c.unmountBlock}/${c.unmountScope}`,
 		);
 	}
+}
+for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
+	console.log(
+		`plain-${environment}: context bytes=${context.bytes}, use calls=${context.use.calls}, batch imports/calls=${context.batch.imports}/${context.batch.calls}; mixed batch imports/calls=${mixed.batch.imports}/${mixed.batch.calls}`,
+	);
 }
 
 const outputPath = process.env.BENCH_JSON || process.env.WORK_JSON;
 if (outputPath) {
 	const payload = {
 		suite: 'recursive-context-work',
-		targets: TARGETS.map((target) => ({
-			name: `${target.name}-work`,
-			ops: Object.fromEntries(
-				OPS.flatMap((op) =>
-					METRICS.map((metric) => [
-						`${op.name}_${metric}`,
-						deterministicStatForJson(deterministicCount(results[target.name][op.name][metric])),
+		targets: [
+			...TARGETS.map((target) => ({
+				name: `${target.name}-work`,
+				ops: Object.fromEntries(
+					OPS.flatMap((op) =>
+						METRICS.map((metric) => [
+							`${op.name}_${metric}`,
+							deterministicStatForJson(deterministicCount(results[target.name][op.name][metric])),
+						]),
+					),
+				),
+				meta: {
+					gates: failures.some((failure) => failure.startsWith(`${target.name}.`))
+						? 'fail'
+						: 'pass',
+				},
+			})),
+			...Object.entries(PLAIN_HOOKS).map(([environment, { context, mixed }]) => ({
+				name: `plain-${environment}-work`,
+				ops: Object.fromEntries(
+					Object.entries({
+						context_bytes: context.bytes,
+						context_use_calls: context.use.calls,
+						context_batch_imports: context.batch.imports,
+						context_batch_calls: context.batch.calls,
+						mixed_batch_imports: mixed.batch.imports,
+						mixed_batch_calls: mixed.batch.calls,
+					}).map(([metric, value]) => [
+						metric,
+						deterministicStatForJson(deterministicCount(value)),
 					]),
 				),
-			),
-			meta: {
-				gates: failures.some((failure) => failure.startsWith(`${target.name}.`)) ? 'fail' : 'pass',
-			},
-		})),
+				meta: {
+					gates: failures.some((failure) => failure.startsWith(`${environment}.`))
+						? 'fail'
+						: 'pass',
+				},
+			})),
+		],
 	};
 	if (failures.length > 0) payload.failed = failures.join('; ');
 	fs.writeFileSync(outputPath, JSON.stringify(payload, null, '\t') + '\n');

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -92,6 +92,7 @@ import {
 	wrapNativeWarmScope,
 } from './native-read-codegen.js';
 import { createTextTypeFactsLookup } from './text-type-facts.js';
+import { collectProvenContextBindings, isProvenContextUse } from './context-use.js';
 import { applyCssModuleConstants } from './css-module-constants.js';
 import { assertUniversalRuntimeTarget, normalizeUniversalRuntime } from './universal-runtime.js';
 
@@ -9185,6 +9186,7 @@ function compileInternal(
 		ctx.octaneImportLocals = imports.locals;
 		ctx.octaneImportNamespaces = imports.namespaces;
 		ctx.foreignImportLocals = imports.foreignLocals;
+		ctx.provenContextBindings = collectProvenContextBindings(ast);
 		ctx.activityModuleAst = ast;
 	}
 	if (ctx.dev) {
@@ -10456,6 +10458,7 @@ function compileServer(
 		ctx.octaneImportLocals = imports.locals;
 		ctx.octaneImportNamespaces = imports.namespaces;
 		ctx.foreignImportLocals = imports.foreignLocals;
+		ctx.provenContextBindings = collectProvenContextBindings(ast);
 		ctx.activityModuleAst = ast;
 	}
 	// M3 inherit-range exclusion set — must match the client compile's
@@ -16233,6 +16236,19 @@ function rewriteParallelUse(statements, ctx, componentName, warmThunk) {
 	function emitRun(run, out) {
 		const uses = run.members.filter((m) => m.call);
 		if (uses.length === 0) {
+			for (const m of run.members) out.push(m.stmt);
+			return;
+		}
+		if (
+			uses.every(
+				(m) =>
+					m.call._octaneImportedHook === 'use' &&
+					isProvenContextUse(m.creation, ctx.provenContextBindings),
+			)
+		) {
+			// Context reads cannot suspend. Preserve the authored statements in
+			// their original order, and leave the first warm thunk available for
+			// the next real data batch. The trailing child-only registration stays.
 			for (const m of run.members) out.push(m.stmt);
 			return;
 		}

--- a/packages/octane/src/compiler/context-use.js
+++ b/packages/octane/src/compiler/context-use.js
@@ -1,0 +1,154 @@
+// A direct module const initialized by Octane's createContext is the only
+// context identity we can prove without following values between modules.
+// Reject a name if any nested scope binds it: both compiler pipelines can
+// then use this module-wide proof without guessing which scope owns a use().
+export function collectProvenContextBindings(ast) {
+	const factories = new Set();
+	for (const statement of ast.body || []) {
+		if (
+			statement.type !== 'ImportDeclaration' ||
+			statement.importKind === 'type' ||
+			statement.source?.value !== 'octane'
+		)
+			continue;
+		for (const specifier of statement.specifiers || []) {
+			if (
+				specifier.type === 'ImportSpecifier' &&
+				specifier.importKind !== 'type' &&
+				(specifier.imported?.name ?? specifier.imported?.value) === 'createContext' &&
+				specifier.local?.name
+			)
+				factories.add(specifier.local.name);
+		}
+	}
+	if (factories.size === 0) return new Set();
+
+	const contexts = new Set();
+	for (const original of ast.body || []) {
+		const declaration = unwrapExport(original);
+		if (declaration?.type !== 'VariableDeclaration' || declaration.kind !== 'const') continue;
+		for (const entry of declaration.declarations || []) {
+			if (
+				entry.id?.type === 'Identifier' &&
+				entry.init?.type === 'CallExpression' &&
+				entry.init.optional !== true &&
+				entry.init.callee?.type === 'Identifier' &&
+				factories.has(entry.init.callee.name)
+			)
+				contexts.add(entry.id.name);
+		}
+	}
+	if (contexts.size === 0) return contexts;
+
+	const shadowed = new Set();
+	const seen = new WeakSet();
+	const bind = (pattern) => {
+		if (!pattern) return;
+		switch (pattern.type) {
+			case 'Identifier':
+				if (contexts.has(pattern.name)) shadowed.add(pattern.name);
+				break;
+			case 'ArrayPattern':
+				for (const item of pattern.elements || []) bind(item);
+				break;
+			case 'ObjectPattern':
+				for (const item of pattern.properties || [])
+					bind(item.type === 'RestElement' ? item.argument : item.value);
+				break;
+			case 'AssignmentPattern':
+				bind(pattern.left);
+				break;
+			case 'RestElement':
+				bind(pattern.argument);
+				break;
+			case 'TSParameterProperty':
+				bind(pattern.parameter);
+				break;
+		}
+	};
+	const scan = (node) => {
+		if (!node || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const item of node) scan(item);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		if (node.type === 'ImportDeclaration') return;
+		switch (node.type) {
+			case 'VariableDeclarator':
+				bind(node.id);
+				break;
+			case 'FunctionDeclaration':
+			case 'FunctionExpression':
+			case 'ArrowFunctionExpression':
+			case 'TSDeclareFunction':
+				bind(node.id);
+				for (const param of node.params || []) bind(param);
+				break;
+			case 'ClassDeclaration':
+			case 'ClassExpression':
+			case 'TSEnumDeclaration':
+			case 'TSModuleDeclaration':
+				bind(node.id);
+				break;
+			case 'CatchClause':
+				bind(node.param);
+				break;
+			case 'JSXForExpression':
+				if (node.left?.type !== 'VariableDeclaration') bind(node.left);
+				bind(node.index);
+				break;
+			case 'JSXTryExpression':
+				bind(node.handler?.param);
+				bind(node.handler?.resetParam);
+				break;
+		}
+		for (const key in node) {
+			if (
+				key === 'loc' ||
+				key === 'start' ||
+				key === 'end' ||
+				key === 'range' ||
+				key === 'parent' ||
+				key === 'metadata' ||
+				key.startsWith('_octane')
+			)
+				continue;
+			scan(node[key]);
+		}
+	};
+	for (const original of ast.body || []) {
+		if (original.type === 'ImportDeclaration') continue;
+		const declaration = unwrapExport(original);
+		if (declaration?.type === 'VariableDeclaration') {
+			// These IDs belong to the module itself, including the proven
+			// contexts. Their initializers can still contain nested shadows.
+			for (const entry of declaration.declarations || []) scan(entry.init);
+		} else {
+			scan(declaration);
+		}
+	}
+	for (const name of shadowed) contexts.delete(name);
+	return contexts;
+}
+
+export function isProvenContextUse(argument, contexts) {
+	let value = argument;
+	while (
+		value?.type === 'TSAsExpression' ||
+		value?.type === 'TSTypeAssertion' ||
+		value?.type === 'TSSatisfiesExpression' ||
+		value?.type === 'TSNonNullExpression' ||
+		value?.type === 'TSInstantiationExpression' ||
+		value?.type === 'ParenthesizedExpression'
+	)
+		value = value.expression;
+	return value?.type === 'Identifier' && contexts.has(value.name);
+}
+
+function unwrapExport(node) {
+	return node?.type === 'ExportNamedDeclaration' || node?.type === 'ExportDefaultDeclaration'
+		? node.declaration
+		: node;
+}

--- a/packages/octane/src/compiler/slot-hooks.js
+++ b/packages/octane/src/compiler/slot-hooks.js
@@ -24,6 +24,7 @@ import { assertNativeReadDiagnostics, nativeReadOptions } from './native-read-di
 import { nativeReadActivationIndex } from './native-read-codegen.js';
 import { findManualHookProviders, manualHookWrapperParameters } from './manual-hooks.js';
 import { findLeadingJsxImportSourcePragma } from './pragma.js';
+import { collectProvenContextBindings, isProvenContextUse } from './context-use.js';
 import {
 	hookMethodName,
 	hasHookMethods,
@@ -868,6 +869,10 @@ function requireParallelHelper(st, imported) {
 
 function emitParallelUseRun(run, owner, st) {
 	if (run.uses.length === 0) return;
+	if (run.uses.every((entry) => isProvenContextUse(entry.arg, st.provenContextBindings))) {
+		// Leave plain source untouched when every read is a proven context.
+		return;
+	}
 	const memoName = st.nativeReads
 		? 'nativePuMemo'
 		: st.environment === 'server'
@@ -1396,6 +1401,7 @@ export function slotHooks(source, id, options) {
 		edits: [],
 		decls: [],
 		parallelHelpers: new Map(),
+		provenContextBindings: collectProvenContextBindings(ast),
 		usedNames: collectIdentifierNames(ast),
 		slotBaseName: null,
 		hookSlotsName: null,

--- a/packages/octane/tests/_fixtures/context.tsrx
+++ b/packages/octane/tests/_fixtures/context.tsrx
@@ -4,6 +4,7 @@ import { useState, createContext, use, createPortal } from 'octane';
 export const ThemeCtx = createContext('light');
 export const UserCtx = createContext('anon');
 export const CountCtx = createContext(0);
+export const ShadowCtx = createContext('default');
 
 // Reads a single context value.
 export function ThemeReader() @{
@@ -192,4 +193,130 @@ export function LiveCount(props) @{
 			</ul>
 		</div>
 	</CountCtx.Provider>
+}
+
+function useProfileLabel() {
+	const theme = use(ThemeCtx);
+	const user = use(UserCtx);
+	return theme + '/' + user;
+}
+
+export function ContextOnlyReader(props: { selected: typeof ThemeCtx | typeof UserCtx }) @{
+	const theme = use(ThemeCtx);
+	const selected = use(props.selected);
+	const profile = useProfileLabel();
+	<output class="context-only">{theme + '|' + selected + '|' + profile as string}</output>
+}
+
+export function ContextOnlyHost() @{
+	const [theme, setTheme] = useState('light');
+	const [user, setUser] = useState('alice');
+	const [pickTheme, setPickTheme] = useState(false);
+	<div>
+		<button
+			id="change-theme"
+			onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+		>{'theme'}</button>
+		<button
+			id="change-user"
+			onClick={() => setUser(user === 'alice' ? 'bob' : 'alice')}
+		>{'user'}</button>
+		<button id="change-selection" onClick={() => setPickTheme(!pickTheme)}>{'selection'}</button>
+		<ThemeCtx.Provider value={theme}>
+			<UserCtx.Provider value={user}>
+				<ContextOnlyReader selected={pickTheme ? ThemeCtx : UserCtx} />
+			</UserCtx.Provider>
+		</ThemeCtx.Provider>
+	</div>
+}
+
+function MixedContextPromiseLeaf(props: { load: (key: string) => Promise<string> }) @{
+	const detail = use(props.load('detail'));
+	<span class="mixed-context-detail">{detail as string}</span>
+}
+
+function MixedContextPromiseReader(props: { load: (key: string) => Promise<string> }) @{
+	const first = use(props.load('first'));
+	const theme = use(ThemeCtx);
+	const second = use(props.load('second'));
+	<section>
+		<p class="mixed-context-promise">{theme + ':' + first + '/' + second as string}</p>
+		<MixedContextPromiseLeaf load={props.load} />
+	</section>
+}
+
+export function MixedContextPromiseHost(props: { load: (key: string) => Promise<string> }) @{
+	const [theme, setTheme] = useState('dark');
+	<div>
+		<button
+			id="change-pending-theme"
+			onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+		>{'theme'}</button>
+		<ThemeCtx.Provider value={theme}>
+			<>
+				@try {
+					<MixedContextPromiseReader load={props.load} />
+				} @pending {
+					<p class="mixed-context-pending">{'loading'}</p>
+				}
+			</>
+		</ThemeCtx.Provider>
+	</div>
+}
+
+function ContextAsyncFirst(props: { load: (key: string) => Promise<string> }) @{
+	const value = use(props.load('first'));
+	<span class="context-async-first">{value as string}</span>
+}
+
+function ContextAsyncSecond(props: { load: (key: string) => Promise<string> }) @{
+	const value = use(props.load('second'));
+	<span class="context-async-second">{value as string}</span>
+}
+
+function ContextOnlyAsyncSiblings(props: { load: (key: string) => Promise<string> }) @{
+	const theme = use(ThemeCtx);
+	<section class="context-async-siblings" data-theme={theme}>
+		<ContextAsyncFirst load={props.load} />
+		<ContextAsyncSecond load={props.load} />
+	</section>
+}
+
+export function ContextOnlyAsyncHost(props: { load: (key: string) => Promise<string> }) @{
+	const selectedLoad = props.load;
+	<ThemeCtx.Provider value="dark">
+		<>
+			@try {
+				<ContextOnlyAsyncSiblings load={selectedLoad} />
+			} @pending {
+				<p class="context-async-pending">{'loading'}</p>
+			}
+		</>
+	</ThemeCtx.Provider>
+}
+
+function ShadowedContextPromiseLeaf(props: { load: () => Promise<string> }) @{
+	const detail = use(props.load());
+	<span class="shadowed-context-detail">{detail as string}</span>
+}
+
+export function ShadowedContextPromiseHost(props: {
+	gate: Promise<string>;
+	load: () => Promise<string>;
+}) @{
+	<ThemeCtx.Provider value="dark">
+		<>
+			@try {
+				const theme = use(ThemeCtx);
+				const ShadowCtx = props.gate;
+				const value = use(ShadowCtx);
+				<section>
+					<span class="shadowed-context-result">{theme + ':' + value as string}</span>
+					<ShadowedContextPromiseLeaf load={props.load} />
+				</section>
+			} @pending {
+				<span class="shadowed-context-pending">{'loading'}</span>
+			}
+		</>
+	</ThemeCtx.Provider>
 }

--- a/packages/octane/tests/context.test.ts
+++ b/packages/octane/tests/context.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { mount } from './_helpers';
+import { prerender } from 'octane/static';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { mount, act } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
 import {
 	DynamicProvider,
 	CombinedDynamic,
@@ -12,6 +15,10 @@ import {
 	PortalledContext,
 	LiveCount,
 	StableChildren,
+	ContextOnlyHost,
+	MixedContextPromiseHost,
+	ContextOnlyAsyncHost,
+	ShadowedContextPromiseHost,
 } from './_fixtures/context.tsrx';
 
 describe('context — value updates', () => {
@@ -146,5 +153,132 @@ describe('context — through portals', () => {
 		expect(target.querySelector('.theme')!.textContent).toBe('from-portal-parent');
 		r.unmount();
 		target.remove();
+	});
+});
+
+describe('context — use() alongside other reads', () => {
+	it('direct reads, a custom hook, and a selected context follow provider updates', () => {
+		const r = mount(ContextOnlyHost);
+		try {
+			expect(r.find('.context-only').textContent).toBe('light|alice|light/alice');
+			r.click('#change-theme');
+			expect(r.find('.context-only').textContent).toBe('dark|alice|dark/alice');
+			r.click('#change-selection');
+			expect(r.find('.context-only').textContent).toBe('dark|dark|dark/alice');
+			r.click('#change-user');
+			expect(r.find('.context-only').textContent).toBe('dark|dark|dark/bob');
+			r.click('#change-selection');
+			expect(r.find('.context-only').textContent).toBe('dark|bob|dark/bob');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('starts independent descendant data while pending and reads the latest context', async () => {
+		const requests: string[] = [];
+		const jobs = new Map<string, { promise: Promise<string>; resolve: (value: string) => void }>();
+		for (const key of ['first', 'second', 'detail']) {
+			let resolve!: (value: string) => void;
+			const promise = new Promise<string>((done) => (resolve = done));
+			jobs.set(key, { promise, resolve });
+		}
+		const r = mount(MixedContextPromiseHost, {
+			load(key: string) {
+				requests.push(key);
+				return jobs.get(key)!.promise;
+			},
+		});
+		try {
+			// The descendant can begin before its parent has usable data.
+			expect(requests).toEqual(['first', 'second', 'detail']);
+			expect(r.find('.mixed-context-pending').textContent).toBe('loading');
+			r.click('#change-pending-theme');
+			await act(() => jobs.get('first')!.resolve('one'));
+			expect(r.find('.mixed-context-pending').textContent).toBe('loading');
+			await act(() => jobs.get('second')!.resolve('two'));
+			expect(r.find('.mixed-context-pending').textContent).toBe('loading');
+			await act(() => jobs.get('detail')!.resolve('more'));
+			expect(r.find('.mixed-context-promise').textContent).toBe('light:one/two');
+			expect(r.find('.mixed-context-detail').textContent).toBe('more');
+			r.click('#change-pending-theme');
+			expect(r.find('.mixed-context-promise').textContent).toBe('dark:one/two');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('starts an independent sibling request while a context-only parent is pending', async () => {
+		let resolveFirst!: (value: string) => void;
+		let resolveSecond!: (value: string) => void;
+		const first = new Promise<string>((resolve) => (resolveFirst = resolve));
+		const second = new Promise<string>((resolve) => (resolveSecond = resolve));
+		const requests: string[] = [];
+		const r = mount(ContextOnlyAsyncHost, {
+			load(key: string) {
+				requests.push(key);
+				return key === 'first' ? first : second;
+			},
+		});
+		try {
+			expect(r.find('.context-async-pending').textContent).toBe('loading');
+			// Both child requests begin in the first attempt, before either settles.
+			expect(requests).toEqual(['first', 'second']);
+			await act(() => {
+				resolveFirst('one');
+				resolveSecond('two');
+			});
+			expect(r.find('.context-async-siblings').getAttribute('data-theme')).toBe('dark');
+			expect(r.find('.context-async-first').textContent).toBe('one');
+			expect(r.find('.context-async-second').textContent).toBe('two');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('keeps a locally shadowed context name pending and starts its independent child', async () => {
+		let resolveGate!: (value: string) => void;
+		let resolveDetail!: (value: string) => void;
+		const gate = new Promise<string>((resolve) => (resolveGate = resolve));
+		const detail = new Promise<string>((resolve) => (resolveDetail = resolve));
+		let detailStarted = false;
+		const r = mount(ShadowedContextPromiseHost, {
+			gate,
+			load() {
+				detailStarted = true;
+				return detail;
+			},
+		});
+		try {
+			expect(r.find('.shadowed-context-pending').textContent).toBe('loading');
+			expect(detailStarted).toBe(true);
+			await act(() => resolveGate('ready'));
+			expect(r.find('.shadowed-context-pending').textContent).toBe('loading');
+			await act(() => resolveDetail('more'));
+			expect(r.find('.shadowed-context-result').textContent).toBe('dark:ready');
+			expect(r.find('.shadowed-context-detail').textContent).toBe('more');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('hydrates context-only reads and keeps provider updates live', async () => {
+		const server = loadServerFixture('packages/octane/tests/_fixtures/context.tsrx');
+		const { html } = await prerender(server.ContextOnlyHost, {});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const output = container.querySelector('.context-only')!;
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			expect(output.textContent).toBe('light|alice|light/alice');
+			root = hydrateRoot(container, ContextOnlyHost);
+			flushSync(() => {});
+			expect(container.querySelector('.context-only')).toBe(output);
+			flushSync(() => (container.querySelector('#change-theme') as HTMLElement).click());
+			expect(output.textContent).toBe('dark|alice|dark/alice');
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Skip compiler-generated `useBatch`/`puBatch` for runs made entirely of proven module-level `createContext` reads in TSRX and plain TypeScript. Keep the authored `use(Context)` calls, mixed promise batches, and the first applicable child warm plan. Advances #981.

## Why

A recursive context workload emitted one context-only batch per leaf render. The production browser work gate measured 3,072 `useBatch` calls on mount and full update, including 1,024 redundant context-only calls; partial updates and remounts emitted 94, including 32 redundant calls.

## Changes

- Prove direct module `const Context = createContext(...)` bindings, with a conservative lexical-shadow guard, in client/server TSRX and plain hook compilation. Only Octane's lexically resolved `use` qualifies.
- Preserve batching for promises and mixed reads, plus the trailing registration that warms async descendants of context-only parents.
- Add consumer behavior coverage for provider changes, dynamic and shadowed reads, pending siblings, mixed promises, and SSR hydration. The deterministic benchmark now gates browser batch counts and plain TypeScript client/server output.
- Repair the browser work gate's named-call attribution by rebuilding diagnostic production bundles without minification after the timed pass.

## Validation

- [x] Scoped Prettier check on changed files
- [x] `pnpm typecheck`
- [ ] `pnpm test` locally: the repository-wide run reached a Chromium MachPort sandbox denial; the isolated browser test passed with browser permission. Current-head CI passed on attempt 3.
- [x] Targeted Vitest context, parallel-use, and SSR suites (development and production)
- [x] Recursive-context Chromium precise-call gate: TSRX 3,072→2,048 full-render batch calls and 94→62 partial-render calls; exact 1,024/32 text-write controls unchanged. Plain TypeScript client/server context-only output has zero batch calls; mixed promise control retains one.
- [x] `pnpm sync`, clean generated-file diff
- [x] Current-head CI: 28 passing checks, six expected skips, no pending or failed checks; Bugbot passed. Two unrelated 5-second test timeouts in earlier attempts passed on rerun without code changes.

## Risk / follow-ups

The proof deliberately leaves imported, dynamically selected, and lexically shadowed contexts on the existing batch path. Other unchecked #981 items remain separate follow-ups.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791558793&installation_model_id=432790&pr_number=1018&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1018&signature=f4deee10ed43746f9661484a213fc0f0767989a583fc6584935d757d20e37e48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes parallel-`use()` codegen in client and server compilers; the proof is intentionally narrow (shadow/import/dynamic reads stay batched) but incorrect analysis could affect suspense/warming behavior.
> 
> **Overview**
> The compiler **stops emitting parallel `useBatch`/`puBatch`** when a run of `use()` calls is made entirely of **provably module-level** `createContext` identities (direct `const X = createContext(...)` with a conservative lexical-shadow guard). Authored `use(Context)` stays in place; **promise reads, mixed context+async runs, dynamically selected contexts, and shadowed names** still go through batching, including the trailing child warm registration.
> 
> This lands in **both TSRX** (`emitRun` in `compile.js`) and **plain `.ts` hook slotting** (`emitParallelUseRun` in `slot-hooks.js`), backed by new **`context-use.js`** analysis wired into compile contexts.
> 
> **Benchmark and test coverage** tighten the contract: `recursive-context/work.mjs` rebuilds unminified production bundles for named `useBatch` coverage, adds exact batch-count gates (e.g. TSRX mount/root **3072→2048**, partial/remount **94→62**), and AST-checks plain hooks for zero vs one batch call. New context fixture scenarios cover custom hooks, dynamic context selection, pending siblings, mixed promises, shadowed locals, and SSR hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c404f3014c1098f4c99436f181e86e42dccbde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
