### PR TITLE
perf: use numeric indices for unkeyed de-opt children

### DIFF
--- a/.changeset/deopt-implicit-index.md
+++ b/.changeset/deopt-implicit-index.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid building prefixed string keys for unkeyed top-level descriptor lists.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -111,6 +111,7 @@ CLEAR_1K=1 CPU_THROTTLE=4 TARGETS='[{"name":"octane-tsrx","url":"http://localhos
 
 This diagnostic reports `clear_1k` under the separate `js-framework-clear-1k`
 suite name. The canonical `clear` operation still starts from 10,000 rows.
+
 This local in-page click timer excludes paint and browser automation latency;
 its numbers should not be compared directly with the official benchmark's
 Chrome timeline measurements.
@@ -143,6 +144,32 @@ count, insertion position and order, survivor DOM identity, connectivity,
 delegated events, and selection, then uses precise production call coverage in
 a separate `--jitless` browser to guard reduced per-row framework work without
 depending on minified helper names or contaminating wall-clock measurements.
+
+### Implicit de-opt list key work gate
+
+The opt-in `unkeyed` mode of `style-work.mjs` checks the production de-opt list
+path with 1,000 unkeyed host descriptors and an explicit key `"0"`. The rows
+cross a compiled `.tsrx` child hole, so `scopedDeoptKey` runs once per row. An
+unrelated update supplies fresh descriptors; the gate checks row order and DOM
+identity, typed uncontrolled input values, focus, and separation between the
+implicit index zero and explicit key `"0"`. Chromium precise coverage counts
+the production helper calls. The readable production asset also identifies
+whether top-level implicit keys concatenate a string for each of the 1,000
+rows or use the numeric index. This is a deterministic source-work check, not
+a wall-time or measured heap-allocation comparison.
+
+```bash
+# From the repo root, build the separate fixture under the ignored
+# octane-tsrx/dist/unkeyed-work directory:
+pnpm --filter octane-tsrx-jsbench exec vite build --config vite.config.unkeyed.js
+pnpm --filter octane-tsrx-jsbench exec vite preview --config vite.config.unkeyed.js --host 127.0.0.1 --port 5316 --strictPort
+
+# In another terminal, require the numeric-key candidate:
+WORK_MODE=unkeyed WORK_REQUIRE_NUMERIC=1 TARGET_URL=http://127.0.0.1:5316/unkeyed-work.html node benchmarks/js-framework/style-work.mjs
+```
+
+Omit `WORK_REQUIRE_NUMERIC=1` to check an unchanged upstream baseline. Set
+`WORK_JSON=/path/to/result.json` to retain the machine-readable gate result.
 
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 

--- a/benchmarks/js-framework/octane-tsrx/src/UnkeyedRows.tsrx
+++ b/benchmarks/js-framework/octane-tsrx/src/UnkeyedRows.tsrx
@@ -1,0 +1,7 @@
+import type { OctaneNode } from 'octane';
+
+// The descriptor array must cross a compiled child hole: a raw host descriptor's
+// children use a different positional reconciler and never reach scopedDeoptKey.
+export function UnkeyedRows(props: { rows: OctaneNode[]; version: number }) @{
+	<ul id="unkeyed-work-rows" data-version={props.version}>{props.rows}</ul>
+}

--- a/benchmarks/js-framework/octane-tsrx/src/unkeyed-work-main.js
+++ b/benchmarks/js-framework/octane-tsrx/src/unkeyed-work-main.js
@@ -1,0 +1,4 @@
+import { runUnkeyedWork } from './unkeyed-work.ts';
+
+window.__unkeyedWork = runUnkeyedWork;
+window.__ready = true;

--- a/benchmarks/js-framework/octane-tsrx/src/unkeyed-work.ts
+++ b/benchmarks/js-framework/octane-tsrx/src/unkeyed-work.ts
@@ -1,0 +1,58 @@
+import { createElement, createRoot, flushSync, type OctaneNode } from 'octane';
+import { UnkeyedRows } from './UnkeyedRows.tsrx';
+
+const ROWS = 1000;
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLElement | null = null;
+
+function makeRows(): OctaneNode[] {
+	const rows: OctaneNode[] = [];
+	for (let index = 0; index < ROWS; index++) {
+		rows.push(
+			createElement(
+				'li',
+				{ 'data-work-index': index },
+				createElement('input', { defaultValue: String(index), 'aria-label': `row ${index}` }),
+			),
+		);
+		if (index === 0) {
+			// Explicit string "0" must never adopt the unkeyed row at implicit index 0.
+			rows.push(
+				createElement(
+					'li',
+					{ key: '0', 'data-work-index': 'explicit' },
+					createElement('input', { defaultValue: 'explicit', 'aria-label': 'explicit row' }),
+				),
+			);
+		}
+	}
+	return rows;
+}
+
+export function runUnkeyedWork(operation: string): void {
+	if (operation === 'load') return;
+	if (operation === 'mount') {
+		if (root !== null) throw new Error('unkeyed work root is already mounted');
+		container = document.createElement('div');
+		container.id = 'unkeyed-work-root';
+		document.body.appendChild(container);
+		root = createRoot(container);
+		root.render(UnkeyedRows, { rows: makeRows(), version: 0 });
+		flushSync(() => {});
+		return;
+	}
+	if (operation === 'update') {
+		if (root === null) throw new Error('unkeyed work root is not mounted');
+		root.render(UnkeyedRows, { rows: makeRows(), version: 1 });
+		flushSync(() => {});
+		return;
+	}
+	if (operation === 'unmount') {
+		root?.unmount();
+		root = null;
+		container?.remove();
+		container = null;
+		return;
+	}
+	throw new Error(`unknown unkeyed work operation: ${operation}`);
+}

--- a/benchmarks/js-framework/octane-tsrx/unkeyed-work.html
+++ b/benchmarks/js-framework/octane-tsrx/unkeyed-work.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Octane unkeyed descriptor work</title>
+	</head>
+	<body>
+		<script type="module" src="/src/unkeyed-work-main.js"></script>
+	</body>
+</html>

--- a/benchmarks/js-framework/octane-tsrx/vite.config.unkeyed.js
+++ b/benchmarks/js-framework/octane-tsrx/vite.config.unkeyed.js
@@ -1,0 +1,17 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mergeConfig } from 'vite';
+import base from './vite.config.js';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+// Work-only entry: ordinary `vite build` still uses index.html and never sees
+// the unkeyed fixture or its descriptors in the js-framework timing bundle.
+export default mergeConfig(base, {
+	build: {
+		outDir: 'dist/unkeyed-work',
+		minify: false,
+		rollupOptions: { input: resolve(root, 'unkeyed-work.html') },
+	},
+	preview: { port: 5316, strictPort: true },
+});

--- a/benchmarks/js-framework/style-work.mjs
+++ b/benchmarks/js-framework/style-work.mjs
@@ -5,6 +5,13 @@
 import fs from 'node:fs';
 import { chromium } from 'playwright';
 
+// An opt-in work case shares this already-registered benchmark entry. Its
+// separate fixture is never loaded by the ordinary inline-style run.
+if (process.env.WORK_MODE === 'unkeyed') {
+	await import('./unkeyed-work.mjs');
+	process.exit(process.exitCode ?? 0);
+}
+
 const DIALECT = process.env.WORK_DIALECT || 'tsrx';
 if (DIALECT !== 'tsrx' && DIALECT !== 'jsx') {
 	throw new Error(`Unsupported WORK_DIALECT ${JSON.stringify(DIALECT)}; expected "tsrx" or "jsx".`);

--- a/benchmarks/js-framework/unkeyed-work.mjs
+++ b/benchmarks/js-framework/unkeyed-work.mjs
@@ -1,0 +1,200 @@
+// Production browser work for top-level implicit de-opt list keys. Run through
+// style-work.mjs with WORK_MODE=unkeyed; no new benchmark suite is registered.
+// The fixture's pure-host descriptors reach scopedDeoptKey only because the
+// list is handed through a compiled child hole.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ASSETS = path.join(HERE, 'octane-tsrx', 'dist', 'unkeyed-work', 'assets');
+const URL = process.env.TARGET_URL || 'http://localhost:5316/unkeyed-work.html';
+const ROWS = 1000;
+const ITEMS = ROWS + 1; // one explicit key="0" beside the 1,000 implicit indices
+const METRICS = ['scopedDeoptKey', 'deoptItemBody', 'reconcileKeyed'];
+
+function sourceWork() {
+	const sources = fs
+		.readdirSync(ASSETS)
+		.filter((name) => name.endsWith('.js'))
+		.map((name) => fs.readFileSync(path.join(ASSETS, name), 'utf8'));
+	const matches = sources.flatMap((source) => {
+		const start = source.indexOf('function scopedDeoptKey(');
+		if (start < 0) return [];
+		const end = source.indexOf('\n}', start);
+		if (end < 0) throw new Error('could not identify scopedDeoptKey in production output');
+		return [source.slice(start, end + 2)];
+	});
+	if (matches.length !== 1) {
+		throw new Error(`expected one readable production scopedDeoptKey, found ${matches.length}`);
+	}
+	const body = matches[0];
+	const oldBranch =
+		/if \(path\.length === 0\) return explicit \? ["']k["'] \+ String\(key\) : ["']i["'] \+ index;/.test(
+			body,
+		);
+	const numericBranch =
+		/if \(path\.length === 0\) return explicit \? ["']k["'] \+ String\(key\) : index;/.test(body);
+	if (!oldBranch && !numericBranch) {
+		throw new Error('top-level implicit-key branch changed; review the source work gate');
+	}
+	return {
+		implicitKeyStringConversionsPerRender: oldBranch ? ROWS : 0,
+		implicitKeyNumeric: numericBranch,
+	};
+}
+
+function countCalls(coverage) {
+	const counts = Object.fromEntries(METRICS.map((name) => [name, 0]));
+	for (const script of coverage.result) {
+		if (!script.url.includes('/assets/')) continue;
+		for (const fn of script.functions) {
+			if (Object.hasOwn(counts, fn.functionName)) {
+				counts[fn.functionName] += fn.ranges[0]?.count ?? 0;
+			}
+		}
+	}
+	return counts;
+}
+
+async function invoke(page, operation) {
+	await page.evaluate((name) => window.__unkeyedWork(name), operation);
+}
+
+async function verify(page, version, preserve) {
+	return page.evaluate(
+		({ count, version, preserve }) => {
+			const list = document.querySelector('#unkeyed-work-rows');
+			if (list?.getAttribute('data-version') !== String(version)) {
+				throw new Error(`expected visible version ${version}`);
+			}
+			const rows = Array.from(list.children);
+			if (rows.length !== count + 1)
+				throw new Error(`expected ${count + 1} rows, got ${rows.length}`);
+			for (let index = 0; index < count; index++) {
+				const row = rows[index === 0 ? 0 : index + 1];
+				if (row.getAttribute('data-work-index') !== String(index)) {
+					throw new Error(`unkeyed row ${index} has incorrect content or order`);
+				}
+				if (!preserve && row.querySelector('input')?.value !== String(index)) {
+					throw new Error(`unkeyed row ${index} has incorrect initial input value`);
+				}
+			}
+			const plain = rows[0].querySelector('input');
+			const explicit = rows[1].querySelector('input');
+			if (rows[1].getAttribute('data-work-index') !== 'explicit' || plain === explicit) {
+				throw new Error('implicit index zero and explicit key "0" were conflated');
+			}
+			if (!preserve) {
+				if (explicit.value !== 'explicit') throw new Error('explicit row has wrong initial input');
+				window.__unkeyedRowsBefore = rows;
+				window.__unkeyedPlainBefore = plain;
+				window.__unkeyedExplicitBefore = explicit;
+				plain.value = 'typed plain';
+				explicit.value = 'typed explicit';
+				plain.focus();
+			} else {
+				if (rows.some((row, index) => row !== window.__unkeyedRowsBefore[index])) {
+					throw new Error('an unchanged unkeyed row lost DOM identity');
+				}
+				if (plain !== window.__unkeyedPlainBefore || explicit !== window.__unkeyedExplicitBefore) {
+					throw new Error('implicit or explicit input lost DOM identity');
+				}
+				if (plain.value !== 'typed plain' || explicit.value !== 'typed explicit') {
+					throw new Error('uncontrolled input state was reset');
+				}
+				if (document.activeElement !== plain) throw new Error('focused input was replaced');
+			}
+			return { rows: rows.length, preserved: preserve ? rows.length : 0 };
+		},
+		{ count: ROWS, version, preserve },
+	);
+}
+
+async function measure(browser, operation) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const errors = [];
+	page.on('pageerror', (error) => errors.push(error.message));
+	const cdp = await context.newCDPSession(page);
+	let profiling = false;
+	try {
+		await page.goto(URL, { waitUntil: 'load' });
+		await page.waitForFunction(() => window.__ready === true, null, { timeout: 10_000 });
+		await cdp.send('Profiler.enable');
+		await cdp.send('Profiler.startPreciseCoverage', {
+			callCount: true,
+			detailed: true,
+			allowTriggeredUpdates: false,
+		});
+		profiling = true;
+		if (operation === 'update') {
+			await invoke(page, 'mount');
+			await verify(page, 0, false);
+		}
+		await cdp.send('Profiler.takePreciseCoverage');
+		await invoke(page, operation === 'update' ? 'update' : 'mount');
+		const coverage = await cdp.send('Profiler.takePreciseCoverage');
+		const counts = countCalls(coverage);
+		const visible = await verify(page, operation === 'update' ? 1 : 0, operation === 'update');
+		if (errors.length !== 0) throw new Error(`browser errors: ${errors.join('; ')}`);
+		await invoke(page, 'unmount');
+		return { ...counts, ...visible };
+	} finally {
+		if (profiling) {
+			await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});
+			await cdp.send('Profiler.disable').catch(() => {});
+		}
+		await context.close();
+	}
+}
+
+const source = sourceWork();
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--no-sandbox', '--js-flags=--jitless'],
+});
+const results = {};
+const failures = [];
+try {
+	for (const operation of ['mount', 'update']) {
+		const observed = await measure(browser, operation);
+		results[operation] = observed;
+		for (const [metric, expected] of Object.entries({
+			scopedDeoptKey: ITEMS,
+			deoptItemBody: ITEMS,
+			reconcileKeyed: operation === 'update' ? 1 : 0,
+			rows: ITEMS,
+			preserved: operation === 'update' ? ITEMS : 0,
+		})) {
+			if (observed[metric] !== expected) {
+				failures.push(`${operation}.${metric}: ${observed[metric]} !== ${expected}`);
+			}
+		}
+	}
+} finally {
+	await browser.close();
+}
+
+if (process.env.WORK_REQUIRE_NUMERIC === '1' && !source.implicitKeyNumeric) {
+	failures.push('top-level implicit keys still use strings, expected numeric indices');
+}
+console.log(
+	JSON.stringify({ suite: 'js-framework-style-work/unkeyed', source, results, failures }, null, 2),
+);
+if (process.env.WORK_JSON) {
+	fs.writeFileSync(
+		process.env.WORK_JSON,
+		JSON.stringify(
+			{ suite: 'js-framework-style-work/unkeyed', source, results, failures },
+			null,
+			'\t',
+		) + '\n',
+	);
+}
+if (failures.length !== 0) {
+	for (const failure of failures) console.error(`- ${failure}`);
+	process.exitCode = 1;
+}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -23702,22 +23702,19 @@ function scopedDeoptKey(
 	item: any,
 	index: number,
 	key: any,
-): string {
-	// Reconciliation keys are an internal encoding, not raw user strings. Encode
-	// both wrapper path and leaf-key KIND so an implicit index 0 cannot alias an
-	// explicit key="0", and a user key that resembles a serialized wrapper path
-	// cannot alias a nested child. JSON quoting makes arbitrary user strings data,
-	// never structure, while remaining stable across renders without an intern map.
+): string | number {
+	// Reconciliation keys are internal: top-level implicit positions are numbers,
+	// explicit keys carry a 'k' prefix, and nested paths are JSON strings. These
+	// namespaces keep index 0 distinct from key="0" and user keys distinct from
+	// nested wrapper paths without allocating a string for every unkeyed child.
 	const explicit = (isElementDescriptor(item) || item?.$$kind === PORTAL_TAG) && item.key != null;
 	// The unwrapped top level — a plain children array or a single-layer Fragment,
 	// which is what every `{items.map(...)}` list and every binding's rendered
 	// output produces — is the hot path: it re-keys EVERY child on EVERY parent
 	// render, including renders where all children go on to bail. Skip the
-	// serializer there. A JSON encoding always begins with '[', so no 'k'/'i'
-	// prefixed key can collide with a nested wrapper path, and the differing
-	// prefixes keep an explicit key="0" distinct from an implicit index 0 — the
-	// same two aliasing properties the serialized form provides.
-	if (path.length === 0) return explicit ? 'k' + String(key) : 'i' + index;
+	// serializer there. JSON paths begin with '[', so they remain distinct from
+	// explicit 'k' keys; numeric indices are distinct from both string forms.
+	if (path.length === 0) return explicit ? 'k' + String(key) : index;
 	return JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]);
 }
 

--- a/packages/octane/tests/deopt-child-key-aliasing.test.ts
+++ b/packages/octane/tests/deopt-child-key-aliasing.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { createElement, Fragment, positionalChildren, useState, type OctaneNode } from 'octane';
+import {
+	createElement,
+	flushSync,
+	Fragment,
+	hydrateRoot,
+	positionalChildren,
+	useState,
+	type OctaneNode,
+} from 'octane';
+import { renderToString } from 'octane/server';
 import { mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
 import { RowsHole } from './_fixtures/deopt-child-keys.tsrx';
 
 // Descriptors handed to a template HOLE reach the de-opt keyed list, which
@@ -18,6 +28,7 @@ import { RowsHole } from './_fixtures/deopt-child-keys.tsrx';
 // spelling — the encoding may change as long as these hold.
 
 const text = (nodes: Element[]) => nodes.map((n) => n.textContent);
+const server = loadServerFixture('packages/octane/tests/_fixtures/deopt-child-keys.tsrx');
 
 function TextHost({ value }: { value: OctaneNode }) {
 	return createElement('p', { 'data-testid': 'text' }, value);
@@ -262,6 +273,148 @@ describe('de-opt child keys — user keys never collide with wrapper paths', () 
 });
 
 describe('de-opt child keys — wrapper boundaries survive the top-level fast path', () => {
+	it('adopts mixed keyed and unkeyed server children before a keyed move', () => {
+		function rows(keyedFirst: boolean) {
+			const plain = createElement(
+				'li',
+				{ 'data-testid': 'plain' },
+				createElement('input', { 'data-testid': 'plain-input' }),
+			);
+			const keyed = createElement(
+				'li',
+				{ key: '0', 'data-testid': 'keyed' },
+				createElement('input', { 'data-testid': 'keyed-input' }),
+			);
+			const nested = [
+				createElement(
+					'li',
+					{ key: '0', 'data-testid': 'nested' },
+					createElement('input', { 'data-testid': 'nested-input' }),
+				),
+			];
+			return positionalChildren(keyedFirst ? [keyed, plain, nested] : [plain, keyed, nested]);
+		}
+
+		const initialRows = rows(false);
+		const container = document.createElement('div');
+		container.innerHTML = renderToString(server.RowsHole, { rows: initialRows }).html;
+		document.body.appendChild(container);
+		const plain = container.querySelector('[data-testid="plain-input"]') as HTMLInputElement;
+		const keyed = container.querySelector('[data-testid="keyed-input"]') as HTMLInputElement;
+		const nested = container.querySelector('[data-testid="nested-input"]') as HTMLInputElement;
+		plain.value = 'typed plain';
+		keyed.value = 'typed keyed';
+		nested.value = 'typed nested';
+		plain.focus();
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			root = hydrateRoot(container, RowsHole, { rows: initialRows });
+			flushSync(() => {});
+			expect(container.querySelector('[data-testid="plain-input"]')).toBe(plain);
+			expect(container.querySelector('[data-testid="keyed-input"]')).toBe(keyed);
+			expect(container.querySelector('[data-testid="nested-input"]')).toBe(nested);
+			expect(document.activeElement).toBe(plain);
+			expect(plain.value).toBe('typed plain');
+			expect(keyed.value).toBe('typed keyed');
+			expect(nested.value).toBe('typed nested');
+
+			flushSync(() => root!.render(RowsHole, { rows: rows(true) }));
+			expect(
+				Array.from(container.querySelectorAll('li'), (el) => el.getAttribute('data-testid')),
+			).toEqual(['keyed', 'plain', 'nested']);
+			expect(container.querySelector('[data-testid="keyed-input"]')).toBe(keyed);
+			expect(keyed.value).toBe('typed keyed');
+			expect(container.querySelector('[data-testid="nested-input"]')).toBe(nested);
+			expect(nested.value).toBe('typed nested');
+			expect(container.querySelector('[data-testid="plain-input"]')).not.toBe(plain);
+			expect(
+				(container.querySelector('[data-testid="plain-input"]') as HTMLInputElement).value,
+			).toBe('');
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
+	it('preserves unkeyed positions beside keyed and nested children after a keyed move', () => {
+		function App({ phase }: { phase: 0 | 1 | 2 }) {
+			const plain = createElement(
+				'li',
+				{ 'data-testid': 'plain' },
+				createElement('input', { 'data-testid': 'plain-input' }),
+			);
+			const keyed = createElement(
+				'li',
+				{ key: phase === 0 ? '0' : 0, 'data-testid': 'keyed' },
+				createElement('input', { 'data-testid': 'keyed-input' }),
+			);
+			const nested = [
+				createElement(
+					'li',
+					{ key: '0', 'data-testid': 'nested' },
+					createElement('input', { 'data-testid': 'nested-input' }),
+				),
+			];
+			const tail = createElement(
+				'li',
+				{ 'data-testid': 'tail' },
+				createElement('input', { 'data-testid': 'tail-input' }),
+			);
+			const rows = positionalChildren(
+				phase === 0
+					? [plain, keyed, nested, tail]
+					: phase === 1
+						? [plain, null, nested, tail, keyed]
+						: [keyed, plain, nested, tail],
+			);
+			return createElement(RowsHole, { rows });
+		}
+
+		const r = mount(App, { phase: 0 });
+		try {
+			const before = new Map(
+				(['plain', 'keyed', 'nested', 'tail'] as const).map((name) => [
+					name,
+					r.find(`[data-testid="${name}-input"]`) as HTMLInputElement,
+				]),
+			);
+			for (const [name, input] of before) input.value = name;
+			before.get('plain')!.focus();
+			expect(document.activeElement).toBe(before.get('plain'));
+
+			r.update(App, { phase: 1 });
+			expect(r.findAll('li').map((el) => el.getAttribute('data-testid'))).toEqual([
+				'plain',
+				'nested',
+				'tail',
+				'keyed',
+			]);
+			for (const [name, input] of before) {
+				expect(r.find(`[data-testid="${name}-input"]`)).toBe(input);
+				expect(input.value).toBe(name);
+			}
+			expect(document.activeElement).toBe(before.get('plain'));
+
+			r.update(App, { phase: 2 });
+			expect(r.findAll('li').map((el) => el.getAttribute('data-testid'))).toEqual([
+				'keyed',
+				'plain',
+				'nested',
+				'tail',
+			]);
+			for (const name of ['keyed', 'nested', 'tail'] as const) {
+				const input = r.find(`[data-testid="${name}-input"]`) as HTMLInputElement;
+				expect(input).toBe(before.get(name));
+				expect(input.value).toBe(name);
+			}
+			const newPlain = r.find('[data-testid="plain-input"]') as HTMLInputElement;
+			expect(newPlain).not.toBe(before.get('plain'));
+			expect(newPlain.value).toBe('');
+		} finally {
+			r.unmount();
+		}
+	});
+
 	it('carries a keyed fragment’s children through a reorder', () => {
 		function App() {
 			const [rev, setRev] = useState(false);


### PR DESCRIPTION
## Summary
- Use numeric positions for top-level unkeyed descriptor children in the client de-opt list reconciler.
- Preserve the string namespaces for explicit keys and nested wrapper paths, with DOM and hydration regression coverage.
- Add an isolated opt-in production browser work gate for 1,000 unkeyed children plus an explicit `key="0"`.

## Why
- #981 identifies a per-item string allocation in `scopedDeoptKey` on every mount and update of a descriptor list. The internal `Map` already separates a numeric index from explicit and nested string keys.

## Changes
- Return the numeric index for the top-level implicit case; leave explicit `k…` and nested JSON keys intact. No new cache or per-item work is introduced.
- Assert survivor identity, positional remounts, user-edited input values, focus, and server-to-client adoption around mixed keyed and unkeyed children. Both new tests fail when the implicit key is deliberately made to collide with `key="0"`.
- Keep the new benchmark fixture in a separate Vite HTML entry and ignored build output so the standard js-framework timing bundle is unchanged.

## Validation
- [x] `pnpm sync` (no generated diff)
- [x] `pnpm format:files:check` on all changed files; `git diff --check`
- [x] `pnpm changeset:check`
- [x] `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json` and TSRX-aware check of the changed test and fixture
- [x] `pnpm exec vitest run --project octane --project octane-prod --silent=passed-only`: 989 files, 17,592 passing tests, 14 expected failures
- [x] Focused de-opt keys and pure-host upgrade suites: 38/38 across development and production modes; both new tests confirmed red under a deliberately colliding key and green after restoring the candidate
- [x] Isolated production browser work gate: baseline constructs 1,000 implicit key strings per render, candidate constructs 0; mount/update each call `scopedDeoptKey` and `deoptItemBody` 1,001 times, update calls `reconcileKeyed` once, all 1,001 rows retain expected identity/order, uncontrolled input state, and focus
- [ ] Full repository `pnpm test` and `pnpm typecheck` (the focused core suite and package/fixture checks above were run locally; repository CI will run the broader gates)

## Risk / follow-ups
- This removes one client allocation source, not the full #981 item: explicit-key strings, nested wrapper encodings, two list `getKey` closures, and keyed component-slot coercion remain. SSR has a separate serializer and is unchanged.
- The browser gate proves production source work and semantics, not a wall-time or heap-allocation improvement.

Refs #981.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791631935&installation_model_id=432790&pr_number=1030&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1030&signature=c6cbc99fc315d84bdd3abd61b97aa3559eb28d208887eb27cb84c543876fa5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path reconciliation key derivation in the client runtime; semantics are heavily tested but incorrect key typing could cause list mis-reconciliation.
> 
> **Overview**
> **Top-level unkeyed de-opt list children now reconcile with numeric indices** instead of allocating `'i' + index` strings on every parent render. Explicit keys still use the `'k'…` prefix and nested wrapper paths still use JSON; `scopedDeoptKey`’s return type becomes `string | number`.
> 
> Regression coverage adds **hydration and reorder scenarios** for mixed keyed/unkeyed/nested lists (DOM identity, typed inputs, focus, and keeping implicit index 0 separate from `key="0"`).
> 
> An **opt-in js-framework work gate** (`WORK_MODE=unkeyed`) mounts 1,001 rows through a separate Vite entry, asserts production helper call counts and semantics, and can require the numeric-key implementation via `WORK_REQUIRE_NUMERIC=1` without affecting the main timing bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37cf3fe57cff104791197d8dfb35b5e8e551986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->