### PR TITLE
feat: Reject Strong render-time state getter calls

### DIFF
--- a/.changeset/strong-render-state-getters.md
+++ b/.changeset/strong-render-state-getters.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Reject render-time calls to known state getters from `useState`, `useReducer`, and `useLinkedState` in Strong modules, with source-located diagnostics. Keep event, effect, deferred, and compatibility-mode calls legal and document the snapshot-safe render pattern.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -495,8 +495,12 @@ in compatibility mode unless their own source opts in.
 
 A Strong module cannot call a state updater during render or synchronously while
 setting up an effect, and it cannot read or assign to a `useRef` object's
-`current` during render (`OCTANE_STRONG_RENDER_REF_READ` for reads). The
-checks follow provable synchronous calls through `useCallback`, `useEffectEvent`,
+`current` during render (`OCTANE_STRONG_RENDER_REF_READ` for reads). It also
+rejects calling a known third-tuple state getter during render
+(`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`): the getter can observe scheduled
+state that differs from the render snapshot. Read the state tuple's first member
+when rendering; call the getter in events, effects, or deferred work. The checks
+follow provable synchronous calls through `useCallback`, `useEffectEvent`,
 and functions returned by analyzable `useMemo` factories. Calling a statically
 known Effect Event during render or including it in an explicit hook dependency
 list is also a compile error. The hooks themselves remain supported, and other

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -741,6 +741,9 @@ These patterns become compile errors:
 
 - Calling a `useState`, `useReducer`, or `useLinkedState` updater during render.
 - Calling one of those updaters synchronously while an effect is being set up.
+- Calling a known third-tuple state getter during render
+  (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`). Render from the first tuple member;
+  read the latest scheduled state in an event, effect, or deferred callback.
 - Assigning to a `useRef` object's `current` during render.
 - Reading a `useRef` object's `current` during render
   (`OCTANE_STRONG_RENDER_REF_READ`). Pass the ref to a `ref` prop as usual; read

--- a/packages/octane-mcp-server/skills/react-divergences.md
+++ b/packages/octane-mcp-server/skills/react-divergences.md
@@ -36,10 +36,12 @@ Ordinary two-item destructures keep the allocation-free React shape.
 
 In a module with `"use strong"` or application-wide Strong enabled, reading a
 `useRef` object's `current` while rendering is a compiler error
-(`OCTANE_STRONG_RENDER_REF_READ`). Its value can change without a witnessed
-render input changing. Pass the ref directly to a `ref` prop, read it in an event
-or effect, or use state when its value must appear in render output. Compatibility
-modules keep their existing behavior.
+(`OCTANE_STRONG_RENDER_REF_READ`). Calling a known third-tuple state getter
+while rendering is also an error (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`): it
+can read scheduled state that differs from the render snapshot. Pass the ref
+directly to a `ref` prop and render from the state tuple's first member. Read
+the ref or call the getter in an event, effect, or deferred callback.
+Compatibility modules keep their existing behavior.
 
 ## Controlled inputs match React — on native events
 

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -53,8 +53,17 @@ const NO_RETURN_VALUE = Symbol('no return value');
 const OTHER_BINDING = { kind: 'other' };
 const SNAPSHOT_BINDING = { kind: 'snapshot' };
 const ARRAY_SNAPSHOT_BINDING = { kind: 'snapshot', array: true };
-const STATE_TUPLE_BINDING = { kind: 'state-tuple', snapshot: SNAPSHOT_BINDING };
-const ARRAY_STATE_TUPLE_BINDING = { kind: 'state-tuple', snapshot: ARRAY_SNAPSHOT_BINDING };
+const STATE_GETTER_BINDING = { kind: 'getter' };
+const STATE_TUPLE_BINDING = {
+	kind: 'state-tuple',
+	snapshot: SNAPSHOT_BINDING,
+	getter: STATE_GETTER_BINDING,
+};
+const ARRAY_STATE_TUPLE_BINDING = {
+	kind: 'state-tuple',
+	snapshot: ARRAY_SNAPSHOT_BINDING,
+	getter: STATE_GETTER_BINDING,
+};
 const UNDEFINED_BINDING = { kind: 'constant', value: UNDEFINED_VALUE, primitive: undefined };
 const SKIP_KEYS = new Set([
 	'type',
@@ -72,6 +81,7 @@ const SKIP_KEYS = new Set([
 ]);
 
 export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
+export const STRONG_RENDER_STATE_GETTER_CALL = 'OCTANE_STRONG_RENDER_STATE_GETTER_CALL';
 export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
 export const STRONG_RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
@@ -1267,7 +1277,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	let returnCycles = 0;
 	let currentFunctionIsAsync = false;
 	let currentFunctionChecksImpureCalls = false;
-	let currentFunctionChecksRefReads = false;
+	let currentFunctionChecksRenderReads = false;
 	let currentRetainedRowScope = null;
 
 	function predeclareHoistedVars(node, scope) {
@@ -1328,6 +1338,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			? 'Strong mode does not allow synchronous state updates inside effect setup. Derive the value during render or use useLinkedState when state follows another value.'
 			: 'Strong mode does not allow state updates during render. Use useLinkedState when state needs to reset or change with another value.';
 		report(code, node, message, [{ hook: 'useLinkedState' }]);
+	}
+
+	function reportStateGetterCall(node) {
+		report(
+			STRONG_RENDER_STATE_GETTER_CALL,
+			node,
+			'Strong mode does not allow calling a state getter during render. Render from the state tuple snapshot; call the getter in an event, effect, or deferred callback for the latest scheduled state.',
+		);
 	}
 
 	function reportRef(node) {
@@ -1812,6 +1830,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	function visitParameters(node, parentScope, phase, args) {
 		const parameters = node.params ?? [];
 		const parameterScope = createScope(parentScope, 'function', [], parameters);
+		function bindGetter(identifier, binding) {
+			if (identifier?.type === 'Identifier' && !isReassigned(identifier)) {
+				parameterScope.bindings.set(identifier.name, binding);
+			}
+		}
 		if (
 			node.type === 'FunctionExpression' &&
 			node.id?.name &&
@@ -1826,12 +1849,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			if (parameter.type === 'AssignmentPattern') {
 				const usesDefault = !definitelyDefined(value);
 				if (usesDefault) visit(parameter.right, parameterScope, phase);
+				const defaultValue = usesDefault
+					? expressionBinding(parameter.right, parameterScope)
+					: null;
 				value =
 					value.kind === 'constant' && value.primitive === undefined
-						? expressionBinding(parameter.right, parameterScope)
+						? defaultValue
 						: definitelyDefined(value)
 							? value
-							: OTHER_BINDING;
+							: defaultValue?.kind === 'getter' || defaultValue?.kind === 'state-tuple'
+								? defaultValue
+								: OTHER_BINDING;
 				visitPatternExpressions(
 					parameter.left,
 					parameterScope,
@@ -1840,9 +1868,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						(value?.kind === 'ref' ||
 							(usesDefault && isRefObject(parameter.right, parameterScope))),
 				);
+				bindStateGetterPattern(parameter.left, value, parameterScope, bindGetter);
 				parameter = parameter.left;
 			} else {
 				visitPatternExpressions(parameter, parameterScope, phase, value?.kind === 'ref');
+				bindStateGetterPattern(parameter, value, parameterScope, bindGetter);
 			}
 			if (parameter.type === 'Identifier' && !isReassigned(parameter)) {
 				parameterScope.bindings.set(parameter.name, value);
@@ -1854,12 +1884,12 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	function visitFunction(node, parentScope, phase, args = null) {
 		const enclosingFunctionIsAsync = currentFunctionIsAsync;
 		const enclosingFunctionChecksImpureCalls = currentFunctionChecksImpureCalls;
-		const enclosingFunctionChecksRefReads = currentFunctionChecksRefReads;
+		const enclosingFunctionChecksRenderReads = currentFunctionChecksRenderReads;
 		currentFunctionIsAsync = node.async === true;
 		if (phase === 'render' && !activeCallbacks.has(node)) {
 			// Ordinary module helpers may be used only by events. Check their
 			// standard calls when a known render root invokes them synchronously.
-			currentFunctionChecksImpureCalls = currentFunctionChecksRefReads =
+			currentFunctionChecksImpureCalls = currentFunctionChecksRenderReads =
 				renderRoots.has(node) || node.body?.type === 'JSXCodeBlock';
 		}
 		try {
@@ -1891,7 +1921,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		} finally {
 			currentFunctionIsAsync = enclosingFunctionIsAsync;
 			currentFunctionChecksImpureCalls = enclosingFunctionChecksImpureCalls;
-			currentFunctionChecksRefReads = enclosingFunctionChecksRefReads;
+			currentFunctionChecksRenderReads = enclosingFunctionChecksRenderReads;
 		}
 	}
 
@@ -1924,7 +1954,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (
 					refSource &&
 					executionPhase === 'render' &&
-					currentFunctionChecksRefReads &&
+					currentFunctionChecksRenderReads &&
 					(currentProperty || (property.type === 'RestElement' && !currentExcluded))
 				) {
 					reportRefRead(currentProperty ? property.key : property);
@@ -1949,6 +1979,26 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		return executionPhase;
 	}
 
+	function bindStateGetterPattern(pattern, tuple, scope, bind) {
+		if (tuple?.kind !== 'state-tuple') return;
+		if (pattern?.type === 'ArrayPattern') {
+			const element = pattern.elements?.[2];
+			bind(element?.type === 'AssignmentPattern' ? element.left : element, tuple.getter);
+		} else if (pattern?.type === 'ObjectPattern') {
+			for (const property of pattern.properties ?? []) {
+				if (property.type !== 'Property') continue;
+				const key = property.computed
+					? staticPrimitiveValue(property.key, scope)
+					: property.key?.type === 'Identifier'
+						? property.key.name
+						: property.key?.value;
+				if (key !== 2 && key !== '2') continue;
+				const value = property.value;
+				bind(value?.type === 'AssignmentPattern' ? value.left : value, tuple.getter);
+			}
+		}
+	}
+
 	function bindDeclarationValue(declaration, declarationKind, scope) {
 		const target = declarationScope(scope, declarationKind);
 		const initial = unwrap(declaration.init);
@@ -1967,6 +2017,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			const element = declaration.id.elements?.[1];
 			const setter = element?.type === 'AssignmentPattern' ? element.left : element;
 			bind(setter, { kind: 'setter' });
+			bindStateGetterPattern(declaration.id, stateTuple, scope, bind);
 		} else if (declaration.id?.type === 'ObjectPattern' && stateTuple) {
 			for (const property of declaration.id.properties ?? []) {
 				if (property.type !== 'Property') continue;
@@ -1983,6 +2034,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					bindSnapshotPattern(value, stateTuple.snapshot, bind);
 				}
 			}
+			bindStateGetterPattern(declaration.id, stateTuple, scope, bind);
 		} else if (declaration.id?.type === 'Identifier') {
 			if (stateTuple) {
 				bind(declaration.id, stateTuple);
@@ -1993,12 +2045,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				bind(declaration.id, { kind: 'ref' });
 			} else if (declarationKind === 'const' && stateTupleUpdater(initial, scope)) {
 				target.bindings.set(declaration.id.name, { kind: 'setter' });
+			} else if (declarationKind === 'const' && stateTupleGetter(initial, scope)) {
+				target.bindings.set(declaration.id.name, STATE_GETTER_BINDING);
 			} else if (snapshot !== null) {
 				target.bindings.set(declaration.id.name, snapshot);
 			} else if (declarationKind === 'const' && initial?.type === 'Identifier') {
 				const value = resolve(scope, initial.name);
 				if (
 					value?.kind === 'setter' ||
+					value?.kind === 'getter' ||
 					value?.kind === 'ref' ||
 					value?.kind === 'callback' ||
 					value?.kind === 'callback-choice' ||
@@ -2119,6 +2174,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			(property === 1 || property === '1') &&
 			unwrap(member.object)?.type === 'Identifier' &&
 			resolve(scope, unwrap(member.object).name)?.kind === 'state-tuple'
+		);
+	}
+
+	function stateTupleGetter(value, scope) {
+		const member = unwrap(value);
+		if (member?.type !== 'MemberExpression' || member.computed !== true) return false;
+		const key = staticPrimitiveValue(member.property, scope);
+		return (
+			(key === 2 || key === '2') &&
+			stateTupleBinding(member.object, scope)?.getter === STATE_GETTER_BINDING
 		);
 	}
 
@@ -2247,7 +2312,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			FUNCTION_TYPES.has(expression?.type) ||
 			expression?.type === 'ObjectExpression' ||
 			expression?.type === 'ArrayExpression' ||
-			stateTupleUpdater(expression, scope)
+			stateTupleUpdater(expression, scope) ||
+			stateTupleGetter(expression, scope)
 		) {
 			return TRUTHY_VALUE;
 		} else if (
@@ -2266,6 +2332,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				binding?.kind === 'callback' ||
 				binding?.kind === 'effect-event' ||
 				binding?.kind === 'setter' ||
+				binding?.kind === 'getter' ||
 				binding?.kind === 'ref' ||
 				binding?.kind === 'state-tuple' ||
 				binding?.kind === 'linked-key' ||
@@ -2364,7 +2431,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			value?.kind === 'callback' ||
 			value?.kind === 'callback-choice' ||
 			value?.kind === 'effect-event' ||
-			value?.kind === 'setter'
+			value?.kind === 'setter' ||
+			value?.kind === 'getter'
 		);
 	}
 
@@ -2391,7 +2459,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (scopes === undefined) functions.set(callback.node, (scopes = new Set()));
 				scopes.add(callback.scope);
 			} else {
-				const identity = callback.kind === 'setter' ? 'setter' : callback;
+				const identity =
+					callback.kind === 'setter' || callback.kind === 'getter' ? callback.kind : callback;
 				if (seen.has(identity)) return;
 				seen.add(identity);
 			}
@@ -2455,6 +2524,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			return isCallableValue(binding) ? binding : null;
 		}
 		if (stateTupleUpdater(node, scope)) return { kind: 'setter' };
+		if (stateTupleGetter(node, scope)) return STATE_GETTER_BINDING;
 		if (node?.type === 'SequenceExpression') {
 			return callableValue(node.expressions?.[node.expressions.length - 1], scope);
 		}
@@ -2740,6 +2810,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			else if (phase === 'effect') visitCallable(value.callback, origin, phase, args);
 		} else if (value?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
 			reportSetter(origin, phase);
+		} else if (value?.kind === 'getter' && phase === 'render' && currentFunctionChecksRenderReads) {
+			reportStateGetterCall(origin);
 		}
 	}
 
@@ -2992,7 +3064,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						const spreadPhase = phaseAfter(property.argument, executionPhase);
 						if (
 							spreadPhase === 'render' &&
-							currentFunctionChecksRefReads &&
+							currentFunctionChecksRenderReads &&
 							isRefObject(property.argument, scope)
 						) {
 							reportRefRead(property);
@@ -3019,7 +3091,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					if (
 						readAccess &&
 						propertyPhase === 'render' &&
-						currentFunctionChecksRefReads &&
+						currentFunctionChecksRenderReads &&
 						readCurrentRef(node, scope) &&
 						phaseAfter(node.property, propertyPhase) === 'render'
 					) {
@@ -3028,7 +3100,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				} else if (
 					readAccess &&
 					phase === 'render' &&
-					currentFunctionChecksRefReads &&
+					currentFunctionChecksRenderReads &&
 					readCurrentRef(node, scope) &&
 					phaseAfter(node.object, phase, true, node.optional === true) === 'render'
 				) {
@@ -3160,14 +3232,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					// memo owns a component callback. lazy also accepts a module
 					// loader, so require JSX evidence before treating it as a render.
 					const checkImpureCalls = currentFunctionChecksImpureCalls;
-					const checkRefReads = currentFunctionChecksRefReads;
+					const checkRenderReads = currentFunctionChecksRenderReads;
 					currentFunctionChecksImpureCalls = true;
-					currentFunctionChecksRefReads = true;
+					currentFunctionChecksRenderReads = true;
 					try {
 						visitCallback(component.node, component.scope, 'render');
 					} finally {
 						currentFunctionChecksImpureCalls = checkImpureCalls;
-						currentFunctionChecksRefReads = checkRefReads;
+						currentFunctionChecksRenderReads = checkRenderReads;
 					}
 					return;
 				}
@@ -3198,7 +3270,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 							callback,
 							callee,
 							executionPhase,
-							callback.kind === 'setter' ? null : argumentValues(node.arguments, scope),
+							callback.kind === 'setter' || callback.kind === 'getter'
+								? null
+								: argumentValues(node.arguments, scope),
 						);
 					}
 				}
@@ -3295,7 +3369,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (
 					node.operator !== '=' &&
 					rightPhase === 'render' &&
-					currentFunctionChecksRefReads &&
+					currentFunctionChecksRenderReads &&
 					(executionPhase !== 'render' || !currentRef(node.left, scope)) &&
 					readCurrentRef(node.left, scope)
 				) {

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -4,6 +4,7 @@ import { slotHooks } from '../../src/compiler/slot-hooks.js';
 import { compileToVolarMappings } from '../../src/compiler/volar.js';
 
 const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
+const RENDER_STATE_GETTER_CALL = 'OCTANE_STRONG_RENDER_STATE_GETTER_CALL';
 const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
 const RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
@@ -4409,6 +4410,209 @@ export function App() {
 
 		expect(() => slotHooks(hook, '/src/useValue.ts')).toThrow(RENDER_REF_READ);
 		expect(() => compile(component, '/src/App.tsx')).toThrow(RENDER_REF_READ);
+	});
+});
+
+describe('Strong mode render-time state getters', () => {
+	function component(setup: string): string {
+		return `import { useState, useReducer, useLinkedState, useEffect, useCallback, useMemo } from 'octane';
+export function App(props) @{
+  ${setup}
+  <div />
+}`;
+	}
+
+	it('rejects a live state getter during render while compatibility remains live', () => {
+		const source = `import { useState } from 'octane';
+export function App() @{
+  const [count, setCount, getCount] = useState(0);
+  const latest = getCount();
+  <button onClick={() => setCount(count + 1)}>{latest as string}</button>
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_GETTER_CALL,
+		);
+	});
+
+	it.each([
+		['useState', 'const [, , get] = useState(0); get();'],
+		['useReducer', 'const [, , get] = useReducer((value) => value, 0); get();'],
+		['useLinkedState', 'const [, , get] = useLinkedState(props.value, (value) => value); get();'],
+	])('diagnoses the latest-value getter from %s', (_hook, setup) => {
+		const source = component(setup);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_GETTER_CALL,
+		);
+	});
+
+	it.each([
+		['direct tuple indexing', 'const tuple = useState(0); tuple[2]();'],
+		['a tuple alias', 'const tuple = useState(0); const pair = tuple; pair[2]();'],
+		[
+			'a constant computed index',
+			'const tuple = useState(0); const index = 2 as const; tuple[index]?.();',
+		],
+		['a string index', "const tuple = useState(0); tuple['2']();"],
+		['direct hook indexing', 'useState(0)[2]();'],
+		['object destructuring', 'const { 2: get } = useState(0); get();'],
+		['a computed object key', 'const { [2]: get } = useState(0); get();'],
+		[
+			'array destructuring of an alias',
+			'const tuple = useState(0); const [, , get] = tuple; get();',
+		],
+		[
+			'getter aliases',
+			'const tuple = useState(0); const [, , get] = tuple; const latest = get; latest();',
+		],
+		['optional calls', 'const [, , get] = useState(0); get?.();'],
+	])('follows state getter calls through %s', (_shape, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_GETTER_CALL,
+		);
+	});
+
+	it.each([
+		['getter arguments', 'function read(getter) { return getter(); } read(getCount);'],
+		['tuple arguments', 'function read(pair) { return pair[2](); } read(tuple);'],
+		[
+			'destructured tuple parameters',
+			'function read([, , getter]) { return getter(); } read(tuple);',
+		],
+		['immediate callbacks', '((getter) => getter())(getCount);'],
+		['memo calculations', 'useMemo(() => getCount(), []);'],
+	])('follows render-time calls through %s', (_shape, expression) => {
+		const setup = `const tuple = useState(0); const [, , getCount] = tuple; ${expression}`;
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_GETTER_CALL,
+		);
+	});
+
+	it.each([
+		[
+			'getter parameter',
+			'const [, , get] = useState(0); function read(value = get) { return value(); } read(props.maybe);',
+		],
+		[
+			'destructured tuple parameter',
+			'const tuple = useState(0); function read([, , value] = tuple) { return value(); } read(props.maybe);',
+		],
+	])('checks a possible %s default when an argument can be undefined', (_shape, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_GETTER_CALL,
+		);
+	});
+
+	it.each([
+		[
+			'getter parameter',
+			'const [, , get] = useState(0); function read(value = get) { return value(); } read(() => 1);',
+		],
+		[
+			'destructured tuple parameter',
+			'const tuple = useState(0); function read([, , value] = tuple) { return value(); } read([0, () => {}, () => 1]);',
+		],
+	])('allows a definitely provided safe %s argument', (_shape, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['aliased hook imports', "import { useState as createState } from 'octane';", 'createState(0)'],
+		['namespace hook imports', "import * as Octane from 'octane';", 'Octane.useState(0)'],
+	])('recognizes %s', (_shape, imported, hook) => {
+		const source = `"use strong";
+${imported}
+export function App() @{
+  const [, , get] = ${hook};
+  <p>{get() as string}</p>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_GETTER_CALL);
+	});
+
+	it('keeps getters live in events, effects, cleanup, and deferred callbacks', () => {
+		const source = `"use strong";
+import { useState, useEffect, useCallback } from 'octane';
+export function App(props) @{
+  const [count, setCount, getCount] = useState(0);
+  const readLater = useCallback(() => getCount(), []);
+  useEffect(() => {
+    props.record(getCount());
+    return () => { props.record(getCount()); };
+  }, []);
+  setTimeout(() => props.record(getCount()), 0);
+  Promise.resolve().then(() => props.record(getCount()));
+  (async () => { await Promise.resolve(); props.record(getCount()); })();
+  <button onClick={() => { setCount(count + 1); props.record(readLater()); }}>
+    {count as string}
+  </button>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['unrelated tuple indexing', 'const tuple = [0, () => {}, () => 1]; tuple[2]();'],
+		[
+			'unrelated tuple arguments',
+			'function read([, , getter]) { return getter(); } read([0, () => {}, () => 1]);',
+		],
+		[
+			'shadowed getters',
+			'const [, , getCount] = useState(0); { const getCount = () => 1; getCount(); }',
+		],
+		['unknown tuple keys', 'const tuple = useState(0); const key = props.index; tuple[key]();'],
+	])('preserves %s', (_shape, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each(['client', 'server'] as const)('preserves valid getter code in %s output', (mode) => {
+		const source = component('const [, , get] = useState(0); const readLater = () => get();');
+		const standard = compile(source, '/src/App.tsrx', { mode });
+		const strong = compile(source, '/src/App.tsrx', { mode, strong: true } as any);
+		expect(strong.code).toBe(standard.code);
+		expect(strong.diagnostics).toEqual(standard.diagnostics);
+	});
+
+	it('locates the getter call in compiler and Volar diagnostics', () => {
+		const source = `"use strong";\n${component('const [, , getCount] = useState(0); getCount();')}`;
+		const position = source.indexOf('getCount();');
+		const result = compileToVolarMappings(source, '/src/App.tsrx');
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_STATE_GETTER_CALL,
+				severity: 'error',
+				filename: '/src/App.tsrx',
+				start: expect.objectContaining({ offset: position }),
+				end: expect.objectContaining({ offset: position + 'getCount'.length }),
+			}),
+		);
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_STATE_GETTER_CALL,
+				type: 'usage',
+				fileName: '/src/App.tsrx',
+				pos: position,
+			}),
+		);
+	});
+
+	it('enforces getters in plain custom hooks and Octane TSX components', () => {
+		const plain = `"use strong";
+import { useState } from 'octane';
+export function useCurrent() {
+  const [, , get] = useState(0);
+  return get();
+}`;
+		const tsx = `/** @jsxImportSource octane */
+"use strong";
+import { useReducer } from 'octane';
+export function App() {
+  const [, , get] = useReducer((value) => value, 0);
+  return <p>{get()}</p>;
+}`;
+		expect(() => slotHooks(plain, '/src/useCurrent.ts')).toThrow(RENDER_STATE_GETTER_CALL);
+		expect(() => compile(tsx, '/src/App.tsx')).toThrow(RENDER_STATE_GETTER_CALL);
 	});
 });
 

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -226,6 +226,9 @@ A Strong module cannot:
 
 - Call a state setter or reducer dispatcher while rendering.
 - Call one synchronously while an effect is being set up.
+- Call a known third-tuple state getter while rendering
+  (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`). Render from the state snapshot;
+  use the getter in events, effects, or deferred work.
 - Assign to a ref's `current` value while rendering.
 - Read a `useRef` object's `current` while rendering
   (`OCTANE_STRONG_RENDER_REF_READ`). Keep refs as `ref` props and read them in


### PR DESCRIPTION
## Summary

- Reject render-time calls to known third-tuple state getters in Strong modules. Part of #1027.

## Why

The getter can observe scheduled state that differs from the current render snapshot. Rendering should read the tuple's first member; events, effects, and deferred callbacks can use the getter for the latest value.

## Changes

- Track index 2 from `useState`, `useReducer`, and `useLinkedState` through tuple aliases, destructuring, direct indexing, and synchronous helper arguments/defaults.
- Report a source-located `OCTANE_STRONG_RENDER_STATE_GETTER_CALL` error only when the known getter is invoked during a Strong render.
- Add positive and negative compiler tests, Volar mapping coverage, client/server output parity checks, documentation, and patch changesets for `octane` and `@octanejs/mcp-server`.

## Validation

- [ ] `pnpm format:check` (scoped formatting check passed)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full repository CI runs when the PR is ready)
- [x] Targeted tests: `pnpm exec vitest run packages/octane/tests/compiler --reporter=dot --silent=passed-only` — 55 files passed, 1,927 tests passed, 14 expected failures.
- [x] `pnpm format:files:check` on changed files; `pnpm sync`; `git diff --check`.
- [x] Paired baseline/candidate compiler throughput with explicit GC: output hashes identical; 10/100 component deltas within noise, 1,000 component delta changed sign across repeats (inconclusive; no reproducible regression).

## Risk / follow-ups

- The analyzer's bounded proof does not follow callbacks through mutable object/array containers or indirect `.call`/`.apply` invocations; the existing setter check has the same limit. Unknown call shapes are left to the separately proposed dev runtime guard in #1027.
- Valid emitted client and server code is unchanged; compatibility-mode getter calls remain legal.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791631946&installation_model_id=432790&pr_number=1031&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1031&signature=dbacbb18a2a8387d64a7cd1bc0565be53485396f3e4f13f181f64c435df09fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds compile-time enforcement in Strong modules for a previously legal Octane API pattern; valid emitted code is unchanged, but apps on Strong may need to stop calling getters during render.
> 
> **Overview**
> **Strong mode** now treats render-time calls to the third-tuple getter from `useState`, `useReducer`, and `useLinkedState` as compile errors (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`), alongside the existing ref-read guard. The analyzer tracks index-`2` getters through destructuring, tuple indexing/aliases, parameters, and synchronous helper paths, while **events, effects, deferred work, and compatibility modules** stay unchanged.
> 
> Implementation extends `strong-mode.js` with getter bindings and folds ref-read checks under `currentFunctionChecksRenderReads`. Docs, MCP skill text, website build-tools page, a patch changeset, and broad compiler/Volar tests document and lock the snapshot-safe pattern (render from tuple index `0`; use the getter outside render).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c461e0e51f6d3240eb53403ff0912aa29ee0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->