### PR TITLE
feat: Reject Strong render-time ref reads

### DIFF
--- a/.changeset/strong-render-ref-reads.md
+++ b/.changeset/strong-render-ref-reads.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Reject render-time reads of `useRef.current` in Strong modules with a source-located diagnostic, while retaining event and effect reads and compatibility-mode behavior. Document the rule in Octane's authoring guidance and MCP skill.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -494,7 +494,8 @@ Alternatively, enable it across application-owned modules with
 in compatibility mode unless their own source opts in.
 
 A Strong module cannot call a state updater during render or synchronously while
-setting up an effect, and it cannot assign to `ref.current` during render. The
+setting up an effect, and it cannot read or assign to a `useRef` object's
+`current` during render (`OCTANE_STRONG_RENDER_REF_READ` for reads). The
 checks follow provable synchronous calls through `useCallback`, `useEffectEvent`,
 and functions returned by analyzable `useMemo` factories. Calling a statically
 known Effect Event during render or including it in an explicit hook dependency

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -742,6 +742,9 @@ These patterns become compile errors:
 - Calling a `useState`, `useReducer`, or `useLinkedState` updater during render.
 - Calling one of those updaters synchronously while an effect is being set up.
 - Assigning to a `useRef` object's `current` during render.
+- Reading a `useRef` object's `current` during render
+  (`OCTANE_STRONG_RENDER_REF_READ`). Pass the ref to a `ref` prop as usual; read
+  its current value in an event or effect, or use state for render output.
 - Calling a statically known `useEffectEvent` result during render
   (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
 - Including a statically known Effect Event in an explicit hook dependency list

--- a/packages/octane-mcp-server/skills/react-divergences.md
+++ b/packages/octane-mcp-server/skills/react-divergences.md
@@ -32,6 +32,15 @@ recompute after every render.
 (`[state, update, getState]`) that reads the latest scheduled hook-cell value.
 Ordinary two-item destructures keep the allocation-free React shape.
 
+## Strong mode reads render snapshots
+
+In a module with `"use strong"` or application-wide Strong enabled, reading a
+`useRef` object's `current` while rendering is a compiler error
+(`OCTANE_STRONG_RENDER_REF_READ`). Its value can change without a witnessed
+render input changing. Pass the ref directly to a `ref` prop, read it in an event
+or effect, or use state when its value must appear in render output. Compatibility
+modules keep their existing behavior.
+
 ## Controlled inputs match React — on native events
 
 Controlled `value`/`checked` follow React's semantics exactly: the prop drives

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -74,6 +74,7 @@ const SKIP_KEYS = new Set([
 export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+export const STRONG_RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
 export const STRONG_RENDER_SNAPSHOT_MUTATION = 'OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION';
 export const STRONG_RETAINED_ROW_MUTATION = 'OCTANE_STRONG_RETAINED_ROW_MUTATION';
 export const STRONG_RENDER_IMPURE_CALL = 'OCTANE_STRONG_RENDER_IMPURE_CALL';
@@ -1266,6 +1267,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	let returnCycles = 0;
 	let currentFunctionIsAsync = false;
 	let currentFunctionChecksImpureCalls = false;
+	let currentFunctionChecksRefReads = false;
 	let currentRetainedRowScope = null;
 
 	function predeclareHoistedVars(node, scope) {
@@ -1334,6 +1336,32 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			node,
 			'Strong mode does not allow writing to useRef.current during render. Move the write to an event or effect, or express the value as state.',
 		);
+	}
+
+	function reportRefRead(node) {
+		report(
+			STRONG_RENDER_REF_READ,
+			node,
+			'Strong mode does not allow reading useRef.current during render. Read the ref in an event or effect, or use state or useLinkedState for values that drive render output.',
+		);
+	}
+
+	function isRefObject(value, scope) {
+		const object = unwrap(value);
+		if (object?.type === 'Identifier') return resolve(scope, object.name)?.kind === 'ref';
+		if (object?.type === 'SequenceExpression') {
+			return isRefObject(object.expressions?.[object.expressions.length - 1], scope);
+		}
+		return object?.type === 'CallExpression' && importedHook(object.callee, scope) === 'useRef';
+	}
+
+	function readCurrentRef(member, scope) {
+		const value = unwrap(member);
+		if (value?.type !== 'MemberExpression') return false;
+		const isCurrent = value.computed
+			? staticPrimitiveValue(value.property, scope) === 'current'
+			: value.property?.type === 'Identifier' && value.property.name === 'current';
+		return isCurrent && isRefObject(value.object, scope);
 	}
 
 	function reportSnapshotMutation(node) {
@@ -1796,17 +1824,25 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			if (parameter.type === 'TSParameterProperty') parameter = parameter.parameter;
 			let value = args === null ? OTHER_BINDING : (args[index] ?? UNDEFINED_BINDING);
 			if (parameter.type === 'AssignmentPattern') {
-				visitPatternExpressions(parameter.left, parameterScope, phase);
-				if (!definitelyDefined(value)) visit(parameter.right, parameterScope, phase);
+				const usesDefault = !definitelyDefined(value);
+				if (usesDefault) visit(parameter.right, parameterScope, phase);
 				value =
 					value.kind === 'constant' && value.primitive === undefined
 						? expressionBinding(parameter.right, parameterScope)
 						: definitelyDefined(value)
 							? value
 							: OTHER_BINDING;
+				visitPatternExpressions(
+					parameter.left,
+					parameterScope,
+					usesDefault ? phaseAfter(parameter.right, phase) : phase,
+					parameter.left.type === 'ObjectPattern' &&
+						(value?.kind === 'ref' ||
+							(usesDefault && isRefObject(parameter.right, parameterScope))),
+				);
 				parameter = parameter.left;
 			} else {
-				visitPatternExpressions(parameter, parameterScope, phase);
+				visitPatternExpressions(parameter, parameterScope, phase, value?.kind === 'ref');
 			}
 			if (parameter.type === 'Identifier' && !isReassigned(parameter)) {
 				parameterScope.bindings.set(parameter.name, value);
@@ -1818,11 +1854,12 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	function visitFunction(node, parentScope, phase, args = null) {
 		const enclosingFunctionIsAsync = currentFunctionIsAsync;
 		const enclosingFunctionChecksImpureCalls = currentFunctionChecksImpureCalls;
+		const enclosingFunctionChecksRefReads = currentFunctionChecksRefReads;
 		currentFunctionIsAsync = node.async === true;
 		if (phase === 'render' && !activeCallbacks.has(node)) {
 			// Ordinary module helpers may be used only by events. Check their
 			// standard calls when a known render root invokes them synchronously.
-			currentFunctionChecksImpureCalls =
+			currentFunctionChecksImpureCalls = currentFunctionChecksRefReads =
 				renderRoots.has(node) || node.body?.type === 'JSXCodeBlock';
 		}
 		try {
@@ -1854,10 +1891,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		} finally {
 			currentFunctionIsAsync = enclosingFunctionIsAsync;
 			currentFunctionChecksImpureCalls = enclosingFunctionChecksImpureCalls;
+			currentFunctionChecksRefReads = enclosingFunctionChecksRefReads;
 		}
 	}
 
-	function visitPatternExpressions(pattern, scope, phase) {
+	function visitPatternExpressions(pattern, scope, phase, refSource = false) {
 		let executionPhase = phase;
 		if (pattern?.type === 'TSParameterProperty') {
 			return visitPatternExpressions(pattern.parameter, scope, phase);
@@ -1871,11 +1909,27 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				executionPhase = visitPatternExpressions(element, scope, executionPhase);
 			}
 		} else if (pattern?.type === 'ObjectPattern') {
+			let currentExcluded = false;
 			for (const property of pattern.properties ?? []) {
 				if (property.computed) {
 					visit(property.key, scope, executionPhase);
 					executionPhase = phaseAfter(property.key, executionPhase);
 				}
+				const currentProperty =
+					refSource &&
+					property.type === 'Property' &&
+					(property.computed
+						? staticPrimitiveValue(property.key, scope)
+						: (property.key?.name ?? property.key?.value)) === 'current';
+				if (
+					refSource &&
+					executionPhase === 'render' &&
+					currentFunctionChecksRefReads &&
+					(currentProperty || (property.type === 'RestElement' && !currentExcluded))
+				) {
+					reportRefRead(currentProperty ? property.key : property);
+				}
+				if (currentProperty) currentExcluded = true;
 				executionPhase = visitPatternExpressions(
 					property.argument ?? property.value,
 					scope,
@@ -1885,7 +1939,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		} else if (pattern?.type === 'RestElement') {
 			executionPhase = visitPatternExpressions(pattern.argument, scope, executionPhase);
 		} else if (pattern?.type === 'MemberExpression') {
-			visit(pattern, scope, executionPhase);
+			visit(pattern, scope, executionPhase, false);
 			executionPhase = phaseAfter(pattern, executionPhase, true);
 			if (executionPhase === 'render') {
 				reportSnapshotWrite(pattern, scope);
@@ -2038,7 +2092,12 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	function bindDeclaration(declaration, declarationKind, scope, phase) {
 		bindDeclarationValue(declaration, declarationKind, scope);
 		visit(declaration.init, scope, phase);
-		return visitPatternExpressions(declaration.id, scope, phaseAfter(declaration.init, phase));
+		return visitPatternExpressions(
+			declaration.id,
+			scope,
+			phaseAfter(declaration.init, phase),
+			declaration.id?.type === 'ObjectPattern' && isRefObject(declaration.init, scope),
+		);
 	}
 
 	function visitCallback(node, parentScope, phase, args = null) {
@@ -2853,14 +2912,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
-	function visit(node, scope, phase) {
+	function visit(node, scope, phase, readAccess = true) {
 		if (node == null || typeof node !== 'object') return;
 		if (Array.isArray(node)) {
 			for (const child of node) visit(child, scope, phase);
 			return;
 		}
 		if (TRANSPARENT_EXPRESSIONS.has(node.type)) {
-			visit(node.expression, scope, phase);
+			visit(node.expression, scope, phase, readAccess);
 			return;
 		}
 		if (node.type?.startsWith('TS')) return;
@@ -2930,7 +2989,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				for (const property of node.properties ?? []) {
 					if (property.type === 'SpreadElement') {
 						visit(property.argument, scope, executionPhase);
-						executionPhase = phaseAfter(property.argument, executionPhase);
+						const spreadPhase = phaseAfter(property.argument, executionPhase);
+						if (
+							spreadPhase === 'render' &&
+							currentFunctionChecksRefReads &&
+							isRefObject(property.argument, scope)
+						) {
+							reportRefRead(property);
+						}
+						executionPhase = spreadPhase;
 						continue;
 					}
 					if (property.computed === true) {
@@ -2947,7 +3014,25 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'MemberExpression': {
 				visit(node.object, scope, phase);
 				if (node.computed === true) {
-					visit(node.property, scope, phaseAfter(node.object, phase, true, node.optional === true));
+					const propertyPhase = phaseAfter(node.object, phase, true, node.optional === true);
+					visit(node.property, scope, propertyPhase);
+					if (
+						readAccess &&
+						propertyPhase === 'render' &&
+						currentFunctionChecksRefReads &&
+						readCurrentRef(node, scope) &&
+						phaseAfter(node.property, propertyPhase) === 'render'
+					) {
+						reportRefRead(node);
+					}
+				} else if (
+					readAccess &&
+					phase === 'render' &&
+					currentFunctionChecksRefReads &&
+					readCurrentRef(node, scope) &&
+					phaseAfter(node.object, phase, true, node.optional === true) === 'render'
+				) {
+					reportRefRead(node);
 				}
 				return;
 			}
@@ -3075,11 +3160,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					// memo owns a component callback. lazy also accepts a module
 					// loader, so require JSX evidence before treating it as a render.
 					const checkImpureCalls = currentFunctionChecksImpureCalls;
+					const checkRefReads = currentFunctionChecksRefReads;
 					currentFunctionChecksImpureCalls = true;
+					currentFunctionChecksRefReads = true;
 					try {
 						visitCallback(component.node, component.scope, 'render');
 					} finally {
 						currentFunctionChecksImpureCalls = checkImpureCalls;
+						currentFunctionChecksRefReads = checkRefReads;
 					}
 					return;
 				}
@@ -3185,10 +3273,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'AssignmentExpression': {
 				if (node.left?.type === 'ArrayPattern' || node.left?.type === 'ObjectPattern') {
 					visit(node.right, scope, phase);
-					visitPatternExpressions(node.left, scope, phaseAfter(node.right, phase));
+					visitPatternExpressions(
+						node.left,
+						scope,
+						phaseAfter(node.right, phase),
+						node.left.type === 'ObjectPattern' && isRefObject(node.right, scope),
+					);
 					return;
 				}
-				visit(node.left, scope, phase);
+				visit(node.left, scope, phase, false);
 				const rightPhase = phaseAfter(node.left, phase, true);
 				visit(node.right, scope, rightPhase);
 				const executionPhase = phaseAfter(node.right, rightPhase);
@@ -3197,18 +3290,29 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					reportSnapshotWrite(node.left, scope);
 					reportRetainedRowMutation(node.left, scope);
 				}
+				// Compound and logical assignments read the old value before the
+				// right side, even when an await defers the eventual write.
+				if (
+					node.operator !== '=' &&
+					rightPhase === 'render' &&
+					currentFunctionChecksRefReads &&
+					(executionPhase !== 'render' || !currentRef(node.left, scope)) &&
+					readCurrentRef(node.left, scope)
+				) {
+					reportRefRead(node.left);
+				}
 				return;
 			}
 			case 'UpdateExpression':
 				if (phase === 'render' && currentRef(node.argument, scope)) reportRef(node.argument);
-				visit(node.argument, scope, phase);
+				visit(node.argument, scope, phase, false);
 				if (phaseAfter(node.argument, phase, true) === 'render') {
 					reportSnapshotWrite(node.argument, scope);
 					reportRetainedRowMutation(node.argument, scope);
 				}
 				return;
 			case 'UnaryExpression':
-				visit(node.argument, scope, phase);
+				visit(node.argument, scope, phase, node.operator !== 'delete');
 				if (node.operator === 'delete' && phaseAfter(node.argument, phase, true) === 'render') {
 					reportSnapshotWrite(node.argument, scope);
 					reportRetainedRowMutation(node.argument, scope);
@@ -3291,7 +3395,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					(alwaysAwaits(node.right) || (node.type === 'ForOfStatement' && node.await === true))
 						? 'deferred'
 						: phase;
-				visit(node.left, loop, executionPhase);
+				if (node.left?.type === 'ArrayPattern' || node.left?.type === 'ObjectPattern') {
+					visitPatternExpressions(node.left, loop, executionPhase);
+				} else {
+					visit(node.left, loop, executionPhase, false);
+				}
 				visit(node.body, loop, executionPhase);
 				return;
 			}

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -6,6 +6,7 @@ import { compileToVolarMappings } from '../../src/compiler/volar.js';
 const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+const RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
 const RENDER_SNAPSHOT_MUTATION = 'OCTANE_STRONG_RENDER_SNAPSHOT_MUTATION';
 const RETAINED_ROW_MUTATION = 'OCTANE_STRONG_RETAINED_ROW_MUTATION';
 const RENDER_IMPURE_CALL = 'OCTANE_STRONG_RENDER_IMPURE_CALL';
@@ -2210,7 +2211,7 @@ export function App(props) @{
 		],
 		[
 			'conditional reconcilers',
-			'useLinkedState(0, ref.current ? (value) => value : (value) => { ref.current = value; return value; });',
+			'useLinkedState(0, props.enabled ? (value) => value : (value) => { ref.current = value; return value; });',
 		],
 		[
 			'named computed comparators',
@@ -2223,7 +2224,7 @@ export function App(props) @{
 	])('rejects render-time ref writes from %s', (_label, setup) => {
 		const source = `"use strong";
 import { useLinkedState, useReducer, useRef, useState } from 'octane';
-export function App() @{
+export function App(props) @{
   const ref = useRef(0);
   ${setup}
   <div />
@@ -4051,7 +4052,6 @@ export function useCounter() {
 
 	it.each([
 		['assignments', 'ref.current = await Promise.resolve(1);'],
-		['compound assignments', 'ref.current += await Promise.resolve(1);'],
 		[
 			'awaited conditional tests',
 			'(await Promise.resolve(true)) ? (ref.current = 1) : (ref.current = 2);',
@@ -4067,6 +4067,18 @@ export function App() @{
 }`;
 
 		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('rejects the ref read that precedes an awaited compound-assignment operand', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  (async () => { ref.current += await Promise.resolve(1); })();
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_READ);
 	});
 
 	it('still rejects ref writes evaluated before a later yield', () => {
@@ -4194,6 +4206,209 @@ export function useCounter() {
 		expect(
 			compileToVolarMappings(source, '/src/Counter.tsrx', { strong: true } as any).diagnostics,
 		).toContainEqual(expect.objectContaining({ code: RENDER_STATE_UPDATE, severity: 'error' }));
+	});
+});
+
+describe('Strong mode render-time ref reads', () => {
+	function component(setup: string): string {
+		return `import { useRef, useEffect, useCallback, useMemo, useState } from 'octane';
+export function App(props) @{
+  const ref = useRef({ foo: 0 });
+  ${setup}
+  <div />
+}`;
+	}
+
+	it.each([
+		['direct property access', 'const value = ref.current;'],
+		['an immediate hook result', 'const value = useRef(0).current;'],
+		['an immutable ref alias', 'const alias = ref; const value = alias.current;'],
+		['a computed literal key', "const value = ref['current' as const];"],
+		['a computed constant key', "const key = 'current' as const; const value = ref[key];"],
+		['optional property access', 'const value = ref?.current;'],
+		['nested property mutation', 'ref.current.foo = 1;'],
+		['object destructuring', 'const { current: value } = ref;'],
+		['computed object destructuring', "const { ['current']: value } = ref;"],
+		['object spread', 'const copy = { ...ref };'],
+		['object rest', 'const { ...copy } = ref;'],
+		['sequence-tail members', 'const value = (0, ref).current;'],
+		['sequence-tail spreads', 'const copy = { ...(0, ref) };'],
+		['lazy state initializers', 'useState(() => ref.current);'],
+	])('rejects %s during render', (_label, setup) => {
+		const source = component(setup);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_REF_READ);
+	});
+
+	it('rejects a ref read used directly by rendered JSX', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  <p>{ref.current as string}</p>
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_READ);
+	});
+
+	it.each([
+		['named helpers', 'function read() { return ref.current; } const value = read();'],
+		['argument aliases', 'function read(value) { return value.current; } const value = read(ref);'],
+		['immediately invoked callbacks', 'const value = (() => ref.current)();'],
+		['memo factories', 'const value = useMemo(() => ref.current, []);'],
+		['invoked useCallback results', 'const read = useCallback(() => ref.current, []); read();'],
+		[
+			'destructured helper parameters',
+			'function read({ current }) { return current; } const value = read(ref);',
+		],
+		[
+			'default destructured helper parameters',
+			'function read({ current } = ref) { return current; } const value = read();',
+		],
+	])('follows render-time ref reads through %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_REF_READ,
+		);
+	});
+
+	it('allows ref identities and reads in event, effect, cleanup, and deferred callbacks', () => {
+		const source = `"use strong";
+import { useRef, useEffect, useCallback } from 'octane';
+export function App(props) @{
+  const ref = useRef(null);
+  const readLater = useCallback(() => ref.current, []);
+  const identity = { ref };
+  useEffect(() => {
+    const mounted = ref.current;
+    setTimeout(() => ref.current, 0);
+    return () => { const cleaned = ref.current; };
+  }, []);
+  (async () => { await Promise.resolve(); const afterYield = ref.current; })();
+  <button ref={ref} onClick={() => { const clicked = readLater(); }} />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['unrelated objects', 'const other = { current: 1 }; const value = other.current;'],
+		['lexically shadowed refs', '{ const ref = { current: 1 }; const value = ref.current; }'],
+		[
+			'helper parameters with unrelated arguments',
+			'function read(value) { return value.current; } const value = read({ current: 1 });',
+		],
+		[
+			'destructured parameters with unrelated arguments',
+			'function read({ current }) { return current; } const value = read({ current: 1 });',
+		],
+		['unknown computed keys', 'const key = props.field; const value = ref[key];'],
+	])('preserves %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['aliased imports', "import { useRef as createRef } from 'octane';", 'createRef(0)'],
+		['namespace imports', "import * as Octane from 'octane';", "Octane['useRef' as const](0)"],
+	])('recognizes useRef through %s', (_label, imported, hook) => {
+		const source = `"use strong";
+${imported}
+export function App() @{
+  const ref = ${hook};
+  <p>{ref.current as string}</p>
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_READ);
+	});
+
+	it.each(['client', 'server'] as const)('preserves valid ref code in %s output', (mode) => {
+		const source = component('const readLater = () => ref.current;');
+		const standard = compile(source, '/src/App.tsrx', { mode });
+		const strong = compile(source, '/src/App.tsrx', { mode, strong: true } as any);
+
+		expect(strong.code).toBe(standard.code);
+	});
+
+	it.each(['ref.current = 1;', 'ref.current += 1;', 'ref.current++;'])(
+		'keeps %s under the ref-write diagnostic',
+		(write) => {
+			const result = compileToVolarMappings(`"use strong";\n${component(write)}`, '/src/App.tsrx');
+			expect(result.diagnostics.map(({ code }) => code)).toEqual([RENDER_REF_WRITE]);
+		},
+	);
+
+	it('does not classify a deleted ref property as a read', () => {
+		const result = compileToVolarMappings(
+			`"use strong";\n${component('delete ref.current;')}`,
+			'/src/App.tsrx',
+		);
+		expect(result.diagnostics.map(({ code }) => code)).not.toContain(RENDER_REF_READ);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'server', dev: false },
+	])('enforces the same read diagnostic during $mode compilation', (options) => {
+		expect(() =>
+			compile(
+				`"use strong";\n${component('const value = ref.current;')}`,
+				'/src/App.tsrx',
+				options,
+			),
+		).toThrow(RENDER_REF_READ);
+	});
+
+	it('reports the ref expression location to the compiler and Volar', () => {
+		const source = `"use strong";\n${component('const value = ref.current;')}`;
+		const position = source.indexOf('ref.current');
+
+		try {
+			compile(source, '/src/App.tsrx');
+			throw new Error('expected a Strong render-time ref-read diagnostic');
+		} catch (error: any) {
+			expect(error).toMatchObject({
+				code: RENDER_REF_READ,
+				filename: '/src/App.tsrx',
+				loc: { line: 5 },
+			});
+		}
+
+		const result = compileToVolarMappings(source, '/src/App.tsrx');
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_REF_READ,
+				severity: 'error',
+				filename: '/src/App.tsrx',
+				start: expect.objectContaining({ line: 5 }),
+			}),
+		);
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_REF_READ,
+				type: 'usage',
+				fileName: '/src/App.tsrx',
+				pos: position,
+				loc: expect.objectContaining({ start: expect.objectContaining({ line: 5 }) }),
+			}),
+		);
+	});
+
+	it('enforces reads in plain hook modules and Octane TSX components', () => {
+		const hook = `"use strong";
+import { useRef } from 'octane';
+export function useValue() {
+  const ref = useRef(0);
+  return ref.current;
+}`;
+		const component = `/** @jsxImportSource octane */
+"use strong";
+import { useRef } from 'octane';
+export function App() {
+  const ref = useRef(0);
+  return <p>{ref.current}</p>;
+}`;
+
+		expect(() => slotHooks(hook, '/src/useValue.ts')).toThrow(RENDER_REF_READ);
+		expect(() => compile(component, '/src/App.tsx')).toThrow(RENDER_REF_READ);
 	});
 });
 

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -227,6 +227,9 @@ A Strong module cannot:
 - Call a state setter or reducer dispatcher while rendering.
 - Call one synchronously while an effect is being set up.
 - Assign to a ref's `current` value while rendering.
+- Read a `useRef` object's `current` while rendering
+  (`OCTANE_STRONG_RENDER_REF_READ`). Keep refs as `ref` props and read them in
+  events or effects; use state for values that drive render output.
 - Call a statically known `useEffectEvent` result during render
   (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
 - Include a statically known Effect Event in explicit hook dependencies


### PR DESCRIPTION
## Summary

- Add `OCTANE_STRONG_RENDER_REF_READ` as a source-located error for provable `useRef.current` reads during Strong render.
- Keep compatibility modules, ref identities, and reads in events, effects, cleanup, and deferred callbacks legal.

Part of #1027.

## Why

A ref can change without a render input changing. Strong render output that reads `current` can therefore become stale when compilation reuses a region.

## Changes

- Follow known ref aliases, optional and computed access, immediate hook results, object spread/rest, and destructured arguments to synchronous render helpers.
- Preserve the existing ref-write diagnostic for writes; report nested reads and read-before-`await` compound assignments.
- Add compiler and Volar regression coverage, client/server output parity tests, documentation, MCP guidance, and patch changesets for `octane` and `@octanejs/mcp-server`.

## Validation

- [ ] `pnpm format:check` (scoped `pnpm format:files:check` passed for all changed files)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (prechecks passed; full Vitest stopped after browser suites failed to launch Chromium in the local sandbox)
- [x] targeted tests: `pnpm exec vitest run packages/octane/tests/compiler/strong-mode.test.ts --silent=passed-only` (754 passed)
- [x] `pnpm sync` (no generated changes)
- [x] compiler throughput: paired baseline/candidate runs in both orders on the same host, Node, and dependencies; 1000-component Strong medians were 279.6→314.8 ms and 322.2→297.5 ms in reverse order (n=5 each), so timing is noisy with no repeatable regression. Output hashes and byte counts match for 10, 100, and 1000 components in both modes.

## Risk / follow-ups

The static proof follows known refs and synchronous calls; opaque values remain outside this diagnostic. The remaining items in #1027 should land as separate PRs. Browser coverage needs CI because local Chromium exits before test bodies with `MachPortRendezvousServer: Permission denied`.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791629194&installation_model_id=432790&pr_number=1029&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1029&signature=5a88c224d04e71821e5dd82a4b8bfeecc8ec0f2275a7bcf488f403a6dd139ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in Strong mode gains a new compile-time error that can break apps reading refs during render; emitted code for valid modules is unchanged per tests.
> 
> **Overview**
> Strong mode now rejects **reading** `useRef` object's `current` during render, not only assigning to it. Modules with `"use strong"` or `compiler.strong: true` get compile error **`OCTANE_STRONG_RENDER_REF_READ`** with source locations (compiler + Volar); compatibility modules are unchanged.
> 
> The Strong analyzer tracks ref identities through aliases, optional/computed `.current`, destructuring/spread, synchronous helpers (`useMemo`/`useCallback`/IIFEs), and compound assignments that read before `await`. **Ref writes** still use `OCTANE_STRONG_RENDER_REF_WRITE`; reads in events, effects, cleanup, and post-yield async paths stay allowed.
> 
> Docs (TSRX basics, React differences, build tools) and the MCP **react-divergences** skill document the rule. Patch changesets cover `octane` and `@octanejs/mcp-server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e956f95b3b9a61adb3cb528cbadd06f40b4898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->