### PR TITLE
perf: reuse child-only warm plans

### DIFF
--- a/.changeset/reuse-child-warm-plans.md
+++ b/.changeset/reuse-child-warm-plans.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Reuse static children-only warm plans when registering compiled component
+descendants, avoiding a fresh empty batch and warm closure on each render while
+preserving the first pending descendant's fetch discovery.

--- a/benchmarks/recursive-context/README.md
+++ b/benchmarks/recursive-context/README.md
@@ -167,11 +167,28 @@ root and partial updates must still execute exactly 1024 and 32 `setText` calls.
 The TSRX leaf reads two local `createContext` values and no promises. Before
 removing its redundant context-only `useBatch`, the 1024-leaf mount and root
 update each called `useBatch` 3072 times; the 32-leaf partial update and
-remount each called it 94 times. Exact gates now require 2048 and 62 calls,
-respectively: the remaining calls register the independent child warm plans
-with `useBatch([], warmThunk)`. The JSX twin emits no `useBatch` calls for this
-fixture. The normal DOM checks in `run.mjs` still verify all 1024 leaf paths,
-both context values, the isolated 32-leaf provider update, and remount identity.
+remount each called it 94 times. The baseline after that removal was 2048 and
+62 calls, respectively, all
+`useBatch([], warmThunk)` child-plan registrations. The child-only plan now
+registers through `registerWarmPlan(plan, props)`, with exact production-call
+gates of 2048 on mount/root update and 62 on partial update/remount. The same
+operations must call `useBatch` zero times; the JSX twin stays at zero for both
+helpers. `setText` still runs exactly 1024/32 times for root/partial updates.
+The normal DOM checks in `run.mjs` verify all 1024 leaf paths, both context
+values, the isolated 32-leaf provider update, and remount identity.
+
+A separate production entry (`warm-plan-control.html`) renders a parent with
+its own promise creation and a same-module async child. That parent must retain
+the direct batch and trailing `useBatch([], warmThunk)` because its warm plan
+does more than traverse children. A fresh Chromium pass confirms the visible
+parent/child values and that each resource starts exactly once; it requires
+four `useBatch` calls over the suspending mount/retry and zero
+`registerWarmPlan` calls. The work gate also parses production compiler output
+for this fixture, a child-only parent that reassigns its props after
+registration, and a parent whose body shadows its function name; each must
+retain the original `useBatch` path. Standalone work
+gate runs may set `RECURSIVE_WORK_TARGETS` to JSON target URLs for isolated
+ephemeral preview ports, avoiding stale assets from other worktrees.
 
 The same work pass also compiles a plain TypeScript custom hook with two reads
 from a directly initialized module context in both client and server modes. Its

--- a/benchmarks/recursive-context/octane-tsrx/src/WarmPlanControl.tsrx
+++ b/benchmarks/recursive-context/octane-tsrx/src/WarmPlanControl.tsrx
@@ -1,0 +1,20 @@
+import { use } from 'octane';
+
+type Resource = (name: 'parent' | 'child', version: number) => Promise<string>;
+
+function AsyncChild(props: { load: Resource; version: number }) @{
+	const value = use(props.load('child', props.version));
+	<span id="warm-child">{value as string}</span>
+}
+
+export default function WarmPlanControl(props: { load: Resource; version: number }) @{
+	@try {
+		const own = use(props.load('parent', props.version));
+		<main id="warm-control">
+			<strong id="warm-parent">{own as string}</strong>
+			<AsyncChild load={props.load} version={props.version} />
+		</main>
+	} @pending {
+		<p id="warm-pending">{'waiting'}</p>
+	}
+}

--- a/benchmarks/recursive-context/octane-tsrx/src/warm-plan-control-main.js
+++ b/benchmarks/recursive-context/octane-tsrx/src/warm-plan-control-main.js
@@ -1,0 +1,45 @@
+import { createRoot } from 'octane';
+import WarmPlanControl from './WarmPlanControl.tsrx';
+
+const container = document.getElementById('main');
+const started = { parent: 0, child: 0 };
+let root = null;
+
+function load(name, version) {
+	started[name]++;
+	return Promise.resolve(`${name}:${version}`);
+}
+
+window.__mountWarmPlanControl = async () => {
+	root = createRoot(container);
+	root.render(WarmPlanControl, { load, version: 1 });
+	if (container.querySelector('#warm-child')?.textContent === 'child:1') return;
+	await new Promise((resolve, reject) => {
+		const observer = new MutationObserver(() => {
+			if (container.querySelector('#warm-child')?.textContent !== 'child:1') return;
+			observer.disconnect();
+			clearTimeout(timeout);
+			resolve();
+		});
+		const timeout = setTimeout(() => {
+			observer.disconnect();
+			reject(new Error('warm-plan control did not settle'));
+		}, 1000);
+		observer.observe(container, { childList: true, subtree: true, characterData: true });
+	});
+};
+
+window.__verifyWarmPlanControl = () => {
+	if (container.querySelector('#warm-parent')?.textContent !== 'parent:1') {
+		throw new Error('warm-plan control lost the parent resource');
+	}
+	if (container.querySelector('#warm-child')?.textContent !== 'child:1') {
+		throw new Error('warm-plan control lost the child resource');
+	}
+	if (started.parent !== 1 || started.child !== 1) {
+		throw new Error(`warm-plan control started ${started.parent}/${started.child} resources`);
+	}
+	root.unmount();
+};
+
+window.__ready = true;

--- a/benchmarks/recursive-context/octane-tsrx/vite.config.js
+++ b/benchmarks/recursive-context/octane-tsrx/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
 			input: {
 				recursive: fileURLToPath(new URL('./index.html', import.meta.url)),
 				contextCache: fileURLToPath(new URL('./context-cache.html', import.meta.url)),
+				warmPlanControl: fileURLToPath(new URL('./warm-plan-control.html', import.meta.url)),
 			},
 		},
 	},

--- a/benchmarks/recursive-context/octane-tsrx/warm-plan-control.html
+++ b/benchmarks/recursive-context/octane-tsrx/warm-plan-control.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>warm-plan control — octane (TSRX)</title>
+	</head>
+	<body>
+		<div id="main"></div>
+		<script type="module" src="/src/warm-plan-control-main.js"></script>
+	</body>
+</html>

--- a/benchmarks/recursive-context/work.mjs
+++ b/benchmarks/recursive-context/work.mjs
@@ -7,14 +7,19 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
 import ts from 'typescript';
+import { compile } from '../../packages/octane/src/compiler/compile.js';
 import { slotHooks } from '../../packages/octane/src/compiler/slot-hooks.js';
 import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
 import { collectPreciseCalls } from '../lib/precise-work.mjs';
 
-const TARGETS = [
-	{ name: 'octane-tsrx', url: 'http://localhost:5185/' },
-	{ name: 'octane-jsx', url: 'http://localhost:5188/' },
-];
+// Standalone runs can target ephemeral previews so an unrelated worktree's
+// server on the standard benchmark ports cannot produce stale-bundle counts.
+const TARGETS = process.env.RECURSIVE_WORK_TARGETS
+	? JSON.parse(process.env.RECURSIVE_WORK_TARGETS)
+	: [
+			{ name: 'octane-tsrx', url: 'http://localhost:5185/' },
+			{ name: 'octane-jsx', url: 'http://localhost:5188/' },
+		];
 
 // The unified runner finishes its timed pass against normally minified assets
 // before invoking this untimed gate. Build the same production fixtures without
@@ -40,6 +45,7 @@ const METRICS = [
 	'updateSurvivor',
 	'setText',
 	'useBatch',
+	'registerWarmPlan',
 	'unmountBlock',
 	'unmountScope',
 ];
@@ -129,6 +135,54 @@ const PLAIN_HOOKS = Object.fromEntries(
 	]),
 );
 
+// The own-promise control must keep its direct batch and trailing warm thunk;
+// reassigned props and locally shadowed components need the legacy closure.
+// Inspect imported calls in the parsed production compiler output so helper
+// aliases and generated formatting cannot obscure either negative case.
+const REASSIGNED_PROPS_SOURCE = `import { use } from 'octane';
+function Child(props) @{
+  const value = use(props.load('child', props.version));
+  <span>{value as string}</span>
+}
+export function Parent(props) @{
+  <main>
+    {((props = props.next), '') as string}
+    <Child load={props.load} version={props.version} />
+  </main>
+}`;
+const SHADOWED_COMPONENT_SOURCE = `import { use } from 'octane';
+function Child(props) @{
+  const value = use(props.load('child', props.version));
+  <span>{value as string}</span>
+}
+export function Parent(props) @{
+  const Parent = () => null;
+  <main><Child load={props.load} version={props.version} /></main>
+}`;
+
+function measureCompiledControl(source, filename) {
+	const code = compile(source, filename, { dev: false, hmr: false }).code;
+	const ast = ts.createSourceFile(filename, code, ts.ScriptTarget.Latest, true);
+	if (ast.parseDiagnostics.length > 0) throw new Error(`${filename}: invalid compiled TypeScript`);
+	return {
+		batch: countImportedCalls(ast, 'useBatch'),
+		plan: countImportedCalls(ast, 'registerWarmPlan'),
+		warmMemo: countImportedCalls(ast, 'warmMemo'),
+	};
+}
+
+const WARM_CONTROL_FILE = fileURLToPath(
+	new URL('./octane-tsrx/src/WarmPlanControl.tsrx', import.meta.url),
+);
+const COMPILED_CONTROLS = {
+	ownPromise: measureCompiledControl(fs.readFileSync(WARM_CONTROL_FILE, 'utf8'), WARM_CONTROL_FILE),
+	reassignedProps: measureCompiledControl(REASSIGNED_PROPS_SOURCE, 'warm-reassigned-props.tsrx'),
+	shadowedComponent: measureCompiledControl(
+		SHADOWED_COMPONENT_SOURCE,
+		'warm-shadowed-component.tsrx',
+	),
+};
+
 // Scaffolding is bounded above so later direct-return lowering can reduce it
 // without rebaselining this gate. The visible update cardinality is exact.
 const GATES = {
@@ -146,7 +200,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
-			exact: { useBatch: 2048 },
+			exact: { useBatch: 0, registerWarmPlan: 2048 },
 		},
 		update_root: {
 			maxFullSlotCalls: 1027,
@@ -161,7 +215,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
-			exact: { setText: 1024, useBatch: 2048 },
+			exact: { setText: 1024, useBatch: 0, registerWarmPlan: 2048 },
 		},
 		update_partial: {
 			maxFullSlotCalls: 33,
@@ -176,7 +230,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
-			exact: { setText: 32, useBatch: 62 },
+			exact: { setText: 32, useBatch: 0, registerWarmPlan: 62 },
 		},
 		partial_unmount: {
 			maxFullSlotCalls: 0,
@@ -193,6 +247,7 @@ const GATES = {
 				unmountBlock: 126,
 				unmountScope: 188,
 			},
+			exact: { useBatch: 0, registerWarmPlan: 0 },
 		},
 		partial_remount: {
 			maxFullSlotCalls: 33,
@@ -207,12 +262,13 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
-			exact: { useBatch: 62 },
+			exact: { useBatch: 0, registerWarmPlan: 62 },
 		},
 		unmount: {
 			maxFullSlotCalls: 0,
 			maxSlotCalls: 0,
 			max: { unmountBlock: 4099, unmountScope: 6146 },
+			exact: { useBatch: 0, registerWarmPlan: 0 },
 		},
 	},
 	'octane-jsx': {
@@ -229,6 +285,7 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
+			exact: { useBatch: 0, registerWarmPlan: 0 },
 		},
 		update_root: {
 			maxFullSlotCalls: 2049,
@@ -243,7 +300,7 @@ const GATES = {
 				reconcileKeyed: 1,
 				updateSurvivor: 2,
 			},
-			exact: { setText: 1024 },
+			exact: { setText: 1024, useBatch: 0, registerWarmPlan: 0 },
 		},
 		update_partial: {
 			maxFullSlotCalls: 64,
@@ -258,7 +315,7 @@ const GATES = {
 				reconcileKeyed: 1,
 				updateSurvivor: 2,
 			},
-			exact: { setText: 32 },
+			exact: { setText: 32, useBatch: 0, registerWarmPlan: 0 },
 		},
 		partial_unmount: {
 			maxFullSlotCalls: 0,
@@ -275,6 +332,7 @@ const GATES = {
 				unmountBlock: 162,
 				unmountScope: 222,
 			},
+			exact: { useBatch: 0, registerWarmPlan: 0 },
 		},
 		partial_remount: {
 			maxFullSlotCalls: 64,
@@ -289,11 +347,13 @@ const GATES = {
 				reconcileKeyed: 0,
 				updateSurvivor: 0,
 			},
+			exact: { useBatch: 0, registerWarmPlan: 0 },
 		},
 		unmount: {
 			maxFullSlotCalls: 0,
 			maxSlotCalls: 0,
 			max: { unmountBlock: 5128, unmountScope: 7172 },
+			exact: { useBatch: 0, registerWarmPlan: 0 },
 		},
 	},
 };
@@ -384,6 +444,19 @@ for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
 		failures.push(`${environment}.plain_mixed: expected one imported batch call`);
 	}
 }
+for (const [name, control] of Object.entries(COMPILED_CONTROLS)) {
+	const expectedBatchCalls = name === 'ownPromise' ? 3 : 2;
+	const expectedWarmMemos = name === 'ownPromise' ? 2 : 1;
+	if (control.batch.imports !== 1 || control.batch.calls !== expectedBatchCalls) {
+		failures.push(`${name}: expected ${expectedBatchCalls} retained batch calls`);
+	}
+	if (control.plan.imports !== 0 || control.plan.calls !== 0) {
+		failures.push(`${name}: unexpected extracted child-only warm plan`);
+	}
+	if (control.warmMemo.calls !== expectedWarmMemos) {
+		failures.push(`${name}: expected ${expectedWarmMemos} warmable promise creations`);
+	}
+}
 try {
 	for (const target of TARGETS) {
 		results[target.name] = {};
@@ -398,23 +471,43 @@ try {
 			validate(target.name, op.name, counts, failures);
 		}
 	}
+	results.warmPlanControl = await collectPreciseCalls(browser, {
+		url: TARGETS.find((target) => target.name === 'octane-tsrx').url + 'warm-plan-control.html',
+		operation: '__mountWarmPlanControl',
+		after: ['__verifyWarmPlanControl'],
+		metrics: ['useBatch', 'registerWarmPlan'],
+	});
+	if (results.warmPlanControl.useBatch !== 4 || results.warmPlanControl.registerWarmPlan !== 0) {
+		failures.push(
+			`ownPromise: expected 4 batch calls and no extracted plan, got ` +
+				`${results.warmPlanControl.useBatch}/${results.warmPlanControl.registerWarmPlan}`,
+		);
+	}
 } finally {
 	await browser.close();
 }
 
 console.log(
-	'Operation                 | render | full | void | lite | child | descriptors | host/deopt/keyed/survivors | text | batch | unmount block/scope',
+	'Operation                 | render | full | void | lite | child | descriptors | host/deopt/keyed/survivors | text | batch/plan | unmount block/scope',
 );
 console.log(
-	'--------------------------+--------+------+------+------+-------+-------------+----------------------------+------+-------+--------------------',
+	'--------------------------+--------+------+------+------+-------+-------------+----------------------------+------+------------+--------------------',
 );
 for (const target of TARGETS) {
 	for (const op of OPS) {
 		const c = results[target.name][op.name];
 		console.log(
-			`${`${target.name}.${op.name}`.padEnd(25)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${c.hostElementBody}/${c.deoptItemBody}/${c.reconcileKeyed}/${c.updateSurvivor} | ${String(c.setText).padStart(4)} | ${String(c.useBatch).padStart(5)} | ${c.unmountBlock}/${c.unmountScope}`,
+			`${`${target.name}.${op.name}`.padEnd(25)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${c.hostElementBody}/${c.deoptItemBody}/${c.reconcileKeyed}/${c.updateSurvivor} | ${String(c.setText).padStart(4)} | ${`${c.useBatch}/${c.registerWarmPlan}`.padStart(10)} | ${c.unmountBlock}/${c.unmountScope}`,
 		);
 	}
+}
+console.log(
+	`own-promise async parent/child: batch/plan=${results.warmPlanControl.useBatch}/${results.warmPlanControl.registerWarmPlan}, resources=1/1 and visible output verified`,
+);
+for (const [name, { batch, plan, warmMemo }] of Object.entries(COMPILED_CONTROLS)) {
+	console.log(
+		`${name} compiled: batch calls=${batch.calls}, plan calls=${plan.calls}, warmable creations=${warmMemo.calls}`,
+	);
 }
 for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
 	console.log(
@@ -469,6 +562,34 @@ if (outputPath) {
 						: 'pass',
 				},
 			})),
+			...Object.entries(COMPILED_CONTROLS).map(([name, { batch, plan, warmMemo }]) => ({
+				name: `octane-${name}-compiled-work`,
+				ops: Object.fromEntries(
+					Object.entries({
+						batch_calls: batch.calls,
+						plan_calls: plan.calls,
+						warm_memo_calls: warmMemo.calls,
+					}).map(([metric, value]) => [
+						metric,
+						deterministicStatForJson(deterministicCount(value)),
+					]),
+				),
+				meta: {
+					gates: failures.some((failure) => failure.startsWith(`${name}:`)) ? 'fail' : 'pass',
+				},
+			})),
+			{
+				name: 'octane-own-promise-runtime-work',
+				ops: Object.fromEntries(
+					Object.entries(results.warmPlanControl).map(([metric, value]) => [
+						metric,
+						deterministicStatForJson(deterministicCount(value)),
+					]),
+				),
+				meta: {
+					gates: failures.some((failure) => failure.startsWith('ownPromise:')) ? 'fail' : 'pass',
+				},
+			},
 			{
 				name: 'octane-context-cache-work',
 				ops: Object.fromEntries(

--- a/docs/suspense-parallel-use-plan.md
+++ b/docs/suspense-parallel-use-plan.md
@@ -124,9 +124,14 @@ What shipped, and where it deviates from the phases as written:
   modules now apply the same memoize/stratify/batch transform to lexically
   imported `use()` calls (including aliases), with client `useMemo`/`useBatch`
   and server `puMemo`/`puBatch` twins. The first direct batch carries its warm
-  thunk; once setup reaches the final output, child-only plans register through
-  an empty compiler batch and stay lazy until a descendant batch actually
-  suspends. Components with setup early returns conservatively publish no
+  thunk; once setup reaches the final output, descendant plans register and
+  stay lazy until a descendant batch actually suspends. The DOM client reuses
+  an attached child-only plan through `registerWarmPlan(plan, props)` when the
+  component binding and captured props are provably stable. The runtime keeps
+  flat block/plan/props triples on the render stack, avoiding a registration
+  object per render. Own creations, mutable bindings, and unattached plans
+  retain the empty compiler batch and lexical thunk. Components with setup
+  early returns conservatively publish no
   descendant plan. Every live ancestor plan warms into an episode-scoped cache
   owned above adjacent siblings. Warmable creation slots use globally
   composable Symbols (scope-local integers collide across sibling components),

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -5111,7 +5111,9 @@ function collectImmutableModuleFunctions(body) {
 	const declared = new Map();
 	for (const statement of body) {
 		const declaration =
-			statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+			statement.type === 'ExportNamedDeclaration' || statement.type === 'ExportDefaultDeclaration'
+				? statement.declaration
+				: statement;
 		if (declaration?.type === 'FunctionDeclaration' && declaration.id?.type === 'Identifier') {
 			declared.set(declaration.id.name, declaration);
 		}
@@ -5126,10 +5128,31 @@ function collectImmutableModuleFunctions(body) {
 		}
 		if (seen.has(n)) return;
 		seen.add(n);
-		if (n.type === 'AssignmentExpression' && n.left?.type === 'Identifier') {
-			declared.delete(n.left.name);
-		} else if (n.type === 'UpdateExpression' && n.argument?.type === 'Identifier') {
-			declared.delete(n.argument.name);
+		const writeTarget =
+			n.type === 'AssignmentExpression'
+				? n.left
+				: n.type === 'UpdateExpression'
+					? n.argument
+					: n.type === 'VariableDeclarator'
+						? n.id
+						: (n.type === 'ForOfStatement' || n.type === 'ForInStatement') &&
+							  n.left?.type !== 'VariableDeclaration'
+							? n.left
+							: null;
+		if (writeTarget?.type === 'Identifier') {
+			declared.delete(writeTarget.name);
+		} else if (writeTarget !== null) {
+			const names = new Set();
+			collectPatternNames(unwrapTsExpr(writeTarget), names);
+			for (const name of names) declared.delete(name);
+		} else if (
+			n.type === 'CallExpression' &&
+			unwrapTsExpr(n.callee)?.type === 'Identifier' &&
+			unwrapTsExpr(n.callee).name === 'eval'
+		) {
+			// Direct eval can write a module function binding without a visible
+			// assignment node. Exclude those names from identity proofs.
+			declared.clear();
 		}
 		for (const key in n) {
 			if (AST_WALK_SKIP_KEYS.has(key)) continue;
@@ -14039,6 +14062,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 		ctx.inlineHookMemo && ctx.mode !== 'server' && ctx._universalRuntimeUnit == null;
 	ctx._puInlineLowering = inlineLowering;
 	let warmThunk = null;
+	let staticChildOnly = false;
 	if (options && options.autoCallback) {
 		const creations = [];
 		const warmChildren = [];
@@ -14097,9 +14121,21 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 		jsxNodes = parallelUseWalkJsx(jsxNodes, ctx, name, creations, warmChildren, [], new Set());
 		const warm = buildWarmArtifacts(node, ctx, name, creations, warmChildren);
 		warmThunk = warm.thunk;
+		staticChildOnly = warm.staticChildOnly === true;
 		ctx._pendingWarm = warm.warmNode;
 	}
-	workingStatements = rewriteParallelUse(workingStatements, ctx, name, warmThunk);
+	workingStatements = rewriteParallelUse(
+		workingStatements,
+		ctx,
+		name,
+		warmThunk,
+		staticChildOnly &&
+			ctx.mode !== 'server' &&
+			ctx._universalRuntimeUnit == null &&
+			ctx.moduleFunctionDeclarations.get(name)?.start === node.start
+			? staticChildWarmPlanProps(node, name)
+			: null,
+	);
 
 	// De-callback the hook memo tier (production client compile). Authored and
 	// auto-generated useMemo/useCallback declarations become inline flat-cache
@@ -14825,6 +14861,7 @@ function transformUniversalParallelUse(ast, ctx, metadata) {
 // Names bound by a binding pattern (params, declarator ids). Mirrors the
 // pattern handling of collectFreeIdentifiers' collectBindings.
 function collectPatternNames(pat, into) {
+	pat = unwrapTsExpr(pat);
 	if (!pat) return into;
 	switch (pat.type) {
 		case 'Identifier':
@@ -16124,8 +16161,61 @@ function isWarmSafeExpr(expr, paramNames, componentLocals, armLocals) {
 	return true;
 }
 
+// The registration records props now and invokes the already-attached module
+// plan only if a descendant suspends. A reassigned parameter would differ from
+// the old thunk's live lexical capture, including writes in JSX expressions or
+// nested callbacks. A same-name write in a shadowed scope merely declines the
+// optimization. Dynamic bindings are conservatively excluded as well.
+function staticChildWarmPlanProps(node, componentName) {
+	const params = node.params || [];
+	if (params.length > 1 || (params.length === 1 && params[0].type !== 'Identifier')) {
+		return null;
+	}
+	const name = params[0]?.name ?? null;
+	if (name === componentName) return null;
+	const seen = new WeakSet();
+	const bindsName = (pattern, binding) => {
+		if (binding === null || pattern === null) return false;
+		if (pattern.type === 'Identifier') return pattern.name === binding;
+		const names = new Set();
+		collectPatternNames(unwrapTsExpr(pattern), names);
+		return names.has(binding);
+	};
+	const unsafe = (value) => {
+		if (value === null || typeof value !== 'object') return false;
+		if (Array.isArray(value)) return value.some(unsafe);
+		if (seen.has(value)) return false;
+		seen.add(value);
+		if (
+			(value.type === 'AssignmentExpression' && bindsName(value.left, name)) ||
+			(value.type === 'UpdateExpression' && bindsName(value.argument, name)) ||
+			(value.type === 'VariableDeclarator' &&
+				(bindsName(value.id, name) || bindsName(value.id, componentName))) ||
+			((value.type === 'FunctionDeclaration' || value.type === 'ClassDeclaration') &&
+				value.id?.name === componentName) ||
+			(value.type === 'CatchClause' && bindsName(value.param, componentName)) ||
+			((value.type === 'ForOfStatement' || value.type === 'ForInStatement') &&
+				bindsName(value.left, name)) ||
+			(value.type === 'CallExpression' &&
+				unwrapTsExpr(value.callee)?.type === 'Identifier' &&
+				unwrapTsExpr(value.callee).name === 'eval') ||
+			(value.type === 'Identifier' && value.name === 'arguments') ||
+			value.type === 'ThisExpression' ||
+			value.type === 'Super' ||
+			value.type === 'MetaProperty'
+		) {
+			return true;
+		}
+		for (const key in value) {
+			if (!AST_WALK_SKIP_KEYS.has(key) && unsafe(value[key])) return true;
+		}
+		return false;
+	};
+	return unsafe(node.body) ? null : name === null ? b.unary('void', b.literal(0, '0')) : b.id(name);
+}
+
 // ── Pass B: run detection + hoist + batch ───────────────────────────────────
-function rewriteParallelUse(statements, ctx, componentName, warmThunk) {
+function rewriteParallelUse(statements, ctx, componentName, warmThunk, staticPlanProps = null) {
 	let firstBatch = true;
 	const output = transformList(statements);
 	if (warmThunk) {
@@ -16137,15 +16227,39 @@ function rewriteParallelUse(statements, ctx, componentName, warmThunk) {
 		// same thunk below so it can still warm before setup reaches this registration.
 		const batchHelper = ctx.mode === 'server' ? 'puBatch' : 'useBatch';
 		const batchAlias = requireRuntimeForContext(ctx, batchHelper);
-		const registration = inheritOriginLoc(
+		const fallback = inheritOriginLoc(
 			b.stmt(b.call(batchAlias, b.array([]), warmThunk)),
 			warmThunk,
 		);
+		let registration = [fallback];
+		if (staticPlanProps !== null) {
+			// Hoisted functions can render before the module-tail markWarm stamp,
+			// and route extraction can leave that stamp behind. Only the common
+			// attached-plan path may omit the in-body closure and array.
+			const planName = allocCompilerName(ctx, '__warmPlan');
+			registration = [
+				inheritOriginLoc(b.const(planName, b.member(b.id(componentName), '__warm')), warmThunk),
+				inheritOriginLoc(
+					b.if(
+						b.binary('===', b.unary('typeof', b.id(planName)), b.literal('function', "'function'")),
+						b.stmt(
+							b.call(
+								requireRuntimeForContext(ctx, 'registerWarmPlan'),
+								b.id(planName),
+								staticPlanProps,
+							),
+						),
+						fallback,
+					),
+					warmThunk,
+				),
+			];
+		}
 		const finalIndex =
 			output.length > 0 && output[output.length - 1].type === 'ReturnStatement'
 				? output.length - 1
 				: output.length;
-		output.splice(finalIndex, 0, registration);
+		output.splice(finalIndex, 0, ...registration);
 	}
 	return output;
 
@@ -16442,7 +16556,19 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 			node,
 		);
 	}
-	return { thunk, warmNode };
+	return {
+		thunk,
+		warmNode,
+		// The module plan contains own creations before child calls. Reuse it
+		// for this component's registration only when it is child-only like the
+		// original thunk; otherwise a descendant suspend could refetch its own
+		// earlier memo. Memoized child props stay on the existing path too.
+		staticChildOnly:
+			warmNode !== null &&
+			thunk !== null &&
+			warmMemos.length === 0 &&
+			warmKids.every((child) => child.props.every((prop) => prop.memo == null)),
+	};
 }
 
 // ===========================================================================

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -255,6 +255,7 @@ export {
 	// Compiler-emitted parallel use(): batched stratum unwrap + fetch-tree
 	// warming (docs/suspense-parallel-use-plan.md).
 	useBatch,
+	registerWarmPlan,
 	seedOrCreate,
 	warmMemo,
 	warmChild,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1147,15 +1147,12 @@ let CURRENT_BLOCK: Block | null = null;
 let CURRENT_EFFECT_RENDER_VERSION = 0;
 let CURRENT_EFFECT_REACHED = 0;
 let NEXT_EFFECT_RENDER_VERSION = 1;
-interface ActiveWarmPlan {
-	block: Block;
-	fn: () => void;
-}
-// Compiler-emitted empty useBatch calls register child-only warm plans on the
-// synchronous component render stack. A descendant's first pending batch runs
-// the active plans while every ancestor frame (and its current props closure)
-// is still live; render entry/exit checkpoints below provide stack discipline.
-const ACTIVE_WARM_PLANS: ActiveWarmPlan[] = [];
+// Compiler-emitted child-only warm plans register on the synchronous component
+// render stack. A descendant's first pending batch runs the active plans while
+// every ancestor frame and its props are still live; render entry/exit
+// checkpoints below provide stack discipline. Flat [block, plan, props] triples
+// avoid allocating a record for every render that has reachable async children.
+const ACTIVE_WARM_PLANS: any[] = [];
 // Warm entries live for exactly one outer render/suspension episode. A retry
 // re-enters with the episode recorded on its block; an ordinary update starts
 // a new one so consumed entries cannot suppress warming after prop changes or
@@ -12519,7 +12516,7 @@ export function useBatch(items: any[], warm?: () => void): void {
 	// the active render stack. It is intentionally lazy — a fully synchronous
 	// tree neither walks its children nor allocates a warm cache.
 	if (items.length === 0) {
-		if (warm !== undefined) ACTIVE_WARM_PLANS.push({ block: CURRENT_BLOCK!, fn: warm });
+		if (warm !== undefined) ACTIVE_WARM_PLANS.push(CURRENT_BLOCK!, warm, undefined);
 		return;
 	}
 	// Hydrating: every use() adopts a server seed synchronously — nothing to
@@ -12554,6 +12551,14 @@ export function useBatch(items: any[], warm?: () => void): void {
 		}
 	});
 	throw new SuspenseException(combined);
+}
+
+/** @internal Compiler-owned registration for a hoisted child-only warm plan. */
+export function registerWarmPlan(fn: (props: any) => void, props: any): void {
+	// This must register before the first descendant suspends, even in an app
+	// that has never warmed. The enclosing render's checkpoint drops the registration
+	// on normal return, suspension, and rollback.
+	ACTIVE_WARM_PLANS.push(CURRENT_BLOCK!, fn, props);
 }
 
 // ── Fetch-tree warming ──────────────────────────────────────────────────────
@@ -12634,10 +12639,10 @@ function recordRealWarmMemo(slot: HookSlot, deps: any[], source: MemoHookEntry):
 	const block = CURRENT_BLOCK;
 	if (block === null) return false;
 	let owner: Block | null = null;
-	for (let i = 0; i < ACTIVE_WARM_PLANS.length; i++) {
-		const plan = ACTIVE_WARM_PLANS[i];
-		if (!blockIsAncestor(plan.block, block)) continue;
-		owner = plan.block;
+	for (let i = 0; i < ACTIVE_WARM_PLANS.length; i += 3) {
+		const planBlock = ACTIVE_WARM_PLANS[i] as Block;
+		if (!blockIsAncestor(planBlock, block)) continue;
+		owner = planBlock;
 		break;
 	}
 	if (owner === null) return false;
@@ -12719,13 +12724,13 @@ function blockIsAncestor(ancestor: Block, block: Block): boolean {
  * adjacent descendants as well as the source branch. */
 function runActiveWarmPlans(local?: () => void): void {
 	const block = CURRENT_BLOCK!;
-	let plans: ActiveWarmPlan[] | null = null;
+	let plans: number[] | null = null;
 	let owner = block;
-	for (let i = 0; i < ACTIVE_WARM_PLANS.length; i++) {
-		const plan = ACTIVE_WARM_PLANS[i];
-		if (!blockIsAncestor(plan.block, block)) continue;
-		(plans ??= []).push(plan);
-		if (plans.length === 1) owner = plan.block;
+	for (let i = 0; i < ACTIVE_WARM_PLANS.length; i += 3) {
+		const planBlock = ACTIVE_WARM_PLANS[i] as Block;
+		if (!blockIsAncestor(planBlock, block)) continue;
+		(plans ??= []).push(i);
+		if (plans.length === 1) owner = planBlock;
 	}
 	if (plans === null && local === undefined) return;
 	runWarm(() => {
@@ -12733,7 +12738,8 @@ function runActiveWarmPlans(local?: () => void): void {
 			for (let i = 0; i < plans.length; i++) {
 				CURRENT_WARM_CLAIMS = new Set();
 				try {
-					plans[i].fn();
+					const index = plans[i];
+					(ACTIVE_WARM_PLANS[index + 1] as (props: any) => void)(ACTIVE_WARM_PLANS[index + 2]);
 				} catch {
 					// Each speculative plan is independent. One throwing getter or
 					// creation must not prevent adjacent plans from warming.

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -1200,6 +1200,190 @@ describe('parallel use() — fetch-tree warming (nested chain)', () => {
 	});
 });
 
+describe('parallel use() — child plans across render attempts', () => {
+	it('starts eight independent descendants before a blocking sibling resolves, again on update', async () => {
+		const children = Array.from({ length: 8 }, (_, index) => `detail-${index}`);
+		const source = `
+			import { use } from 'octane';
+
+			function Gate(props) @{
+				const value = use(props.gate);
+				<span class="plan-gate">{value as string}</span>
+			}
+
+			function Detail(props) @{
+				const value = use(props.load(props.name, props.version));
+				<span class="plan-detail">{value as string}</span>
+			}
+
+			export function Branches(props) @{
+				<main>
+					<Gate gate={props.gate} />
+					${children
+						.map((name) => `<Detail name="${name}" load={props.load} version={props.version} />`)
+						.join('\n')}
+				</main>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'child-plan-eight-descendants.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const calls: string[] = [];
+		const jobs = new Map<string, Deferred<string>>();
+		const load = (name: string, version: number) => {
+			const key = `${name}:${version}`;
+			calls.push(key);
+			const job = deferred<string>();
+			jobs.set(key, job);
+			return job.promise;
+		};
+		const gate = deferred<string>();
+		const root = mount(client.Branches, { gate: gate.promise, load, version: 0 });
+		try {
+			const firstWave = children.map((name) => `${name}:0`);
+			expect(calls).toEqual(firstWave);
+			await act(() => {
+				gate.resolve('ready');
+				for (const key of firstWave) jobs.get(key)!.resolve(key);
+			});
+			expect(root.findAll('.plan-detail').map((node) => node.textContent)).toEqual(firstWave);
+			expect(calls).toEqual(firstWave);
+
+			const nextGate = deferred<string>();
+			root.update(client.Branches, { gate: nextGate.promise, load, version: 1 });
+			const secondWave = children.map((name) => `${name}:1`);
+			expect(calls).toEqual([...firstWave, ...secondWave]);
+			await act(() => {
+				nextGate.resolve('ready');
+				for (const key of secondWave) jobs.get(key)!.resolve(key);
+			});
+			expect(root.findAll('.plan-detail').map((node) => node.textContent)).toEqual(secondWave);
+			expect(calls).toEqual([...firstWave, ...secondWave]);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([
+		['typed direct eval', "(eval as any)('Branches = Other');"],
+		['asserted array assignment', '[Branches!] = [Other];'],
+		['asserted object assignment', '({ value: Branches! } = { value: Other });'],
+	] as const)(
+		'warms a saved component after %s reassigns its module binding',
+		async (_label, reassign) => {
+			const source = `
+			import { use } from 'octane';
+			export const Saved = Branches;
+			function Gate(props) @{
+				const value = use(props.gate);
+				<span>{value as string}</span>
+			}
+			function Detail(props) @{
+				const value = use(props.load(props.name));
+				<span class="saved-plan-detail">{value as string}</span>
+			}
+			function Other(props) @{
+				<main><Gate gate={props.gate} /><Detail load={props.load} name="other" /></main>
+			}
+			function Branches(props) @{
+				<main><Gate gate={props.gate} /><Detail load={props.load} name="original" /></main>
+			}
+			${reassign}
+		`;
+			const client = loadCompiledFixtureSource(source, {
+				id: 'child-plan-saved-binding.tsrx',
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const gate = deferred<string>();
+			const detail = deferred<string>();
+			const calls: string[] = [];
+			const load = (name: string) => {
+				calls.push(name);
+				return detail.promise;
+			};
+			const root = mount(client.Saved, { gate: gate.promise, load });
+			try {
+				expect(calls).toEqual(['original']);
+				await act(() => {
+					gate.resolve('ready');
+					detail.resolve('original result');
+				});
+				expect(root.find('.saved-plan-detail').textContent).toBe('original result');
+				expect(calls).toEqual(['original']);
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it.each([
+		[
+			'reassigned props object',
+			`function Branches(props) @{
+				props = { ...props, version: props.version + 1 };
+				<main><Gate gate={props.gate} /><Detail load={props.load} version={props.version} /></main>
+			}`,
+		],
+		[
+			'reassigned asserted props object',
+			`function Branches(props) @{
+				[props!] = [{ ...props, version: props.version + 1 }];
+				<main><Gate gate={props.gate} /><Detail load={props.load} version={props.version} /></main>
+			}`,
+		],
+		[
+			'reassigned destructured parameter',
+			`function Branches({ gate, load, version }) @{
+				version = version + 1;
+				<main><Gate gate={gate} /><Detail load={load} version={version} /></main>
+			}`,
+		],
+	] as const)(
+		'uses the current values after a %s before warming children',
+		async (description, body) => {
+			const source = `
+			import { use } from 'octane';
+			function Gate(props) @{
+				const value = use(props.gate);
+				<span class="rebound-plan-gate">{value as string}</span>
+			}
+			function Detail(props) @{
+				const value = use(props.load('detail', props.version));
+				<span class="rebound-plan-detail">{value as string}</span>
+			}
+			export ${body}
+		`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `child-plan-${description.replace(/\W+/g, '-')}.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const gate = deferred<string>();
+			const detail = deferred<string>();
+			const calls: number[] = [];
+			const load = (_key: string, version: number) => {
+				calls.push(version);
+				return detail.promise;
+			};
+			const root = mount(client.Branches, { gate: gate.promise, load, version: 0 });
+			try {
+				expect(calls).toEqual([1]);
+				await act(() => {
+					gate.resolve('ready');
+					detail.resolve('detail-v1');
+				});
+				expect(root.find('.rebound-plan-detail').textContent).toBe('detail-v1');
+				expect(calls).toEqual([1]);
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+});
+
 describe('parallel use() — directives in JSX setup values', () => {
 	it('starts each creation once and reuses it across the suspense replay', async () => {
 		const calls: string[] = [];


### PR DESCRIPTION
## Summary

Compiled components with independent same-module children register a warm plan on every render. The old path allocates an empty batch array, a child-plan closure, and a registration object even when the tree renders synchronously.

Reuse the existing attached child-only plan with the current props, and store registrations as flat block/plan/props triples. A descendant's first pending read still starts independent sibling requests, including on later updates.

- Retain lexical plans for own async creations, reassigned props, mutable or shadowed component bindings, and plans that have not been attached yet. Keep SSR and universal-renderer emission on the established path.
- Cover saved hoisted components whose bindings change through typed eval or destructuring, and preserve render-stack cleanup on success, suspension, and rollback.
- Add a patch changeset, production work gates, and documentation. Partial progress on #981; complex warm-plan allocations and memo ancestor walks remain open.

## Performance evidence

Same-machine production Chromium call counts against base `266302ef9`:

| TSRX operation | Empty `useBatch` registrations before | Empty `useBatch` registrations after | Hoisted plan registrations after |
| --- | ---: | ---: | ---: |
| Mount / full update | 2048 | 0 | 2048 |
| Partial update / remount | 62 | 0 | 62 |

Root/partial text writes remain exactly 1024/32; the TSX control uses neither registration helper. The own-promise control retains four batch calls, starts each parent/child resource once, and renders the expected values. Reassignment, local-shadow, context-cache, DOM, and survivor-identity controls pass. Timing is diagnostic only; this PR claims removal of the measured registration work and associated explicit allocations, not a wall-clock speedup.

## Validation

- [x] Current-head [CI run](https://github.com/octanejs/octane/actions/runs/34383634083): all 26 jobs passed. Attempts 1 and 2 hit upstream React input-otp selection and SWR polling controls; their isolated local suites passed (19 and 362 tests), and attempt 3 passed without code changes.
- [x] Scoped `pnpm format:files:check`, source `pnpm typecheck:files`, `git diff --check`, and `pnpm sync`.
- [x] Parallel-use tests: 118 passed across development and production. New saved-binding regressions were observed failing before the guard fix; disabling the new helper also made the eight-request regression fail.
- [x] Focused compiler suites: 867 tests, plus final AST/parser/memo checks: 101 tests.
- [x] Final production recursive-context work gate and TSRX/TSX semantic benchmark.
- [x] Retried HTTP/browser checks with local access: 36 tests passed.
- [x] Full repository `pnpm typecheck`.
- [x] Full Octane development/production test projects: 989 files, 17,514 tests passed (14 expected failures).
- [ ] `pnpm test` — broad sandboxed run interrupted after HTTP/browser access failures and unrelated package failures; the targeted HTTP/browser retry above passed. Repository CI will provide the complete suite result.
- [ ] Repo-wide `pnpm format:check` — scoped formatting used instead.

## Risk / follow-ups

The optimization is deliberately limited to plans proven to contain only child traversal with stable captures. The legacy fallback still allocates its array/closure, and the warm-memo ancestor traversal in #981 is separate work. Registration remains active before any suspension has occurred so first-request parallel discovery is preserved.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791567086&installation_model_id=432790&pr_number=1020&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1020&signature=f6b75306ed17c7166a61123667cee49cd8cb2712e49c60be3606382b036cb216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 18296d007320eb6692230099a233e4e3bf82bca7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->