### PR TITLE
perf: register client warm plans without empty batches

### DIFF
--- a/.changeset/warm-fallback-registration.md
+++ b/.changeset/warm-fallback-registration.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid empty batch arrays when registering client warm plans for complex components.

--- a/benchmarks/recursive-context/README.md
+++ b/benchmarks/recursive-context/README.md
@@ -178,17 +178,34 @@ The normal DOM checks in `run.mjs` verify all 1024 leaf paths, both context
 values, the isolated 32-leaf provider update, and remount identity.
 
 A separate production entry (`warm-plan-control.html`) renders a parent with
-its own promise creation and a same-module async child. That parent must retain
-the direct batch and trailing `useBatch([], warmThunk)` because its warm plan
-does more than traverse children. A fresh Chromium pass confirms the visible
-parent/child values and that each resource starts exactly once; it requires
-four `useBatch` calls over the suspending mount/retry and zero
-`registerWarmPlan` calls. The work gate also parses production compiler output
-for this fixture, a child-only parent that reassigns its props after
-registration, and a parent whose body shadows its function name; each must
-retain the original `useBatch` path. Standalone work
-gate runs may set `RECURSIVE_WORK_TARGETS` to JSON target URLs for isolated
-ephemeral preview ports, avoiding stale assets from other worktrees.
+its own promise creation and a same-module async child. Its nonempty batch must
+still start the independent child before the parent suspends. A fresh Chromium
+pass verifies the visible parent/child values and that each resource starts
+exactly once. The fallback warm registration now uses `registerWarmPlan(thunk,
+undefined)`, so the suspending mount/retry requires three direct `useBatch`
+calls (parent twice, child once) and one plan registration on the successful
+parent retry. Parsed production output verifies that the parent
+keeps its direct batch, while the trailing empty batch array disappears.
+
+Other compiler controls cover child-only parents with reassigned props and a
+locally shadowed component name. Their in-body warm closure cannot be replaced
+by a lookup of the attached plan; the registration uses that same closure. A
+parent-only module imports its async child so its one previous `useBatch` import
+and call can disappear altogether: the candidate must emit zero batch imports
+and calls, one `registerWarmPlan` import and call, and no empty batch array.
+The same source compiled in server and universal modes keeps its existing
+empty-batch registration. Standalone work-gate runs may set
+`RECURSIVE_WORK_TARGETS` to JSON target URLs for isolated ephemeral preview
+ports, avoiding stale assets from other worktrees.
+
+Before this change, the parent/child browser fixture called `useBatch` four
+times and `registerWarmPlan` zero times on mount/retry. The three client
+compiler controls (own promise, reassigned props, shadowed name) emitted
+3/2/2 batch call sites, including one empty-array registration each. The
+parent-only module emitted one batch import, one empty-array call site, and no
+plan import. Server and universal output each emitted one empty batch call site
+for that module. These are deterministic source and browser call counts, not a
+measured latency or heap-allocation improvement.
 
 The same work pass also compiles a plain TypeScript custom hook with two reads
 from a directly initialized module context in both client and server modes. Its

--- a/benchmarks/recursive-context/work.mjs
+++ b/benchmarks/recursive-context/work.mjs
@@ -94,6 +94,7 @@ function countImportedCalls(ast, importedName) {
 		}
 	}
 	let calls = 0;
+	let emptyArrayCalls = 0;
 	function visit(node) {
 		if (
 			ts.isCallExpression(node) &&
@@ -101,11 +102,17 @@ function countImportedCalls(ast, importedName) {
 			locals.has(node.expression.text)
 		) {
 			calls++;
+			if (
+				node.arguments[0] &&
+				ts.isArrayLiteralExpression(node.arguments[0]) &&
+				node.arguments[0].elements.length === 0
+			)
+				emptyArrayCalls++;
 		}
 		ts.forEachChild(node, visit);
 	}
 	visit(ast);
-	return { imports: locals.size, calls };
+	return { imports: locals.size, calls, emptyArrayCalls };
 }
 
 function measurePlainHook(source, environment) {
@@ -136,10 +143,10 @@ const PLAIN_HOOKS = Object.fromEntries(
 	]),
 );
 
-// The own-promise control must keep its direct batch and trailing warm thunk;
-// reassigned props and locally shadowed components need the legacy closure.
-// Inspect imported calls in the parsed production compiler output so helper
-// aliases and generated formatting cannot obscure either negative case.
+// The own-promise control must keep its direct batch. Reassigned props and a
+// locally shadowed component name need the in-body warm closure rather than the
+// attached plan. Inspect imports and calls in parsed production output so
+// helper aliases and generated formatting cannot obscure the split.
 const REASSIGNED_PROPS_SOURCE = `import { use } from 'octane';
 function Child(props) @{
   const value = use(props.load('child', props.version));
@@ -160,13 +167,20 @@ export function Parent(props) @{
   const Parent = () => null;
   <main><Child load={props.load} version={props.version} /></main>
 }`;
+// Keep the async child in its own module. This parent's only batch call is the
+// fallback registration, so the client output can drop the useBatch import.
+const FALLBACK_ONLY_SOURCE = `import AsyncChild from './AsyncChild.tsrx';
+export function Parent(props) @{
+  const Parent = () => null;
+  <main><AsyncChild load={props.load} version={props.version} /></main>
+}`;
 
-function measureCompiledControl(source, filename) {
-	const code = compile(source, filename, { dev: false, hmr: false }).code;
+function measureCompiledControl(source, filename, options = {}) {
+	const code = compile(source, filename, { dev: false, hmr: false, ...options }).code;
 	const ast = ts.createSourceFile(filename, code, ts.ScriptTarget.Latest, true);
 	if (ast.parseDiagnostics.length > 0) throw new Error(`${filename}: invalid compiled TypeScript`);
 	return {
-		batch: countImportedCalls(ast, 'useBatch'),
+		batch: countImportedCalls(ast, options.mode === 'server' ? 'puBatch' : 'useBatch'),
 		plan: countImportedCalls(ast, 'registerWarmPlan'),
 		warmMemo: countImportedCalls(ast, 'warmMemo'),
 	};
@@ -182,6 +196,15 @@ const COMPILED_CONTROLS = {
 		SHADOWED_COMPONENT_SOURCE,
 		'warm-shadowed-component.tsrx',
 	),
+	fallbackOnly: measureCompiledControl(FALLBACK_ONLY_SOURCE, 'warm-fallback-only.tsrx'),
+};
+const NON_CLIENT_FALLBACK_CONTROLS = {
+	server: measureCompiledControl(FALLBACK_ONLY_SOURCE, 'warm-fallback-only.tsrx', {
+		mode: 'server',
+	}),
+	universal: measureCompiledControl(FALLBACK_ONLY_SOURCE, 'warm-fallback-only.tsrx', {
+		renderer: { id: 'object', module: 'octane/universal', target: 'universal' },
+	}),
 };
 
 // Scaffolding is bounded above so later direct-return lowering can reduce it
@@ -446,16 +469,33 @@ for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
 	}
 }
 for (const [name, control] of Object.entries(COMPILED_CONTROLS)) {
-	const expectedBatchCalls = name === 'ownPromise' ? 3 : 2;
-	const expectedWarmMemos = name === 'ownPromise' ? 2 : 1;
-	if (control.batch.imports !== 1 || control.batch.calls !== expectedBatchCalls) {
-		failures.push(`${name}: expected ${expectedBatchCalls} retained batch calls`);
+	const expectedBatchCalls = name === 'ownPromise' ? 2 : name === 'fallbackOnly' ? 0 : 1;
+	const expectedBatchImports = name === 'fallbackOnly' ? 0 : 1;
+	const expectedWarmMemos = name === 'ownPromise' ? 2 : name === 'fallbackOnly' ? 0 : 1;
+	if (
+		control.batch.imports !== expectedBatchImports ||
+		control.batch.calls !== expectedBatchCalls
+	) {
+		failures.push(
+			`${name}: expected ${expectedBatchImports} batch imports and ${expectedBatchCalls} direct batch calls`,
+		);
 	}
-	if (control.plan.imports !== 0 || control.plan.calls !== 0) {
-		failures.push(`${name}: unexpected extracted child-only warm plan`);
+	if (control.batch.emptyArrayCalls !== 0) {
+		failures.push(`${name}: unexpected empty batch arrays: ${control.batch.emptyArrayCalls}`);
+	}
+	if (control.plan.imports !== 1 || control.plan.calls !== 1) {
+		failures.push(`${name}: expected one explicit fallback warm-plan registration`);
 	}
 	if (control.warmMemo.calls !== expectedWarmMemos) {
 		failures.push(`${name}: expected ${expectedWarmMemos} warmable promise creations`);
+	}
+}
+for (const [name, { batch, plan, warmMemo }] of Object.entries(NON_CLIENT_FALLBACK_CONTROLS)) {
+	if (batch.imports !== 1 || batch.calls !== 1 || batch.emptyArrayCalls !== 1) {
+		failures.push(`${name}.fallbackOnly: expected one unchanged empty batch registration`);
+	}
+	if (plan.imports !== 0 || plan.calls !== 0 || warmMemo.calls !== 0) {
+		failures.push(`${name}.fallbackOnly: unexpected plan extraction or warm creation`);
 	}
 }
 try {
@@ -478,9 +518,9 @@ try {
 		after: ['__verifyWarmPlanControl'],
 		metrics: ['useBatch', 'registerWarmPlan'],
 	});
-	if (results.warmPlanControl.useBatch !== 4 || results.warmPlanControl.registerWarmPlan !== 0) {
+	if (results.warmPlanControl.useBatch !== 3 || results.warmPlanControl.registerWarmPlan !== 1) {
 		failures.push(
-			`ownPromise: expected 4 batch calls and no extracted plan, got ` +
+			`ownPromise: expected 3 direct batch calls and 1 fallback plan registration, got ` +
 				`${results.warmPlanControl.useBatch}/${results.warmPlanControl.registerWarmPlan}`,
 		);
 	}
@@ -511,7 +551,12 @@ console.log(
 );
 for (const [name, { batch, plan, warmMemo }] of Object.entries(COMPILED_CONTROLS)) {
 	console.log(
-		`${name} compiled: batch calls=${batch.calls}, plan calls=${plan.calls}, warmable creations=${warmMemo.calls}`,
+		`${name} compiled: batch calls=${batch.calls}, empty arrays=${batch.emptyArrayCalls}, plan calls=${plan.calls}, warmable creations=${warmMemo.calls}`,
+	);
+}
+for (const [name, { batch, plan }] of Object.entries(NON_CLIENT_FALLBACK_CONTROLS)) {
+	console.log(
+		`${name} fallback compiled: batch imports/calls=${batch.imports}/${batch.calls}, empty arrays=${batch.emptyArrayCalls}, plan calls=${plan.calls}`,
 	);
 }
 for (const [environment, { context, mixed }] of Object.entries(PLAIN_HOOKS)) {
@@ -571,7 +616,10 @@ if (outputPath) {
 				name: `octane-${name}-compiled-work`,
 				ops: Object.fromEntries(
 					Object.entries({
+						batch_imports: batch.imports,
 						batch_calls: batch.calls,
+						empty_batch_arrays: batch.emptyArrayCalls,
+						plan_imports: plan.imports,
 						plan_calls: plan.calls,
 						warm_memo_calls: warmMemo.calls,
 					}).map(([metric, value]) => [
@@ -581,6 +629,25 @@ if (outputPath) {
 				),
 				meta: {
 					gates: failures.some((failure) => failure.startsWith(`${name}:`)) ? 'fail' : 'pass',
+				},
+			})),
+			...Object.entries(NON_CLIENT_FALLBACK_CONTROLS).map(([name, { batch, plan }]) => ({
+				name: `octane-${name}-fallback-compiled-work`,
+				ops: Object.fromEntries(
+					Object.entries({
+						batch_imports: batch.imports,
+						batch_calls: batch.calls,
+						empty_batch_arrays: batch.emptyArrayCalls,
+						plan_calls: plan.calls,
+					}).map(([metric, value]) => [
+						metric,
+						deterministicStatForJson(deterministicCount(value)),
+					]),
+				),
+				meta: {
+					gates: failures.some((failure) => failure.startsWith(`${name}.fallbackOnly:`))
+						? 'fail'
+						: 'pass',
 				},
 			})),
 			{

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -16225,10 +16225,26 @@ function rewriteParallelUse(statements, ctx, componentName, warmThunk, staticPla
 		// setup preserves early-return reachability: an alternate returned tree must
 		// not activate the final template's plan. The first direct batch receives the
 		// same thunk below so it can still warm before setup reaches this registration.
-		const batchHelper = ctx.mode === 'server' ? 'puBatch' : 'useBatch';
-		const batchAlias = requireRuntimeForContext(ctx, batchHelper);
+		// Only the DOM client has registerWarmPlan. Its two-argument form pushes
+		// the same block, thunk, and undefined props as an empty useBatch call,
+		// without creating an array on every render. Server and universal units
+		// continue to use their own batch helpers.
+		const fallbackHelper =
+			ctx.mode === 'client' && ctx._universalRuntimeUnit == null
+				? 'registerWarmPlan'
+				: ctx.mode === 'server'
+					? 'puBatch'
+					: 'useBatch';
 		const fallback = inheritOriginLoc(
-			b.stmt(b.call(batchAlias, b.array([]), warmThunk)),
+			b.stmt(
+				fallbackHelper === 'registerWarmPlan'
+					? b.call(
+							requireRuntimeForContext(ctx, fallbackHelper),
+							warmThunk,
+							b.unary('void', b.literal(0, '0')),
+						)
+					: b.call(requireRuntimeForContext(ctx, fallbackHelper), b.array([]), warmThunk),
+			),
 			warmThunk,
 		);
 		let registration = [fallback];

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12553,7 +12553,7 @@ export function useBatch(items: any[], warm?: () => void): void {
 	throw new SuspenseException(combined);
 }
 
-/** @internal Compiler-owned registration for a hoisted child-only warm plan. */
+/** @internal Compiler-owned registration for a component warm plan. */
 export function registerWarmPlan(fn: (props: any) => void, props: any): void {
 	// This must register before the first descendant suspends, even in an app
 	// that has never warmed. The enclosing render's checkpoint drops the registration

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -1203,7 +1203,193 @@ describe('parallel use() — fetch-tree warming (nested chain)', () => {
 	});
 });
 
+const REBOUND_OWN_SOURCE = `
+			import { use, useLayoutEffect } from 'octane';
+
+			function Detail(props) @{
+				const value = use(props.load(props.name, props.version));
+				useLayoutEffect(() => {
+					props.onMount(props.name);
+					return () => props.onCleanup(props.name);
+				}, []);
+				<span class="rebound-own-detail">{value as string}</span>
+			}
+
+			export function Branches(props) @{
+				props = { ...props, version: props.version + 1 };
+				const own = use(props.load('own', props.version));
+				<section>
+					<span class="rebound-own-value">{own as string}</span>
+					<Detail name="left" load={props.load} version={props.version} onMount={props.onMount} onCleanup={props.onCleanup} />
+					<Detail name="right" load={props.load} version={props.version} onMount={props.onMount} onCleanup={props.onCleanup} />
+				</section>
+			}
+
+			export function App(props) @{
+				const Content = props.content;
+				<>
+					@try {
+						<Content load={props.load} version={props.version} onMount={props.onMount} onCleanup={props.onCleanup} />
+					} @pending {
+						<span class="rebound-own-pending">loading</span>
+					}
+				</>
+			}
+		`;
+
 describe('parallel use() — child plans across render attempts', () => {
+	it('starts independent children after a fulfilled own request with rebound props', async () => {
+		const client = loadCompiledFixtureSource(REBOUND_OWN_SOURCE, {
+			id: 'child-plan-rebound-own-request.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const calls: string[] = [];
+		const jobs = new Map<string, Deferred<string>>();
+		const activeEffects = new Map<string, number>();
+		const load = (name: string, version: number): Promise<string> => {
+			const key = `${name}:${version}`;
+			calls.push(key);
+			if (name === 'own') {
+				// The own request is already available, so only descendant suspension
+				// can start the independent child requests in this render.
+				const value = `own-v${version}`;
+				return Object.assign(Promise.resolve(value), { status: 'fulfilled', value });
+			}
+			const job = deferred<string>();
+			jobs.set(key, job);
+			return job.promise;
+		};
+		const onMount = (name: string) => {
+			activeEffects.set(name, (activeEffects.get(name) ?? 0) + 1);
+		};
+		const onCleanup = (name: string) => {
+			activeEffects.set(name, (activeEffects.get(name) ?? 0) - 1);
+		};
+		const root = mount(client.App, {
+			content: client.Branches,
+			load,
+			version: 0,
+			onMount,
+			onCleanup,
+		});
+		try {
+			expect([...calls].sort()).toEqual(['left:1', 'own:1', 'right:1']);
+			expect(root.find('.rebound-own-pending').textContent).toBe('loading');
+			await act(() => jobs.get('right:1')!.resolve('right-v1'));
+			expect(root.find('.rebound-own-pending').textContent).toBe('loading');
+			expect([...calls].sort()).toEqual(['left:1', 'own:1', 'right:1']);
+			await act(() => jobs.get('left:1')!.resolve('left-v1'));
+			expect(root.find('.rebound-own-value').textContent).toBe('own-v1');
+			expect(root.findAll('.rebound-own-detail').map((node) => node.textContent)).toEqual([
+				'left-v1',
+				'right-v1',
+			]);
+			expect([...calls].sort()).toEqual(['left:1', 'own:1', 'right:1']);
+			expect(Object.fromEntries(activeEffects)).toEqual({ left: 1, right: 1 });
+
+			root.update(client.App, { content: client.Branches, load, version: 2, onMount, onCleanup });
+			expect(calls.slice(3).sort()).toEqual(['left:3', 'own:3', 'right:3']);
+			await act(() => {
+				jobs.get('left:3')!.resolve('left-v3');
+				jobs.get('right:3')!.resolve('right-v3');
+			});
+			expect(root.find('.rebound-own-value').textContent).toBe('own-v3');
+			expect(root.findAll('.rebound-own-detail').map((node) => node.textContent)).toEqual([
+				'left-v3',
+				'right-v3',
+			]);
+			expect(calls).toHaveLength(6);
+			expect(Object.fromEntries(activeEffects)).toEqual({ left: 1, right: 1 });
+		} finally {
+			root.unmount();
+		}
+		expect(Object.fromEntries(activeEffects)).toEqual({ left: 0, right: 0 });
+	});
+
+	it('starts independent children on an update after adopting server content', async () => {
+		const id = 'hydrated-child-plan-rebound-own-request.tsrx';
+		const server = loadCompiledFixtureSource(REBOUND_OWN_SOURCE, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const client = loadCompiledFixtureSource(REBOUND_OWN_SOURCE, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const noop = () => {};
+		const rendered = await prerender(server.Branches, {
+			load: (name: string, version: number) => Promise.resolve(`${name}-v${version}`),
+			version: 0,
+			onMount: noop,
+			onCleanup: noop,
+		});
+		const container = document.createElement('div');
+		container.innerHTML = rendered.html;
+		document.body.appendChild(container);
+		const own = container.querySelector('.rebound-own-value');
+		const details = Array.from(container.querySelectorAll('.rebound-own-detail'));
+		const calls: string[] = [];
+		const jobs = new Map<string, Deferred<string>>();
+		const load = (name: string, version: number): Promise<string> => {
+			const key = `${name}:${version}`;
+			calls.push(key);
+			if (name === 'own') {
+				const value = `own-v${version}`;
+				return Object.assign(Promise.resolve(value), { status: 'fulfilled', value });
+			}
+			let job = jobs.get(key);
+			if (job === undefined) {
+				job = deferred<string>();
+				jobs.set(key, job);
+			}
+			return job.promise;
+		};
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			root = hydrateRoot(container, client.Branches, {
+				load,
+				version: 0,
+				onMount: noop,
+				onCleanup: noop,
+			});
+			flushSync(() => {});
+			expect(calls).toEqual([]);
+			expect(own?.textContent).toBe('own-v1');
+			expect(details.map((node) => node.textContent)).toEqual(['left-v1', 'right-v1']);
+			expect(container.querySelector('.rebound-own-value')).toBe(own);
+			expect(Array.from(container.querySelectorAll('.rebound-own-detail'))).toEqual(details);
+
+			flushSync(() =>
+				root!.render(client.Branches, {
+					load,
+					version: 2,
+					onMount: noop,
+					onCleanup: noop,
+				}),
+			);
+			// Both independent descendants must start before either pending
+			// promise settles, even though the own read is already fulfilled.
+			expect([...calls].sort()).toEqual(['left:3', 'own:3', 'right:3']);
+			expect(own?.textContent).toBe('own-v1');
+			await act(() => jobs.get('right:3')!.resolve('right-v3'));
+			expect(own?.textContent).toBe('own-v1');
+			await act(() => jobs.get('left:3')!.resolve('left-v3'));
+			expect(container.querySelector('.rebound-own-value')?.textContent).toBe('own-v3');
+			expect(
+				Array.from(container.querySelectorAll('.rebound-own-detail')).map(
+					(node) => node.textContent,
+				),
+			).toEqual(['left-v3', 'right-v3']);
+			expect([...calls].sort()).toEqual(['left:3', 'own:3', 'right:3']);
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
 	it('starts eight independent descendants before a blocking sibling resolves, again on update', async () => {
 		const children = Array.from({ length: 8 }, (_, index) => `detail-${index}`);
 		const source = `


### PR DESCRIPTION
## Summary

- Register complex DOM client warm plans with `registerWarmPlan(thunk, void 0)` instead of allocating an empty `useBatch` array on each reachable render.
- Preserve direct data batches and the existing server and universal fallback paths. This is a partial follow-up to #981; other warm-plan work remains open.

## Why

The compiler already uses `registerWarmPlan` for attached child plans. For client fallbacks that need an in-body closure, `useBatch([], thunk)` performs the same active-plan stack registration, but creates an array merely to select that branch. Passing `void 0` preserves the former stack entry's props value and registration point.

## Changes

- Select the client registration helper only for DOM client units, leaving `puBatch([], thunk)` on the server and `useBatch([], thunk)` on universal units.
- Add dev/prod regressions for independent child requests, rebound props, retry and cleanup, plus post-hydration updates after server DOM adoption. Removing the registration makes both new cases fail before the second independent child request starts.
- Extend the recursive-context production work gate with parsed compiler output and live browser counters. The own-promise fixture changes from 4 `useBatch` / 0 `registerWarmPlan` calls to 3 / 1 across suspension and retry, with one start per resource and identical visible output. A fallback-only parent module drops its sole empty batch call and import; server/universal controls remain unchanged.
- Add an `octane` patch changeset.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm format:files:check` on all six changed files
- [x] `pnpm sync` (no additional tracked changes)
- [x] `vitest run packages/octane/tests/parallel-use.test.ts --project octane --project octane-prod` (126 passed)
- [x] Octane core projects: 17,547 passed, 14 expected failures; one Volar typecheck case timed out under parallel load and passed when rerun alone (1 passed).
- [x] Recursive-context production work gate, paired with merged `main` on isolated previews; all semantic, client-output, server/universal, context, and warm-adoption guards passed.
- [ ] `pnpm test`: the local Node 26 run encountered unrelated `localStorage` availability failures in Jotai and an email preview file-watcher assertion; repository CI uses Node 24. Current-head CI is the full-suite gate.

## Risk / follow-ups

The measured result is fewer emitted empty-batch call sites and fewer browser helper calls for the fallback case. No latency, heap-allocation, or bundle-size improvement is claimed. The remaining active-plan and cache work in #981 stays open.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791628949&installation_model_id=432790&pr_number=1028&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1028&signature=d37f7740e21c42f6109d18b775fd24730efe263a0e9e1f7bfb51a7f19d8b90d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler output and runtime registration for client suspense/warm-plan paths; behavior is heavily gated but incorrect lowering could break parallel child warming or hydration updates.
> 
> **Overview**
> DOM **client** codegen for complex parallel-`use()` components now registers fallback warm plans with **`registerWarmPlan(thunk, void 0)`** instead of **`useBatch([], thunk)`**, avoiding a per-render empty array while keeping the same active-plan stack behavior. **Server** still emits **`puBatch([], thunk)`** and **universal** still uses **`useBatch([], thunk)`**; direct data batches are unchanged.
> 
> **`parallel-use.test.ts`** adds coverage for independent child fetches when the parent’s own read is already fulfilled (including rebound props) and for post-hydration updates after server prerender. The **recursive-context** work gate rebaselines compiler and browser counters (e.g. warm-plan control **3** `useBatch` / **1** `registerWarmPlan`, fallback-only parents with **zero** batch imports, **no** empty-array batch sites on client controls) and documents before/after counts in the README. An **`octane` patch** changeset records the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c7a8ef312921700c6e9bef1e83e709a5c5a524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->