### PR TITLE
perf: inline first context provider cache entry

### DIFF
--- a/.changeset/inline-context-provider-cache.md
+++ b/.changeset/inline-context-provider-cache.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Keep the first resolved context provider inline on each consumer, allocating a
+provider cache Map only when that consumer reads a second distinct context.
+Continue reading provider values live through updates and hosted-root changes.

--- a/benchmarks/recursive-context/README.md
+++ b/benchmarks/recursive-context/README.md
@@ -22,6 +22,7 @@ benchmarks/recursive-context/
 ├── svelte/           # Vite app, dev :5275 — Svelte 5 createContext + runes
 ├── run.mjs            # Playwright harness — drives all adapters
 ├── work.mjs           # untimed Chromium precise-call-coverage gates for Octane
+├── context-cache-work.mjs # Map-construction gate and observational update timings
 ├── package.json       # umbrella: `pnpm bench`
 └── README.md
 ```
@@ -97,6 +98,9 @@ node benchmarks/bench.mjs recursive-context
 The unified runner also executes `work.mjs` against the already-built Octane
 previews. Run it directly with `pnpm --dir benchmarks/recursive-context
 bench:work` when those two previews are already running.
+Run `pnpm --dir benchmarks/recursive-context bench:cache` for the focused
+context-cache gate. It builds the Octane production fixture and starts its own
+preview on an ephemeral local port; no other preview servers are needed.
 
 Output is a side-by-side table of median / min / p95 millis per op, followed by a
 pairwise ratio block, e.g.:
@@ -175,6 +179,27 @@ codegen-size gate permits no growth beyond the authored source, preserves both
 `use()` calls, and requires zero generated `useBatch`/`puBatch` imports or calls.
 A separate mixed context/promise hook must still generate one batch call in each
 mode, confirming that the analyzer detects the helper when batching is needed.
+
+The context-cache work pass builds a second production HTML entry in the TSRX
+fixture. It renders 512 keyed consumer components with zero, one, or two
+**distinct** context reads and identical visible DOM. An initialization script
+wraps the browser's native `Map` constructor; the harness resets its counter
+around mount, root-context update, second-context update, keyed reorder, and
+unmount. An explicit `new Map()` verifies the probe. It checks every row's
+text and identity after updates and reversal, including the second provider's
+new value in the two-context case, and checks teardown. The zero-context
+fixture controls for shared root, provider, and keyed-row allocations.
+
+Before the inline single-context cache, mount constructed 6 Maps for the
+zero-context control and 518 Maps each for one- and two-context consumers: 512
+extra Maps in each reader mode. The exact production gates now require zero
+extra Maps for the one-context mode and 512 for the two-context spill. All
+three modes must incur no extra Map construction over the zero-context control
+on subsequent updates, reorder, and teardown. The gate runs from `work.mjs`
+after its precise-coverage pass, and can also run independently via
+`bench:cache`. A fresh, uninstrumented browser realm records 40 batches of
+20 root updates per mode with 12 warmup updates; update times are diagnostics,
+not wall-time pass/fail gates.
 
 Default: 10 warmups + 20 iters. Pass an integer to `bench` to override iters
 (`bench:long` runs 40).

--- a/benchmarks/recursive-context/context-cache-work.mjs
+++ b/benchmarks/recursive-context/context-cache-work.mjs
@@ -1,0 +1,204 @@
+// Production-bundle allocation control: zero, one, and two distinct context
+// reads in the same 512 keyed consumer positions. It instruments Map construction
+// at the browser boundary without changing compiler-visible source.
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { summarizeSamples } from '../lib/stats.mjs';
+
+const fixture = new URL('./octane-tsrx/', import.meta.url);
+const requireFixture = createRequire(new URL('package.json', fixture));
+const { preview } = await import(requireFixture.resolve('vite'));
+const VARIANTS = ['zero', 'one', 'two'];
+const ROW_COUNT = 512;
+
+execFileSync('pnpm', ['exec', 'vite', 'build'], {
+	cwd: fileURLToPath(fixture),
+	stdio: 'inherit',
+});
+
+// This page has a distinct HTML entry. An ephemeral port prevents unrelated
+// long-running Octane preview servers from serving another worktree's assets.
+const server = await preview({
+	root: fileURLToPath(fixture),
+	configFile: fileURLToPath(new URL('vite.config.js', fixture)),
+	preview: { host: '127.0.0.1', port: 0, strictPort: false },
+});
+const port = server.httpServer.address().port;
+console.log(`Context-cache preview port: ${port}`);
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+const results = {};
+try {
+	for (const variant of VARIANTS) {
+		const context = await browser.newContext();
+		await context.addInitScript(() => {
+			const NativeMap = globalThis.Map;
+			let constructions = 0;
+			globalThis.Map = new Proxy(NativeMap, {
+				construct(target, args, newTarget) {
+					constructions++;
+					return Reflect.construct(target, args, newTarget);
+				},
+			});
+			globalThis.__mapWork = {
+				reset() {
+					constructions = 0;
+				},
+				count() {
+					return constructions;
+				},
+			};
+		});
+		const page = await context.newPage();
+		page.on('pageerror', (error) => console.error('Context-cache browser error:', error));
+		page.on('response', (response) => {
+			if (response.status() >= 400)
+				console.error(`Context-cache HTTP ${response.status()}: ${response.url()}`);
+		});
+		try {
+			await page.goto(`http://127.0.0.1:${port}/context-cache.html`);
+			await page.waitForFunction(() => window.__readyCache === true);
+			const values = await page.evaluate(
+				({ mode, rowCount }) => {
+					const work = window.__mapWork;
+					work.reset();
+					new Map(); // Confirm this browser observed actual Map construction.
+					if (work.count() !== 1) throw new Error('Map constructor probe was not installed');
+					function operation(callback) {
+						work.reset();
+						callback();
+						return work.count();
+					}
+					function verify(version, secondary, ids) {
+						const rows = [...document.querySelectorAll('.cache-row')];
+						if (rows.length !== ids.length) throw new Error(`${mode}: ${rows.length} visible rows`);
+						for (let index = 0; index < rows.length; index++) {
+							const id = ids[index];
+							if (rows[index].dataset.id !== String(id))
+								throw new Error(`${mode}: row ${index} id`);
+							const expected = `${id}|${version}:${secondary}`;
+							if (rows[index].textContent !== expected) {
+								throw new Error(
+									`${mode}: row ${index} text ${rows[index].textContent} != ${expected}`,
+								);
+							}
+						}
+						return rows;
+					}
+					const forwardIds = Array.from({ length: rowCount }, (_, index) => index);
+					const reversedIds = [...forwardIds].reverse();
+					const mount = operation(() => window.__mountCache(mode));
+					const mounted = verify(0, 0, forwardIds);
+					const update = operation(window.__updateCache);
+					const updated = verify(1, 0, forwardIds);
+					if (updated.some((row, index) => row !== mounted[index])) {
+						throw new Error(`${mode}: update replaced a keyed row`);
+					}
+					const secondary = operation(window.__updateSecondaryCache);
+					verify(1, mode === 'two' ? 1 : 0, forwardIds);
+					const reorder = operation(window.__reorderCache);
+					const reversed = verify(1, mode === 'two' ? 1 : 0, reversedIds);
+					if (reversed.some((row, index) => row !== mounted[rowCount - 1 - index])) {
+						throw new Error(`${mode}: reorder replaced a keyed row`);
+					}
+					const unmount = operation(window.__unmountCache);
+					if (document.querySelectorAll('.cache-row').length !== 0) {
+						throw new Error(`${mode}: unmount left rows in DOM`);
+					}
+					return { mount, update, secondary, reorder, unmount };
+				},
+				{ mode: variant, rowCount: ROW_COUNT },
+			);
+			results[variant] = values;
+		} finally {
+			await context.close();
+		}
+	}
+	// The preceding exact allocation count uses a Map constructor wrapper.
+	// Timing takes place in fresh, uninstrumented Chromium realms; report the
+	// distribution as observational data, without a noisy wall-time gate.
+	for (const variant of VARIANTS) {
+		const context = await browser.newContext();
+		try {
+			const page = await context.newPage();
+			await page.goto(`http://127.0.0.1:${port}/context-cache.html`);
+			await page.waitForFunction(() => window.__readyCache === true);
+			const samples = await page.evaluate(
+				({ mode, rowCount }) => {
+					window.__mountCache(mode);
+					for (let i = 0; i < 12; i++) window.__updateCache();
+					const times = [];
+					const updatesPerSample = 20;
+					for (let i = 0; i < 40; i++) {
+						const start = performance.now();
+						for (let j = 0; j < updatesPerSample; j++) window.__updateCache();
+						times.push((performance.now() - start) / updatesPerSample);
+					}
+					const rows = document.querySelectorAll('.cache-row');
+					if (rows.length !== rowCount) throw new Error(`${mode}: timed update lost rows`);
+					for (let id = 0; id < rows.length; id++) {
+						if (rows[id].textContent !== `${id}|812:0`) {
+							throw new Error(`${mode}: timed update did not flush row ${id}`);
+						}
+					}
+					return times;
+				},
+				{ mode: variant, rowCount: ROW_COUNT },
+			);
+			results[variant].updateMs = summarizeSamples(samples);
+		} finally {
+			await context.close();
+		}
+	}
+} finally {
+	await browser.close();
+	await new Promise((resolve, reject) => {
+		server.httpServer.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+console.log('variant  mount Map  update Map  other Map  reorder Map  unmount Map');
+for (const variant of VARIANTS) {
+	const { mount, update, secondary, reorder, unmount } = results[variant];
+	console.log(
+		`${variant.padEnd(7)} ${String(mount).padStart(9)} ${String(update).padStart(11)} ${String(secondary).padStart(10)} ${String(reorder).padStart(12)} ${String(unmount).padStart(12)}`,
+	);
+}
+
+// One-context and two-context variants differ only in the consumer reads.
+// The zero-context variant captures shared keyed-row, root, and provider work.
+const oneExtra = results.one.mount - results.zero.mount;
+const twoExtra = results.two.mount - results.zero.mount;
+console.log(
+	`Consumer Map constructions above zero-context control: one=${oneExtra}, two=${twoExtra}`,
+);
+for (const variant of VARIANTS) {
+	const { median, min, p95 } = results[variant].updateMs;
+	console.log(
+		`${variant} update (uninstrumented): median=${median.toFixed(3)}ms min=${min.toFixed(3)}ms p95=${p95.toFixed(3)}ms`,
+	);
+}
+
+// The first context resolution uses the per-reader inline entry. A second
+// *distinct* context spills that reader into exactly one Map. The zero-context
+// variant establishes the shared root/keyed/provider allocation control.
+if (oneExtra !== 0 || twoExtra !== ROW_COUNT) {
+	throw new Error(
+		`Context-cache Map gate: one extra=${oneExtra} (expected 0), two extra=${twoExtra} (expected ${ROW_COUNT})`,
+	);
+}
+const ceilings = { mount: 6, update: 1, secondary: 1, reorder: 2, unmount: 0 };
+for (const [op, max] of Object.entries(ceilings)) {
+	if (results.zero[op] > max) {
+		throw new Error(`Zero-context ${op} allocated ${results.zero[op]} Maps (maximum ${max})`);
+	}
+	for (const variant of ['one', 'two']) {
+		if (op !== 'mount' && results[variant][op] > results.zero[op]) {
+			throw new Error(`${variant} ${op} allocated more Maps than the zero-context control`);
+		}
+	}
+}
+console.log('Context-cache allocation and semantic gates passed.');
+
+export { results as contextCacheResults };

--- a/benchmarks/recursive-context/octane-tsrx/context-cache.html
+++ b/benchmarks/recursive-context/octane-tsrx/context-cache.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>context cache work — octane (TSRX)</title>
+	</head>
+	<body>
+		<div id="main"></div>
+		<script type="module" src="/src/context-cache-main.js"></script>
+	</body>
+</html>

--- a/benchmarks/recursive-context/octane-tsrx/src/ContextCache.tsrx
+++ b/benchmarks/recursive-context/octane-tsrx/src/ContextCache.tsrx
@@ -1,0 +1,37 @@
+import { createContext, use } from 'octane';
+
+const RootCtx = createContext(0);
+const OtherCtx = createContext(0);
+
+export const ROW_IDS = Array.from({ length: 512 }, (_, index) => index);
+
+function ZeroRow(props) @{
+	<span class="cache-row" data-id={props.id}>{props.id + '|' + props.version +
+		':0' as string}</span>
+}
+
+function OneRow(props) @{
+	const root = use(RootCtx);
+	<span class="cache-row" data-id={props.id}>{props.id + '|' + root + ':0' as string}</span>
+}
+
+function TwoRow(props) @{
+	const root = use(RootCtx);
+	const other = use(OtherCtx);
+	<span class="cache-row" data-id={props.id}>{props.id + '|' + root + ':' + other as string}</span>
+}
+
+const ROWS = { zero: ZeroRow, one: OneRow, two: TwoRow };
+
+export default function ContextCache(props) @{
+	const Row = ROWS[props.mode];
+	<RootCtx.Provider value={props.version}>
+		<OtherCtx.Provider value={props.secondary}>
+			<div class="cache-rows">
+				@for (const id of props.ids; key id) {
+					<Row id={id} version={props.version} />
+				}
+			</div>
+		</OtherCtx.Provider>
+	</RootCtx.Provider>
+}

--- a/benchmarks/recursive-context/octane-tsrx/src/context-cache-main.js
+++ b/benchmarks/recursive-context/octane-tsrx/src/context-cache-main.js
@@ -1,0 +1,41 @@
+import { createRoot, flushSync } from 'octane';
+import ContextCache, { ROW_IDS } from './ContextCache.tsrx';
+
+const target = document.getElementById('main');
+let root = null;
+let ids = ROW_IDS;
+let mode = 'zero';
+let version = 0;
+let secondary = 0;
+
+function render() {
+	root.render(ContextCache, { ids, mode, version, secondary });
+}
+
+window.__mountCache = (variant) => {
+	if (root !== null) throw new Error('Cache fixture already mounted');
+	if (!['zero', 'one', 'two'].includes(variant)) throw new Error('Unknown cache fixture variant');
+	mode = variant;
+	ids = ROW_IDS;
+	version = 0;
+	secondary = 0;
+	root = createRoot(target);
+	render();
+};
+window.__updateCache = () => {
+	version++;
+	flushSync(render);
+};
+window.__updateSecondaryCache = () => {
+	secondary++;
+	flushSync(render);
+};
+window.__reorderCache = () => {
+	ids = [...ids].reverse();
+	flushSync(render);
+};
+window.__unmountCache = () => {
+	root?.unmount();
+	root = null;
+};
+window.__readyCache = true;

--- a/benchmarks/recursive-context/octane-tsrx/vite.config.js
+++ b/benchmarks/recursive-context/octane-tsrx/vite.config.js
@@ -1,9 +1,19 @@
 import { defineConfig } from 'vite';
 import { octane } from 'octane/compiler/vite';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
 	plugins: [octane()],
 	optimizeDeps: { exclude: ['octane', 'octane/compiler'] },
-	build: { target: 'esnext', minify: 'esbuild' },
+	build: {
+		target: 'esnext',
+		minify: 'esbuild',
+		rollupOptions: {
+			input: {
+				recursive: fileURLToPath(new URL('./index.html', import.meta.url)),
+				contextCache: fileURLToPath(new URL('./context-cache.html', import.meta.url)),
+			},
+		},
+	},
 	server: { port: 5185, strictPort: true },
 });

--- a/benchmarks/recursive-context/package.json
+++ b/benchmarks/recursive-context/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "bench": "node run.mjs",
     "bench:work": "node work.mjs",
+    "bench:cache": "node context-cache-work.mjs",
     "bench:long": "node run.mjs 40"
   },
   "dependencies": {

--- a/benchmarks/recursive-context/work.mjs
+++ b/benchmarks/recursive-context/work.mjs
@@ -422,6 +422,11 @@ for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
 	);
 }
 
+// The separate keyed-row fixture shares this Vite app but runs on an ephemeral
+// preview port so an existing preview of another worktree cannot hide a stale
+// bundle. It rebuilds with normal minification after precise coverage finishes.
+const { contextCacheResults } = await import('./context-cache-work.mjs');
+
 const outputPath = process.env.BENCH_JSON || process.env.WORK_JSON;
 if (outputPath) {
 	const payload = {
@@ -464,6 +469,20 @@ if (outputPath) {
 						: 'pass',
 				},
 			})),
+			{
+				name: 'octane-context-cache-work',
+				ops: Object.fromEntries(
+					Object.entries(contextCacheResults).flatMap(([variant, measurements]) =>
+						Object.entries(measurements).map(([operation, value]) => [
+							`${variant}_${operation}`,
+							operation === 'updateMs'
+								? value
+								: deterministicStatForJson(deterministicCount(value)),
+						]),
+					),
+				),
+				meta: { gates: 'pass' },
+			},
 		],
 	};
 	if (failures.length > 0) payload.failed = failures.join('; ');

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -331,10 +331,12 @@ export interface Scope {
 	 * never drops a context it stamped, and a closer provider can't appear above a
 	 * surviving consumer — so only the provider's VALUE varies, read live from the
 	 * cached scope. Collapses useContextInternal's O(depth) walk to an O(1) read.
-	 * Lazily minted on a consumer's first `use()`, so non-consumer blocks (the
-	 * vast majority) carry just this one null field, not a per-context slot set.
+	 * The first context and its resolved owner live inline; only a second distinct
+	 * context allocates a Map. The owner is never the value itself, so Provider
+	 * updates remain visible on subsequent reads.
 	 */
-	$$ctxCache: Map<Context<any>, any> | null;
+	$$ctxCache: Context<any> | Map<Context<any>, Scope | typeof DEFAULT_CTX> | null;
+	$$ctxCacheOwner: Scope | typeof DEFAULT_CTX | null;
 	// Per-scope dense slot array. Holds, by COMPILE-TIME index, this scope's binding
 	// bag (slot 0) and every control-flow / component / child slot state — plus the
 	// runtime-internal slots (`__ret`, `__kids`, `_item`, `_children`, `_fb`). Indexing
@@ -6739,7 +6741,8 @@ class BlockImpl {
 	// block can bail its body and refresh just its consuming child blocks.
 	declare $$ctxDirect: Map<Context<any>, any> | null;
 	// Resolved-provider cache for `use(ctx)` — see Scope.$$ctxCache.
-	declare $$ctxCache: Map<Context<any>, any> | null;
+	declare $$ctxCache: Context<any> | Map<Context<any>, Scope | typeof DEFAULT_CTX> | null;
+	declare $$ctxCacheOwner: Scope | typeof DEFAULT_CTX | null;
 	// Armed for React's IMPLICIT same-element bailout (beginWork's
 	// oldProps === newProps skip). Set at value-position component mounts
 	// (childSlot) — the only sites that can receive a cached descriptor back.
@@ -6836,6 +6839,7 @@ class BlockImpl {
 		this.$$ctxReads = null;
 		this.$$ctxDirect = null;
 		this.$$ctxCache = null;
+		this.$$ctxCacheOwner = null;
 		this.$$implicitBail = false;
 		this.__thenableIdx = 0;
 		this.drainStamp = 0;
@@ -6893,7 +6897,8 @@ class ScopeImpl {
 	declare refFields: string[] | null;
 	declare $$ctxValues: Map<Context<any>, any> | null;
 	declare $$ctxReads: Map<Context<any>, any> | null;
-	declare $$ctxCache: Map<Context<any>, any> | null;
+	declare $$ctxCache: Context<any> | Map<Context<any>, Scope | typeof DEFAULT_CTX> | null;
+	declare $$ctxCacheOwner: Scope | typeof DEFAULT_CTX | null;
 	declare mounted: boolean;
 	// Per-scope dense slot array (binding bag + control-flow/component/child slots),
 	// indexed by compile-time slot index. Keeps the scope shape monomorphic.
@@ -6911,6 +6916,7 @@ class ScopeImpl {
 		this.$$ctxValues = null;
 		this.$$ctxReads = null;
 		this.$$ctxCache = null;
+		this.$$ctxCacheOwner = null;
 		this.mounted = false;
 		this.slots = [];
 	}
@@ -11882,7 +11888,8 @@ export function bindRendererRegionOwner(props: unknown): void {
 	const binding = { bridge, release };
 	RENDERER_REGION_DOM_BINDINGS.set(root, binding);
 	RENDERER_REGION_DOM_OWNERS.set(root, bridge);
-	root.$$ctxCache?.clear();
+	root.$$ctxCache = null;
+	root.$$ctxCacheOwner = null;
 	if (previous === undefined) {
 		(root.cleanups ??= []).push(() => {
 			const current = RENDERER_REGION_DOM_BINDINGS.get(root);
@@ -12071,13 +12078,43 @@ function createNativeScopedResolver<T>(read: () => T): () => T {
 	};
 }
 
+function cacheContextOwner(
+	reader: Scope | null,
+	context: Context<any>,
+	owner: Scope | typeof DEFAULT_CTX,
+): void {
+	if (reader === null) return;
+	const cache = reader.$$ctxCache;
+	if (cache === null) {
+		reader.$$ctxCache = context;
+		reader.$$ctxCacheOwner = owner;
+		return;
+	}
+	const inlineOwner = reader.$$ctxCacheOwner;
+	if (inlineOwner !== null) {
+		const spill = new Map<Context<any>, Scope | typeof DEFAULT_CTX>();
+		spill.set(cache as Context<any>, inlineOwner);
+		spill.set(context, owner);
+		reader.$$ctxCache = spill;
+		reader.$$ctxCacheOwner = null;
+	} else {
+		(cache as Map<Context<any>, Scope | typeof DEFAULT_CTX>).set(context, owner);
+	}
+}
+
 function readContextFrom<T>(reader: Scope | null, block: Block | null, context: Context<T>): T {
 	// One boolean test per context read; the map is allocated only for a
 	// descriptor that reads context while resolving.
 	if (SCOPED_READ_TRACKING) (SCOPED_READS ??= new Map()).set(context, context.$$version);
-	if (reader !== null && reader.$$ctxCache !== null) {
-		const hit = reader.$$ctxCache.get(context);
-		if (hit !== undefined) {
+	if (reader !== null) {
+		const cache = reader.$$ctxCache;
+		const hit =
+			cache === context
+				? reader.$$ctxCacheOwner
+				: cache !== null && reader.$$ctxCacheOwner === null
+					? (cache as Map<Context<any>, Scope | typeof DEFAULT_CTX>).get(context)
+					: undefined;
+		if (hit !== null && hit !== undefined) {
 			if (hit === DEFAULT_CTX) {
 				const bridge = rendererRegionOwnerForBlock(block);
 				return bridge === null ? context.defaultValue : bridge.readContext(context);
@@ -12090,7 +12127,7 @@ function readContextFrom<T>(reader: Scope | null, block: Block | null, context: 
 	while (scope !== null) {
 		const values = scope.$$ctxValues;
 		if (values !== null && values.has(context)) {
-			if (reader !== null) (reader.$$ctxCache ??= new Map()).set(context, scope);
+			cacheContextOwner(reader, context, scope);
 			return values.get(context) as T;
 		}
 		scope = scope.parent;
@@ -12099,14 +12136,14 @@ function readContextFrom<T>(reader: Scope | null, block: Block | null, context: 
 	while (current !== null) {
 		const values = current.$$ctxValues;
 		if (values !== null && values.has(context)) {
-			if (reader !== null) (reader.$$ctxCache ??= new Map()).set(context, current);
+			cacheContextOwner(reader, context, current);
 			return values.get(context) as T;
 		}
 		current = current.parentBlock;
 	}
 	const bridge = rendererRegionOwnerForBlock(block);
 	if (bridge !== null) return bridge.readContext(context);
-	if (reader !== null) (reader.$$ctxCache ??= new Map()).set(context, DEFAULT_CTX);
+	cacheContextOwner(reader, context, DEFAULT_CTX);
 	return context.defaultValue;
 }
 

--- a/packages/octane/tests/context.test.ts
+++ b/packages/octane/tests/context.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { prerender } from 'octane/static';
-import { flushSync, hydrateRoot } from '../src/index.js';
+import {
+	createContext,
+	createElement,
+	createRoot,
+	flushSync,
+	hydrateRoot,
+	use,
+} from '../src/index.js';
 import { mount, act } from './_helpers';
 import { loadServerFixture } from './_server-fixture';
 import {
@@ -278,6 +285,137 @@ describe('context — use() alongside other reads', () => {
 			expect(output.textContent).toBe('dark|alice|dark/alice');
 		} finally {
 			root?.unmount();
+			container.remove();
+		}
+	});
+});
+
+describe('context — retained provider resolution', () => {
+	it('distinguishes a provided undefined from the default after the provider changes', () => {
+		const Value = createContext<string | undefined>('fallback');
+		function Reader() {
+			return createElement('output', { className: 'optional-value' }, String(use(Value)));
+		}
+		function Host(props: { value: string | undefined }) {
+			return createElement(Value.Provider, { value: props.value }, createElement(Reader));
+		}
+		const r = mount(Host, { value: 'first' });
+		try {
+			const output = r.find('.optional-value');
+			expect(output.textContent).toBe('first');
+			r.update(Host, { value: undefined });
+			expect(r.find('.optional-value')).toBe(output);
+			expect(output.textContent).toBe('undefined');
+			r.update(Host, { value: 'second' });
+			expect(output.textContent).toBe('second');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('keeps second and third providers and a default distinct through independent updates', () => {
+		const First = createContext('first-default');
+		const Second = createContext('second-default');
+		const Third = createContext('third-default');
+		const Bare = createContext('bare-default');
+		function Reader() {
+			const values = [use(First), use(Second), use(Third), use(Bare)];
+			return createElement('output', { className: 'many-values' }, values.join('|'));
+		}
+		function Host(props: { first: string; second: string; third: string }) {
+			return createElement(
+				First.Provider,
+				{ value: props.first },
+				createElement(
+					Second.Provider,
+					{ value: props.second },
+					createElement(Third.Provider, { value: props.third }, createElement(Reader)),
+				),
+			);
+		}
+		const r = mount(Host, { first: 'a0', second: 'b0', third: 'c0' });
+		try {
+			const output = r.find('.many-values');
+			expect(output.textContent).toBe('a0|b0|c0|bare-default');
+			r.update(Host, { first: 'a0', second: 'b1', third: 'c0' });
+			expect(output.textContent).toBe('a0|b1|c0|bare-default');
+			r.update(Host, { first: 'a0', second: 'b1', third: 'c1' });
+			expect(output.textContent).toBe('a0|b1|c1|bare-default');
+			r.update(Host, { first: 'a1', second: 'b1', third: 'c1' });
+			expect(r.find('.many-values')).toBe(output);
+			expect(output.textContent).toBe('a1|b1|c1|bare-default');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('keeps earlier and later reads aligned when a second context read appears conditionally', () => {
+		const First = createContext('a-default');
+		const Second = createContext('b-default');
+		const Third = createContext('c-default');
+		function Reader(props: { readSecond: boolean }) {
+			const first = use(First);
+			const second = props.readSecond ? use(Second) : '(off)';
+			const third = use(Third);
+			return createElement(
+				'output',
+				{ className: 'conditional-values' },
+				`${first}|${second}|${third}`,
+			);
+		}
+		function Host(props: { readSecond: boolean; second: string; third: string }) {
+			return createElement(
+				First.Provider,
+				{ value: 'a0' },
+				createElement(
+					Second.Provider,
+					{ value: props.second },
+					createElement(
+						Third.Provider,
+						{ value: props.third },
+						createElement(Reader, { readSecond: props.readSecond }),
+					),
+				),
+			);
+		}
+		const r = mount(Host, { readSecond: false, second: 'b0', third: 'c0' });
+		try {
+			const output = r.find('.conditional-values');
+			expect(output.textContent).toBe('a0|(off)|c0');
+			r.update(Host, { readSecond: true, second: 'b0', third: 'c0' });
+			expect(output.textContent).toBe('a0|b0|c0');
+			r.update(Host, { readSecond: false, second: 'b0', third: 'c1' });
+			expect(output.textContent).toBe('a0|(off)|c1');
+			r.update(Host, { readSecond: true, second: 'b1', third: 'c1' });
+			expect(r.find('.conditional-values')).toBe(output);
+			expect(output.textContent).toBe('a0|b1|c1');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('reads a fresh provider after its root is unmounted and recreated', () => {
+		const Value = createContext('fallback');
+		function Reader() {
+			return createElement('output', { className: 'new-root-value' }, use(Value));
+		}
+		function Host(props: { value: string }) {
+			return createElement(Value.Provider, { value: props.value }, createElement(Reader));
+		}
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		let root = createRoot(container);
+		try {
+			root.render(Host, { value: 'old-root' });
+			const oldOutput = container.querySelector('.new-root-value')!;
+			expect(oldOutput.textContent).toBe('old-root');
+			root.unmount();
+			root = createRoot(container);
+			root.render(Host, { value: 'new-root' });
+			expect(oldOutput.isConnected).toBe(false);
+			expect(container.querySelector('.new-root-value')?.textContent).toBe('new-root');
+		} finally {
+			root.unmount();
 			container.remove();
 		}
 	});

--- a/packages/octane/tests/react-hosted/host-bridge.test.ts
+++ b/packages/octane/tests/react-hosted/host-bridge.test.ts
@@ -9,7 +9,14 @@
  */
 import { describe, expect, it } from 'vitest';
 import * as React from 'react';
-import { flushSync as octaneFlushSync } from '../../src/index.js';
+import {
+	bindRendererRegionOwner,
+	createContext,
+	createElement,
+	createRoot,
+	flushSync as octaneFlushSync,
+	use,
+} from '../../src/index.js';
 import { createLog } from '../_helpers.js';
 import {
 	h,
@@ -18,6 +25,7 @@ import {
 	reactAct,
 	IslandController,
 	OctaneCompatSpike,
+	RENDERER_REGION_OWNER,
 	SpikeErrorBoundary,
 } from './_react-host.js';
 import {
@@ -157,6 +165,51 @@ describe('react-hosted island — ownership and lifecycle', () => {
 });
 
 describe('react-hosted island — transparent context via the owner bridge', () => {
+	it('reads the latest owner after rebinding a retained root', () => {
+		const Theme = createContext('unbound-default');
+		function Envelope(props: { owner?: object }) {
+			if (props.owner !== undefined) bindRendererRegionOwner(props);
+			return createElement('output', { className: 'rebound-theme' }, use(Theme));
+		}
+		function ownedProps(value: string) {
+			const owner = {
+				active: true,
+				readContext: () => value,
+				routeError: () => false,
+				routeSuspense: () => false,
+				registerDispose: () => () => {},
+			};
+			const props = { owner };
+			Object.defineProperty(props, RENDERER_REGION_OWNER, { value: owner });
+			return props;
+		}
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = createRoot(container);
+		try {
+			root.render(Envelope, {});
+			const output = container.querySelector('.rebound-theme')!;
+			expect(output.textContent).toBe('unbound-default');
+			const dormant = ownedProps('activated-owner');
+			dormant.owner.active = false;
+			octaneFlushSync(() => root.render(Envelope, dormant));
+			expect(output.textContent).toBe('unbound-default');
+			dormant.owner.active = true;
+			octaneFlushSync(() =>
+				root.render(Envelope, { ...dormant, [RENDERER_REGION_OWNER]: dormant.owner }),
+			);
+			expect(output.textContent).toBe('activated-owner');
+			octaneFlushSync(() => root.render(Envelope, ownedProps('first-owner')));
+			expect(container.querySelector('.rebound-theme')).toBe(output);
+			expect(output.textContent).toBe('first-owner');
+			octaneFlushSync(() => root.render(Envelope, ownedProps('second-owner')));
+			expect(output.textContent).toBe('second-owner');
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	});
+
 	const ThemeCtx = React.createContext('unset-theme');
 	const LocaleCtx = React.createContext('unset-locale');
 	const themePair = { react: ThemeCtx as React.Context<any>, mirror: MirrorTheme };


### PR DESCRIPTION
## Summary

- Store the first resolved context and provider owner inline on each consumer; allocate the existing Map only when a second distinct context is read.
- Keep provider values live through updates, explicit `undefined`, default-context reads, hosted owner activation/rebind, conditional reads, and remounts.
- Add a production browser work gate with zero-, one-, and two-context keyed consumers. Contributes to #981; the separate provider-walk `has`/`get` work remains open.

## Validation

- [ ] `pnpm format:check` (scoped `pnpm format:files:check` passed for every changed path)
- [x] `pnpm typecheck`
- [ ] `pnpm test` locally (160 targeted context, host-bridge, JSX, manual-hook, and hydration tests passed in dev and prod compile modes; the full suite passed in current-head CI)
- [x] `pnpm sync` (no unrelated tracked diff)
- [x] `node benchmarks/recursive-context/context-cache-work.mjs` (production Chromium; baseline/current Map constructions for 512 keyed rows: zero 6/6, one 518/6, two 518/518; update, reorder, and teardown counts unchanged; DOM/identity controls pass)
- [x] Deliberately broken default-owner recheck and wrong spill owner each failed the new consumer-visible regressions in both compile modes, then passed after restoration.
- [x] [Current-head CI run](https://github.com/octanejs/octane/actions/runs/34375090673) passed 26/26 jobs on `21ae658a1` (attempt 2 after a Vitest worker failed to run an unrelated SliderTrack test on attempt 1; that file passed locally 30/30). Bugbot passed.

## Risk / follow-ups

- One additional initialized pointer field is carried by every Block and Scope. The zero-context control verifies no extra Map construction, but does not quantify its footprint or establish a throughput win. Uninstrumented update timings are diagnostic only.
- #981's provider-discovery `Map.has` + `Map.get` probes remain a separate item; changing their order can add probes to deep misses.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title, with the type-prefixed head branch as a
fallback. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791562249&installation_model_id=432790&pr_number=1019&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1019&signature=aa5c91ef779cc4a588905b26da2e283beff8f64e5dce9a3a781d4757f6c1bc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `readContextFrom` / context caching on every `use()` call and adds a new pointer field on all scopes; behavior is heavily gated but incorrect cache semantics would surface as stale or wrong context values.
> 
> **Overview**
> **Octane’s `use()` resolved-provider cache** no longer allocates a `Map` on every consumer’s first context read. The first context key and its provider owner are stored inline on `Scope`/`Block` (`$$ctxCache` + `$$ctxCacheOwner`); a `Map` is created only when that consumer reads a second distinct context. Cached entries still point at the owning scope (or the default/bridge sentinel), so values stay live across provider updates, `undefined`, hosted-owner rebinds, and remounts—hosted roots now **drop** the cache on rebind instead of calling `Map.clear()`.
> 
> **Benchmarking and CI gates:** the recursive-context suite adds a production Chromium work pass (`context-cache-work.mjs`, `bench:cache`) with 512 keyed rows in zero/one/two-context modes. It counts `Map` constructions (expect **0** extra Maps for single-context mount vs control, **512** for two-context spill) and checks DOM/identity on update, secondary provider, reorder, and unmount; `work.mjs` runs this after precise coverage.
> 
> **Tests** extend context and react-hosted coverage for multi-context updates, conditional second reads, optional `undefined`, full root remount, and owner rebinding on a retained root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ae658a1faad96a81691446c026889b7ac7d5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
