### PR TITLE
perf: skip warm cache scans in new render episodes

### DIFF
--- a/.changeset/skip-stale-warm-cache-walks.md
+++ b/.changeset/skip-stale-warm-cache-walks.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Skip ancestor cache searches for memo values when a new render cannot match any prefetched cache, while preserving suspended retries and transition resource reuse.

--- a/benchmarks/recursive-context/README.md
+++ b/benchmarks/recursive-context/README.md
@@ -220,3 +220,30 @@ not wall-time pass/fail gates.
 
 Default: 10 warmups + 20 iters. Pass an integer to `bench` to override iters
 (`bench:long` runs 40).
+
+## Warm-cache ancestor work
+
+`pnpm --dir benchmarks/recursive-context bench:warm-adoption` builds a dedicated
+production entry and starts a preview on an ephemeral localhost port. The main
+`bench:work` pass runs the same guard using its existing preview and browser.
+The fixture mounts and updates a chain of ordinary synchronous custom-hook
+`useMemo` values after an unrelated async root has warmed and unmounted. Every
+value and surviving DOM node is checked. A fresh realm with no warming is the
+zero-work control; a pending parent/child resource pair checks the
+live warm-cache path, concurrent starts, final values, and one creation per
+resource through retry.
+
+The untimed runner enables detailed Chromium coverage on unminified production
+output. It finds `adoptWarmEntry`'s parent-property read through the emitted AST
+and uses the narrowest enclosing coverage range to count actual parent steps.
+No probes are inserted into authored components or runtime source. At depths
+32 and 128 (33 and 129 memo values), the baseline performs 1,089 and 16,641
+parent steps on both mount and update after unrelated warming. The guard
+requires zero steps while retaining all 33/129 adoption calls. The pending
+retry must still perform one warm-cache probe and one or two parent steps.
+
+`BENCH_JSON` records operation counts and source/helper hashes. Use `--measure`
+with the standalone runner to record historical implementations without the
+zero-parent-step ceiling. This measures ancestor lookup work, not total render
+cost or end-user latency; compiler and scheduler work outside the helper remains
+covered by the existing recursive-context suites.

--- a/benchmarks/recursive-context/octane-tsrx/src/WarmAdoptionControl.tsrx
+++ b/benchmarks/recursive-context/octane-tsrx/src/WarmAdoptionControl.tsrx
@@ -1,0 +1,13 @@
+import { useOrdinaryMemo } from './warm-adoption-memo.js';
+
+type Props = { depth: number; version: number };
+
+export default function WarmAdoptionControl(props: Props) @{
+	const value = useOrdinaryMemo(props.version, props.depth);
+	<div>
+		<span class="memo-value" data-depth={props.depth}>{value as string}</span>
+		@if (props.depth > 0) {
+			<WarmAdoptionControl depth={props.depth - 1} version={props.version} />
+		}
+	</div>
+}

--- a/benchmarks/recursive-context/octane-tsrx/src/warm-adoption-main.js
+++ b/benchmarks/recursive-context/octane-tsrx/src/warm-adoption-main.js
@@ -1,0 +1,111 @@
+import { createRoot, flushSync } from 'octane';
+import WarmAdoptionControl from './WarmAdoptionControl.tsrx';
+import WarmPlanControl from './WarmPlanControl.tsrx';
+
+const container = document.getElementById('main');
+const warmContainer = document.getElementById('warm');
+let root;
+let warmRoot;
+let depth;
+let version;
+let mounted;
+let starts;
+let resolvers;
+
+function waitForWarmResult() {
+	if (warmContainer.querySelector('#warm-child')?.textContent === 'child:1')
+		return Promise.resolve();
+	return new Promise((resolve, reject) => {
+		const observer = new MutationObserver(() => {
+			if (warmContainer.querySelector('#warm-child')?.textContent !== 'child:1') return;
+			observer.disconnect();
+			clearTimeout(timeout);
+			resolve();
+		});
+		const timeout = setTimeout(() => {
+			observer.disconnect();
+			reject(new Error('warm resource control did not settle'));
+		}, 2000);
+		observer.observe(warmContainer, { childList: true, subtree: true, characterData: true });
+	});
+}
+
+function verifyWarmResult() {
+	if (
+		warmContainer.querySelector('#warm-parent')?.textContent !== 'parent:1' ||
+		warmContainer.querySelector('#warm-child')?.textContent !== 'child:1'
+	)
+		throw new Error('warm result lost');
+	if (starts.parent !== 1 || starts.child !== 1)
+		throw new Error(`resources started ${starts.parent}/${starts.child} times`);
+}
+
+window.__primeWarm = async () => {
+	starts = { parent: 0, child: 0 };
+	warmRoot = createRoot(warmContainer);
+	warmRoot.render(WarmPlanControl, {
+		version: 1,
+		load(name, version) {
+			starts[name]++;
+			return Promise.resolve(`${name}:${version}`);
+		},
+	});
+	await waitForWarmResult();
+	verifyWarmResult();
+	warmRoot.unmount();
+	if (warmContainer.childNodes.length !== 0) throw new Error('prime root did not unmount');
+};
+window.__mountDeep = (nextDepth) => {
+	depth = nextDepth;
+	version = 0;
+	root = createRoot(container);
+	root.render(WarmAdoptionControl, { depth, version });
+	mounted = [...container.querySelectorAll('.memo-value')];
+};
+window.__updateDeep = () => {
+	version++;
+	flushSync(() => root.render(WarmAdoptionControl, { depth, version }));
+};
+window.__verifyDeep = () => {
+	const values = [...container.querySelectorAll('.memo-value')];
+	if (values.length !== depth + 1) throw new Error('deep memo values missing');
+	for (let index = 0; index < values.length; index++) {
+		const expectedDepth = depth - index;
+		if (
+			values[index] !== mounted[index] ||
+			values[index].dataset.depth !== String(expectedDepth) ||
+			values[index].textContent !== `${version}:${expectedDepth}`
+		)
+			throw new Error('memo value or identity changed');
+	}
+};
+window.__unmountDeep = () => {
+	root.unmount();
+	if (container.childNodes.length !== 0) throw new Error('deep root did not unmount');
+};
+window.__mountPendingWarm = () => {
+	starts = { parent: 0, child: 0 };
+	resolvers = [];
+	warmRoot = createRoot(warmContainer);
+	warmRoot.render(WarmPlanControl, {
+		version: 1,
+		load(name, version) {
+			starts[name]++;
+			return new Promise((resolve) => resolvers.push(() => resolve(`${name}:${version}`)));
+		},
+	});
+	if (starts.parent !== 1 || starts.child !== 1)
+		throw new Error('independent resources did not start together');
+	if (warmContainer.querySelector('#warm-pending')?.textContent !== 'waiting')
+		throw new Error('pending UI missing');
+};
+window.__resolvePendingWarm = async () => {
+	for (const resolve of resolvers) resolve();
+	await waitForWarmResult();
+};
+window.__verifyPendingWarm = () => {
+	verifyWarmResult();
+	warmRoot.unmount();
+	if (warmContainer.childNodes.length !== 0) throw new Error('warm root did not unmount');
+};
+window.__ready = true;

--- a/benchmarks/recursive-context/octane-tsrx/src/warm-adoption-memo.js
+++ b/benchmarks/recursive-context/octane-tsrx/src/warm-adoption-memo.js
@@ -1,0 +1,9 @@
+import { useMemo } from 'octane';
+
+const valueSlot = Symbol();
+
+// An ordinary custom hook exercises the runtime memo adoption path. Its value
+// is synchronous; only the separate control ever creates a warmable resource.
+export function useOrdinaryMemo(version, depth) {
+	return useMemo(() => `${version}:${depth}`, [version, depth], valueSlot);
+}

--- a/benchmarks/recursive-context/octane-tsrx/vite.config.js
+++ b/benchmarks/recursive-context/octane-tsrx/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
 				recursive: fileURLToPath(new URL('./index.html', import.meta.url)),
 				contextCache: fileURLToPath(new URL('./context-cache.html', import.meta.url)),
 				warmPlanControl: fileURLToPath(new URL('./warm-plan-control.html', import.meta.url)),
+				warmAdoption: fileURLToPath(new URL('./warm-adoption.html', import.meta.url)),
 			},
 		},
 	},

--- a/benchmarks/recursive-context/octane-tsrx/warm-adoption.html
+++ b/benchmarks/recursive-context/octane-tsrx/warm-adoption.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+	<body>
+		<div id="main"></div>
+		<div id="warm"></div>
+		<script type="module" src="/src/warm-adoption-main.js"></script>
+	</body>
+</html>

--- a/benchmarks/recursive-context/package.json
+++ b/benchmarks/recursive-context/package.json
@@ -8,6 +8,7 @@
     "bench": "node run.mjs",
     "bench:work": "node work.mjs",
     "bench:cache": "node context-cache-work.mjs",
+    "bench:warm-adoption": "node warm-adoption-work.mjs",
     "bench:long": "node run.mjs 40"
   },
   "dependencies": {

--- a/benchmarks/recursive-context/warm-adoption-work.mjs
+++ b/benchmarks/recursive-context/warm-adoption-work.mjs
@@ -1,0 +1,185 @@
+// Untimed production-bundle work guard. Detailed Chromium coverage measures
+// the real memo-adoption helper and its parent step after compilation.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import ts from 'typescript';
+
+const fixture = new URL('./octane-tsrx/', import.meta.url);
+const sha256 = (source) => createHash('sha256').update(source).digest('hex');
+const metrics = ['adoptWarmEntry', 'adoptWarmCacheEntry', 'useMemo', 'memoTake2'];
+
+async function invoke(page, hook) {
+	const { name, arg } = typeof hook === 'string' ? { name: hook } : hook;
+	await page.evaluate(
+		async ({ name, arg }) => {
+			if (typeof window[name] !== 'function') throw new Error(`missing ${name}`);
+			await window[name](arg);
+		},
+		{ name, arg },
+	);
+}
+
+function parentStepOffset(source, start, end) {
+	const ast = ts.createSourceFile('production.js', source, ts.ScriptTarget.Latest, true);
+	const positions = [];
+	function visit(node) {
+		if (node.end < start || node.pos > end) return;
+		if (ts.isPropertyAccessExpression(node) && node.name.text === 'parentBlock')
+			positions.push(node.getStart(ast));
+		ts.forEachChild(node, visit);
+	}
+	visit(ast);
+	assert.equal(positions.length, 1, 'adoption helper has one parent advance');
+	return positions[0];
+}
+
+async function observe(browser, url, before, operation, after) {
+	const context = await browser.newContext();
+	try {
+		const page = await context.newPage();
+		const errors = [];
+		page.on('pageerror', (error) => errors.push(error.message));
+		page.on('console', (message) => {
+			if (message.type() === 'error') errors.push(message.text());
+		});
+		const cdp = await context.newCDPSession(page);
+		await cdp.send('Debugger.enable');
+		await cdp.send('Profiler.enable');
+		await cdp.send('Profiler.startPreciseCoverage', { callCount: true, detailed: true });
+		await page.goto(url);
+		await page.waitForFunction(() => window.__ready === true);
+		for (const hook of before) await invoke(page, hook);
+		await cdp.send('Profiler.takePreciseCoverage');
+		await invoke(page, operation);
+		const coverage = await cdp.send('Profiler.takePreciseCoverage');
+		const counts = Object.fromEntries(metrics.map((name) => [name, 0]));
+		let parentSteps = 0;
+		let productionCalls = 0;
+		let helperSeen = false;
+		let helperHash;
+		for (const script of coverage.result) {
+			if (!script.url.includes('/assets/')) continue;
+			for (const fn of script.functions) {
+				productionCalls += fn.ranges[0].count;
+				if (metrics.includes(fn.functionName)) counts[fn.functionName] += fn.ranges[0].count;
+				if (fn.functionName !== 'adoptWarmEntry') continue;
+				helperSeen = true;
+				const { scriptSource } = await cdp.send('Debugger.getScriptSource', {
+					scriptId: script.scriptId,
+				});
+				const { startOffset, endOffset } = fn.ranges[0];
+				helperHash = sha256(scriptSource.slice(startOffset, endOffset));
+				const offset = parentStepOffset(scriptSource, startOffset, endOffset);
+				// Coverage ranges nest. The narrowest enclosing block supplies the
+				// exact execution count for this property read; the enclosing function
+				// count is insufficient because each call may walk many ancestors.
+				const enclosing = fn.ranges
+					.filter((range) => range.startOffset <= offset && offset < range.endOffset)
+					.sort((a, b) => a.endOffset - a.startOffset - (b.endOffset - b.startOffset));
+				assert.ok(enclosing.length > 0, 'parent read is covered');
+				parentSteps += enclosing[0].count;
+			}
+		}
+		assert.ok(productionCalls > 0, 'live production asset coverage is present');
+		if (before.includes('__primeWarm')) assert.ok(helperSeen, 'primed adoption helper is covered');
+		for (const hook of after) await invoke(page, hook);
+		assert.deepEqual(errors, [], 'production page errors');
+		return { ...counts, parentSteps, helperHash };
+	} finally {
+		await context.close();
+	}
+}
+
+export async function collectWarmAdoptionWork(browser, url, { measureOnly = false } = {}) {
+	const results = {};
+	for (const depth of [32, 128]) {
+		const mount = { name: '__mountDeep', arg: depth };
+		const verify = ['__verifyDeep', '__unmountDeep'];
+		results[`cold_mount_${depth}`] = await observe(browser, url, [], mount, verify);
+		results[`primed_mount_${depth}`] = await observe(browser, url, ['__primeWarm'], mount, verify);
+		results[`primed_update_${depth}`] = await observe(
+			browser,
+			url,
+			['__primeWarm', mount],
+			'__updateDeep',
+			verify,
+		);
+	}
+	results.pending_mount = await observe(browser, url, [], '__mountPendingWarm', []);
+	results.pending_retry = await observe(
+		browser,
+		url,
+		['__mountPendingWarm'],
+		'__resolvePendingWarm',
+		['__verifyPendingWarm'],
+	);
+	for (const depth of [32, 128]) {
+		assert.equal(results[`cold_mount_${depth}`].adoptWarmEntry, 0, 'cold memo misses do not adopt');
+		for (const operation of ['mount', 'update']) {
+			const row = results[`primed_${operation}_${depth}`];
+			assert.equal(
+				row.adoptWarmEntry,
+				depth + 1,
+				'every ordinary memo miss still consults adoption',
+			);
+			if (!measureOnly)
+				assert.equal(row.parentSteps, 0, 'no ancestor cache can match a new ordinary episode');
+		}
+	}
+	assert.equal(results.pending_retry.adoptWarmEntry, 1, 'pending retry exercises adoption');
+	assert.equal(
+		results.pending_retry.adoptWarmCacheEntry,
+		1,
+		'pending retry consults its warm cache',
+	);
+	assert.ok(
+		results.pending_retry.parentSteps > 0 && results.pending_retry.parentSteps <= 2,
+		'pending retry retains the live ancestor-cache path',
+	);
+	return results;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	const requireFixture = createRequire(new URL('package.json', fixture));
+	const { preview } = await import(requireFixture.resolve('vite'));
+	execFileSync('pnpm', ['exec', 'vite', 'build', '--minify', 'false'], {
+		cwd: fileURLToPath(fixture),
+		stdio: 'inherit',
+	});
+	const server = await preview({
+		root: fileURLToPath(fixture),
+		configFile: fileURLToPath(new URL('vite.config.js', fixture)),
+		preview: { host: '127.0.0.1', port: 0, strictPort: false },
+	});
+	let browser;
+	try {
+		browser = await chromium.launch({
+			headless: true,
+			args: ['--no-sandbox', '--js-flags=--jitless'],
+		});
+		const url = `http://127.0.0.1:${server.httpServer.address().port}/warm-adoption.html`;
+		const results = await collectWarmAdoptionWork(browser, url, {
+			measureOnly: process.argv.includes('--measure'),
+		});
+		const payload = {
+			suite: 'warm-adoption',
+			node: process.version,
+			browser: browser.version(),
+			runtimeHash: sha256(
+				readFileSync(new URL('../../packages/octane/src/runtime.ts', import.meta.url)),
+			),
+			results,
+		};
+		console.log(JSON.stringify(payload, null, 2));
+		if (process.env.BENCH_JSON)
+			writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, 2) + '\n');
+	} finally {
+		await browser?.close();
+		await server.close();
+	}
+}

--- a/benchmarks/recursive-context/work.mjs
+++ b/benchmarks/recursive-context/work.mjs
@@ -11,6 +11,7 @@ import { compile } from '../../packages/octane/src/compiler/compile.js';
 import { slotHooks } from '../../packages/octane/src/compiler/slot-hooks.js';
 import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
 import { collectPreciseCalls } from '../lib/precise-work.mjs';
+import { collectWarmAdoptionWork } from './warm-adoption-work.mjs';
 
 // Standalone runs can target ephemeral previews so an unrelated worktree's
 // server on the standard benchmark ports cannot produce stale-bundle counts.
@@ -483,6 +484,10 @@ try {
 				`${results.warmPlanControl.useBatch}/${results.warmPlanControl.registerWarmPlan}`,
 		);
 	}
+	results.warmAdoption = await collectWarmAdoptionWork(
+		browser,
+		TARGETS.find((target) => target.name === 'octane-tsrx').url + 'warm-adoption.html',
+	);
 } finally {
 	await browser.close();
 }
@@ -589,6 +594,20 @@ if (outputPath) {
 				meta: {
 					gates: failures.some((failure) => failure.startsWith('ownPromise:')) ? 'fail' : 'pass',
 				},
+			},
+			{
+				name: 'octane-warm-adoption-work',
+				ops: Object.fromEntries(
+					Object.entries(results.warmAdoption).flatMap(([operation, measurements]) =>
+						Object.entries(measurements)
+							.filter(([, value]) => typeof value === 'number')
+							.map(([metric, value]) => [
+								`${operation}_${metric}`,
+								deterministicStatForJson(deterministicCount(value)),
+							]),
+					),
+				),
+				meta: { gates: 'pass' },
 			},
 			{
 				name: 'octane-context-cache-work',

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12596,6 +12596,9 @@ let CURRENT_WARM_CLAIMS: Set<object> | null = null;
 /** Flips true forever on first warm — gates useMemo's ancestor walk so apps
  * that never warm never pay for it. */
 let WARM_EVER = false;
+// New episodes cannot match an older attached cache. Keep the maximum rather
+// than the last attachment's episode: independent roots may resume older work.
+let LATEST_WARM_CACHE_EPISODE = 0;
 let WARM_DEPTH = 0;
 const WARM_DEPTH_CAP = 64;
 // Do not cap per-slot occurrence queues: dropping their FIFO head would map a
@@ -12627,6 +12630,8 @@ function warmCacheForOwner(owner: Block): Map<HookSlot, WarmEntry[]> {
 	}
 	(owner as any).__warmCache = cache;
 	(owner as any).__warmCacheEpisode = CURRENT_WARM_EPISODE;
+	if (CURRENT_WARM_EPISODE > LATEST_WARM_CACHE_EPISODE)
+		LATEST_WARM_CACHE_EPISODE = CURRENT_WARM_EPISODE;
 	return cache;
 }
 
@@ -12953,7 +12958,8 @@ function adoptWarmEntry(
 	deps: any[],
 	accept?: WarmMemoAccept,
 ): WarmEntry | WarmHarvestEntry | typeof WARM_MISS {
-	let b: Block | null = CURRENT_BLOCK;
+	// Root retries and held-transition harvests below are independently eligible.
+	let b: Block | null = CURRENT_WARM_EPISODE <= LATEST_WARM_CACHE_EPISODE ? CURRENT_BLOCK : null;
 	while (b !== null) {
 		const cache: Map<HookSlot, WarmEntry[]> | undefined = (b as any).__warmCache;
 		if ((b as any).__warmCacheEpisode === CURRENT_WARM_EPISODE && cache !== undefined) {

--- a/packages/octane/tests/_fixtures/parallel-use.tsrx
+++ b/packages/octane/tests/_fixtures/parallel-use.tsrx
@@ -1,4 +1,4 @@
-import { use } from 'octane';
+import { use, useMemo } from 'octane';
 import {
 	useImportedCaptured,
 	useImportedDependent,
@@ -30,6 +30,48 @@ export function DriftedWarmBoundary(props: DriftedWarmProps) @{
 			<DriftedWarmParent gate={props.gate} record={props.record} load={props.load} />
 		} @pending {
 			<p class="fallback">loading</p>
+		}
+	</>
+}
+
+export function OrdinaryMemoRoot(props: {
+	version: number;
+	create: (version: number) => { label: string };
+}) @{
+	const value = useMemo(() => props.create(props.version), [props.create, props.version]);
+	<p class="ordinary-memo-value">{value.label as string}</p>
+}
+
+function IndependentWarmPanel(props: {
+	name: string;
+	load: (name: string) => Promise<string>;
+}) @{
+	const value = use(props.load(props.name));
+	<p class="independent-warm-value">{value as string}</p>
+}
+
+export function IndependentWarmPanels(props: { load: (name: string) => Promise<string> }) @{
+	<main>
+		@try {
+			<IndependentWarmPanel name="first" load={props.load} />
+		} @pending {
+			<p class="first-pending">first pending</p>
+		}
+		@try {
+			<IndependentWarmPanel name="second" load={props.load} />
+		} @pending {
+			<p class="second-pending">second pending</p>
+		}
+	</main>
+}
+
+export function IndependentWarmRoot(props) @{
+	const Content = props.content;
+	<>
+		@try {
+			<Content load={props.load} version={props.version} />
+		} @pending {
+			<p class="root-pending">root pending</p>
 		}
 	</>
 }

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -25,6 +25,9 @@ import {
 	SetupValueParallelHost,
 	DriftedWarmParent,
 	DriftedWarmBoundary,
+	OrdinaryMemoRoot,
+	IndependentWarmPanels,
+	IndependentWarmRoot,
 } from './_fixtures/parallel-use.tsrx';
 
 // Runtime behavior of the compiler's unconditional parallel-use pipeline.
@@ -1634,6 +1637,90 @@ describe('parallel use() — imported data hooks', () => {
 });
 
 describe('parallel use() — adjacent async component trees', () => {
+	it('retains pending requests while independent roots render and warm newer work', async () => {
+		const firstResources = freshResourceFetcher();
+		const secondResources = freshResourceFetcher();
+		const first = mount(IndependentWarmRoot, {
+			content: AdjacentPanelsHost,
+			load: firstResources.load,
+			version: 0,
+		});
+		let serial = 0;
+		const create = (version: number) => ({ label: `memo-v${version}-${++serial}` });
+		const ordinary = mount(OrdinaryMemoRoot, { create, version: 0 });
+		const second = mount(IndependentWarmRoot, {
+			content: AdjacentPanelsHost,
+			load: secondResources.load,
+			version: 1,
+		});
+		try {
+			const memoNode = ordinary.find('.ordinary-memo-value');
+			expect(memoNode.textContent).toBe('memo-v0-1');
+			ordinary.update(OrdinaryMemoRoot, { create, version: 0 });
+			expect(memoNode.textContent).toBe('memo-v0-1');
+			ordinary.update(OrdinaryMemoRoot, { create, version: 1 });
+			expect(ordinary.find('.ordinary-memo-value')).toBe(memoNode);
+			expect(memoNode.textContent).toBe('memo-v1-2');
+
+			await firstResources.settleRound(0);
+			expect(first.find('.activity-value').textContent).toBe('activity-v0');
+			expect(first.find('.activity-summary').textContent).toBe('activity-summary-v0');
+			expect(first.find('.insights-value').textContent).toBe('insights-v0');
+			expect(first.find('.insights-chart').textContent).toBe('insights-chart-v0');
+			expect(firstResources.calls.slice().sort()).toEqual([
+				'activity-summary:0',
+				'activity:0',
+				'insights-chart:0',
+				'insights:0',
+			]);
+			expect(second.find('.fallback').textContent).toBe('panels-loading');
+
+			await secondResources.settleRound(1);
+			expect(second.find('.activity-value').textContent).toBe('activity-v1');
+			expect(second.find('.activity-summary').textContent).toBe('activity-summary-v1');
+			expect(second.find('.insights-value').textContent).toBe('insights-v1');
+			expect(second.find('.insights-chart').textContent).toBe('insights-chart-v1');
+			expect(secondResources.calls.slice().sort()).toEqual([
+				'activity-summary:1',
+				'activity:1',
+				'insights-chart:1',
+				'insights:1',
+			]);
+			expect(ordinary.find('.ordinary-memo-value')).toBe(memoNode);
+			expect(memoNode.textContent).toBe('memo-v1-2');
+		} finally {
+			second.unmount();
+			ordinary.unmount();
+			first.unmount();
+		}
+	});
+
+	it('uses sibling requests started before their independent boundaries render', async () => {
+		const requests: Array<{ name: string } & Deferred<string>> = [];
+		const load = (name: string) => {
+			const request = { name, ...deferred<string>() };
+			requests.push(request);
+			return request.promise;
+		};
+		const root = mount(IndependentWarmRoot, { content: IndependentWarmPanels, load });
+		try {
+			expect(root.find('.first-pending').textContent).toBe('first pending');
+			expect(root.find('.second-pending').textContent).toBe('second pending');
+			expect(requests.map((request) => request.name)).toEqual(['first', 'second']);
+			await act(() => requests[1].resolve('second result'));
+			expect(root.find('.first-pending').textContent).toBe('first pending');
+			expect(root.find('.independent-warm-value').textContent).toBe('second result');
+			await act(() => requests[0].resolve('first result'));
+			expect(root.findAll('.independent-warm-value').map((node) => node.textContent)).toEqual([
+				'first result',
+				'second result',
+			]);
+			expect(requests.map((request) => request.name)).toEqual(['first', 'second']);
+		} finally {
+			root.unmount();
+		}
+	});
+
 	it('does not warm the final template after setup returns an alternate subtree', async () => {
 		const resources = resourceFetcher();
 		const r = mount(EarlyReturnPanelsHost, {


### PR DESCRIPTION
## Summary

- Skip the ancestor warm-cache scan when the current render episode is newer than every attached cache.
- Advance one numeric maximum at the existing cache attachment point. Older retries remain eligible; root retry caches and held/promoted transition harvests keep their existing lookup paths.
- Add behavioral regressions, a production benchmark guard integrated into recursive-context work checks, and an `octane` patch changeset.

Partially addresses #981's parallel-use warm-plan item. This targets irrelevant adoption scans after prior warming; complex warm-plan allocation and other active-plan traversal work remain separate follow-ups.

## Performance evidence

Baseline: merged main `7804852be69a78d11f3dc160f44d3bd358bedfc1`. Same production fixture, Node 26.4.0, and Chromium 149.0.7827.55. Detailed Chromium coverage observes the parent-property read in the actual emitted runtime helper, without source probes.

```sh
BENCH_JSON=/tmp/warm-adoption.json node benchmarks/recursive-context/warm-adoption-work.mjs
```

| Scenario | Memo misses | Parent reads before | After |
| --- | ---: | ---: | ---: |
| Depth 32 mount after unrelated warming | 33 | 1,089 | 0 |
| Depth 32 update after unrelated warming | 33 | 1,089 | 0 |
| Depth 128 mount after unrelated warming | 129 | 16,641 | 0 |
| Depth 128 update after unrelated warming | 129 | 16,641 | 0 |

Adoption calls remain 33/129, all memo values and surviving DOM nodes match, and the no-warming control remains at zero adoption calls. A real pending retry retains one adoption, one cache probe, and two parent reads; parent and child resources each start once. The final zero-parent-step guard fails on the untouched baseline. This measures removed lookup work, not an end-user latency improvement.

## Validation

- [x] New dev/prod regressions: **4/4 passed** on baseline and final candidate. Omitting marker advancement causes four failures (duplicate request and missing content); using equality instead of `<=` causes two older-root failures. Both deliberate mutations were restored.
- [x] Broad Octane suite plus targeted recovery runs: the initial run passed **18,182 tests with 14 expected failures**; three compiler cases timed out and 15 browser suites were blocked at launch by the local sandbox. Both compiler files then passed **51/51** with two workers, and all **15 browser files / 130 tests passed** with Chromium permissions and two workers. No code changes were needed for these reruns.
- [x] `pnpm typecheck:files packages/octane/src/runtime.ts`
- [x] Scoped `pnpm format:files:check` for all changed files and `git diff --check`
- [x] `pnpm sync` (no generated changes)
- [x] Standalone warm-adoption benchmark and complete integrated recursive-context work pass for TSRX/TSX
- [x] Production async-composition: initialization and transition update each retain eight network starts, eight creators, seven first-wave resources, two dependency waves, and zero mixed states. Existing resource retention, dependent-owner ordering, and lazy-module/node identity gates passed.
- Full repository `pnpm test`, `pnpm typecheck`, and `pnpm format:check` were not run locally; the core suite and scoped checks above cover the local change. [Current-head CI](https://github.com/octanejs/octane/actions/runs/34397388909) passed **all 26 jobs** on `c176cd00e2fdc01647a3488929003652e1b2efcf` (attempt 2). The first attempt hit the same five-second Volar compiler-test timeout; that shard and one canceled shard passed unchanged on rerun. Cursor Bugbot completed successfully with no findings, and there are no review threads to resolve.

## Risk / follow-ups

The maximum is never reset or reduced, including when an older root resumes. An outdated maximum can only permit extra scanning; it cannot hide a matching cache. This adds no per-block fields, allocations, retained trees, or cache invalidation hooks. SSR has a separate runtime; client hydration and native resource adoption retain their existing semantics. Independent source review found no correctness issues.

The tests use a retained outer boundary around dynamic content so a root retry cache cannot hide a broken ancestor lookup. Active-plan recording stays intact because earlier completed siblings must still be remembered before later siblings suspend.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575338&installation_model_id=432790&pr_number=1024&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1024&signature=c82e97da79df2eb0cf1aa32161216ec761fe5da8df8adf331661dd3ccca9d863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches suspense/memo warm-cache adoption in the client runtime; incorrect episode gating could break retries or duplicate fetches, though tests and benchmarks target those paths.
> 
> **Overview**
> **Skips pointless ancestor walks** when `useMemo` adoption runs in a render episode newer than every attached warm cache, while still calling adoption itself and leaving root-retry / pending-suspense paths unchanged.
> 
> The runtime tracks **`LATEST_WARM_CACHE_EPISODE`** when caches attach and gates `adoptWarmEntry`’s `parentBlock` loop on `CURRENT_WARM_EPISODE <= LATEST_WARM_CACHE_EPISODE`, so ordinary sync memos after unrelated warming no longer scan the block chain (thousands of parent steps at depth 128).
> 
> Adds a **recursive-context warm-adoption benchmark** (Chromium precise coverage on `adoptWarmEntry`, zero parent-step ceiling after priming) wired into `bench:work`, plus **parallel-use regressions** for independent async roots alongside ordinary `useMemo` and sibling resource starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c176cd00e2fdc01647a3488929003652e1b2efcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->