### PR TITLE
perf: avoid implicit SSR descriptor key serialization

### DIFF
--- a/.changeset/ssr-deopt-implicit-index.md
+++ b/.changeset/ssr-deopt-implicit-index.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Avoid serializing top-level unkeyed descriptor positions into JSON for server async identity.

--- a/benchmarks/ssr-throughput/README.md
+++ b/benchmarks/ssr-throughput/README.md
@@ -109,6 +109,25 @@ shared contract: ms stats under `ops.render` (plus `opsPerSec`), payload
 bytes / marker counts / memory growth under `meta`, a top-level `failed` on any
 gate failure (and a non-zero exit).
 
+### Positional descriptor identity work gate (opt-in)
+
+`unkeyed-work.mjs` builds only its separate production SSR fixture entry under
+ignored `dist/unkeyed-work/`; the standard throughput fixtures and scores are
+untouched. Its 1,000 unkeyed component descriptors exercise the top-level
+server child-list identity path. One adjacent explicitly keyed child with key
+`"0"` checks that the two key namespaces stay distinct. The gate verifies row
+order, complete HTML/CSS equality, and an untimed count of positional key
+serialization before reporting warmed render timings. Compare the same output
+hash across a baseline and candidate build:
+
+```bash
+EXPECT_IMPLICIT_JSON=1000 node benchmarks/ssr-throughput/unkeyed-work.mjs 2
+EXPECTED_HTML_SHA=YOUR_BASELINE_SHA node benchmarks/ssr-throughput/unkeyed-work.mjs 2
+```
+
+Timing deltas within process-to-process variance are inconclusive; the
+serialization count is the deterministic work gate.
+
 ### Private loop HTML carriers — 2026-09-03
 
 Compared merged main `44d50dbc0` with private loop bodies returning serialized

--- a/benchmarks/ssr-throughput/fixtures/src/deopt-unkeyed.ts
+++ b/benchmarks/ssr-throughput/fixtures/src/deopt-unkeyed.ts
@@ -1,0 +1,19 @@
+import { createElement } from 'octane/server';
+
+// A plain descriptor list of component children is the server path that builds
+// identity keys for every positional child. Pure host children are serialized
+// directly and would never exercise this path.
+const h = createElement as (type: any, props?: any, ...children: any[]) => any;
+
+const ROWS = 1000;
+
+function Row(props: { id: number | 'explicit' }) {
+	return h('li', { 'data-index': props.id }, `row ${props.id}`);
+}
+
+export function UnkeyedDescriptorPage() {
+	const rows = Array.from({ length: ROWS }, (_, id) => h(Row, { id }));
+	// The explicit string key must remain distinct from the positional 0 key.
+	rows.splice(1, 0, h(Row, { id: 'explicit', key: '0' }));
+	return h('ul', { id: 'unkeyed-descriptors' }, rows);
+}

--- a/benchmarks/ssr-throughput/fixtures/src/entry-unkeyed-server.ts
+++ b/benchmarks/ssr-throughput/fixtures/src/entry-unkeyed-server.ts
@@ -1,0 +1,7 @@
+import { prerender } from 'octane/static';
+import { UnkeyedDescriptorPage } from './deopt-unkeyed';
+
+// Separate entry: the regular SSR throughput bundle and fixture remain intact.
+export async function renderUnkeyedDescriptors() {
+	return prerender(UnkeyedDescriptorPage as any);
+}

--- a/benchmarks/ssr-throughput/unkeyed-work.mjs
+++ b/benchmarks/ssr-throughput/unkeyed-work.mjs
@@ -1,0 +1,104 @@
+// Opt-in production SSR work gate for positional descriptor children.
+// Run from the repository root:
+//   EXPECT_IMPLICIT_JSON=1000 node benchmarks/ssr-throughput/unkeyed-work.mjs 2
+//   EXPECT_IMPLICIT_JSON=0 EXPECTED_HTML_SHA=YOUR_BASELINE_SHA node benchmarks/ssr-throughput/unkeyed-work.mjs 2
+// `dist/unkeyed-work` is ignored and separate from the regular suite's build.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'vite';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.join(here, 'fixtures');
+const output = path.join(here, 'dist', 'unkeyed-work');
+const seconds = Math.max(0.2, Number(process.argv[2] ?? 2));
+
+await build({
+	root: fixture,
+	logLevel: 'warn',
+	build: { ssr: 'src/entry-unkeyed-server.ts', outDir: output, emptyOutDir: true },
+	ssr: { noExternal: ['@tsrx/react'] },
+});
+
+const { renderUnkeyedDescriptors: render } = await import(
+	pathToFileURL(path.join(output, 'entry-unkeyed-server.js')).href
+);
+const first = await render();
+const second = await render();
+assert.equal(second.html, first.html, 'repeated SSR output');
+assert.equal(second.css, first.css, 'repeated CSS output');
+assert.equal(first.css, '', 'fixture does not produce CSS');
+
+const ids = [...first.html.matchAll(/<li data-index="([^"]+)">/g)].map((match) => match[1]);
+assert.equal(ids.length, 1001, 'rendered rows');
+assert.deepEqual(ids, ['0', 'explicit', ...Array.from({ length: 999 }, (_, i) => String(i + 1))]);
+assert.equal((first.html.match(/<!--\[/g) ?? []).length > 1000, true, 'hydratable rows');
+
+const htmlSha = createHash('sha256').update(first.html).digest('hex');
+if (process.env.EXPECTED_HTML_SHA) {
+	assert.equal(htmlSha, process.env.EXPECTED_HTML_SHA, 'baseline/candidate HTML bytes');
+}
+
+// Keep the observer out of all timing and memory measurements. Its shape
+// excludes unrelated serialization and checks that instrumentation did not
+// alter the public response.
+let implicitJson = 0;
+let explicitJson = 0;
+const originalStringify = JSON.stringify;
+let observed;
+try {
+	JSON.stringify = function (value, ...args) {
+		if (Array.isArray(value) && value.length === 3 && Array.isArray(value[0])) {
+			if (value[0].length === 0 && value[1] === 'index' && Number.isInteger(value[2])) {
+				implicitJson++;
+			} else if (value[0].length === 0 && value[1] === 'key' && value[2] === '0') {
+				explicitJson++;
+			}
+		}
+		return Reflect.apply(originalStringify, this, [value, ...args]);
+	};
+	observed = await render();
+} finally {
+	JSON.stringify = originalStringify;
+}
+assert.equal(observed.html, first.html, 'observed HTML bytes');
+assert.equal(observed.css, first.css, 'observed CSS bytes');
+assert.equal(explicitJson, 1, 'explicit key control');
+assert.equal(implicitJson, Number(process.env.EXPECT_IMPLICIT_JSON ?? 0), 'implicit key work');
+
+const now = () => process.hrtime.bigint();
+const warmEnd = now() + 350_000_000n;
+let warmRenders = 0;
+while (warmRenders < 3 || now() < warmEnd) {
+	Buffer.byteLength((await render()).html);
+	warmRenders++;
+}
+const samples = [];
+const end = now() + BigInt(Math.round(seconds * 1e9));
+do {
+	const start = now();
+	Buffer.byteLength((await render()).html);
+	samples.push(Number(now() - start) / 1e6);
+} while (now() < end);
+samples.sort((a, b) => a - b);
+const medianMs = samples[Math.floor(samples.length / 2)];
+const p95Ms = samples[Math.floor(samples.length * 0.95)];
+const result = {
+	htmlSha,
+	htmlBytes: Buffer.byteLength(first.html),
+	rows: ids.length,
+	implicitJson,
+	explicitJson,
+	warmRenders,
+	samples: samples.length,
+	medianMs,
+	p95Ms,
+};
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(result, null, 2) + '\n');
+}
+console.log(result);

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1143,8 +1143,12 @@ function scopedSsrDeoptKey(
 	item: any,
 	index: number,
 	key: any,
-): string {
+): string | number {
 	const explicit = isElementDescriptor(item) && item.key != null;
+	// The async-identity encoder keeps numbers distinct from strings. Preserve
+	// the encoded wrapper/explicit-key paths, but avoid serializing each plain
+	// top-level position before the encoder sees it.
+	if (path.length === 0 && !explicit) return index;
 	return JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]);
 }
 

--- a/packages/octane/tests/ssr-deopt-list-identity.test.ts
+++ b/packages/octane/tests/ssr-deopt-list-identity.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createElement, Fragment, renderToPipeableStream, use } from 'octane/server';
+import { prerender } from 'octane/static';
+import { loadCompiledFixtureSource } from './_server-fixture';
+import {
+	activateStreamedMarkup,
+	createPipeableCollector,
+	resetStreamRuntimeGlobals,
+} from './_server-stream';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+interface ListScenario {
+	phase: 'keyed-first' | 'nested-first' | 'mixed';
+	plain: Promise<string>;
+	keyed: Promise<string>;
+	nested: Promise<string>;
+}
+
+function Row(props: { kind: string; value: Promise<string> }) {
+	return createElement('li', { 'data-kind': props.kind }, use(props.value));
+}
+
+function Page(props: { scenario: ListScenario }) {
+	const { scenario } = props;
+	const plain = createElement(Row, { kind: 'plain', value: scenario.plain });
+	const keyed = createElement(Row, { key: '0', kind: 'keyed', value: scenario.keyed });
+	const nested = createElement(
+		Fragment,
+		{ key: 'branch' },
+		createElement(Row, { key: '0', kind: 'nested', value: scenario.nested }),
+	);
+	return createElement(
+		'ul',
+		null,
+		scenario.phase === 'keyed-first' ? [keyed, nested] : [plain, keyed, nested],
+	);
+}
+
+function NestedPage(props: { scenario: ListScenario }) {
+	const { scenario } = props;
+	const plain = createElement(Row, { kind: 'plain', value: scenario.plain });
+	const keyed = createElement(Row, { key: '0', kind: 'keyed', value: scenario.keyed });
+	const nested = createElement(
+		Fragment,
+		{ key: 'branch' },
+		createElement(Row, { kind: 'nested', value: scenario.nested }),
+	);
+	return createElement(
+		'ul',
+		null,
+		scenario.phase === 'nested-first' ? [nested, keyed] : [plain, keyed, nested],
+	);
+}
+
+function rows(html: string): string[] {
+	const host = document.createElement('div');
+	host.innerHTML = html;
+	return Array.from(
+		host.querySelectorAll('li'),
+		(row) => `${row.getAttribute('data-kind')}:${row.textContent}`,
+	);
+}
+
+const { StreamingRow } = loadCompiledFixtureSource(
+	`import { use } from 'octane';
+	 export function StreamingRow(props) @{
+		@try {
+			const value = use(props.value);
+			<li data-kind={props.kind}>{value as string}</li>
+		} @pending {
+			<li data-kind={props.kind}>waiting</li>
+		}
+	 }`,
+	{ id: 'ssr-deopt-list-streaming-row.tsrx', mode: 'server' },
+);
+
+function StreamingPage(props: { scenario: ListScenario }) {
+	const { scenario } = props;
+	return createElement('ul', null, [
+		createElement(StreamingRow, { kind: 'plain', value: scenario.plain }),
+		createElement(StreamingRow, { key: '0', kind: 'keyed', value: scenario.keyed }),
+		createElement(
+			Fragment,
+			{ key: 'branch' },
+			createElement(StreamingRow, { key: '0', kind: 'nested', value: scenario.nested }),
+		),
+	]);
+}
+
+describe('server descriptor lists across async retries', () => {
+	it("does not reuse a nested unkeyed child's result for a new top-level position", async () => {
+		const plain = deferred<string>();
+		const keyed = deferred<string>();
+		const nested = deferred<string>();
+		const scenario: ListScenario = {
+			phase: 'nested-first',
+			plain: plain.promise,
+			keyed: keyed.promise,
+			nested: nested.promise,
+		};
+
+		// The nested child starts at its own wrapper position. A later top-level
+		// child at index zero must read its own promise, even on an SSR retry.
+		const pending = prerender(NestedPage, { scenario });
+		scenario.phase = 'mixed';
+		nested.resolve('NESTED');
+		plain.resolve('PLAIN');
+		keyed.resolve('KEYED');
+
+		expect(rows((await pending).html)).toEqual(['plain:PLAIN', 'keyed:KEYED', 'nested:NESTED']);
+	});
+
+	it('keeps an implicit position distinct from an explicit key and a nested wrapper', async () => {
+		const plain = deferred<string>();
+		const keyed = deferred<string>();
+		const nested = deferred<string>();
+		const scenario: ListScenario = {
+			phase: 'keyed-first',
+			plain: plain.promise,
+			keyed: keyed.promise,
+			nested: nested.promise,
+		};
+
+		// The first pass reaches the keyed row at position zero and suspends.
+		// On retry a new unkeyed row occupies that position, while the keyed
+		// row moves beside it and the nested keyed row keeps its own boundary.
+		const pending = prerender(Page, { scenario });
+		scenario.phase = 'mixed';
+		keyed.resolve('KEYED');
+		plain.resolve('PLAIN');
+		nested.resolve('NESTED');
+
+		expect(rows((await pending).html)).toEqual(['plain:PLAIN', 'keyed:KEYED', 'nested:NESTED']);
+	});
+
+	it('keeps interleaved requests isolated when list shape changes during suspension', async () => {
+		const a = {
+			plain: deferred<string>(),
+			keyed: deferred<string>(),
+			nested: deferred<string>(),
+		};
+		const b = {
+			plain: deferred<string>(),
+			keyed: deferred<string>(),
+			nested: deferred<string>(),
+		};
+		const first: ListScenario = {
+			phase: 'keyed-first',
+			plain: a.plain.promise,
+			keyed: a.keyed.promise,
+			nested: a.nested.promise,
+		};
+		const second: ListScenario = {
+			phase: 'keyed-first',
+			plain: b.plain.promise,
+			keyed: b.keyed.promise,
+			nested: b.nested.promise,
+		};
+		const firstResult = prerender(Page, { scenario: first });
+		const secondResult = prerender(Page, { scenario: second });
+		first.phase = 'mixed';
+		second.phase = 'mixed';
+		b.keyed.resolve('B-KEYED');
+		a.keyed.resolve('A-KEYED');
+		a.plain.resolve('A-PLAIN');
+		b.plain.resolve('B-PLAIN');
+		b.nested.resolve('B-NESTED');
+		a.nested.resolve('A-NESTED');
+
+		const [firstHtml, secondHtml] = await Promise.all([firstResult, secondResult]);
+		expect(rows(firstHtml.html)).toEqual(['plain:A-PLAIN', 'keyed:A-KEYED', 'nested:A-NESTED']);
+		expect(rows(secondHtml.html)).toEqual(['plain:B-PLAIN', 'keyed:B-KEYED', 'nested:B-NESTED']);
+	});
+
+	it('reveals unkeyed, explicitly keyed, and nested rows out of order in a stream', async () => {
+		const plain = deferred<string>();
+		const keyed = deferred<string>();
+		const nested = deferred<string>();
+		const scenario: ListScenario = {
+			phase: 'mixed',
+			plain: plain.promise,
+			keyed: keyed.promise,
+			nested: nested.promise,
+		};
+		const output = createPipeableCollector();
+		const errors: unknown[] = [];
+		const stream = renderToPipeableStream(
+			StreamingPage,
+			{ scenario },
+			{
+				onError: (error) => errors.push(error),
+			},
+		);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		try {
+			stream.pipe(output.destination);
+			await vi.waitFor(() => {
+				expect(rows(output.chunks.join(''))).toEqual([
+					'plain:waiting',
+					'keyed:waiting',
+					'nested:waiting',
+				]);
+			});
+
+			nested.resolve('NESTED');
+			await vi.waitFor(() => expect(output.chunks.join('')).toContain('NESTED'));
+			plain.resolve('PLAIN');
+			await vi.waitFor(() => expect(output.chunks.join('')).toContain('PLAIN'));
+			keyed.resolve('KEYED');
+			container.innerHTML = await output.ended;
+			activateStreamedMarkup(container);
+			expect(rows(container.innerHTML)).toEqual(['plain:PLAIN', 'keyed:KEYED', 'nested:NESTED']);
+			expect(errors).toEqual([]);
+		} finally {
+			stream.abort();
+			container.remove();
+			resetStreamRuntimeGlobals();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Use the numeric positional identity for top-level unkeyed SSR descriptor children.
- Preserve JSON-scoped identities for explicitly keyed and nested children, with async retry, concurrent request, and out-of-order stream regressions.
- Add an opt-in production SSR work gate that keeps output bytes constant while measuring implicit key serialization.

## Why

The server counterpart to #1030 still serialized every top-level unkeyed position into a JSON string and then encoded it for async identity. The existing async encoder has a distinct numeric namespace, so these positions can enter it directly. This continues the open de-opt list item in #981.

## Changes

- Return a numeric index only when an SSR descriptor list leaf has no wrapper path and no explicit key; leave other keys unchanged.
- Cover changing list shapes across suspended retries, nested unkeyed children, explicit `"0"`, interleaved requests, and streaming reveals in both dev and production test projects. A deliberate omission of the nested-path guard made the regression fail in both projects before restoration.
- Add a separate SSR fixture with 1,000 unkeyed component descriptors and one explicitly keyed control. The normal throughput fixture is untouched.

## Validation

- [x] `pnpm format:files:check` on changed files
- [x] `pnpm typecheck:files packages/octane/src/runtime.server.ts packages/octane/tests/ssr-deopt-list-identity.test.ts`
- [x] `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `pnpm changeset:check`
- [x] `pnpm exec vitest run --project octane --project octane-prod packages/octane/tests/ssr-deopt-list-identity.test.ts --silent=passed-only` (8/8)
- [ ] `pnpm exec vitest run --project octane --project octane-prod --silent=passed-only` (17,631 passed, 14 expected failures, three unrelated 5-second timeouts while two broad runners competed)
- [x] Isolated rerun of timed-out Volar and HMR files in both projects (96/96 passed at default timeout)
- [x] Production SSR work gate: baseline/candidate HTML SHA `83d216ef73c364b89da459c53f83f27150878ba4cd004a65c5c036db567dd980` (64,921 bytes, 1,001 rows); implicit JSON key serializations **1,000 → 0**, explicit key control **1 → 1**.

## Risk / follow-ups

The change only affects the server's implicit top-level descriptor identities. Explicit and nested key encoding, list closures, and keyed component slot coercion remain open under #981. In four paired production-bundle A–B–B–A cycles, candidate/baseline median ratios were 0.901, 0.827, 0.938, and 0.972; absolute latency varied with concurrent machine work, so these are directional rather than a precise throughput claim.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791641007&installation_model_id=432790&pr_number=1032&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1032&signature=1fb3c97f1d4cc31fa55f203c5323e83d66a8a25952c84f88fda82e91338344d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server async child-list identity for descriptor SSR; behavior is narrow (top-level unkeyed only) but correctness across retries, concurrency, and streaming is security-adjacent for output isolation.
> 
> **Overview**
> Top-level **unkeyed** server descriptor children now use a **numeric positional identity** in `scopedSsrDeoptKey` instead of wrapping each index in `JSON.stringify`, while **explicit keys** and **nested wrapper paths** still use the JSON-scoped identity shape.
> 
> Regression coverage adds SSR list scenarios across **suspense retries** (changing list shape), **implicit vs explicit `"0"` keys**, **concurrent prerenders**, and **streaming** reveals. An opt-in **`unkeyed-work.mjs`** benchmark gate (1,001-row fixture) asserts unchanged HTML/CSS and counts implicit positional serializations (**1000 → 0** on the candidate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043c3cd434cbe76a4e490ed8d992d1f44190546b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->