### PR TITLE
fix: support signals in the website playground

### DIFF
--- a/website/playground-runtime.ts
+++ b/website/playground-runtime.ts
@@ -10,7 +10,7 @@ import type { RuntimeManifest } from './src/lib/playground-sandbox.ts';
 // it into blob modules on its own side of the boundary.
 //
 // The runtime ships as a JSON MANIFEST of esbuild code-split chunks rather
-// than one file: `octane`, its compiler-only client ABI, and `octane/react`
+// than one file: `octane`, its compiler-only client ABI, signals, and `octane/react`
 // are separate entries sharing the core through common chunks. Bundling any
 // entry standalone would duplicate the runtime's hook/context singletons. React
 // itself stays EXTERNAL: the sandbox's import map resolves the react family to
@@ -25,6 +25,8 @@ export async function buildPlaygroundRuntimeManifest(): Promise<RuntimeManifest>
 			octane: require.resolve('octane'),
 			'octane-internal-client': require.resolve('octane/internal/client'),
 			'octane-react': require.resolve('octane/react'),
+			'octane-signals': require.resolve('octane/signals'),
+			'octane-signals-client': require.resolve('octane/signals/client'),
 		},
 		bundle: true,
 		splitting: true,
@@ -83,6 +85,8 @@ export async function buildPlaygroundRuntimeManifest(): Promise<RuntimeManifest>
 			octane: 'octane.mjs',
 			'octane/internal/client': 'octane-internal-client.mjs',
 			'octane/react': 'octane-react.mjs',
+			'octane/signals': 'octane-signals.mjs',
+			'octane/signals/client': 'octane-signals-client.mjs',
 		},
 		order,
 		files,

--- a/website/src/lib/playground-examples.ts
+++ b/website/src/lib/playground-examples.ts
@@ -119,6 +119,77 @@ export default function App() {
 }
 `;
 
+const SIGNALS_TSRX = `import { createScope } from 'octane/signals';
+import { useSignal$ } from 'octane/signals/client';
+
+// Shared state lives outside the component. Derived values track their reads.
+const scope = createScope({ scopeKey: 'playground-signals' });
+const shared$ = scope.signal$('count', 0);
+const doubled$ = scope.derived$('doubled', () => shared$.get() * 2);
+
+export default function App() @{
+	// Each component instance owns its local signal, disposed on unmount.
+	const local$ = useSignal$(10);
+
+	<>
+		<style>
+			.demo {
+				display: grid;
+				gap: 1rem;
+				justify-items: start;
+			}
+			button {
+				padding: 0.4rem 0.9rem;
+				border-radius: 8px;
+				border: 1px solid #8886;
+				background: transparent;
+				color: inherit;
+				cursor: pointer;
+			}
+		</style>
+		<div class="demo">
+			<section>
+				<h2>Shared signal</h2>
+				<button onClick={() => shared$.set((count) => count + 1)}>{'Shared: ' + shared$.get()}</button>
+				<p>{'Doubled: ' + doubled$.get()}</p>
+			</section>
+			<section>
+				<h2>Local signal</h2>
+				<button onClick={() => local$.set((count) => count + 1)}>{'Local: ' + local$.get()}</button>
+			</section>
+		</div>
+	</>
+}
+`;
+
+const SIGNALS_TSX = `import { createScope } from 'octane/signals';
+import { useSignal$ } from 'octane/signals/client';
+
+// Shared state lives outside the component. Derived values track their reads.
+const scope = createScope({ scopeKey: 'playground-signals' });
+const shared$ = scope.signal$('count', 0);
+const doubled$ = scope.derived$('doubled', () => shared$.get() * 2);
+
+export default function App() {
+	// Each component instance owns its local signal, disposed on unmount.
+	const local$ = useSignal$(10);
+
+	return (
+		<div style={{ display: 'grid', gap: '1rem', justifyItems: 'start' }}>
+			<section>
+				<h2>Shared signal</h2>
+				<button onClick={() => shared$.set((count) => count + 1)}>{'Shared: ' + shared$.get()}</button>
+				<p>{'Doubled: ' + doubled$.get()}</p>
+			</section>
+			<section>
+				<h2>Local signal</h2>
+				<button onClick={() => local$.set((count) => count + 1)}>{'Local: ' + local$.get()}</button>
+			</section>
+		</div>
+	);
+}
+`;
+
 const LIST_TSRX = `import { useState } from 'octane';
 
 // Keyed @for reconciliation — rows keep their DOM identity across
@@ -1641,6 +1712,15 @@ export const EXAMPLES: PlaygroundExample[] = [
 		variants: {
 			tsrx: workspace([{ name: 'App.tsrx', source: COUNTER_TSRX }]),
 			tsx: workspace([{ name: 'App.tsx', source: COUNTER_TSX }]),
+		},
+	},
+	{
+		id: 'signals',
+		label: 'Signals',
+		group: 'Basics',
+		variants: {
+			tsrx: workspace([{ name: 'App.tsrx', source: SIGNALS_TSRX }]),
+			tsx: workspace([{ name: 'App.tsx', source: SIGNALS_TSX }]),
 		},
 	},
 	{

--- a/website/src/lib/playground-modules.ts
+++ b/website/src/lib/playground-modules.ts
@@ -11,6 +11,7 @@
 //   octane, octane/react, octane/internal/client, react family → left bare;
 //                         the sandbox import map resolves them (Octane's
 //                         public and compiler-only APIs share local blobs)
+//   octane/signals, octane/signals/client → shared local signal runtime blobs
 //   other octane/*      → error (not available in the playground)
 //   https://esm.sh/*    → allowed verbatim; any other URL → error
 //   any other bare id   → https://esm.sh/<id>?external=octane — `external`
@@ -45,6 +46,8 @@ const IMPORT_MAP_SPECIFIERS = new Set([
 	'octane',
 	'octane/internal/client',
 	'octane/react',
+	'octane/signals',
+	'octane/signals/client',
 	'react',
 	'react/jsx-runtime',
 	'react/jsx-dev-runtime',

--- a/website/src/lib/playground-sandbox.ts
+++ b/website/src/lib/playground-sandbox.ts
@@ -67,7 +67,13 @@ export const PLAYGROUND_REACT_VERSION = '19.2.0';
 
 /** Shape of the runtime manifest built by the playgroundRuntime() vite plugin. */
 export interface RuntimeManifest {
-	entries: { octane: string; 'octane/internal/client': string; 'octane/react': string };
+	entries: {
+		octane: string;
+		'octane/internal/client': string;
+		'octane/react': string;
+		'octane/signals': string;
+		'octane/signals/client': string;
+	};
 	order: string[];
 	files: Record<string, string>;
 }
@@ -145,6 +151,8 @@ window.addEventListener('message', async (event) => {
 					octane: blobs[entries['octane']],
 					'octane/internal/client': blobs[entries['octane/internal/client']],
 					'octane/react': blobs[entries['octane/react']],
+					'octane/signals': blobs[entries['octane/signals']],
+					'octane/signals/client': blobs[entries['octane/signals/client']],
 					react: esm('react@' + REACT_VERSION),
 					'react/jsx-runtime': esm('react@' + REACT_VERSION + '/jsx-runtime'),
 					'react/jsx-dev-runtime': esm('react@' + REACT_VERSION + '/jsx-dev-runtime'),

--- a/website/tests/playground-modules.test.ts
+++ b/website/tests/playground-modules.test.ts
@@ -143,6 +143,22 @@ describe('third-party import policy', () => {
 		);
 	});
 
+	it.each(['octane/signals', 'octane/signals/client'])(
+		'keeps %s available through the sandbox import map',
+		async (specifier) => {
+			const graph = await buildModuleGraph(
+				[app(`import * as signals from '${specifier}'; export const value = signals;`)],
+				APP,
+			);
+			expect(graph.ok).toBe(true);
+			if (!graph.ok) return;
+			const { init, parse } = await import('es-module-lexer');
+			await init;
+			const [imports] = parse(graph.modules[0].code);
+			expect(imports.map((entry) => entry.n)).toContain(specifier);
+		},
+	);
+
 	it('allows verbatim esm.sh URLs but no other URL imports', async () => {
 		const ok = await buildModuleGraph(
 			[app("import x from 'https://esm.sh/canvas-confetti';\nexport const y = x;")],
@@ -157,7 +173,12 @@ describe('third-party import policy', () => {
 	});
 
 	it('rejects octane subpaths the sandbox does not provide', async () => {
-		for (const specifier of ['octane/compiler', 'octane/internal/server', 'octane/not-provided']) {
+		for (const specifier of [
+			'octane/compiler',
+			'octane/internal/server',
+			'octane/signals/server',
+			'octane/not-provided',
+		]) {
 			const graph = await buildModuleGraph(
 				[app(`import * as unavailable from '${specifier}'; export const value = unavailable;`)],
 				APP,

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -2600,7 +2600,7 @@ describe(
 							name: 'App.tsrx',
 							source: `import { createScope } from 'octane/signals';
 import { useSignal$ } from 'octane/signals/client';
-const scope = createScope();
+const scope = createScope({ scopeKey: 'shared' });
 const shared$ = scope.signal$('count', 0);
 export default function App() @{
 	const local$ = useSignal$(10);

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -2590,42 +2590,26 @@ describe(
 		);
 
 		it.concurrent(
-			'playground runs shared and component-local signals in its sandbox',
+			'playground runs the Signals example selected from the dropdown',
 			async () => {
-				const hash = encodePlaygroundHash({
-					lang: 'tsrx',
-					entry: 'App.tsrx',
-					files: [
-						{
-							name: 'App.tsrx',
-							source: `import { createScope } from 'octane/signals';
-import { useSignal$ } from 'octane/signals/client';
-const scope = createScope({ scopeKey: 'shared' });
-const shared$ = scope.signal$('count', 0);
-export default function App() @{
-	const local$ = useSignal$(10);
-	<div>
-		<button onClick={() => shared$.set(shared$.get() + 1)}>{'Shared: ' + shared$.get()}</button>
-		<button onClick={() => local$.set(local$.get() + 1)}>{'Local: ' + local$.get()}</button>
-	</div>
-}`,
-						},
-					],
-				});
-				const { page, errors } = await loadRoute(PREVIEW_ORIGIN, `/playground#${hash}`);
+				const { page, errors } = await loadRoute(PREVIEW_ORIGIN, '/playground');
 				try {
 					await page.waitForSelector('.pg-grid.ready', { timeout: PLAYWRIGHT_ACTION_TIMEOUT });
-					await page.click('.pg-consent-run');
+					await page.selectOption('.pg-select', 'signals');
 					const preview = page.frameLocator('iframe[title="Playground preview"]');
 					const shared = preview.getByRole('button', { name: 'Shared:' });
 					const local = preview.getByRole('button', { name: 'Local:' });
 					await waitForLocatorText(shared, 'Shared: 0');
 					await waitForLocatorText(local, 'Local: 10');
+					const doubled = preview.locator('p');
+					await waitForLocatorText(doubled, 'Doubled: 0');
 					await shared.click();
 					await waitForLocatorText(shared, 'Shared: 1');
+					await waitForLocatorText(doubled, 'Doubled: 2');
 					await local.click();
 					await waitForLocatorText(local, 'Local: 11');
 					await waitForLocatorText(shared, 'Shared: 1');
+					await waitForLocatorText(doubled, 'Doubled: 2');
 					expect(errors).toEqual([]);
 				} finally {
 					await page.close();

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -2590,6 +2590,51 @@ describe(
 		);
 
 		it.concurrent(
+			'playground runs shared and component-local signals in its sandbox',
+			async () => {
+				const hash = encodePlaygroundHash({
+					lang: 'tsrx',
+					entry: 'App.tsrx',
+					files: [
+						{
+							name: 'App.tsrx',
+							source: `import { createScope } from 'octane/signals';
+import { useSignal$ } from 'octane/signals/client';
+const scope = createScope();
+const shared$ = scope.signal$('count', 0);
+export default function App() @{
+	const local$ = useSignal$(10);
+	<div>
+		<button onClick={() => shared$.set(shared$.get() + 1)}>{'Shared: ' + shared$.get()}</button>
+		<button onClick={() => local$.set(local$.get() + 1)}>{'Local: ' + local$.get()}</button>
+	</div>
+}`,
+						},
+					],
+				});
+				const { page, errors } = await loadRoute(PREVIEW_ORIGIN, `/playground#${hash}`);
+				try {
+					await page.waitForSelector('.pg-grid.ready', { timeout: PLAYWRIGHT_ACTION_TIMEOUT });
+					await page.click('.pg-consent-run');
+					const preview = page.frameLocator('iframe[title="Playground preview"]');
+					const shared = preview.getByRole('button', { name: 'Shared:' });
+					const local = preview.getByRole('button', { name: 'Local:' });
+					await waitForLocatorText(shared, 'Shared: 0');
+					await waitForLocatorText(local, 'Local: 10');
+					await shared.click();
+					await waitForLocatorText(shared, 'Shared: 1');
+					await local.click();
+					await waitForLocatorText(local, 'Local: 11');
+					await waitForLocatorText(shared, 'Shared: 1');
+					expect(errors).toEqual([]);
+				} finally {
+					await page.close();
+				}
+			},
+			45_000,
+		);
+
+		it.concurrent(
 			'playground runs the OctaneCompat React-host example end to end',
 			async () => {
 				const { page, errors } = await loadRoute(PREVIEW_ORIGIN, '/playground', {


### PR DESCRIPTION
## Summary

The playground rejected `octane/signals` and `octane/signals/client` as unavailable. Bundle both entries alongside the existing runtime, allow their imports, and map them to sandbox-local blobs so signal hooks share the preview's runtime singleton.

Add a Signals example under Basics in both TSRX and TSX, demonstrating shared state, a derived value, and a component-local signal. Import-policy regressions cover both entry points, and the browser scenario selects the actual example from the dropdown and checks its interactive values.

## Validation

- [x] Targeted playground tests: 46 passed across `playground-modules.test.ts`, `playground-runtime.test.ts`, and `playground.test.ts` (`website-unit`). Both new import tests failed before the fix with the reported rejection.
- [x] Scoped `tsrx-tsc` check for the five changed files, including the browser harness declaration file.
- [x] Formatting check for all changed files.
- [x] `pnpm sync`.
- Full repository tests and typechecking were not run locally. The new browser scenario was added but its local run was stopped before completion at the user's request; CI will validate it.

- [x] Signals example checks: 5 passed (`playground-examples.test.ts -t signals`).
- [x] Focused Chromium smoke check using the actual preview engine and sandbox: both TSRX and TSX variants render and update shared, derived, and local signals. The full website dropdown scenario remains for CI.
- [x] Scoped typecheck and formatting for the example and updated browser test.

## Risk / follow-ups

The playground runtime manifest grows from 127,533 to 137,338 gzip bytes (+9,805 bytes), measured consistently across three builds of each version. Both entries use the existing code-split bundle; no core runtime or compiler source changes.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791569675&installation_model_id=432790&pr_number=1021&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1021&signature=d452742b72c25534dee1c735a588be0291d77d7eb1110c9cd7c3d702e6dea00e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to website playground bundling, import policy, and examples; sandbox boundary rules are tightened with tests and no auth or data-path changes.
> 
> **Overview**
> The website playground now supports **`octane/signals`** and **`octane/signals/client`** instead of rejecting those imports.
> 
> The playground runtime build adds both as code-split esbuild entries (alongside `octane`, `octane/react`, etc.), and the sandbox **import map** wires them to the same local blob singletons as the rest of the runtime. The module graph allowlist and docs comments are updated so only client signal entry points pass the security boundary (`octane/signals/server` stays blocked).
> 
> A new **Signals** Basics example (`createScope`, shared/derived signals, `useSignal$`) is in the dropdown in TSRX and TSX. Unit tests assert bare specifiers for the two paths; a Playwright scenario selects that example and checks shared, derived, and local counters update on click.
> 
> The shipped runtime manifest grows by ~10KB gzip; no changes to core Octane compiler packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ceb3e82e74c777dae06f72c14e6a1b6b2e45892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->