### PR TITLE
perf: avoid nested universal hook slot arrays

### DIFF
--- a/.changeset/universal-hook-slot-stack.md
+++ b/.changeset/universal-hook-slot-stack.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid allocating a temporary array when resolving nested universal hook slots.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,6 +87,7 @@ runner loops their per-target invocations and merges them),
 **ssr-throughput**, **streaming-ssr**, **lynx-list**, **universal-leaf-update**,
 **universal-object-teardown**,
 **universal-template-events**, **universal-native-hover**, **universal-owner-drafts**,
+**universal-hook-slot**,
 **universal-draft-lookup**, **scoped-descriptor-shapes**, **memo-wrapper-shapes**,
 **universal-external-store**,
 **lynx-render**, **lynx-bundle-size**, **tsrx-renderer-validation-ranges**, and
@@ -283,6 +284,7 @@ internally, get their own baseline and guard namespace.
 | `universal-template-events` | universal-template-events | none (Node-only) | shape-stable handler updates across 128 and 1,024 retained native event sites through ordinary hosts and the fallback collapsed-template host capability, with host identity, stable listener IDs, latest-handler dispatch, and redundant-command controls |
 | `universal-native-hover` | universal-native-hover | none (Node-only) | compiled production native universal selection in 20 and 80 keyed rows, each with four component/view layers; 2,000 real hover updates per sample, host and prop identity checks, teardown, a same-run scaling ratio, and optional local V8 cumulative allocation profile |
 | `universal-owner-drafts` | universal-owner-drafts | none (Node-only) | retained object-driver roots with 0, 1, 128, and 1,024 changed-prop child owners; output, render, host identity, and structural-command controls |
+| `universal-hook-slot` | universal-hook-slot | none (Node-only) | production universal hook-slot array-creation events across direct and nested hook calls, with state/ref/memo/effect identity and output controls; deterministic zero-array guard |
 | `universal-draft-lookup` | universal-draft-lookup | none (Node-only) | root-owned ref lookups from 0, 1, 128, and 1,024 changing child owners, with own-ref and plain-object controls and host, state, and structural-command checks |
 | `scoped-descriptor-shapes` | scoped-descriptor-shapes | none (Node-only) | production client/server scoped element and value descriptor creation, reads, enumeration, cloning, Children.map and SSR, with plain-element controls and deferred-child/key/order checks |
 | `memo-wrapper-shapes` | memo-wrapper-shapes | none (Node-only) | production client/server creation and metadata reads across 128 and 1,024 distinct memo wrappers, with plain-function/data-only controls, live defaults, static-hoisting checks, and untimed V8 shape diagnostics |

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -879,6 +879,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
 	},
 	{
+		// Production universal hook-slot allocation work in direct and nested
+		// public hooks, with retained state, refs, effects, and host identity.
+		name: 'universal-hook-slot',
+		cwd: 'universal-hook-slot',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'run.mjs', args: () => [] }],
+	},
+	{
 		// Universal draft lookup (Node-only): ancestor-owned refs read across
 		// 128 and 1,024 child owners, with own-ref and plain-property controls.
 		name: 'universal-draft-lookup',

--- a/benchmarks/universal-hook-slot/README.md
+++ b/benchmarks/universal-hook-slot/README.md
@@ -1,0 +1,69 @@
+# Universal hook slot work
+
+This untimed Node benchmark exercises the production universal runtime through
+public object-driver roots. One and 128 keyed child owners each call state, ref,
+memo, and layout-effect hooks at two independent sites. The nested case uses two
+`withSlot` levels; the direct-hook case is a negative control.
+
+The guard measures source array-creation events during mount, changed-prop
+updates, state updates, keyed reorder, and unmount. It also records module
+initialization and fixture setup. Each render of 128 owners calls 1,024 hooks.
+The default gate requires zero arrays from hook-slot resolution in every phase.
+
+```bash
+node benchmarks/universal-hook-slot/run.mjs
+
+# Compare the current resolver with an earlier Git revision using the same
+# dependencies, bundler options, fixture, and other runtime modules.
+BENCH_JSON=/tmp/universal-hook-slot.json \
+  node benchmarks/universal-hook-slot/run.mjs 621147d01
+
+# Record an unoptimized baseline without enforcing the zero-array gate.
+BENCH_SOURCE_REF=621147d01 \
+  node benchmarks/universal-hook-slot/run.mjs --measure
+```
+
+Remove `--measure` from the last command to verify the baseline fails the guard.
+`BENCH_SOURCE_REF` and the comparison argument replace only
+`packages/octane/src/universal-core.ts` from the requested Git object; they are
+for isolated changes to that file. All other sources come from the worktree.
+
+## Measurement boundary
+
+The runner bundles the real universal entry with esbuild and
+`NODE_ENV=production`, then applies the existing allocation observer to emitted
+JavaScript. This keeps instrumentation out of tree shaking and runtime build
+decisions. The observer counts executed array literals, `new Array`, and rest
+parameters. It reports both resolver-local events and events across the bundled
+runtime. A paired run requires the total decrease to equal the resolver decrease
+in every phase, with module initialization unchanged.
+
+These are source creation counts, not retained heap bytes, garbage collections,
+or an elapsed-time speedup. Engine escape analysis may remove some temporary
+arrays. Arrays created inside built-in methods are not counted. Fixture-authored
+arrays and observer overhead are excluded. The benchmark makes no DOM, browser,
+native-device, SSR, or application-throughput claim.
+
+Both clean and observed bundles must produce the same output hash. Each phase
+checks independent state, live state getters, stable refs and setters, memo
+values, retained host identities, keyed order, and effect setup/cleanup. Ordinary
+prop and state updates must emit no structural host commands. Direct and nested
+cases must produce identical visible output and lifecycle counts.
+
+## Recorded comparison
+
+Against `621147d01` on Node 26.4.0 / V8 14.6.202.34-node.21, each render phase
+for 128 nested owners removes 1,024 resolver array events:
+
+| Phase | Baseline runtime arrays | Indexed traversal runtime arrays |
+| --- | ---: | ---: |
+| Mount | 4,543 | 3,519 |
+| Changed props | 3,510 | 2,486 |
+| State update | 3,383 | 2,359 |
+| Keyed reorder | 3,899 | 2,875 |
+
+The one-owner nested case removes eight events in each phase. Direct hooks
+remain at zero resolver arrays; all their runtime counts are unchanged. Module
+initialization (130), fixture setup (nine), and 128-owner unmount (403) are also
+unchanged. Every 128-owner render still calls 1,024 hooks, and all 256 effects
+clean up. JSON output includes source, emitted helper, bundle, and lockfile hashes.

--- a/benchmarks/universal-hook-slot/run.mjs
+++ b/benchmarks/universal-hook-slot/run.mjs
@@ -1,0 +1,335 @@
+// Untimed array-creation work guard over the production universal runtime.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+
+import {
+	COUNTER_GLOBAL,
+	COUNTER_KINDS,
+	emptyCounters,
+	instrumentJavaScript,
+} from '../hook-memo/instrument.mjs';
+
+process.env.NODE_ENV = 'production';
+const repo = path.resolve(import.meta.dirname, '../..');
+const requireDependencies = createRequire(path.join(repo, 'packages/octane/package.json'));
+const { build } = requireDependencies('esbuild');
+const { parseModule, builders } = requireDependencies('@tsrx/core');
+const { print: printAst } = requireDependencies('esrap');
+const tsx = requireDependencies('esrap/languages/tsx').default;
+const file = 'packages/octane/src/universal-core.ts';
+const measureOnly = process.argv.includes('--measure');
+const baselineRef = process.argv.slice(2).find((arg) => !arg.startsWith('--'));
+const sha256 = (source) => createHash('sha256').update(source).digest('hex');
+const temporary = mkdtempSync(path.join(tmpdir(), 'octane-universal-hook-slot-'));
+
+function resetCounters() {
+	globalThis[COUNTER_GLOBAL] = {
+		...emptyCounters(),
+		...Object.fromEntries(COUNTER_KINDS.map((kind) => [`slot_${kind}`, 0])),
+	};
+}
+
+function counters() {
+	const value = globalThis[COUNTER_GLOBAL];
+	const arrayKinds = ['arrayLiterals', 'arrayConstructors', 'restArrays'];
+	return {
+		slotArrays: arrayKinds.reduce((total, kind) => total + value[`slot_${kind}`], 0),
+		runtimeArrays: arrayKinds.reduce(
+			(total, kind) => total + value[`slot_${kind}`] + value[`runtime_${kind}`],
+			0,
+		),
+	};
+}
+
+function workload(runtime, nested, size) {
+	resetCounters();
+	const {
+		createObjectContainer,
+		createObjectDriver,
+		createUniversalRoot,
+		defineUniversalComponent,
+		flushUniversalSync,
+		universalComponent,
+		universalPlan,
+		universalValue,
+		useLayoutEffect,
+		useMemo,
+		useRef,
+		useState,
+		withSlot,
+	} = runtime;
+	const scenePlan = universalPlan('object', {
+		kind: 'host',
+		type: 'scene',
+		bindings: [['version', 0]],
+		children: [{ kind: 'slot', slot: 1 }],
+	});
+	const cellPlan = universalPlan('object', {
+		kind: 'host',
+		type: 'cell',
+		bindings: [
+			['id', 0],
+			['left', 1],
+			['right', 2],
+		],
+	});
+	const retainedHooks = new Map();
+	let hookCalls = 0;
+	let setups = 0;
+	let cleanups = 0;
+	function readHooks(id, site, version) {
+		const prefix = nested ? '' : `${site}:`;
+		const initial = id * 10 + site;
+		const [value, set, get] = useState(initial, `${prefix}state`);
+		const ref = useRef(initial, `${prefix}ref`);
+		const memo = useMemo(() => `${value}:${version}`, [value, version], `${prefix}memo`);
+		useLayoutEffect(
+			() => {
+				setups++;
+				return () => cleanups++;
+			},
+			[],
+			`${prefix}effect`,
+		);
+		hookCalls += 4;
+		const key = `${id}:${site}`;
+		const previous = retainedHooks.get(key);
+		if (previous) {
+			assert.equal(ref, previous.ref, 'refs survive changed props and state');
+			assert.equal(set, previous.set, 'state setters retain identity');
+			assert.equal(get, previous.get, 'state getters retain identity');
+		} else retainedHooks.set(key, { ref, set, get });
+		assert.equal(ref.current, initial);
+		assert.equal(get(), value);
+		return memo;
+	}
+	const Child = defineUniversalComponent('object', ({ id, version }) => {
+		const read = (site) =>
+			nested
+				? withSlot(site, () => withSlot(Symbol.for('inner'), () => readHooks(id, site, version)))
+				: readHooks(id, site, version);
+		return universalValue(cellPlan, [id, read(0), read(1)]);
+	});
+	const Scene = defineUniversalComponent('object', ({ version, children }) =>
+		universalValue(scenePlan, [version, children]),
+	);
+	const ids = Array.from({ length: size }, (_, id) => id);
+	const props = (version, order = ids) => ({
+		version,
+		children: order.map((id) => universalComponent('object', Child, { id, version }, id)),
+	});
+	const container = createObjectContainer('object');
+	const root = createUniversalRoot(container, createObjectDriver('object'));
+	const phases = { setup: { ...counters(), hookCalls: 0 } };
+	const snapshots = {};
+	let retainedScene;
+	let retainedCells;
+	function observe(name, run, version, stateDelta, order = ids) {
+		resetCounters();
+		const previousHookCalls = hookCalls;
+		run();
+		phases[name] = { ...counters(), hookCalls: hookCalls - previousHookCalls };
+		const scene = container.children[0];
+		assert.equal(container.instanceCount, size + 1);
+		assert.equal(scene.props.version, version);
+		assert.equal(scene.children.length, size);
+		if (retainedScene) assert.equal(scene, retainedScene);
+		else {
+			retainedScene = scene;
+			retainedCells = [...scene.children];
+		}
+		for (let index = 0; index < size; index++) {
+			const id = order[index];
+			const cell = scene.children[index];
+			assert.equal(cell, retainedCells[id], 'keyed host identity survives updates and reorder');
+			assert.deepEqual(cell.props, {
+				id,
+				left: `${id * 10 + stateDelta}:${version}`,
+				right: `${id * 10 + 1}:${version}`,
+			});
+		}
+		assert.equal(setups, size * 2);
+		assert.equal(cleanups, 0);
+		snapshots[name] = scene.children.map((cell) => ({ ...cell.props }));
+	}
+	observe('mount', () => root.render(Scene, props(0)), 0, 0);
+	container.commits.length = 0;
+	observe('propsUpdate', () => root.render(Scene, props(1)), 1, 0);
+	observe(
+		'stateUpdate',
+		() =>
+			flushUniversalSync(() => {
+				for (const id of ids) retainedHooks.get(`${id}:0`).set((value) => value + 5);
+			}),
+		1,
+		5,
+	);
+	const structuralUpdates = container.commits
+		.flatMap((batch) => batch.commands)
+		.filter((command) => ['create', 'destroy', 'insert', 'remove'].includes(command.op)).length;
+	assert.equal(structuralUpdates, 0, 'ordinary updates retain host structure');
+	const reversed = [...ids].reverse();
+	observe('reorder', () => root.render(Scene, props(2, reversed)), 2, 5, reversed);
+	resetCounters();
+	root.unmount();
+	phases.unmount = { ...counters(), hookCalls: 0 };
+	assert.equal(container.children.length, 0);
+	assert.equal(container.instanceCount, 0);
+	assert.equal(cleanups, size * 2);
+	return {
+		phases,
+		semantic: {
+			outputHash: sha256(JSON.stringify(snapshots)),
+			setups,
+			cleanups,
+			structuralUpdates,
+		},
+	};
+}
+
+async function measure(source, label) {
+	const result = await build({
+		entryPoints: [path.join(repo, 'packages/octane/src/universal.ts')],
+		bundle: true,
+		format: 'esm',
+		platform: 'node',
+		write: false,
+		define: { 'process.env.NODE_ENV': '"production"' },
+		plugins: [
+			{
+				name: 'paired-universal-source',
+				setup(builder) {
+					builder.onLoad({ filter: /[/\\]universal-core\.ts$/ }, () => ({
+						contents: source,
+						loader: 'ts',
+						resolveDir: path.join(repo, 'packages/octane/src'),
+					}));
+				},
+			},
+		],
+	});
+	const clean = result.outputFiles[0].text;
+	const helper = parseModule(clean, 'universal.mjs').body.find(
+		(node) => node.type === 'FunctionDeclaration' && node.id?.name === 'resolveHookSlot',
+	);
+	assert.ok(helper, 'the emitted hook resolver is present');
+	const observed = instrumentJavaScript(
+		clean,
+		'universal.mjs',
+		(node) => (node.start >= helper.start && node.end <= helper.end ? 'slot' : 'runtime'),
+		{ parseModule, builders, print: (ast) => printAst(ast, tsx()).code },
+	);
+	const cleanFile = path.join(temporary, `${label}-clean.mjs`);
+	const observedFile = path.join(temporary, `${label}-observed.mjs`);
+	writeFileSync(cleanFile, clean);
+	writeFileSync(observedFile, observed);
+	const cleanRuntime = await import(pathToFileURL(cleanFile).href);
+	resetCounters();
+	const observedRuntime = await import(pathToFileURL(observedFile).href);
+	const moduleArrays = counters().runtimeArrays;
+	const cases = {};
+	for (const size of [1, 128]) {
+		for (const nested of [false, true]) {
+			const name = `${nested ? 'nested' : 'direct'}-${size}`;
+			const expected = workload(cleanRuntime, nested, size);
+			const actual = workload(observedRuntime, nested, size);
+			assert.deepEqual(actual.semantic, expected.semantic, 'observer preserves public behavior');
+			cases[name] = actual;
+		}
+		assert.deepEqual(cases[`nested-${size}`].semantic, cases[`direct-${size}`].semantic);
+	}
+	return {
+		sourceHash: sha256(source),
+		bundleHash: sha256(clean),
+		helperHash: sha256(clean.slice(helper.start, helper.end)),
+		moduleArrays,
+		cases,
+	};
+}
+
+function sourceAt(ref) {
+	return ref === undefined
+		? readFileSync(path.join(repo, file), 'utf8')
+		: execFileSync('git', ['show', `${ref}:${file}`], {
+				cwd: repo,
+				encoding: 'utf8',
+				maxBuffer: 8 * 1024 * 1024,
+			});
+}
+
+try {
+	const result = {
+		suite: 'universal-hook-slot',
+		metric: 'source array-creation events in the production runtime',
+		node: process.version,
+		v8: process.versions.v8,
+		platform: process.platform,
+		architecture: process.arch,
+		lockfileHash: sha256(readFileSync(path.join(repo, 'pnpm-lock.yaml'))),
+		candidateRef: process.env.BENCH_SOURCE_REF ?? 'working tree',
+		candidate: await measure(sourceAt(process.env.BENCH_SOURCE_REF), 'candidate'),
+	};
+	if (baselineRef) {
+		result.baselineRef = baselineRef;
+		result.baseline = await measure(sourceAt(baselineRef), 'baseline');
+		assert.equal(
+			result.candidate.moduleArrays,
+			result.baseline.moduleArrays,
+			'array work is not moved to module initialization',
+		);
+		for (const [name, after] of Object.entries(result.candidate.cases)) {
+			const before = result.baseline.cases[name];
+			assert.deepEqual(after.semantic, before.semantic, `${name}: baseline behavior matches`);
+			for (const [phase, counts] of Object.entries(after.phases)) {
+				assert.equal(counts.hookCalls, before.phases[phase].hookCalls);
+				assert.equal(
+					before.phases[phase].runtimeArrays - counts.runtimeArrays,
+					before.phases[phase].slotArrays - counts.slotArrays,
+					`${name}/${phase}: array work is removed, not moved outside the resolver`,
+				);
+			}
+		}
+	}
+	result.iterations = 1;
+	result.targets = Object.entries(result.candidate.cases).map(([name, scenario]) => ({
+		name,
+		ops: Object.fromEntries(
+			Object.entries(scenario.phases).flatMap(([phase, counts]) =>
+				Object.entries(counts).map(([metric, value]) => [
+					`${phase}_${metric}`,
+					deterministicStatForJson(deterministicCount(value)),
+				]),
+			),
+		),
+		meta: scenario.semantic,
+	}));
+	console.log('| case / phase | resolver arrays | all runtime arrays | hook calls |');
+	console.log('| --- | ---: | ---: | ---: |');
+	for (const [name, scenario] of Object.entries(result.candidate.cases)) {
+		for (const [phase, counts] of Object.entries(scenario.phases)) {
+			console.log(
+				`| ${name} / ${phase} | ${counts.slotArrays} | ${counts.runtimeArrays} | ${counts.hookCalls} |`,
+			);
+		}
+	}
+	if (process.env.BENCH_JSON)
+		writeFileSync(process.env.BENCH_JSON, JSON.stringify(result, null, 2) + '\n');
+	if (!measureOnly) {
+		for (const [name, scenario] of Object.entries(result.candidate.cases)) {
+			for (const [phase, counts] of Object.entries(scenario.phases)) {
+				assert.equal(counts.slotArrays, 0, `${name}/${phase}: hook resolution creates no arrays`);
+			}
+		}
+	}
+} finally {
+	delete globalThis[COUNTER_GLOBAL];
+	rmSync(temporary, { recursive: true, force: true });
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -110,6 +110,7 @@ export const BENCHMARK_SUITES = [
 	'universal-template-events',
 	'universal-native-hover',
 	'universal-owner-drafts',
+	'universal-hook-slot',
 	'universal-draft-lookup',
 	'scoped-descriptor-shapes',
 	'memo-wrapper-shapes',

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -4870,9 +4870,11 @@ function resolveHookSlot(slot: unknown): unknown {
 		throw new Error('Universal hooks require an active component owner.');
 	}
 	const own = slot ?? `implicit:${owner.implicitSlot++}`;
-	if (UNIVERSAL_SLOT_STACK.length === 0) return own;
+	const depth = UNIVERSAL_SLOT_STACK.length;
+	if (depth === 0) return own;
 	let key = '@octane:universal-hook:';
-	for (const part of [...UNIVERSAL_SLOT_STACK, own]) {
+	for (let index = 0; index <= depth; index++) {
+		const part = index === depth ? own : UNIVERSAL_SLOT_STACK[index];
 		const value =
 			typeof part === 'symbol'
 				? `s${part.description?.length ?? 0}:${part.description ?? ''}`

--- a/packages/octane/tests/universal-manual-hook-context.test.ts
+++ b/packages/octane/tests/universal-manual-hook-context.test.ts
@@ -129,4 +129,84 @@ describe.each([
 			root.unmount();
 		}
 	});
+
+	it('retains nested hook state and refs across reordering and a failed coercion retry', async () => {
+		type Id = 'a' | 'b';
+		const failure = new Error('slot coercion failed');
+		let failingSite: Id | undefined;
+		function site(id: Id) {
+			let first = true;
+			return {
+				[Symbol.toPrimitive]() {
+					return Runtime.withSlot('coercion', () => {
+						if (failingSite === id) throw failure;
+						// Repeated coercion remains observable even when the first values match.
+						const value = first ? 'shared' : id;
+						first = !first;
+						return value;
+					});
+				},
+			};
+		}
+		const sites = { a: site('a'), b: site('b') };
+		const innerSite = Symbol('inner');
+		const stateSite = Symbol('state');
+		const refSite = Symbol('ref');
+		function useInner(id: Id) {
+			const [state, setState] = Runtime.useState(id.toUpperCase(), stateSite);
+			const ref = Runtime.useRef({ id }, refSite);
+			return { state, setState, ref };
+		}
+		function useOuter(id: Id) {
+			return Runtime.withSlot(innerSite, useInner, id);
+		}
+		let report = new Map<Id, ReturnType<typeof useOuter>>();
+		const plan = Runtime.universalPlan('object', {
+			kind: 'host',
+			type: 'node',
+			bindings: [['label', 0]],
+		});
+		const Scene = Runtime.defineUniversalComponent('object', (props: { order: Id[] }) => {
+			const next = new Map<Id, ReturnType<typeof useOuter>>();
+			for (const id of props.order) next.set(id, Runtime.withSlot(sites[id], useOuter, id));
+			report = next;
+			return Runtime.universalValue(plan, [
+				props.order.map((id) => `${id}:${next.get(id)!.state}`).join('|'),
+			]);
+		});
+		const container = Runtime.createObjectContainer();
+		const root = Runtime.createUniversalRoot(container, Runtime.createObjectDriver());
+		try {
+			root.render(Scene, { order: ['a', 'b'] });
+			const host = container.children[0];
+			const firstRef = report.get('a')!.ref;
+			const secondRef = report.get('b')!.ref;
+			expect(host.props.label).toBe('a:A|b:B');
+			expect(firstRef).not.toBe(secondRef);
+			expect(firstRef.current).toEqual({ id: 'a' });
+			expect(secondRef.current).toEqual({ id: 'b' });
+
+			report.get('a')!.setState('changed');
+			await Promise.resolve();
+			expect(host.props.label).toBe('a:changed|b:B');
+			root.render(Scene, { order: ['b', 'a'] });
+			expect(container.children[0]).toBe(host);
+			expect(host.props.label).toBe('b:B|a:changed');
+			expect(report.get('a')!.ref).toBe(firstRef);
+			expect(report.get('b')!.ref).toBe(secondRef);
+
+			failingSite = 'a';
+			expect(() => root.render(Scene, { order: ['a', 'b'] })).toThrow(failure);
+			expect(host.props.label).toBe('b:B|a:changed');
+			failingSite = undefined;
+			root.render(Scene, { order: ['a', 'b'] });
+			expect(container.children[0]).toBe(host);
+			expect(host.props.label).toBe('a:changed|b:B');
+			expect(report.get('a')!.ref).toBe(firstRef);
+			expect(report.get('b')!.ref).toBe(secondRef);
+		} finally {
+			root.unmount();
+		}
+		expect(container.children).toEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary

- Resolve nested universal hook slots by reading the captured stack depth directly, removing the temporary array spread on every hook call. Universal and native renderers share this path.
- Preserve the existing segment encoding, repeated coercion, implicit slot numbering, and `Symbol.for` behavior.
- Add a public-root regression for sibling state/ref identity, reordered hooks, reentrant slot coercion, failed render, retry, and teardown, plus a production-bundle allocation guard.

## Why

Issue #981 identified temporary arrays in the universal hook-slot path. The direct-hook fast path is unchanged; nested hooks previously evaluated one array literal per lookup.

## Validation

- [ ] `pnpm format:check` (scoped `pnpm format:files:check` passed for all changed files)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (not run as one local command; the full sharded suite passed in current-head CI)
- [x] MCP benchmark manifest test: 15/15 passed after reproducing and fixing the CI mismatch.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34462773321): 26/26 jobs successful at `294f6b0cf`.
- [x] Universal tests: 36 files, 722 tests passed; the new regression failed under a deliberate ancestor-slot break and passed again after restoration.
- [x] `node benchmarks/bench.mjs --quick universal-hook-slot --ratios` (its zero-array assertion passed; no ratio guards selected for this new suite).
- [x] Paired benchmark against `621147d01`: at 128 nested owners, 1,024 → 0 resolver array events on mount, changed-prop update, state update, and keyed reorder; total runtime array events fell by exactly 1,024 in each phase. Direct hooks, setup, and teardown were unchanged, with matching output and hook-call counts.

## Risk / follow-ups

- The benchmark counts executed array-creation expressions in a production bundle, not heap bytes or elapsed time. Engine optimization and built-in method allocations are outside this observer.
- Nested paths still construct a string and call `Symbol.for` on every lookup. That remaining part of #981 stays open.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791625120&installation_model_id=432790&pr_number=1026&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1026&signature=a8b7ac330e9cd9b4d4c65da45f0d5add1b2dc2ff256f0fc4b1e6f077a3d3046e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production universal hook-slot resolver on every nested hook call; behavior is guarded by new tests and a zero-array benchmark gate.
> 
> **Overview**
> **`resolveHookSlot`** no longer builds `[...UNIVERSAL_SLOT_STACK, own]` on nested lookups; it walks the captured stack depth with an indexed loop and the same string/`Symbol.for` encoding, leaving the direct (empty-stack) fast path unchanged.
> 
> A new **`universal-hook-slot`** Node benchmark (wired into **`bench.mjs`**, docs, and the MCP suite list) production-bundles the runtime, instruments **`resolveHookSlot`**, and **fails unless resolver array-creation events are zero** across mount, prop/state updates, reorder, and unmount for direct vs doubly nested **`withSlot`** workloads.
> 
> **`universal-manual-hook-context.test.ts`** adds a regression for nested sibling hook state/refs through reorder, reentrant slot coercion, a failed render, retry, and teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 294f6b0cf3dbe6b80776805c56c445aafadecc8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
