### PR TITLE
feat: Reject Strong render-time module state reads

### DIFF
--- a/.changeset/strong-render-module-state-reads.md
+++ b/.changeset/strong-render-module-state-reads.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Reject render-time reads of reassigned module-scope `let` and `var` bindings in Strong modules with source-located diagnostics. Keep compatibility modules and event, effect, and deferred reads unchanged, and document the snapshot-safe alternative.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -499,8 +499,11 @@ setting up an effect, and it cannot read or assign to a `useRef` object's
 rejects calling a known third-tuple state getter during render
 (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`): the getter can observe scheduled
 state that differs from the render snapshot. Read the state tuple's first member
-when rendering; call the getter in events, effects, or deferred work. The checks
-follow provable synchronous calls through `useCallback`, `useEffectEvent`,
+when rendering; call the getter in events, effects, or deferred work. Reading a
+reassigned module-scope `let` or `var` during render is also an error
+(`OCTANE_STRONG_RENDER_MODULE_STATE_READ`): move changing values into state or
+context, or pass an immutable snapshot as a prop. The checks follow provable
+synchronous calls through `useCallback`, `useEffectEvent`,
 and functions returned by analyzable `useMemo` factories. Calling a statically
 known Effect Event during render or including it in an explicit hook dependency
 list is also a compile error. The hooks themselves remain supported, and other

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -744,6 +744,9 @@ These patterns become compile errors:
 - Calling a known third-tuple state getter during render
   (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`). Render from the first tuple member;
   read the latest scheduled state in an event, effect, or deferred callback.
+- Reading a reassigned module-scope `let` or `var` during render
+  (`OCTANE_STRONG_RENDER_MODULE_STATE_READ`). Move the changing value into
+  state or context, or pass an immutable snapshot as a prop.
 - Assigning to a `useRef` object's `current` during render.
 - Reading a `useRef` object's `current` during render
   (`OCTANE_STRONG_RENDER_REF_READ`). Pass the ref to a `ref` prop as usual; read

--- a/packages/octane-mcp-server/skills/react-divergences.md
+++ b/packages/octane-mcp-server/skills/react-divergences.md
@@ -38,9 +38,13 @@ In a module with `"use strong"` or application-wide Strong enabled, reading a
 `useRef` object's `current` while rendering is a compiler error
 (`OCTANE_STRONG_RENDER_REF_READ`). Calling a known third-tuple state getter
 while rendering is also an error (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`): it
-can read scheduled state that differs from the render snapshot. Pass the ref
-directly to a `ref` prop and render from the state tuple's first member. Read
-the ref or call the getter in an event, effect, or deferred callback.
+can read scheduled state that differs from the render snapshot. Reading a
+reassigned module-scope `let` or `var` during render is an error too
+(`OCTANE_STRONG_RENDER_MODULE_STATE_READ`), since the variable can change
+without a witnessed render input. Pass the ref directly to a `ref` prop and
+render from the state tuple's first member. Move changing module values into
+state or context, or pass an immutable snapshot as a prop. Read the ref or call
+the getter in an event, effect, or deferred callback.
 Compatibility modules keep their existing behavior.
 
 ## Controlled inputs match React — on native events

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -82,6 +82,7 @@ const SKIP_KEYS = new Set([
 
 export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 export const STRONG_RENDER_STATE_GETTER_CALL = 'OCTANE_STRONG_RENDER_STATE_GETTER_CALL';
+export const STRONG_RENDER_MODULE_STATE_READ = 'OCTANE_STRONG_RENDER_MODULE_STATE_READ';
 export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
 export const STRONG_RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
@@ -1211,6 +1212,25 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		return reassignedBindings.has(identifier);
 	}
 	const moduleScope = createScope(null, 'module', ast.body ?? [], [], isReassigned);
+	const mutableModuleDeclarations = new Map();
+	const reassignedModuleNames = new Map();
+	function recordMutableModulePattern(pattern) {
+		if (pattern?.type === 'Identifier') {
+			let declarations = mutableModuleDeclarations.get(pattern.name);
+			if (declarations === undefined) {
+				mutableModuleDeclarations.set(pattern.name, (declarations = []));
+			}
+			declarations.push(pattern);
+		} else if (pattern?.type === 'AssignmentPattern' || pattern?.type === 'RestElement') {
+			recordMutableModulePattern(pattern.left ?? pattern.argument);
+		} else if (pattern?.type === 'ArrayPattern') {
+			for (const element of pattern.elements ?? []) recordMutableModulePattern(element);
+		} else if (pattern?.type === 'ObjectPattern') {
+			for (const property of pattern.properties ?? []) {
+				recordMutableModulePattern(property.argument ?? property.value);
+			}
+		}
+	}
 	const activeCallbacks = new Set();
 	const activeReturnCallbacks = new Set();
 	const callResults = new WeakMap();
@@ -1262,6 +1282,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	for (const statement of ast.body ?? []) {
 		const declaration = declarationOf(statement);
 		if (declaration?.type === 'VariableDeclaration') {
+			if (declaration.kind === 'let' && declaration.declare !== true) {
+				for (const binding of declaration.declarations ?? []) {
+					recordMutableModulePattern(binding.id);
+				}
+			}
 			for (const binding of declaration.declarations ?? []) {
 				if (binding.id?.type === 'Identifier') {
 					addNamedRenderRoot(unwrap(binding.init), binding.id.name);
@@ -1308,6 +1333,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (value.type === 'VariableDeclaration' && value.kind === 'var') {
 					for (const declaration of value.declarations ?? []) {
 						addPatternNames(declaration.id, names, OTHER_BINDING);
+						if (scope === moduleScope && value.declare !== true) {
+							recordMutableModulePattern(declaration.id);
+						}
 					}
 				}
 				for (const key in value) {
@@ -1345,6 +1373,52 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			STRONG_RENDER_STATE_GETTER_CALL,
 			node,
 			'Strong mode does not allow calling a state getter during render. Render from the state tuple snapshot; call the getter in an event, effect, or deferred callback for the latest scheduled state.',
+		);
+	}
+
+	function reportModuleStateRead(node) {
+		report(
+			STRONG_RENDER_MODULE_STATE_READ,
+			node,
+			'Strong mode does not allow reading a reassigned module variable during render. Move the value into state or context, or pass an immutable snapshot as a prop.',
+		);
+	}
+
+	function mutableModuleRead(name, scope) {
+		const declarations = mutableModuleDeclarations.get(name);
+		if (declarations === undefined || resolveScope(scope, name) !== moduleScope) {
+			return false;
+		}
+		let reassigned = reassignedModuleNames.get(name);
+		if (reassigned === undefined) {
+			reassigned = declarations.some(isReassigned);
+			reassignedModuleNames.set(name, reassigned);
+		}
+		return reassigned;
+	}
+
+	function definitelySkippedOptionalContinuation(expression, scope) {
+		let node = expression;
+		while (node != null) {
+			// Grouping ends the chain; the caller decides whether a grouped
+			// undefined value is itself behind an optional access.
+			if (node.type === 'ChainExpression') return false;
+			if (TRANSPARENT_EXPRESSIONS.has(node.type)) {
+				node = node.expression;
+				continue;
+			}
+			if (node.type !== 'CallExpression' && node.type !== 'MemberExpression') return false;
+			const target = node.type === 'CallExpression' ? node.callee : node.object;
+			if (node.optional === true && definitelyNullishOptionalValue(target, scope)) return true;
+			node = target;
+		}
+		return false;
+	}
+
+	function definitelyNullishOptionalValue(expression, scope) {
+		return (
+			(staticExpressionValue(expression, scope) & ~NULLISH_VALUE) === 0 ||
+			definitelySkippedOptionalContinuation(unwrap(expression), scope)
 		);
 	}
 
@@ -2998,12 +3072,36 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 		switch (node.type) {
 			case 'ImportDeclaration':
-			case 'Identifier':
 			case 'JSXIdentifier':
 			case 'Literal':
 			case 'ThisExpression':
 			case 'Super':
 				return;
+			case 'Identifier':
+				if (
+					readAccess &&
+					phase === 'render' &&
+					currentFunctionChecksRenderReads &&
+					mutableModuleRead(node.name, scope)
+				) {
+					reportModuleStateRead(node);
+				}
+				return;
+			case 'JSXOpeningElement': {
+				let name = node.name;
+				const member = name?.type === 'JSXMemberExpression';
+				while (name?.type === 'JSXMemberExpression') name = name.object;
+				if (
+					name?.type === 'JSXIdentifier' &&
+					(member || (!/^[a-z]/.test(name.name) && !name.name.includes('-'))) &&
+					phase === 'render' &&
+					currentFunctionChecksRenderReads &&
+					mutableModuleRead(name.name, scope)
+				) {
+					reportModuleStateRead(name);
+				}
+				break;
+			}
 			case 'ExportNamedDeclaration':
 			case 'ExportDefaultDeclaration':
 				visit(node.declaration, scope, phase);
@@ -3085,6 +3183,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			}
 			case 'MemberExpression': {
 				visit(node.object, scope, phase);
+				if (
+					node.optional === true
+						? definitelyNullishOptionalValue(node.object, scope)
+						: definitelySkippedOptionalContinuation(node.object, scope)
+				) {
+					return;
+				}
 				if (node.computed === true) {
 					const propertyPhase = phaseAfter(node.object, phase, true, node.optional === true);
 					visit(node.property, scope, propertyPhase);
@@ -3172,6 +3277,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						: null;
 				if (!FUNCTION_TYPES.has(callee?.type)) {
 					visit(node.callee, scope, phase);
+				}
+				if (
+					node.optional === true
+						? definitelyNullishOptionalValue(node.callee, scope)
+						: definitelySkippedOptionalContinuation(node.callee, scope)
+				) {
+					return;
 				}
 				let executionPhase = phaseAfter(node.callee, phase, true, node.optional === true);
 				const synchronousCallbackIndex =
@@ -3375,9 +3487,26 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				) {
 					reportRefRead(node.left);
 				}
+				if (
+					node.operator !== '=' &&
+					phase === 'render' &&
+					currentFunctionChecksRenderReads &&
+					unwrap(node.left)?.type === 'Identifier' &&
+					mutableModuleRead(unwrap(node.left).name, scope)
+				) {
+					reportModuleStateRead(unwrap(node.left));
+				}
 				return;
 			}
 			case 'UpdateExpression':
+				if (
+					phase === 'render' &&
+					currentFunctionChecksRenderReads &&
+					unwrap(node.argument)?.type === 'Identifier' &&
+					mutableModuleRead(unwrap(node.argument).name, scope)
+				) {
+					reportModuleStateRead(unwrap(node.argument));
+				}
 				if (phase === 'render' && currentRef(node.argument, scope)) reportRef(node.argument);
 				visit(node.argument, scope, phase, false);
 				if (phaseAfter(node.argument, phase, true) === 'render') {

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -3072,6 +3072,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 		switch (node.type) {
 			case 'ImportDeclaration':
+			case 'MetaProperty':
+			case 'BreakStatement':
+			case 'ContinueStatement':
 			case 'JSXIdentifier':
 			case 'Literal':
 			case 'ThisExpression':
@@ -3110,6 +3113,21 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'FunctionExpression':
 			case 'ArrowFunctionExpression':
 				visitFunction(node, scope, phase === 'module' ? 'render' : 'deferred');
+				return;
+			case 'ClassDeclaration':
+			case 'ClassExpression': {
+				const classScope = createScope(scope, 'block', [], node.id ? [node.id] : []);
+				visit(node.decorators, scope, phase);
+				visit(node.superClass, classScope, phase);
+				visit(node.body, classScope, phase);
+				return;
+			}
+			case 'MethodDefinition':
+			case 'PropertyDefinition':
+			case 'AccessorProperty':
+				visit(node.decorators, scope, phase);
+				if (node.computed) visit(node.key, scope, phase);
+				visit(node.value, scope, phase);
 				return;
 			case 'BlockStatement':
 			case 'JSXCodeBlock': {

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -5,6 +5,7 @@ import { compileToVolarMappings } from '../../src/compiler/volar.js';
 
 const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 const RENDER_STATE_GETTER_CALL = 'OCTANE_STRONG_RENDER_STATE_GETTER_CALL';
+const RENDER_MODULE_STATE_READ = 'OCTANE_STRONG_RENDER_MODULE_STATE_READ';
 const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
 const RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
@@ -4613,6 +4614,282 @@ export function App() {
 }`;
 		expect(() => slotHooks(plain, '/src/useCurrent.ts')).toThrow(RENDER_STATE_GETTER_CALL);
 		expect(() => compile(tsx, '/src/App.tsx')).toThrow(RENDER_STATE_GETTER_CALL);
+	});
+});
+
+describe('Strong mode render-time mutable module state reads', () => {
+	function component(
+		render: string,
+		moduleSetup = 'let revision = 0; function advance() { revision++; }',
+	) {
+		return `${moduleSetup}
+export function App(props) @{
+  ${render}
+}`;
+	}
+
+	it('rejects an updated module binding during render while compatibility remains live', () => {
+		const source = component('<p>{revision as string}</p>');
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_MODULE_STATE_READ,
+		);
+	});
+
+	it.each([
+		['a scalar read', 'const current = revision; <p>{current as string}</p>'],
+		['an attribute value', '<p data-revision={revision} />'],
+		[
+			'a synchronous module helper',
+			'function read() { return revision; } <p>{read() as string}</p>',
+		],
+		[
+			'a helper argument',
+			'function identity(value) { return value; } <p>{identity(revision) as string}</p>',
+		],
+		['an immediate callback', '<p>{(() => revision)() as string}</p>'],
+		['a computed property', 'const record = {}; <p>{record[revision] as string}</p>'],
+		[
+			'an optional computed property',
+			'const record = props.record; <p>{record?.[revision] as string}</p>',
+		],
+		['a memo calculation', 'useMemo(() => revision, []); <p />'],
+	])('rejects a mutable module read through %s', (_shape, render) => {
+		const source = `import { useMemo } from 'octane';\n${component(render)}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_MODULE_STATE_READ,
+		);
+	});
+
+	it.each([
+		['a reassigned var', 'var revision = 0; function advance() { revision++; }'],
+		[
+			'a destructured let',
+			'let { revision } = { revision: 0 }; function advance() { revision = 1; }',
+		],
+		['a reassigned exported let', 'export let revision = 0; function advance() { revision++; }'],
+	])('tracks %s at module scope', (_shape, setup) => {
+		expect(() =>
+			compile(`"use strong";\n${component('<p>{revision as string}</p>', setup)}`, '/src/App.tsrx'),
+		).toThrow(RENDER_MODULE_STATE_READ);
+	});
+
+	it.each(['(revision as number) += 1;', '(revision as number)++;'])(
+		'rejects the module-state read in %s',
+		(expression) => {
+			const source = component(`${expression} <p />`);
+			expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+			expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+				RENDER_MODULE_STATE_READ,
+			);
+		},
+	);
+
+	it.each([
+		[
+			'an ordinary component tag',
+			'let Current = () => <p />; Current = () => <span />;',
+			'<Current />',
+		],
+		[
+			'an optional component expression',
+			'let Current = () => <p />; Current = () => <span />;',
+			'const tag = Current?.displayName; <p>{tag as string}</p>',
+		],
+		[
+			'an underscore-prefixed component tag',
+			'let _Widget = () => <p />; _Widget = () => <span />;',
+			'<_Widget />',
+		],
+		[
+			'a dollar-prefixed component tag',
+			'let $Widget = () => <p />; $Widget = () => <span />;',
+			'<$Widget />',
+		],
+		[
+			'a Unicode component tag',
+			'let ÄWidget = () => <p />; ÄWidget = () => <span />;',
+			'<ÄWidget />',
+		],
+		[
+			'a lowercase member component tag',
+			'let widget = { Part: () => <p /> }; widget = { Part: () => <span /> };',
+			'<widget.Part />',
+		],
+	])('rejects a mutable module component through %s', (_shape, setup, render) => {
+		const source = component(render, setup);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_MODULE_STATE_READ,
+		);
+	});
+
+	it.each([
+		['memo alias', "import { memo as wrap } from 'octane';", 'wrap(() => <p>{revision}</p>)'],
+		[
+			'memo namespace import',
+			"import * as Octane from 'octane';",
+			'Octane.memo(() => <p>{revision}</p>)',
+		],
+	])('checks module reads in a render root reached through %s', (_shape, imported, wrapped) => {
+		const source = `${imported}
+let revision = 0;
+function advance() { revision++; }
+export const App = ${wrapped};`;
+		expect(() => compile(source, '/src/App.tsx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsx')).toThrow(
+			RENDER_MODULE_STATE_READ,
+		);
+	});
+
+	it('keeps module reads in events, effects, cleanup, and deferred work legal', () => {
+		const source = `"use strong";
+import { useEffect } from 'octane';
+let revision = 0;
+function advance() { revision++; }
+function readRevision() { return revision; }
+export function App(props) @{
+  useEffect(() => {
+    props.record(readRevision());
+    return () => props.record(revision);
+  }, []);
+  setTimeout(() => props.record(revision), 0);
+  Promise.resolve().then(() => props.record(revision));
+  (async () => { await Promise.resolve(); props.record(revision); })();
+  <button onClick={() => { advance(); props.record(readRevision()); }}>Check</button>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		[
+			'a module binding that is never reassigned',
+			'let revision = 0;',
+			'<p>{revision as string}</p>',
+		],
+		[
+			'a module constant object',
+			'const revision = { value: 0 }; revision.value = 1;',
+			'<p>{revision.value as string}</p>',
+		],
+		[
+			'a local shadow',
+			'let revision = 0; function advance() { revision++; }',
+			'const revision = props.value; <p>{revision as string}</p>',
+		],
+		[
+			'an unrelated prop',
+			'let revision = 0; function advance() { revision++; }',
+			'<p>{props.revision as string}</p>',
+		],
+		[
+			'a hoisted local var',
+			'let revision = 0; function advance() { revision++; }',
+			'const old = revision; var revision = 1; <p>{old as string}</p>',
+		],
+		[
+			'a module snapshot alias',
+			'let revision = 0; function advance() { revision++; } const captured = revision;',
+			'<p>{captured as string}</p>',
+		],
+		['an intrinsic tag', 'let Current = () => <p />; Current = () => <span />;', '<div />'],
+		[
+			'a shadowed component tag',
+			'let Current = () => <p />; Current = () => <span />;',
+			'const Current = () => <p />; <Current />',
+		],
+		[
+			'an optional chain that cannot evaluate its key',
+			'let revision = 0; function advance() { revision++; }',
+			'<p>{null?.[revision] as string}</p>',
+		],
+		[
+			'an optional call that cannot evaluate its argument',
+			'let revision = 0; function advance() { revision++; }',
+			'null?.(revision); <p />',
+		],
+		[
+			'an optional method that cannot evaluate its argument',
+			'let revision = 0; function advance() { revision++; }',
+			'null?.x(revision); <p />',
+		],
+		[
+			'an optional call of a skipped member',
+			'let revision = 0; function advance() { revision++; }',
+			'(null?.x)?.(revision); <p />',
+		],
+		[
+			'an optional property of a skipped member',
+			'let revision = 0; function advance() { revision++; }',
+			'(null?.x)?.[revision]; <p />',
+		],
+	])('allows %s', (_shape, setup, render) => {
+		expect(() =>
+			compile(`"use strong";\n${component(render, setup)}`, '/src/App.tsrx'),
+		).not.toThrow();
+	});
+
+	it('allows a parameter that shadows the mutable module binding', () => {
+		const source = `"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function App(revision) @{ <p>{revision as string}</p> }`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each(['client', 'server'] as const)('preserves valid code in %s output', (mode) => {
+		const source = component('<button onClick={() => revision++}>Update</button>');
+		const ordinary = compile(source, '/src/App.tsrx', { mode });
+		const strong = compile(source, '/src/App.tsrx', { mode, strong: true } as any);
+		expect(strong.code).toBe(ordinary.code);
+		expect(strong.diagnostics).toEqual(ordinary.diagnostics);
+	});
+
+	it('locates the authored module binding read in compiler and Volar diagnostics', () => {
+		const source = `"use strong";\n${component('<p>{revision as string}</p>')}`;
+		const offset = source.lastIndexOf('revision');
+		try {
+			compile(source, '/src/App.tsrx');
+			throw new Error('expected a Strong render-time module state diagnostic');
+		} catch (error: any) {
+			expect(error).toMatchObject({
+				code: RENDER_MODULE_STATE_READ,
+				filename: '/src/App.tsrx',
+			});
+		}
+		const mapped = compileToVolarMappings(source, '/src/App.tsrx');
+		expect(mapped.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_MODULE_STATE_READ,
+				severity: 'error',
+				filename: '/src/App.tsrx',
+				start: expect.objectContaining({ offset }),
+				end: expect.objectContaining({ offset: offset + 'revision'.length }),
+			}),
+		);
+		expect(mapped.errors).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_MODULE_STATE_READ,
+				type: 'usage',
+				fileName: '/src/App.tsrx',
+				pos: offset,
+			}),
+		);
+	});
+
+	it('rejects mutable module reads in plain custom hooks and Octane TSX components', () => {
+		const plain = `"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function useRevision() { return revision; }`;
+		const tsx = `/** @jsxImportSource octane */
+"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function App() { return <p>{revision}</p>; }`;
+		expect(() => slotHooks(plain, '/src/useRevision.ts')).toThrow(RENDER_MODULE_STATE_READ);
+		expect(() => compile(tsx, '/src/App.tsx')).toThrow(RENDER_MODULE_STATE_READ);
 	});
 });
 

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -4830,6 +4830,74 @@ export function App(props) @{
 		).not.toThrow();
 	});
 
+	it.each([
+		['the `meta` name in `import.meta`', 'meta', 'const url = import.meta.url; <p>{url}</p>'],
+		[
+			'the `target` name in `new.target`',
+			'target',
+			'const ctor = new.target; <p>{ctor?.name as string}</p>',
+		],
+		[
+			'a public class field name',
+			'revision',
+			'class Entry { revision = 1; } const entry = new Entry(); <p>{entry.revision as string}</p>',
+		],
+		[
+			'a class method name',
+			'revision',
+			'class Entry { revision() { return 1; } } <p>{new Entry().revision() as string}</p>',
+		],
+		[
+			'a class getter name',
+			'revision',
+			'class Entry { get revision() { return 1; } } <p>{new Entry().revision as string}</p>',
+		],
+		[
+			'a named class expression binding',
+			'revision',
+			'const Entry = class revision { static self = revision; }; <p>{Entry.self.name}</p>',
+		],
+		['a break label', 'revision', 'revision: { break revision; } <p />'],
+		[
+			'a continue label',
+			'revision',
+			'revision: for (let index = 0; index < 1; index++) { continue revision; } <p />',
+		],
+	])('allows %s when a module variable has the same name', (_shape, name, render) => {
+		const source = `let ${name} = 0; function advance() { ${name}++; }
+export function App() @{
+  ${render}
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['a computed class field name', 'class Entry { [revision] = 1; } <p />'],
+		['a computed class method name', 'class Entry { [revision]() { return 1; } } <p />'],
+	])('rejects a real module binding read in %s', (_shape, render) => {
+		const source = component(render);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
+			RENDER_MODULE_STATE_READ,
+		);
+	});
+
+	it.each([
+		['a class decorator', '@revision class Entry {}'],
+		['a class field decorator', 'class Entry { @revision field = 1; }'],
+		['a class method decorator', 'class Entry { @revision method() {} }'],
+	])('rejects a module binding read in %s', (_shape, declaration) => {
+		const source = `/** @jsxImportSource octane */
+let revision = (value) => value;
+function advance() { revision = (value) => value; }
+export function App() { ${declaration} return <p />; }`;
+		expect(() => compile(source, '/src/App.tsx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsx')).toThrow(
+			RENDER_MODULE_STATE_READ,
+		);
+	});
+
 	it('allows a parameter that shadows the mutable module binding', () => {
 		const source = `"use strong";
 let revision = 0;

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -229,6 +229,9 @@ A Strong module cannot:
 - Call a known third-tuple state getter while rendering
   (`OCTANE_STRONG_RENDER_STATE_GETTER_CALL`). Render from the state snapshot;
   use the getter in events, effects, or deferred work.
+- Read a reassigned module-scope `let` or `var` while rendering
+  (`OCTANE_STRONG_RENDER_MODULE_STATE_READ`). Put changing values in state or
+  context, or pass an immutable snapshot as a prop.
 - Assign to a ref's `current` value while rendering.
 - Read a `useRef` object's `current` while rendering
   (`OCTANE_STRONG_RENDER_REF_READ`). Keep refs as `ref` props and read them in


### PR DESCRIPTION
## Summary

- Reject render-time reads of reassigned module-scope `let` and `var` bindings in Strong modules. Part of #1027.

## Why

A module variable can change without a witnessed render input changing. Strong memoization may then reuse stale output; changing values should come from state, context, or an immutable prop snapshot.

## Changes

- Track authored module declarations, including exported and hoisted `var` bindings, using the existing scope-aware reassignment proof. Diagnose reads in render roots and synchronous helpers while respecting lexical shadowing, deferred work, and JSX component tags.
- Keep plain assignment targets, syntax names (`import.meta`, labels, and noncomputed class keys), and statically skipped optional-chain arguments/keys out of the read diagnostic. Preserve real reads in computed class keys and decorators. Emit the source-located `OCTANE_STRONG_RENDER_MODULE_STATE_READ` error only under Strong.
- Add regression and neighboring-behavior tests, Volar location coverage, client/server code parity checks, documentation, and patch changesets for `octane` and `@octanejs/mcp-server`.

## Validation

- [ ] `pnpm format:check` (scoped formatting check passed)
- [x] `pnpm typecheck`
- [x] Full repository CI on `009535056` passed: [CI run](https://github.com/octanejs/octane/actions/runs/34492009664), including test, React parity, Chromium integration, typecheck, lint, and provenance checks. Cursor Bugbot also passed.
- [x] Targeted tests: `pnpm exec vitest run packages/octane/tests/compiler --reporter=dot --silent=passed-only` — 55 files passed, 1,981 tests passed, 14 expected failures.
- [x] `pnpm format:files:check` on changed files; `git diff --check`.
- [x] `pnpm typecheck:files packages/octane/src/compiler/strong-mode.js packages/octane/tests/compiler/strong-mode.test.ts` on the final head.
- [x] Focused input-OTP browser selection suite: 5 tests passed. The first CI attempt had one selection assertion failure in this compatibility-mode harness; the parity shard passed on retry with the same commit.
- [x] Paired old/new compiler throughput: emitted hashes and byte counts match. In the final focused repeat, Strong medians were 32.77→33.16 ms for 100 components (+1.2%) and 331.14→337.56 ms for 1,000 (+1.9%); paired ratios and compatibility controls remained within substantial timing noise.
- [x] Feedback-fix performance comparison on identical base sources: at 1,000 components, Strong medians were 345.76→344.78 ms; at 1,000 classes, 128.84→128.38 ms. Emitted hashes matched. Timing spread does not support a throughput regression.
- [x] `pnpm sync` immediately before push; clean worktree after merging current `main`.

## Risk / follow-ups

- Static proof covers authored module lexical bindings in the current file. Imported helpers and mutable object contents are outside this rule's scope; the broader runtime guard remains a separate #1027 item.
- Valid emitted client/server code and compatibility-mode behavior are unchanged.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791641198&installation_model_id=432790&pr_number=1033&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1033&signature=18afa1ee0401b2e8b81d4e5225e5656260458eafbbb9b7e059d39fde564e0016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new compile-time error in Strong modules for a previously allowed pattern; compatibility mode and emitted code for valid modules are unchanged, but apps on Strong may need to move mutable module values into state or props.
> 
> **Overview**
> **Strong mode** now rejects **render-time reads of reassigned module-scope `let` and `var`** with `OCTANE_STRONG_RENDER_MODULE_STATE_READ`, so memoization cannot silently reuse output when module state changes without a witnessed prop/state/context input.
> 
> The compiler records module `let`/`var` declarations (including hoisted `var` and destructuring), uses existing reassignment analysis, and reports reads in render roots and synchronous render paths—including JSX component tags, compound assignments, and `++`/`--`—while honoring lexical shadowing, compatibility mode, and reads in events/effects/deferred work. **Optional chaining** is tightened so arguments/keys behind provably skipped optional continuations are not treated as render reads.
> 
> Docs, MCP react-divergences skill, website build-tools page, and a patch changeset document the rule and the fix (state, context, or an immutable prop snapshot). A large `strong-mode.test.ts` suite covers shapes, Volar/source locations, and unchanged emitted code for valid modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 009535056b99ddef9f610347c38c23bcc31889f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->