### PR TITLE
perf: avoid empty effect argument arrays

### DIFF
--- a/.changeset/effect-empty-arguments.md
+++ b/.changeset/effect-empty-arguments.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid temporary argument arrays when running effects without dependency arguments.

--- a/benchmarks/effectful-list/README.md
+++ b/benchmarks/effectful-list/README.md
@@ -199,3 +199,29 @@ output (median/min/p95/sd per op per target).
   plain arrays, which is extra work octane/react/ripple don't do on the items
   ops (it's the idiomatic solid pattern for externally-produced immutable
   data, same as the dbmon bench).
+
+## Dispatch argument allocation guard
+
+```bash
+node benchmarks/effectful-list/dispatch.mjs
+node benchmarks/effectful-list/dispatch.mjs <baseline-git-ref>
+BENCH_JSON=/tmp/effect-dispatch.json node benchmarks/effectful-list/dispatch.mjs <baseline-git-ref>
+```
+
+This untimed companion extracts the actual `runEffectBody` declaration by
+TypeScript AST and compiles its production branch. It dispatches 1,000 effects
+in each of the three effect phases, with omitted arguments, an explicit empty
+array, and three explicit values. Separate clean and observed executions must
+agree on callback arguments and receiver, cleanup delivery, and exception
+handling. Stale revisions, disconnected bodies, and superseded publications
+are skipped. The default guard requires zero argument-array creation events;
+`--measure` records historical implementations without enforcing that ceiling.
+
+The observer runs after production transformation and counts source array-literal
+creation events inside this helper. Its collaborators are boundary stubs; the
+fixture and observer allocations are excluded. The existing browser workload
+and runtime tests cover lifecycle integration. These numbers do not measure
+heap allocation, garbage collection, or end-user latency: an optimizing engine
+may already remove a short-lived empty array. The JSON records Node/V8 versions
+and runtime/helper hashes; a paired run uses the same fixture and toolchain.
+The explicit-array cases are negative controls and must remain at zero.

--- a/benchmarks/effectful-list/dispatch.mjs
+++ b/benchmarks/effectful-list/dispatch.mjs
@@ -1,0 +1,198 @@
+// Untimed work guard for the actual production effect-dispatch helper. Runtime
+// source is extracted by AST; fixture callbacks and observer work are excluded.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { COUNTER_GLOBAL, emptyCounters, instrumentJavaScript } from '../hook-memo/instrument.mjs';
+
+const repo = path.resolve(import.meta.dirname, '../..');
+const requireDependencies = createRequire(
+	path.join(process.env.OCTANE_EFFECT_EXTERNAL_ROOT || repo, 'packages/octane/package.json'),
+);
+const ts = requireDependencies('typescript');
+const { transformSync } = requireDependencies('esbuild');
+const { parseModule, builders } = requireDependencies('@tsrx/core');
+const { print: printAst } = requireDependencies('esrap');
+const tsx = requireDependencies('esrap/languages/tsx').default;
+const file = 'packages/octane/src/runtime.ts';
+const measureOnly = process.argv.includes('--measure');
+const baselineRef = process.argv.slice(2).find((arg) => !arg.startsWith('--'));
+const count = 1000;
+const sha256 = (source) => createHash('sha256').update(source).digest('hex');
+
+function productionHelper(source) {
+	const ast = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	const helper = ast.statements.find(
+		(node) => ts.isFunctionDeclaration(node) && node.name?.text === 'runEffectBody',
+	);
+	assert.ok(helper, 'effect-dispatch helper is present');
+	return transformSync(helper.getText(ast), {
+		loader: 'ts',
+		define: { 'process.env.NODE_ENV': '"production"' },
+		minifySyntax: true,
+	}).code;
+}
+
+function instantiate(code) {
+	// These collaborators form the helper boundary. Full scheduling, cleanup
+	// ordering, rendering, and error-boundary behavior belong to the runtime
+	// suites and the existing effectful-list browser benchmark.
+	return Function(`"use strict";
+		let CURRENT_EFFECT_PHASE = -1;
+		let EFFECT_BODY_DEPTH = 0;
+		const errors = [];
+		class MaximumUpdateDepthError extends Error {}
+		function nativeEffectPublicationCurrent(entry) { return entry.current !== false; }
+		function reportEffectError(block, error) { errors.push({ block, error }); }
+		${code}
+		return { run: runEffectBody, errors, MaximumUpdateDepthError,
+			phase: () => CURRENT_EFFECT_PHASE, depth: () => EFFECT_BODY_DEPTH };
+	`)();
+}
+
+function workload(code, argsKind) {
+	const runtime = instantiate(code);
+	const snapshot = { calls: 0, cleanups: 0, argumentValues: 0 };
+	const token = {};
+	for (let phase = 0; phase < 3; phase++) {
+		for (let index = 0; index < count; index++) {
+			const args =
+				argsKind === 'omitted' ? undefined : argsKind === 'empty' ? [] : [index, token, undefined];
+			const slotKey = Symbol();
+			const slot = { revision: 1, cleanup: undefined };
+			const scope = { block: {}, hooks: new Map([[slotKey, slot]]) };
+			const cleanup = () => snapshot.cleanups++;
+			function body() {
+				assert.equal(this, null);
+				assert.equal(runtime.phase(), phase);
+				assert.equal(runtime.depth(), 1);
+				if (argsKind === 'values') {
+					assert.equal(arguments.length, 3);
+					assert.equal(arguments[0], index);
+					assert.equal(arguments[1], token);
+					assert.equal(arguments[2], undefined);
+					snapshot.argumentValues += arguments[0];
+				} else assert.equal(arguments.length, 0);
+				snapshot.calls++;
+				return cleanup;
+			}
+			const entry = { fn: body, args, slot: slotKey, revision: 1, scope, phase };
+			runtime.run(entry);
+			assert.equal(runtime.phase(), -1);
+			assert.equal(runtime.depth(), 0);
+			assert.equal(slot.cleanup, cleanup);
+			slot.cleanup();
+			// Stale revisions, disconnected bodies, and superseded publications
+			// must neither invoke a callback nor create its argument fallback.
+			runtime.run({ ...entry, revision: 0 });
+			runtime.run({ ...entry, fn: null });
+			runtime.run({ ...entry, current: false });
+		}
+	}
+	assert.equal(snapshot.calls, count * 3);
+	assert.equal(snapshot.cleanups, count * 3);
+	assert.equal(runtime.errors.length, 0);
+	assert.equal(snapshot.argumentValues, argsKind === 'values' ? (count * (count - 1) * 3) / 2 : 0);
+	return snapshot;
+}
+
+function errorControls(code) {
+	const runtime = instantiate(code);
+	const slotKey = Symbol();
+	const slot = { revision: 1 };
+	const block = {};
+	const entry = {
+		args: undefined,
+		phase: 2,
+		revision: 1,
+		slot: slotKey,
+		scope: { block, hooks: new Map([[slotKey, slot]]) },
+	};
+	const error = new Error('effect failure');
+	runtime.run({
+		...entry,
+		fn() {
+			throw error;
+		},
+	});
+	assert.deepEqual(runtime.errors, [{ block, error }]);
+	assert.equal(slot.cleanup, undefined);
+	assert.equal(runtime.phase(), -1);
+	assert.equal(runtime.depth(), 0);
+	const depthError = new runtime.MaximumUpdateDepthError();
+	assert.throws(
+		() =>
+			runtime.run({
+				...entry,
+				fn() {
+					throw depthError;
+				},
+			}),
+		(actual) => actual === depthError,
+	);
+	assert.equal(runtime.phase(), -1);
+	assert.equal(runtime.depth(), 0);
+}
+
+function measure(source) {
+	const clean = productionHelper(source);
+	const observed = instrumentJavaScript(clean, file, 'runtime', {
+		parseModule,
+		builders,
+		print: (ast) => printAst(ast, tsx()).code,
+	});
+	const cases = {};
+	for (const name of ['omitted', 'empty', 'values']) {
+		const expected = workload(clean, name);
+		globalThis[COUNTER_GLOBAL] = emptyCounters();
+		assert.deepEqual(workload(observed, name), expected, 'observer preserves callback behavior');
+		cases[name] = {
+			...expected,
+			emptyArrayCreations: globalThis[COUNTER_GLOBAL].runtime_arrayLiterals,
+		};
+	}
+	errorControls(clean);
+	errorControls(observed);
+	delete globalThis[COUNTER_GLOBAL];
+	return { sourceHash: sha256(source), helperHash: sha256(clean), cases };
+}
+
+const result = {
+	suite: 'effect-dispatch',
+	metric: 'source array-literal creation events in the production dispatch helper',
+	node: process.version,
+	v8: process.versions.v8,
+	effectsPerCase: count * 3,
+	candidate: measure(readFileSync(path.join(repo, file), 'utf8')),
+};
+if (baselineRef) {
+	result.baselineRef = baselineRef;
+	result.baseline = measure(
+		execFileSync('git', ['show', `${baselineRef}:${file}`], {
+			cwd: repo,
+			encoding: 'utf8',
+			maxBuffer: 8 * 1024 * 1024,
+		}),
+	);
+	for (const name of ['omitted', 'empty', 'values']) {
+		const { emptyArrayCreations: before, ...beforeBehavior } = result.baseline.cases[name];
+		const { emptyArrayCreations: after, ...afterBehavior } = result.candidate.cases[name];
+		assert.deepEqual(afterBehavior, beforeBehavior);
+		console.log(`${name}: ${result.effectsPerCase} effects; array creations ${before} → ${after}`);
+	}
+} else console.log(JSON.stringify(result.candidate.cases, null, 2));
+if (process.env.BENCH_JSON)
+	writeFileSync(process.env.BENCH_JSON, JSON.stringify(result, null, 2) + '\n');
+if (!measureOnly) {
+	for (const [name, scenario] of Object.entries(result.candidate.cases)) {
+		assert.equal(
+			scenario.emptyArrayCreations,
+			0,
+			`${name}: dispatch must not create argument arrays`,
+		);
+	}
+}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6362,9 +6362,9 @@ function runEffectBody(e: PendingEffect): void {
 		EFFECT_BODY_DEPTH++;
 		try {
 			// Spread deps as positional args (see PendingEffect.args). A no-deps
-			// effect has args === undefined, so the body is called with zero args.
+			// effect has args === undefined, which apply accepts as zero arguments.
 			// eslint-disable-next-line prefer-spread
-			cleanup = e.fn.apply(null, (e.args ?? []) as []);
+			cleanup = e.fn.apply(null, e.args as []);
 		} finally {
 			EFFECT_BODY_DEPTH--;
 			CURRENT_EFFECT_PHASE = previousPhase;

--- a/packages/octane/tests/_fixtures/hooks.tsrx
+++ b/packages/octane/tests/_fixtures/hooks.tsrx
@@ -208,3 +208,10 @@ export function EffectAlways(props) @{
 	useEffect(() => props.cb(props.n), null);
 	<span>{props.n as string}</span>
 }
+
+export function EffectArguments(props) @{
+	useInsertionEffect(props.insertion, props.deps);
+	useLayoutEffect(props.layout, props.deps);
+	useEffect(props.passive, props.deps);
+	<span>{props.label as string}</span>
+}

--- a/packages/octane/tests/hooks.test.ts
+++ b/packages/octane/tests/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { act, mount, nextPaint } from './_helpers';
+import { act, mount, nextPaint, flushEffects } from './_helpers';
 import { flushSync, startTransition } from '../src/index.js';
 import {
 	LazyInit,
@@ -21,6 +21,7 @@ import {
 	EffectDeps,
 	CustomEffectDeps,
 	EffectAlways,
+	EffectArguments,
 	LayoutVsEffect,
 } from './_fixtures/hooks.tsrx';
 
@@ -382,5 +383,79 @@ describe('three-phase effect pipeline', () => {
 		await nextPaint();
 		expect(order).toEqual(['i', 'l', 'e']);
 		r.unmount();
+	});
+
+	describe.each<{ label: string; deps: unknown[] | null | undefined }>([
+		{ label: 'undefined dependencies', deps: undefined },
+		{ label: 'null dependencies', deps: null },
+		{ label: 'empty dependencies', deps: [] },
+		{ label: 'one dependency', deps: [1] },
+		{ label: 'two dependencies', deps: [1, 'two'] },
+		{ label: 'three dependencies', deps: [1, 'two', null] },
+		{ label: 'four dependencies', deps: [1, 'two', null, undefined] },
+	])('$label', ({ deps }) => {
+		it('passes positional values with a null receiver and retains each setup’s cleanup', () => {
+			const phases = ['insertion', 'layout', 'passive'] as const;
+			type Phase = (typeof phases)[number];
+			const logs: Record<Phase, unknown[]> = { insertion: [], layout: [], passive: [] };
+			const propsFor = (dependencies: unknown[] | null | undefined, version: number) => {
+				const callbackFor = (phase: Phase) =>
+					function (this: unknown, ...args: unknown[]) {
+						logs[phase].push(['setup', version, this, args]);
+						return () => {
+							logs[phase].push(['cleanup', version, args]);
+						};
+					};
+				return {
+					deps: dependencies,
+					label: String(version),
+					insertion: callbackFor('insertion'),
+					layout: callbackFor('layout'),
+					passive: callbackFor('passive'),
+				};
+			};
+			const firstArgs = deps ?? [];
+			const r = mount(EffectArguments, propsFor(deps, 1));
+			flushEffects();
+			for (const phase of phases) {
+				expect(logs[phase]).toEqual([['setup', 1, null, firstArgs]]);
+			}
+
+			const nextDeps = deps?.map((_, index) => `updated-${index}`) ?? deps;
+			const nextArgs = nextDeps ?? [];
+			const repeats = deps == null || deps.length > 0;
+			r.update(EffectArguments, propsFor(nextDeps, 2));
+			flushEffects();
+			expect(r.find('span').textContent).toBe('2');
+			for (const phase of phases) {
+				expect(logs[phase]).toEqual(
+					repeats
+						? [
+								['setup', 1, null, firstArgs],
+								['cleanup', 1, firstArgs],
+								['setup', 2, null, nextArgs],
+							]
+						: [['setup', 1, null, firstArgs]],
+				);
+			}
+
+			r.unmount();
+			flushEffects();
+			for (const phase of phases) {
+				expect(logs[phase]).toEqual(
+					repeats
+						? [
+								['setup', 1, null, firstArgs],
+								['cleanup', 1, firstArgs],
+								['setup', 2, null, nextArgs],
+								['cleanup', 2, nextArgs],
+							]
+						: [
+								['setup', 1, null, firstArgs],
+								['cleanup', 1, firstArgs],
+							],
+				);
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Pass the existing effect argument value directly to `Function.prototype.apply`. An undefined argument list already means zero callback arguments, so no temporary empty array is needed.
- Preserve the null callback receiver, explicit positional dependency values, current callbacks, and their paired cleanups across insertion, layout, and passive effects.
- Add a production helper allocation guard and a patch changeset for `octane`.

Partially addresses #981's effect-dispatch item. Hook-map membership checks remain necessary for cleared or rolled-back slots; this PR does not change those checks or specialize callback arities.

## Performance evidence

Baseline: merged main `9b17f4e2899e1bec886e8577197d40429f006c48`. Same Node 26.4.0 / V8 14.6.202.34-node.21, production transform, workload, and observer for both revisions:

```sh
BENCH_JSON=/tmp/effect-dispatch.json node benchmarks/effectful-list/dispatch.mjs 9b17f4e
```

| Argument list | Effects | Source array creations before | After |
| --- | ---: | ---: | ---: |
| Omitted | 3,000 | 3,000 | 0 |
| Explicit empty array | 3,000 | 0 | 0 |
| Three explicit values | 3,000 | 0 | 0 |

The guard extracts the actual runtime helper by AST and observes it after production transformation. Clean and observed runs agree on callback arguments/receiver, cleanup, phase/depth restoration, stale-entry rejection, and errors. The zero-array guard fails on the baseline. These are source array-creation events at the helper boundary, not measured heap allocations or application latency: an optimizing engine may already eliminate the temporary array.

Both rebuilt production `effectful-list` fixtures (TSRX and TSX) also passed all six existing lifecycle/DOM gates with three iterations. Their explicit dependency arrays are negative controls; no timing improvement is claimed.

## Validation

- [x] Targeted runtime suite: **22 files, 218 tests passed**, including dev/prod hooks, conditional hooks, effect dispatch/timing/order/deletion, insertion effects, error handling, Suspense effects, and deferred/production hydration.
- [x] New behavior matrix: undefined, null, empty, and 1–4 dependency values across all three phases. Deliberately replacing the null receiver with undefined made all **14 new dev/prod cases fail**, then the implementation was restored and final tests passed.
- [x] `pnpm typecheck:files packages/octane/src/runtime.ts`
- [x] Scoped `pnpm format:files:check` for all six changed files and `git diff --check`
- [x] `pnpm sync` (no generated changes)
- [x] Paired dispatch work guard and production TSRX/TSX browser lifecycle controls
- Full repository `pnpm test`, `pnpm typecheck`, and `pnpm format:check` were not run locally for this bounded runtime change. [Current-head CI](https://github.com/octanejs/octane/actions/runs/34389491182) passed **all 26 jobs** on `9fe7ce2f9198500f4af9d678797b0f0421c5fdad`, including lint, typechecking, all runtime and React parity shards, browser integration, package validation, and examples. Cursor Bugbot completed successfully with no findings; there are no review threads to resolve.

## Risk / follow-ups

The runtime change adds no state, caches, branching, or retained references. Existing slot/publication guards, exception routing, and cleanup handling are unchanged. SSR does not execute effect bodies. Independent diff review found no correctness issues. The remaining effect-dispatch ideas in #981 need separate correctness and performance evidence.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791570639&installation_model_id=432790&pr_number=1023&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1023&signature=856d4b0a4d0f22af52257ad2137079cf7f3bdeffee8431a32b1e8fb96f46ca57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line runtime dispatch change with broad new tests and a regression guard; no auth, data, or scheduling logic changes beyond argument passing semantics.
> 
> **Overview**
> **Effect dispatch** no longer allocates a temporary empty array when an effect has no dependency list: `runEffectBody` passes `e.args` straight into `apply` instead of `(e.args ?? [])`, relying on `undefined` meaning zero positional arguments.
> 
> Adds an **untimed allocation guard** (`benchmarks/effectful-list/dispatch.mjs`) that AST-extracts the production `runEffectBody`, instruments array literals, and asserts zero creations for omitted/empty/value dependency cases (with optional baseline compare). Documents it in the effectful-list README and records an **octane patch** changeset.
> 
> **Tests** add `EffectArguments` and a matrix over undefined/null/empty and 1–4 deps for insertion, layout, and passive effects—checking null `this`, positional args, cleanup pairing, and re-fire rules (empty `[]` does not re-run on update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe7ce2f9198500f4af9d678797b0f0421c5fdad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->