### PR TITLE
perf: avoid host child rest-array forwarding

### DIFF
--- a/.changeset/host-component-trampoline.md
+++ b/.changeset/host-component-trampoline.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid allocating a rest-argument array when rendering children inside a reused host component.

--- a/benchmarks/host-component/README.md
+++ b/benchmarks/host-component/README.md
@@ -1,0 +1,58 @@
+# Host component child forwarding
+
+This focused production benchmark exercises `hostComponent`, the runtime host
+adapter used by components such as `motion.div`. Each parent render supplies a
+fresh children body while Octane preserves the host element and positional child.
+
+```sh
+node benchmarks/host-component/work.mjs
+# Observe a baseline that still has a rest parameter:
+BENCH_JSON=/tmp/host-component-baseline.json node benchmarks/host-component/work.mjs --measure
+```
+
+The runner bundles the actual client runtime with esbuild's production define,
+serves it on an ephemeral local port, and launches Chromium with `--jitless`.
+It measures 128 and 1,024 hosts on mount, update, twelve consecutive updates,
+and unmount. No workspace package installation or long-running preview server
+is required once the repository's dependencies are installed. The runner closes
+Chromium and the local server and removes its generated `dist` directory in
+`finally` cleanup, including failed runs.
+
+The function-child fixture renders a span through a fresh body per host and
+render. An equivalent descriptor-child control renders the same elements and
+text without using the forwarding trampoline. Every measurement verifies host
+and child cardinality, updated attributes and text, persistent DOM identity,
+parent/child nesting, and empty DOM after teardown.
+
+The observer parses the emitted bundle to locate the children trampoline and
+its rest parameter, then attributes Chromium's precise function-call coverage
+to that exact source range. Each execution of a rest-parameter function creates
+one argument array in this interpreter-only pass. Multiplying that count by the
+number of rest parameters gives a deterministic allocation-work count; it does
+not claim that an optimizing JIT cannot eliminate the allocation after warmup.
+The descriptor control requires zero trampoline calls and zero rest arrays.
+Function-child work must execute exactly once per host and render in either
+implementation, so removing children work cannot produce a false improvement.
+
+The default gate requires zero rest parameters. `--measure` preserves all
+semantic and work-cardinality checks while reporting an older implementation.
+`BENCH_JSON` writes the measurements, runtime/bundle/trampoline hashes, and
+browser/Node versions. No application throughput gain is inferred from these
+untimed counts.
+
+## Recorded comparison
+
+Node v26.4.0 and Chromium 149.0.7827.55, with the production configuration above:
+
+| Function children | Hosts | Trampoline calls, both versions | Rest arrays, before | Rest arrays, after |
+| --- | ---: | ---: | ---: | ---: |
+| Mount or one update | 128 | 128 | 128 | 0 |
+| Twelve updates | 128 | 1,536 | 1,536 | 0 |
+| Mount or one update | 1,024 | 1,024 | 1,024 | 0 |
+| Twelve updates | 1,024 | 12,288 | 12,288 | 0 |
+
+All descriptor-child cases and all unmounts report zero trampoline calls and
+zero rest arrays in both versions. Host calls are unchanged: twice the
+trampoline count for function children, once per host and render for descriptor
+children, and zero during unmount. Every semantic control passes in both versions.
+The unminified observer bundle grows from 432,907 to 432,933 bytes (+26 bytes).

--- a/benchmarks/host-component/main.js
+++ b/benchmarks/host-component/main.js
@@ -1,0 +1,85 @@
+import {
+	createElement,
+	createRoot,
+	flushSync,
+	hostComponent,
+} from '../../packages/octane/src/index.ts';
+
+const container = document.getElementById('main');
+let root;
+let count;
+let mode;
+let version;
+let hosts;
+let children;
+
+// Runtime adapters such as motion.<tag> call hostComponent directly. The
+// function mode supplies a fresh child body on every parent render, as compiled
+// children do; the value mode supplies an equivalent descriptor.
+function Rows(props, scope) {
+	for (let index = 0; index < props.count; index++) {
+		const label = `${index}:${props.version}`;
+		const content =
+			props.mode === 'function'
+				? (_childProps, childScope) => {
+						hostComponent(childScope, 0, 'span', { 'data-child': index }, label);
+					}
+				: createElement('span', { 'data-child': index }, label);
+		hostComponent(
+			scope,
+			index,
+			'section',
+			{ 'data-host': index, 'data-version': props.version },
+			content,
+		);
+	}
+}
+
+window.__mount = (options) => {
+	count = options.count;
+	mode = options.mode;
+	version = 0;
+	root = createRoot(container);
+	root.render(Rows, { count, mode, version });
+	flushSync(() => {});
+	hosts = [...container.querySelectorAll('section')];
+	children = [...container.querySelectorAll('span')];
+};
+
+window.__update = () => {
+	version++;
+	flushSync(() => root.render(Rows, { count, mode, version }));
+};
+
+window.__updateBatch = () => {
+	for (let index = 0; index < 12; index++) window.__update();
+};
+
+window.__verify = () => {
+	const actualHosts = [...container.querySelectorAll('section')];
+	const actualChildren = [...container.querySelectorAll('span')];
+	if (actualHosts.length !== count || actualChildren.length !== count) {
+		throw new Error(`missing host/child nodes: ${actualHosts.length}/${actualChildren.length}`);
+	}
+	for (let index = 0; index < count; index++) {
+		if (actualHosts[index] !== hosts[index] || actualChildren[index] !== children[index]) {
+			throw new Error(`host or child identity changed at ${index}`);
+		}
+		if (
+			actualHosts[index].getAttribute('data-host') !== String(index) ||
+			actualHosts[index].getAttribute('data-version') !== String(version) ||
+			actualChildren[index].getAttribute('data-child') !== String(index) ||
+			actualChildren[index].textContent !== `${index}:${version}` ||
+			actualChildren[index].parentNode !== actualHosts[index]
+		) {
+			throw new Error(`host props or child output stale at ${index}, version ${version}`);
+		}
+	}
+};
+
+window.__unmount = () => {
+	root.unmount();
+	if (container.childNodes.length !== 0) throw new Error('unmount left host content behind');
+};
+
+window.__ready = true;

--- a/benchmarks/host-component/work.mjs
+++ b/benchmarks/host-component/work.mjs
@@ -1,0 +1,204 @@
+// Observe rest-parameter construction in the emitted production trampoline.
+// No probes are inserted into Octane or its child bodies.
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import ts from 'typescript';
+
+const root = fileURLToPath(new URL('./', import.meta.url));
+const distRoot = fileURLToPath(new URL('./dist/', import.meta.url));
+const bundleFile = fileURLToPath(new URL('./dist/assets/main.js', import.meta.url));
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+const measureOnly = process.argv.includes('--measure');
+
+async function main() {
+	await build({
+		entryPoints: [fileURLToPath(new URL('./main.js', import.meta.url))],
+		outfile: bundleFile,
+		bundle: true,
+		format: 'esm',
+		platform: 'browser',
+		target: 'esnext',
+		minify: false,
+		define: { 'process.env.NODE_ENV': '"production"' },
+		absWorkingDir: root,
+	});
+	const source = readFileSync(bundleFile, 'utf8');
+	const ast = ts.createSourceFile('production.js', source, ts.ScriptTarget.Latest, true);
+	let trampoline;
+	function findTrampoline(node) {
+		if (ts.isFunctionDeclaration(node) && node.name?.text === 'hostComponent') {
+			function visit(child) {
+				if (
+					ts.isBinaryExpression(child) &&
+					child.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+					ts.isPropertyAccessExpression(child.left) &&
+					child.left.name.text === 'body'
+				) {
+					let value = child.right;
+					while (ts.isParenthesizedExpression(value)) value = value.expression;
+					if (ts.isArrowFunction(value) || ts.isFunctionExpression(value)) {
+						assert.equal(trampoline, undefined, 'one host child trampoline');
+						trampoline = value;
+					}
+				}
+				ts.forEachChild(child, visit);
+			}
+			visit(node);
+		}
+		ts.forEachChild(node, findTrampoline);
+	}
+	findTrampoline(ast);
+	assert.ok(trampoline, 'live production bundle contains the host child trampoline');
+	const restParameters = trampoline.parameters.filter(
+		(parameter) => parameter.dotDotDotToken,
+	).length;
+	const trampolineBody = trampoline.body.getStart(ast);
+	const trampolineHash = sha256(source.slice(trampoline.getStart(ast), trampoline.end));
+
+	const server = createServer((request, response) => {
+		if (request.url === '/assets/main.js') {
+			response.setHeader('content-type', 'text/javascript');
+			response.end(source);
+		} else if (request.url === '/') {
+			response.setHeader('content-type', 'text/html');
+			response.end(
+				'<!doctype html><div id="main"></div><script type="module" src="/assets/main.js"></script>',
+			);
+		} else {
+			response.statusCode = 404;
+			response.end();
+		}
+	});
+	await new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			server.removeListener('error', reject);
+			resolve();
+		});
+	});
+	const url = `http://127.0.0.1:${server.address().port}/`;
+
+	async function invoke(page, name, arg) {
+		await page.evaluate(({ name, arg }) => window[name](arg), { name, arg });
+	}
+
+	async function observe(browser, mode, count, operation) {
+		const context = await browser.newContext();
+		try {
+			const page = await context.newPage();
+			const errors = [];
+			page.on('pageerror', (error) => errors.push(error.message));
+			page.on('console', (message) => {
+				if (message.type() === 'error') errors.push(message.text());
+			});
+			const cdp = await context.newCDPSession(page);
+			await cdp.send('Profiler.enable');
+			await cdp.send('Profiler.startPreciseCoverage', { callCount: true, detailed: true });
+			await page.goto(url);
+			await page.waitForFunction(() => window.__ready === true);
+			if (operation !== 'mount') {
+				await invoke(page, '__mount', { mode, count });
+				await invoke(page, '__verify');
+			}
+			await cdp.send('Profiler.takePreciseCoverage');
+			await invoke(page, `__${operation}`, operation === 'mount' ? { mode, count } : undefined);
+			const coverage = await cdp.send('Profiler.takePreciseCoverage');
+			let trampolineCalls = 0;
+			let hostCalls = 0;
+			let productionCalls = 0;
+			for (const script of coverage.result) {
+				if (script.url !== url + 'assets/main.js') continue;
+				const candidates = [];
+				for (const fn of script.functions) {
+					const range = fn.ranges[0];
+					productionCalls += range.count;
+					if (fn.functionName === 'hostComponent') hostCalls += range.count;
+					if (
+						range.startOffset >= trampoline.getStart(ast) &&
+						range.endOffset <= trampoline.end &&
+						range.startOffset <= trampolineBody &&
+						trampolineBody < range.endOffset
+					) {
+						candidates.push(range);
+					}
+				}
+				candidates.sort((a, b) => a.endOffset - a.startOffset - (b.endOffset - b.startOffset));
+				if (candidates.length > 0) {
+					const range = candidates[0];
+					trampolineCalls += range.count;
+				}
+			}
+			assert.ok(productionCalls > 0, 'operation has live production coverage');
+			if (operation !== 'unmount') {
+				await invoke(page, '__verify');
+				await invoke(page, '__unmount');
+			}
+			assert.deepEqual(errors, [], 'production browser errors');
+			const passes = operation === 'unmount' ? 0 : operation === 'updateBatch' ? 12 : 1;
+			assert.equal(
+				trampolineCalls,
+				mode === 'function' ? count * passes : 0,
+				'child work cardinality',
+			);
+			assert.equal(
+				hostCalls,
+				count * passes * (mode === 'function' ? 2 : 1),
+				'host work cardinality',
+			);
+			return { hostCalls, trampolineCalls, restArrays: trampolineCalls * restParameters };
+		} finally {
+			await context.close();
+		}
+	}
+
+	let browser;
+	try {
+		browser = await chromium.launch({
+			headless: true,
+			args: ['--no-sandbox', '--js-flags=--jitless'],
+		});
+		const results = {};
+		for (const count of [128, 1024]) {
+			for (const mode of ['function', 'value']) {
+				for (const operation of ['mount', 'update', 'updateBatch', 'unmount']) {
+					results[`${mode}_${count}_${operation}`] = await observe(browser, mode, count, operation);
+				}
+			}
+		}
+		const payload = {
+			suite: 'host-component',
+			node: process.version,
+			browser: browser.version(),
+			runtimeHash: sha256(
+				readFileSync(new URL('../../packages/octane/src/runtime.ts', import.meta.url)),
+			),
+			bundleHash: sha256(source),
+			bundleBytes: Buffer.byteLength(source),
+			trampolineHash,
+			restParameters,
+			results,
+		};
+		console.log(JSON.stringify(payload, null, 2));
+		if (process.env.BENCH_JSON)
+			writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, 2) + '\n');
+		if (!measureOnly)
+			assert.equal(restParameters, 0, 'host child forwarding avoids a rest-parameter array');
+	} finally {
+		try {
+			await browser?.close();
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
+	}
+}
+
+try {
+	await main();
+} finally {
+	rmSync(distRoot, { recursive: true, force: true });
+}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -23461,7 +23461,7 @@ export function hostComponent(
 		// delegating body whose target we update each render, so childSlot reconciles.
 		state.latest = childrenBody as ComponentBody;
 		if (state.body === undefined) {
-			state.body = ((...args: any[]) => (state!.latest as any)(...args)) as ComponentBody;
+			state.body = (props, scope, extra) => state!.latest!(props, scope, extra);
 		}
 		childSlot(state.childScope!, 0, el, state.body, null, false, el);
 	} else if (childrenBody != null || state.childScope!.slots[0] !== undefined) {

--- a/packages/octane/tests/_fixtures/host-component-children.tsrx
+++ b/packages/octane/tests/_fixtures/host-component-children.tsrx
@@ -1,0 +1,32 @@
+import { useEffect, useState, type ComponentBody, type OctaneNode } from 'octane';
+
+interface ChildProps {
+	label: string;
+	childRef: (element: HTMLButtonElement | null) => void | (() => void);
+	onEffect: (label: string) => () => void;
+}
+
+function StatefulChild(props: ChildProps) @{
+	const [count, setCount] = useState(0);
+	useEffect(() => props.onEffect(props.label), [props.onEffect, props.label]);
+	<button
+		id="host-child"
+		ref={props.childRef}
+		onClick={() => setCount((value) => value + 1)}
+	>{`${props.label}:${count}`}</button>
+}
+
+interface HostChildrenProps extends ChildProps {
+	host: ComponentBody<{ children?: OctaneNode }>;
+	show: boolean;
+}
+
+export function HostComponentChildren(props: HostChildrenProps) @{
+	const Host = props.host;
+	<Host>
+		<p id="host-label">{props.label as string}</p>
+		@if (props.show) {
+			<StatefulChild label={props.label} childRef={props.childRef} onEffect={props.onEffect} />
+		}
+	</Host>
+}

--- a/packages/octane/tests/host-component-props.test.ts
+++ b/packages/octane/tests/host-component-props.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { mount } from './_helpers';
-import { flushSync, hostComponent } from '../src/index.js';
+import { flushEffects, mount } from './_helpers';
+import {
+	createElement,
+	flushSync,
+	hostComponent,
+	type ComponentBody,
+	type OctaneNode,
+} from '../src/index.js';
+import { HostComponentChildren } from './_fixtures/host-component-children.tsrx';
 
 // `hostComponent` (the runtime primitive behind @octanejs/motion's `motion.<tag>`) REUSES its
 // element across renders. Regressions fixed here:
@@ -15,7 +22,100 @@ const HostBody = (props: any, scope: any): void => {
 	hostComponent(scope, 0, props.tag ?? 'div', props.hp, null);
 };
 
-describe('hostComponent — no stale props/events on the reused element', () => {
+describe('hostComponent — reused host and children', () => {
+	it('renders the value returned by callable children', () => {
+		const host: ComponentBody<{ label: string }> = (props, scope) => {
+			hostComponent(scope, 0, 'section', null, () =>
+				createElement('strong', { id: 'returned-child' }, props.label),
+			);
+		};
+		const r = mount(host, { label: 'first' });
+		try {
+			const child = r.find('#returned-child');
+			expect(child.textContent).toBe('first');
+			r.update(host, { label: 'second' });
+			expect(r.find('#returned-child')).toBe(child);
+			expect(child.textContent).toBe('second');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('updates compiled children while retaining their state and cleaning up removed children', () => {
+		const host: ComponentBody<{ children?: OctaneNode }> = (props, scope) => {
+			hostComponent(scope, 0, 'section', { id: 'callable-host' }, props.children);
+		};
+		const lifecycle: string[] = [];
+		const attached: HTMLButtonElement[] = [];
+		const detached: HTMLButtonElement[] = [];
+		const onEffect = (label: string) => {
+			lifecycle.push(`setup:${label}`);
+			return () => {
+				lifecycle.push(`cleanup:${label}`);
+			};
+		};
+		const childRef = (element: HTMLButtonElement | null) => {
+			if (element === null) return;
+			attached.push(element);
+			return () => {
+				detached.push(element);
+			};
+		};
+		const props = { host, childRef, onEffect };
+		const r = mount(HostComponentChildren, { ...props, label: 'first', show: true });
+		try {
+			flushEffects();
+			const section = r.find('#callable-host');
+			const label = r.find('#host-label');
+			const button = r.find('#host-child');
+			expect(button.textContent).toBe('first:0');
+			expect(lifecycle).toEqual(['setup:first']);
+			expect(attached).toEqual([button]);
+
+			r.click('#host-child');
+			flushEffects();
+			expect(button.textContent).toBe('first:1');
+			r.update(HostComponentChildren, { ...props, label: 'second', show: true });
+			flushEffects();
+			expect(r.find('#callable-host')).toBe(section);
+			expect(r.find('#host-label')).toBe(label);
+			expect(label.textContent).toBe('second');
+			expect(r.find('#host-child')).toBe(button);
+			expect(button.textContent).toBe('second:1');
+			expect(lifecycle).toEqual(['setup:first', 'cleanup:first', 'setup:second']);
+			expect(attached).toEqual([button]);
+			expect(detached).toEqual([]);
+
+			r.update(HostComponentChildren, { ...props, label: 'empty', show: false });
+			flushEffects();
+			expect(r.find('#callable-host')).toBe(section);
+			expect(label.textContent).toBe('empty');
+			expect(r.findAll('#host-child')).toEqual([]);
+			expect(detached).toEqual([button]);
+			expect(lifecycle).toEqual(['setup:first', 'cleanup:first', 'setup:second', 'cleanup:second']);
+
+			r.update(HostComponentChildren, { ...props, label: 'third', show: true });
+			flushEffects();
+			const remounted = r.find('#host-child');
+			expect(r.find('#callable-host')).toBe(section);
+			expect(remounted).not.toBe(button);
+			expect(remounted.textContent).toBe('third:0');
+			expect(attached).toEqual([button, remounted]);
+			r.unmount();
+			flushEffects();
+			expect(lifecycle).toEqual([
+				'setup:first',
+				'cleanup:first',
+				'setup:second',
+				'cleanup:second',
+				'setup:third',
+				'cleanup:third',
+			]);
+		} finally {
+			r.unmount();
+		}
+	});
+
 	it('removes attributes that disappear across renders', () => {
 		const r = mount(HostBody as any, { hp: { id: 'h', 'data-x': '1', title: 't', class: 'a' } });
 		const div = r.container.querySelector('#h')!;


### PR DESCRIPTION
## Summary

- Forward the three `ComponentBody` arguments directly through the stable `hostComponent` child body, preserving its latest target and return value without a rest array.
- Add compiled callable-child tests for live props, state, DOM identity, ref/effect cleanup on removal, remounts, and returned renderables.
- Add a production work-count benchmark with equivalent descriptor-child controls.

## Why

Issue #981 identifies per-render rest/spread allocation in the host-child trampoline. The body ABI supplies exactly three arguments; a host adapter such as `motion.div` can forward them directly.

## Validation

- [ ] `pnpm format:check` — scoped formatting passed locally; the CI lint checks passed.
- [ ] `pnpm typecheck` — the local run reached its final command without diagnostics, but a shell wrapper masked its exit code; the CI typecheck passed.
- [ ] `pnpm test` — focused tests passed locally; all current-head CI test shards passed.
- [x] `pnpm typecheck:files packages/octane/src/runtime.ts packages/octane/tests/host-component-props.test.ts packages/octane/tests/_fixtures/host-component-children.tsrx`
- [x] `pnpm format:files:check` on all changed source, tests, benchmark files, and changeset.
- [x] Host-component tests in dev/prod: 16 passed; a deliberately stale child target fails both new cases in both modes before restoring the implementation.
- [x] Motion render/rerender and compiled ref-detach tests: 16 passed.
- [x] `node benchmarks/host-component/work.mjs`: semantic controls and work counts pass.
- [x] `pnpm sync`: no generated changes.

## Performance audit

In the same production esbuild + Chromium 149 jitless observer on Node 26.4, rest-parameter executions fall from 128/1,024 to 0 per mount or update with 128/1,024 callable-child hosts, and from 1,536/12,288 to 0 across twelve updates. Host and child call counts, output, DOM identity, nesting, and teardown match; equivalent descriptor-child controls remain at zero. The unminified observer bundle grows 26 bytes. These are deterministic source/interpreter work counts, not a throughput claim.

## Risk / follow-ups

The wrapper's receiver, latest child target, three positional arguments, and return value remain intact. A separate baseline root-unmount ref cleanup behavior in this host path was observed during test development; removal/ref cleanup and root-unmount effect cleanup are covered here. The remaining per-render allocation examples in #981 stay open.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791578160&installation_model_id=432790&pr_number=1025&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1025&signature=c5870149174430f62e241c0f45befa2d2e48dcf2206a6444320447d4f05cabcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot `hostComponent` child-reconciliation path in core runtime, though the ABI is unchanged and tests/benchmarks target reconciliation and forwarding semantics.
> 
> **Overview**
> Removes per-render **rest-argument array allocation** in reused host components (e.g. `motion.<tag>`) by changing the stable child delegator in `hostComponent` from `(...args) => latest(...args)` to explicit **`(props, scope, extra) => latest!(props, scope, extra)`**, while still updating `state.latest` each render so `childSlot` keeps a stable body identity.
> 
> Adds **regression coverage** for callable children (returned renderables) and compiled host children (props updates, preserved state/DOM, `@if` removal, ref/effect cleanup, remounts), plus a **production benchmark** that bundles the real runtime, asserts semantics/DOM identity, and gates on **zero rest parameters** in the emitted trampoline (with optional `--measure` for baseline comparison).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c46b078ef24e568e55c184eb63ed56efaa57911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

