### PR TITLE
perf: reuse nested implicit descriptor key prefixes

### DIFF
--- a/.changeset/deopt-nested-implicit-keys.md
+++ b/.changeset/deopt-nested-implicit-keys.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reuse the encoded wrapper path for nested unkeyed descriptor siblings during client reconciliation.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -149,7 +149,7 @@ depending on minified helper names or contaminating wall-clock measurements.
 
 The opt-in `unkeyed` mode of `style-work.mjs` checks the production de-opt list
 path with 1,000 unkeyed host descriptors and an explicit key `"0"`. The rows
-cross a compiled `.tsrx` child hole, so `scopedDeoptKey` runs once per row. An
+cross a compiled `.tsrx` child hole, so the scoped key helper runs once per row. An
 unrelated update supplies fresh descriptors; the gate checks row order and DOM
 identity, typed uncontrolled input values, focus, and separation between the
 implicit index zero and explicit key `"0"`. Chromium precise coverage counts

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -171,6 +171,48 @@ WORK_MODE=unkeyed WORK_REQUIRE_NUMERIC=1 TARGET_URL=http://127.0.0.1:5316/unkeye
 Omit `WORK_REQUIRE_NUMERIC=1` to check an unchanged upstream baseline. Set
 `WORK_JSON=/path/to/result.json` to retain the machine-readable gate result.
 
+### Nested de-opt list key work gate
+
+The opt-in `nested` mode uses three independent 1,000-row descriptor lists through
+the same compiled `.tsrx` child hole. One list is wrapped in a same-kind array
+with a top-level sibling, giving its implicit leaves a real nested path; the
+second stays flat as a no-work control. A third uses the nested shape with every
+row explicitly keyed, checking that an implicit prefix is never prepared for
+fully keyed siblings. Each also contains a separate explicit key `"0"`; in the
+first two modes it sits beside implicit index zero. An unrelated update uses a
+different, prebuilt descriptor generation, so descriptor construction is outside timing.
+The gate checks order, complete inner HTML, survivor DOM identity, typed
+uncontrolled inputs, and focus. A `JSON.stringify` observer installed before
+the production module loads reports calls for nested implicit identities,
+nested explicit keys, and any shared wrapper-path serialization. Observation
+finishes in a separate browser context before the clean timing run.
+
+From the repository root, build the separate fixture while the runtime is at
+the baseline revision. This uses the normal minified production build:
+
+```bash
+cd benchmarks/js-framework/octane-tsrx
+../../../node_modules/.bin/vite build --config vite.config.nested.js --outDir dist/nested-work-baseline
+../../../node_modules/.bin/vite preview --config vite.config.nested.js --outDir dist/nested-work-baseline --host 127.0.0.1 --port 5317 --strictPort
+```
+
+From a second terminal at the repository root, record the baseline:
+
+```bash
+WORK_MODE=nested WORK_EXPECT_NESTED_JSON=1000 WORK_EXPECT_PATH_JSON=0 TARGET_URL=http://127.0.0.1:5317/nested-work.html WORK_JSON=/tmp/nested-baseline.json node benchmarks/js-framework/style-work.mjs 30
+```
+
+After a runtime change, build with `--outDir dist/nested-work-candidate`, serve
+that directory on port 5318, and run the same command with
+`WORK_EXPECT_NESTED_JSON=0`, `WORK_EXPECT_PATH_JSON=1`, `TARGET_URL=http://127.0.0.1:5318/nested-work.html`,
+and `WORK_EXPECTED_HTML_SHA` set to the baseline output's `htmlSha`. Keep both
+built bundles and servers fixed; repeat the identical runner in A–B–B–A order
+for timing comparisons. Each of 30 samples measures eight toggled updates,
+dividing the elapsed time by eight. The flat and fully explicit lists measure
+how much general browser load changes between runs. Absolute timing differences inside this
+control's variation are inconclusive; the untimed JSON call counts and
+observable state are deterministic gates.
+
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 
 The canonical suite only ever reorders two rows (`swap`). `run-reorder.mjs`

--- a/benchmarks/js-framework/nested-work.mjs
+++ b/benchmarks/js-framework/nested-work.mjs
@@ -1,0 +1,232 @@
+// Opt-in production browser work gate for nested implicit descriptor keys.
+// Build the separate nested-work.html entry, serve it with Vite preview, then
+// run WORK_MODE=nested node benchmarks/js-framework/style-work.mjs [samples].
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+
+const URL = process.env.TARGET_URL || 'http://127.0.0.1:5317/nested-work.html';
+const SAMPLES = Math.max(4, Number(process.argv[2] ?? 30));
+const UPDATES_PER_SAMPLE = 8;
+const ROWS = 1000;
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+const context = await browser.newContext();
+// Install before the production module evaluates: the runtime can legitimately
+// capture JSON.stringify at module initialization. Keep the wrapper stable for
+// the semantic run, then use a separate clean page for timing.
+await context.addInitScript(() => {
+	const original = JSON.stringify;
+	const counts = {
+		nestedImplicitJson: 0,
+		nestedExplicitJson: 0,
+		flatImplicitJson: 0,
+		pathOnlyJson: 0,
+	};
+	JSON.stringify = function (value, ...rest) {
+		if (Array.isArray(value) && value.length === 3 && Array.isArray(value[0])) {
+			if (value[1] === 'index' && Number.isInteger(value[2])) {
+				if (value[0].length === 0) counts.flatImplicitJson++;
+				else counts.nestedImplicitJson++;
+			} else if (value[0].length > 0 && value[1] === 'key') {
+				counts.nestedExplicitJson++;
+			}
+		} else if (Array.isArray(value) && value.length === 2 && value[0] === 'wrapper') {
+			counts.pathOnlyJson++;
+		}
+		return Reflect.apply(original, this, [value, ...rest]);
+	};
+	window.__nestedJsonObserver = {
+		reset() {
+			for (const key of Object.keys(counts)) counts[key] = 0;
+		},
+		read() {
+			return { ...counts };
+		},
+	};
+});
+const page = await context.newPage();
+let timingContext;
+const errors = [];
+page.on('pageerror', (error) => errors.push(error.message));
+
+let result;
+try {
+	await page.goto(URL, { waitUntil: 'load' });
+	await page.waitForFunction(() => window.__ready === true, null, { timeout: 10_000 });
+	const semantic = await page.evaluate((count) => {
+		const run = (operation) => window.__nestedWork(operation);
+		const kinds = ['nested', 'flat', 'explicit'];
+		const lists = () => ({
+			nested: document.querySelector('#nested-work-rows'),
+			flat: document.querySelector('#flat-work-rows'),
+			explicit: document.querySelector('#explicit-work-rows'),
+		});
+		function check(kind, version, before) {
+			const list = lists()[kind];
+			if (!list || list.getAttribute('data-version') !== String(version)) {
+				throw new Error(`${kind} did not commit version ${version}`);
+			}
+			const rows = Array.from(list.children);
+			const expected = count + 1 + Number(kind !== 'flat');
+			if (rows.length !== expected)
+				throw new Error(`${kind}: ${rows.length} rows, expected ${expected}`);
+			for (let index = 0; index < count; index++) {
+				const row = rows[index === 0 ? 0 : index + 1];
+				if (row.getAttribute('data-work-index') !== String(index)) {
+					throw new Error(`${kind}: wrong order/content at ${index}`);
+				}
+				if (row.querySelector('input')?.getAttribute('value') !== String(index)) {
+					throw new Error(`${kind}: wrong input markup at ${index}`);
+				}
+			}
+			if (rows[1].getAttribute('data-work-index') !== 'explicit') {
+				throw new Error(`${kind}: explicit key "0" did not remain separate from index 0`);
+			}
+			if (kind !== 'flat' && rows.at(-1).getAttribute('data-work-index') !== 'tail') {
+				throw new Error(`${kind} wrapper sentinel is absent`);
+			}
+			if (before && rows.some((row, index) => row !== before[index])) {
+				throw new Error(`${kind}: unchanged child lost DOM identity`);
+			}
+			return rows;
+		}
+		function observe(action) {
+			window.__nestedJsonObserver.reset();
+			run(action);
+			return window.__nestedJsonObserver.read();
+		}
+
+		run('mount');
+		const before = Object.fromEntries(kinds.map((kind) => [kind, check(kind, 0)]));
+		const html = kinds.map((kind) => lists()[kind].innerHTML).join('|');
+		const inputs = kinds.flatMap((kind) =>
+			[before[kind][0], before[kind][1]].map((row) => row.querySelector('input')),
+		);
+		for (const input of inputs) {
+			if (!input) throw new Error('missing input state control');
+			input.value = `typed ${input.getAttribute('aria-label')}`;
+		}
+		inputs[0].focus();
+		const work = {};
+		const versions = { nested: 0, flat: 0, explicit: 0 };
+		for (const kind of kinds) {
+			work[kind] = observe(`update-${kind}`);
+			versions[kind] = 1;
+			for (const other of kinds) check(other, versions[other], before[other]);
+		}
+		const nextHtml = kinds.map((kind) => lists()[kind].innerHTML).join('|');
+		if (html !== nextHtml) throw new Error('visible HTML changed on unrelated updates');
+		for (const input of inputs) {
+			if (input.value !== `typed ${input.getAttribute('aria-label')}`) {
+				throw new Error('uncontrolled input state was reset');
+			}
+		}
+		if (document.activeElement !== inputs[0]) throw new Error('focused input was replaced');
+		run('unmount');
+		return {
+			html,
+			work,
+			rows: Object.fromEntries(kinds.map((kind) => [kind, before[kind].length])),
+		};
+	}, ROWS);
+
+	// The observer and semantic checks have finished. Timings use a fresh mount,
+	// two prepared descriptor generations, and no JSON.stringify interception.
+	timingContext = await browser.newContext();
+	const timingPage = await timingContext.newPage();
+	timingPage.on('pageerror', (error) => errors.push(error.message));
+	await timingPage.goto(URL, { waitUntil: 'load' });
+	await timingPage.waitForFunction(() => window.__ready === true, null, { timeout: 10_000 });
+	const timing = await timingPage.evaluate(
+		({ samples, updatesPerSample }) => {
+			const run = (operation) => window.__nestedWork(operation);
+			run('mount');
+			const kinds = ['nested', 'flat', 'explicit'];
+			for (let i = 0; i < 12; i++) {
+				for (const kind of kinds) run(`update-${kind}`);
+			}
+			const times = { nested: [], flat: [], explicit: [] };
+			for (let i = 0; i < samples; i++) {
+				for (let offset = 0; offset < kinds.length; offset++) {
+					const kind = kinds[(i + offset) % kinds.length];
+					const t0 = performance.now();
+					for (let j = 0; j < updatesPerSample; j++) run(`update-${kind}`);
+					times[kind].push((performance.now() - t0) / updatesPerSample);
+				}
+			}
+			if (
+				document.querySelector('#nested-work-rows')?.children.length !== 1002 ||
+				document.querySelector('#flat-work-rows')?.children.length !== 1001 ||
+				document.querySelector('#explicit-work-rows')?.children.length !== 1002
+			) {
+				throw new Error('timed updates changed the list shapes');
+			}
+			run('unmount');
+			return times;
+		},
+		{ samples: SAMPLES, updatesPerSample: UPDATES_PER_SAMPLE },
+	);
+	const summarize = (values) => {
+		const sorted = values.toSorted((a, b) => a - b);
+		return {
+			samples: sorted.length,
+			medianMs: sorted[Math.floor(sorted.length / 2)],
+			p95Ms: sorted[Math.floor(sorted.length * 0.95)],
+		};
+	};
+	const htmlSha = createHash('sha256').update(semantic.html).digest('hex');
+	assert.equal(semantic.rows.nested, ROWS + 2);
+	assert.equal(semantic.rows.flat, ROWS + 1);
+	assert.equal(semantic.rows.explicit, ROWS + 2);
+	assert.equal(semantic.work.explicit.nestedImplicitJson, 0);
+	assert.equal(semantic.work.explicit.nestedExplicitJson, ROWS + 1);
+	assert.equal(
+		semantic.work.explicit.pathOnlyJson,
+		0,
+		'fully keyed siblings need no implicit prefix',
+	);
+	assert.equal(semantic.work.flat.pathOnlyJson, 0, 'flat siblings need no nested prefix');
+	assert.equal(
+		semantic.work.nested.nestedExplicitJson,
+		1,
+		'nested explicit key retains exact encoding',
+	);
+	assert.equal(semantic.work.nested.flatImplicitJson, 0);
+	assert.equal(
+		semantic.work.flat.nestedImplicitJson,
+		0,
+		'top-level control must not serialize nested keys',
+	);
+	assert.equal(semantic.work.flat.flatImplicitJson, 0, 'top-level implicit keys stay numeric');
+	if (process.env.WORK_EXPECT_NESTED_JSON !== undefined) {
+		assert.equal(
+			semantic.work.nested.nestedImplicitJson,
+			Number(process.env.WORK_EXPECT_NESTED_JSON),
+		);
+	}
+	if (process.env.WORK_EXPECT_PATH_JSON !== undefined) {
+		assert.equal(semantic.work.nested.pathOnlyJson, Number(process.env.WORK_EXPECT_PATH_JSON));
+	}
+	if (process.env.WORK_EXPECTED_HTML_SHA) assert.equal(htmlSha, process.env.WORK_EXPECTED_HTML_SHA);
+	assert.deepEqual(errors, [], 'browser errors');
+	result = {
+		suite: 'js-framework-style-work/nested',
+		target: URL,
+		htmlSha,
+		rows: semantic.rows,
+		work: semantic.work,
+		updatesPerSample: UPDATES_PER_SAMPLE,
+		timing: Object.fromEntries(
+			Object.entries(timing).map(([kind, values]) => [kind, summarize(values)]),
+		),
+	};
+	console.log(JSON.stringify(result, null, 2));
+	if (process.env.WORK_JSON)
+		fs.writeFileSync(process.env.WORK_JSON, JSON.stringify(result, null, 2) + '\n');
+} finally {
+	await context.close();
+	await timingContext?.close();
+	await browser.close();
+}

--- a/benchmarks/js-framework/octane-tsrx/nested-work.html
+++ b/benchmarks/js-framework/octane-tsrx/nested-work.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Octane nested descriptor work</title>
+	</head>
+	<body>
+		<script type="module" src="/src/nested-work-main.js"></script>
+	</body>
+</html>

--- a/benchmarks/js-framework/octane-tsrx/src/NestedWorkRows.tsrx
+++ b/benchmarks/js-framework/octane-tsrx/src/NestedWorkRows.tsrx
@@ -1,0 +1,7 @@
+import type { OctaneNode } from 'octane';
+
+// All modes enter the same compiled child hole. Only the supplied array shape
+// determines whether its implicit descriptor keys have a wrapper path.
+export function NestedWorkRows(props: { id: string; rows: OctaneNode[]; version: number }) @{
+	<ul id={props.id} data-version={props.version}>{props.rows}</ul>
+}

--- a/benchmarks/js-framework/octane-tsrx/src/UnkeyedRows.tsrx
+++ b/benchmarks/js-framework/octane-tsrx/src/UnkeyedRows.tsrx
@@ -1,7 +1,7 @@
 import type { OctaneNode } from 'octane';
 
 // The descriptor array must cross a compiled child hole: a raw host descriptor's
-// children use a different positional reconciler and never reach scopedDeoptKey.
+// children use a different positional reconciler and never reach the scoped key helper.
 export function UnkeyedRows(props: { rows: OctaneNode[]; version: number }) @{
 	<ul id="unkeyed-work-rows" data-version={props.version}>{props.rows}</ul>
 }

--- a/benchmarks/js-framework/octane-tsrx/src/nested-work-main.js
+++ b/benchmarks/js-framework/octane-tsrx/src/nested-work-main.js
@@ -1,0 +1,4 @@
+import { runNestedWork } from './nested-work.ts';
+
+window.__nestedWork = runNestedWork;
+window.__ready = true;

--- a/benchmarks/js-framework/octane-tsrx/src/nested-work.ts
+++ b/benchmarks/js-framework/octane-tsrx/src/nested-work.ts
@@ -1,0 +1,96 @@
+import { createElement, createRoot, flushSync, type OctaneNode } from 'octane';
+import { NestedWorkRows } from './NestedWorkRows.tsrx';
+
+const ROWS = 1000;
+const KINDS = ['nested', 'flat', 'explicit'] as const;
+type Kind = (typeof KINDS)[number];
+type WorkRoot = ReturnType<typeof createRoot>;
+
+function row(index: number, keyed: boolean): OctaneNode {
+	return createElement(
+		'li',
+		{ key: keyed ? `row-${index}` : undefined, 'data-work-index': index },
+		createElement('input', { defaultValue: String(index), 'aria-label': `row ${index}` }),
+	);
+}
+
+function explicit(): OctaneNode {
+	return createElement(
+		'li',
+		{ key: '0', 'data-work-index': 'explicit' },
+		createElement('input', { defaultValue: 'explicit', 'aria-label': 'explicit row' }),
+	);
+}
+
+function makeRows(kind: Kind): OctaneNode[] {
+	const siblings: OctaneNode[] = [];
+	for (let index = 0; index < ROWS; index++) {
+		siblings.push(row(index, kind === 'explicit'));
+		if (index === 0) siblings.push(explicit());
+	}
+	if (kind === 'flat') return siblings;
+	// A same-kind nested array plus a sibling gives each enclosed leaf a real
+	// wrapper path. Its explicit key remains the serialization control.
+	return [siblings, createElement('li', { key: 'tail', 'data-work-index': 'tail' }, 'tail')];
+}
+
+// Prepare the two descriptor generations before timing. Every update still
+// changes the rows reference and traverses the full child list.
+const prepared: Record<Kind, [OctaneNode[], OctaneNode[]]> = {
+	nested: [makeRows('nested'), makeRows('nested')],
+	flat: [makeRows('flat'), makeRows('flat')],
+	explicit: [makeRows('explicit'), makeRows('explicit')],
+};
+const roots: Partial<Record<Kind, WorkRoot>> = {};
+const containers: Partial<Record<Kind, HTMLElement>> = {};
+const versions: Record<Kind, number> = { nested: 0, flat: 0, explicit: 0 };
+
+function update(kind: Kind): void {
+	const root = roots[kind];
+	if (!root) throw new Error(`${kind} work root is not mounted`);
+	versions[kind] = 1 - versions[kind];
+	root.render(NestedWorkRows, {
+		id: `${kind}-work-rows`,
+		rows: prepared[kind][versions[kind]],
+		version: versions[kind],
+	});
+	flushSync(() => {});
+}
+
+export function runNestedWork(operation: string): void {
+	if (operation === 'mount') {
+		if (KINDS.some((kind) => roots[kind])) throw new Error('nested work roots are already mounted');
+		for (const kind of KINDS) {
+			const container = document.createElement('div');
+			container.id = `${kind}-work-root`;
+			document.body.appendChild(container);
+			const root = createRoot(container);
+			roots[kind] = root;
+			containers[kind] = container;
+			versions[kind] = 0;
+			root.render(NestedWorkRows, {
+				id: `${kind}-work-rows`,
+				rows: prepared[kind][0],
+				version: 0,
+			});
+		}
+		flushSync(() => {});
+		return;
+	}
+	if (operation.startsWith('update-')) {
+		const kind = operation.slice(7) as Kind;
+		if (!KINDS.includes(kind)) throw new Error(`unknown nested work kind: ${kind}`);
+		update(kind);
+		return;
+	}
+	if (operation === 'unmount') {
+		for (const kind of KINDS) {
+			roots[kind]?.unmount();
+			containers[kind]?.remove();
+			delete roots[kind];
+			delete containers[kind];
+		}
+		return;
+	}
+	throw new Error(`unknown nested work operation: ${operation}`);
+}

--- a/benchmarks/js-framework/octane-tsrx/vite.config.nested.js
+++ b/benchmarks/js-framework/octane-tsrx/vite.config.nested.js
@@ -1,0 +1,15 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mergeConfig } from 'vite';
+import base from './vite.config.js';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+// This fixture is absent from the ordinary js-framework build.
+export default mergeConfig(base, {
+	build: {
+		outDir: 'dist/nested-work',
+		rollupOptions: { input: resolve(root, 'nested-work.html') },
+	},
+	preview: { port: 5317, strictPort: true },
+});

--- a/benchmarks/js-framework/style-work.mjs
+++ b/benchmarks/js-framework/style-work.mjs
@@ -11,6 +11,10 @@ if (process.env.WORK_MODE === 'unkeyed') {
 	await import('./unkeyed-work.mjs');
 	process.exit(process.exitCode ?? 0);
 }
+if (process.env.WORK_MODE === 'nested') {
+	await import('./nested-work.mjs');
+	process.exit(process.exitCode ?? 0);
+}
 
 const DIALECT = process.env.WORK_DIALECT || 'tsrx';
 if (DIALECT !== 'tsrx' && DIALECT !== 'jsx') {

--- a/benchmarks/js-framework/unkeyed-work.mjs
+++ b/benchmarks/js-framework/unkeyed-work.mjs
@@ -1,6 +1,6 @@
 // Production browser work for top-level implicit de-opt list keys. Run through
 // style-work.mjs with WORK_MODE=unkeyed; no new benchmark suite is registered.
-// The fixture's pure-host descriptors reach scopedDeoptKey only because the
+// The fixture's pure-host descriptors reach the scoped key helper because the
 // list is handed through a compiled child hole.
 
 import fs from 'node:fs';
@@ -13,34 +13,44 @@ const ASSETS = path.join(HERE, 'octane-tsrx', 'dist', 'unkeyed-work', 'assets');
 const URL = process.env.TARGET_URL || 'http://localhost:5316/unkeyed-work.html';
 const ROWS = 1000;
 const ITEMS = ROWS + 1; // one explicit key="0" beside the 1,000 implicit indices
-const METRICS = ['scopedDeoptKey', 'deoptItemBody', 'reconcileKeyed'];
+const KEY_HELPERS = ['scopedDeoptKey', 'appendScopedDeoptKey'];
+const METRICS = [...KEY_HELPERS, 'deoptItemBody', 'reconcileKeyed'];
 
 function sourceWork() {
 	const sources = fs
 		.readdirSync(ASSETS)
 		.filter((name) => name.endsWith('.js'))
 		.map((name) => fs.readFileSync(path.join(ASSETS, name), 'utf8'));
-	const matches = sources.flatMap((source) => {
-		const start = source.indexOf('function scopedDeoptKey(');
-		if (start < 0) return [];
-		const end = source.indexOf('\n}', start);
-		if (end < 0) throw new Error('could not identify scopedDeoptKey in production output');
-		return [source.slice(start, end + 2)];
-	});
+	const matches = sources.flatMap((source) =>
+		KEY_HELPERS.flatMap((keyHelper) => {
+			const start = source.indexOf(`function ${keyHelper}(`);
+			if (start < 0) return [];
+			const end = source.indexOf('\n}', start);
+			if (end < 0) throw new Error(`could not identify ${keyHelper} in production output`);
+			return [{ keyHelper, body: source.slice(start, end + 2) }];
+		}),
+	);
 	if (matches.length !== 1) {
-		throw new Error(`expected one readable production scopedDeoptKey, found ${matches.length}`);
+		throw new Error(`expected one readable production scoped key helper, found ${matches.length}`);
 	}
-	const body = matches[0];
+	const { keyHelper, body } = matches[0];
 	const oldBranch =
+		keyHelper === 'scopedDeoptKey' &&
 		/if \(path\.length === 0\) return explicit \? ["']k["'] \+ String\(key\) : ["']i["'] \+ index;/.test(
 			body,
 		);
-	const numericBranch =
+	const numericReturn =
 		/if \(path\.length === 0\) return explicit \? ["']k["'] \+ String\(key\) : index;/.test(body);
+	const numericAppend =
+		/if \(path\.length === 0\) \{\s*outKeys\.push\(explicit \? ["']k["'] \+ String\(key\) : index\);\s*return implicitPrefix;\s*\}/.test(
+			body,
+		);
+	const numericBranch = keyHelper === 'scopedDeoptKey' ? numericReturn : numericAppend;
 	if (!oldBranch && !numericBranch) {
 		throw new Error('top-level implicit-key branch changed; review the source work gate');
 	}
 	return {
+		keyHelper,
 		implicitKeyStringConversionsPerRender: oldBranch ? ROWS : 0,
 		implicitKeyNumeric: numericBranch,
 	};
@@ -163,7 +173,9 @@ try {
 		const observed = await measure(browser, operation);
 		results[operation] = observed;
 		for (const [metric, expected] of Object.entries({
-			scopedDeoptKey: ITEMS,
+			...Object.fromEntries(
+				KEY_HELPERS.map((name) => [name, name === source.keyHelper ? ITEMS : 0]),
+			),
 			deoptItemBody: ITEMS,
 			reconcileKeyed: operation === 'update' ? 1 : 0,
 			rows: ITEMS,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -23697,12 +23697,27 @@ function deoptWrapperKind(value: any[]): DeoptWrapperKind {
 	return POSITIONAL_CHILDREN.has(value as object) ? 'fragment' : 'array';
 }
 
-function scopedDeoptKey(
+const DEOPT_KEY_STRINGIFY = JSON.stringify;
+
+function nestedImplicitKeyPrefix(path: readonly (string | number)[]): string | null {
+	// Object-valued wrapper keys and custom array serialization may differ for
+	// each leaf. Keep their existing full-key serialization path.
+	if (JSON.stringify !== DEOPT_KEY_STRINGIFY || 'toJSON' in path) return null;
+	for (let i = 0; i < path.length; i++) {
+		const type = typeof path[i];
+		if (type !== 'string' && type !== 'number') return null;
+	}
+	return '[' + JSON.stringify(path) + ',"index",';
+}
+
+function appendScopedDeoptKey(
+	outKeys: any[],
 	path: readonly (string | number)[],
 	item: any,
 	index: number,
 	key: any,
-): string | number {
+	implicitPrefix: string | null | undefined,
+): string | null | undefined {
 	// Reconciliation keys are internal: top-level implicit positions are numbers,
 	// explicit keys carry a 'k' prefix, and nested paths are JSON strings. These
 	// namespaces keep index 0 distinct from key="0" and user keys distinct from
@@ -23714,8 +23729,22 @@ function scopedDeoptKey(
 	// render, including renders where all children go on to bail. Skip the
 	// serializer there. JSON paths begin with '[', so they remain distinct from
 	// explicit 'k' keys; numeric indices are distinct from both string forms.
-	if (path.length === 0) return explicit ? 'k' + String(key) : index;
-	return JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]);
+	if (path.length === 0) {
+		outKeys.push(explicit ? 'k' + String(key) : index);
+		return implicitPrefix;
+	}
+	// Initialize only for the first implicit leaf: keyed-only wrappers must not
+	// pay for a prefix they cannot reuse. `null` disables caching for this scope;
+	// `undefined` means no implicit leaf has needed its prefix yet.
+	if (!explicit) {
+		if (implicitPrefix === undefined) implicitPrefix = nestedImplicitKeyPrefix(path);
+		if (implicitPrefix !== null && JSON.stringify === DEOPT_KEY_STRINGIFY && !('toJSON' in path)) {
+			outKeys.push(implicitPrefix + index + ']');
+			return implicitPrefix;
+		}
+	}
+	outKeys.push(JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]));
+	return implicitPrefix;
 }
 
 // Flatten arrays and Fragment descriptors to renderable leaves while retaining
@@ -23733,12 +23762,20 @@ function flattenReactChildContainer(
 ): void {
 	const keyFn = kind === 'fragment' ? deoptKeyPositional : deoptKey;
 	const count = children.length;
+	let implicitPrefix: string | null | undefined = count > 1 ? undefined : null;
 	for (let i = 0; i < count; i++) {
 		const item = children[i];
 		if (isFragmentDescriptor(item)) {
 			if (item.ref != null || hasOwnProp.call(item.props, 'ref')) {
 				outItems.push(fragmentRefDescriptor(item));
-				outKeys.push(scopedDeoptKey(path, item, i, keyFn(item, i)));
+				implicitPrefix = appendScopedDeoptKey(
+					outKeys,
+					path,
+					item,
+					i,
+					keyFn(item, i),
+					implicitPrefix,
+				);
 				continue;
 			}
 			const nested = fragmentDescriptorChildren(item);
@@ -23771,8 +23808,14 @@ function flattenReactChildContainer(
 			continue;
 		}
 		outItems.push(item);
-		outKeys.push(scopedDeoptKey(path, item, i, keyFn(item, i)));
+		implicitPrefix = appendScopedDeoptKey(outKeys, path, item, i, keyFn(item, i), implicitPrefix);
 	}
+}
+
+function singleDeoptKey(item: any, key: any): string | number {
+	return (isElementDescriptor(item) || item?.$$kind === PORTAL_TAG) && item.key != null
+		? 'k' + String(key)
+		: 0;
 }
 
 function prepareDeoptList(
@@ -23787,7 +23830,7 @@ function prepareDeoptList(
 		if (value.ref != null || hasOwnProp.call(value.props, 'ref')) {
 			return {
 				items: [fragmentRefDescriptor(value)],
-				keys: [scopedDeoptKey([], value, 0, value.key ?? 0)],
+				keys: [singleDeoptKey(value, value.key ?? 0)],
 			};
 		}
 		const items: any[] = [];
@@ -23803,10 +23846,10 @@ function prepareDeoptList(
 		return { items, keys };
 	}
 	if (includeKeyedSingle && isElementDescriptor(value) && value.key != null) {
-		return { items: [value], keys: [scopedDeoptKey([], value, 0, value.key)] };
+		return { items: [value], keys: [singleDeoptKey(value, value.key)] };
 	}
 	if (forceSingle) {
-		return { items: [value], keys: [scopedDeoptKey([], value, 0, deoptKeyPositional(value, 0))] };
+		return { items: [value], keys: [singleDeoptKey(value, deoptKeyPositional(value, 0))] };
 	}
 	return null;
 }

--- a/packages/octane/tests/deopt-child-key-aliasing.test.ts
+++ b/packages/octane/tests/deopt-child-key-aliasing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
 	createElement,
+	createRoot,
 	flushSync,
 	Fragment,
 	hydrateRoot,
@@ -273,6 +274,144 @@ describe('de-opt child keys — user keys never collide with wrapper paths', () 
 });
 
 describe('de-opt child keys — wrapper boundaries survive the top-level fast path', () => {
+	it.each(['client mount', 'server hydration'] as const)(
+		'keeps nested sibling inputs through keyed wrapper reorders after %s',
+		(mode) => {
+			const escaped = 'quote"\\slash\n\u0000\ud800';
+			const wrapperKeys = {
+				first: `first:${escaped}`,
+				second: `second:${escaped}`,
+			};
+			const groupNames = ['first', 'second'] as const;
+			const row = (id: string, key?: string) =>
+				createElement(
+					'li',
+					key === undefined ? { 'data-row': id } : { key, 'data-row': id },
+					createElement('input', { 'data-input': id, defaultValue: id }),
+				);
+			const group = (name: (typeof groupNames)[number]) =>
+				createElement(
+					Fragment,
+					{ key: wrapperKeys[name] },
+					row(`${name}-outer-0`),
+					row(`${name}-outer-escaped`, escaped),
+					positionalChildren([
+						row(`${name}-inner-0`),
+						row(`${name}-inner-key-0`, '0'),
+						row(`${name}-inner-escaped`, escaped),
+					]),
+				);
+			const pathLikeKey = JSON.stringify([
+				['keyed-fragment', wrapperKeys.first, 'wrapper', 2],
+				'key',
+				escaped,
+			]);
+			const rows = (reverse: boolean) =>
+				positionalChildren([
+					...(reverse ? [...groupNames].reverse() : groupNames).map(group),
+					row('outside', pathLikeKey),
+				]);
+			const order = (reverse: boolean) => [
+				...(reverse ? [...groupNames].reverse() : groupNames).flatMap((name) => [
+					`${name}-outer-0`,
+					`${name}-outer-escaped`,
+					`${name}-inner-0`,
+					`${name}-inner-key-0`,
+					`${name}-inner-escaped`,
+				]),
+				'outside',
+			];
+
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			const initialRows = rows(false);
+			if (mode === 'server hydration') {
+				container.innerHTML = renderToString(server.RowsHole, { rows: initialRows }).html;
+			}
+			let root: ReturnType<typeof createRoot> | undefined;
+			try {
+				root =
+					mode === 'server hydration'
+						? hydrateRoot(container, RowsHole, { rows: initialRows })
+						: createRoot(container);
+				const activeRoot = root;
+				if (mode === 'client mount') activeRoot.render(RowsHole, { rows: initialRows });
+				flushSync(() => {});
+				const inputs = new Map(
+					Array.from(container.querySelectorAll<HTMLInputElement>('input[data-input]'), (input) => [
+						input.dataset.input!,
+						input,
+					]),
+				);
+				expect([...inputs.keys()]).toEqual(order(false));
+				for (const [id, input] of inputs) input.value = `typed:${id}`;
+				const focused = inputs.get('second-inner-0')!;
+				focused.focus();
+
+				for (const reverse of [true, false]) {
+					flushSync(() => activeRoot.render(RowsHole, { rows: rows(reverse) }));
+					expect(
+						Array.from(container.querySelectorAll('li'), (li) => li.getAttribute('data-row')),
+					).toEqual(order(reverse));
+					for (const [id, input] of inputs) {
+						expect(container.querySelector(`input[data-input="${id}"]`)).toBe(input);
+						expect(input.value).toBe(`typed:${id}`);
+					}
+					expect(document.activeElement).toBe(focused);
+				}
+			} finally {
+				root?.unmount();
+				container.remove();
+			}
+		},
+	);
+
+	it('preserves nested input state when array serialization is customized', () => {
+		const names = ['first', 'second'];
+		const rows = (reverse: boolean) =>
+			(reverse ? [...names].reverse() : names).map((name) =>
+				createElement(
+					Fragment,
+					{ key: name },
+					...[0, 1].map((index) =>
+						createElement('li', null, createElement('input', { 'data-input': `${name}-${index}` })),
+					),
+				),
+			);
+		const r = mount(RowsHole, { rows: rows(false) });
+		const previous = Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON');
+		try {
+			const inputs = r.findAll('input') as HTMLInputElement[];
+			for (const input of inputs) input.value = `typed:${input.dataset.input}`;
+			inputs[0].focus();
+			// An application serializer can customize standalone primitive arrays
+			// while leaving arrays embedded in another value unchanged.
+			Object.defineProperty(Array.prototype, 'toJSON', {
+				configurable: true,
+				value(this: unknown[], key: string) {
+					return key === '' && this.every((value) => ['string', 'number'].includes(typeof value))
+						? this.join(':')
+						: this;
+				},
+			});
+			for (const reverse of [true, false]) {
+				r.update(RowsHole, { rows: rows(reverse) });
+				expect(r.findAll('input')).toEqual(
+					reverse ? [inputs[2], inputs[3], inputs[0], inputs[1]] : inputs,
+				);
+				for (const input of inputs) {
+					expect(r.find(`[data-input="${input.dataset.input}"]`)).toBe(input);
+					expect(input.value).toBe(`typed:${input.dataset.input}`);
+				}
+				expect(document.activeElement).toBe(inputs[0]);
+			}
+		} finally {
+			if (previous) Object.defineProperty(Array.prototype, 'toJSON', previous);
+			else Reflect.deleteProperty(Array.prototype, 'toJSON');
+			r.unmount();
+		}
+	});
+
 	it('adopts mixed keyed and unkeyed server children before a keyed move', () => {
 		function rows(keyedFirst: boolean) {
 			const plain = createElement(


### PR DESCRIPTION
## Summary

Nested unkeyed descriptor siblings currently serialize the same wrapper path for every leaf. Reuse its encoded prefix within one multi-child scope while retaining the existing reconciliation keys and DOM identity. This is the next bounded follow-up to #981's de-opt list key finding.

## Changes

- Create the prefix lazily at the first implicit leaf; fully keyed wrappers and singleton scopes do no prefix work.
- Keep top-level implicit indices numeric and explicit keys in their existing namespace. Object-valued paths, array `toJSON`, and a serializer replaced after runtime initialization use full serialization.
- Cover escaped wrapper keys, keyed wrapper reorders, nested positional boundaries, typed input values, focus, and server hydration. Add a custom array serializer fallback regression.
- Add an opt-in minified browser work gate with nested implicit, flat, and fully explicit lists, plus an Octane patch changeset.

## Validation

- [x] `vitest run --project octane --project octane-prod --reporter=dot`: 991 files passed; 17,640 tests passed and 14 expected failures.
- [x] Focused key suite: 32/32 dev/prod tests. Deliberately unstable nested keys failed the four new mount/hydration cases; removing the array serializer guards failed both fallback cases. Both mutations were restored.
- [x] Octane and benchmark fixture `tsrx-tsc --noEmit` checks.
- [x] Scoped Prettier check, benchmark JavaScript syntax checks, `git diff --check`, `pnpm changeset:check`, and `pnpm sync`.
- [x] Baseline/candidate minified production browser work gate against `d4bf228c864a33ca19ffeb0c2326e6592892ce33`: identical complete HTML, row order, survivor nodes, uncontrolled input state, and focus.

- [x] Existing unkeyed browser work gate: reproduced the obsolete-helper lookup failure, then passed both unchanged-main and rebuilt-candidate runs with strict helper counts and all DOM/input/focus controls.
- [x] After merging current main (`856febc73`): 874 targeted key/Strong-mode tests and Octane typecheck passed. The rebuilt nested benchmark is byte-identical to the measured candidate and passes the work/semantic gate.

- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34495738574): 26/26 jobs passed on `94d353e9b581f2b7cc79526f3273e3bd92002bbe`. The first attempt had one five-second timeout in an unchanged Vite configuration test; that file passed locally (30/30), and the failed CI jobs passed on the unchanged-head retry.
- [x] Cursor Bugbot passed on the current head; the unkeyed work-gate finding is fixed and its review thread is resolved.

Repository-wide `pnpm test`, `pnpm typecheck`, and `pnpm format:check` were not run locally; the targeted checks above cover the changed runtime and fixture.

### Performance evidence

Per unrelated update in the isolated 1,000-row fixture:

| Work | Baseline | Candidate |
| --- | ---: | ---: |
| Nested implicit full-key JSON serializations | 1,000 | 0 |
| Shared path JSON serializations | 0 | 1 |
| Nested explicit key control | 1 | 1 |
| Fully explicit list key serializations | 1,001 | 1,001 |
| Fully explicit list prefix serializations | 0 | 0 |
| Flat list JSON serializations | 0 | 0 |

The gate runs a transparent JSON observer separately from clean timing contexts. The normal minified fixture bundle grows from 165,458 to 165,876 bytes (+418); Node gzip grows from 53,254 to 53,418 bytes (+164). This supports a serialization-work reduction; no heap reduction is claimed. Reproduction commands are in `benchmarks/js-framework/README.md` under “Nested de-opt list key work gate”.

Quiet A–B–B–A confirmation (200 samples of eight updates per case, milliseconds per update):

| Case | A1 | B1 | B2 | A2 |
| --- | ---: | ---: | ---: | ---: |
| Nested implicit | 0.5625 | 0.5500 | 0.5625 | 0.5500 |
| Flat | 0.5125 | 0.5125 | 0.5125 | 0.5125 |
| Fully explicit | 0.5625 | 0.5625 | 0.5750 | 0.5625 |

Timing distributions overlap. The flat control also shares the changed helper; its equal median and p95 across these longer runs do not indicate a persistent common-path regression. No throughput improvement is claimed.

## Risk / follow-ups

The cache is a local scalar that expires when the wrapper is flattened, with no retained state or rollback state to invalidate. Nested key strings are still created per leaf. The remaining explicit-key coercion, server nested-key work, and other #981 findings remain open.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791645289&installation_model_id=432790&pr_number=1034&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1034&signature=c2ce5b395817273cb2e68ba3c8f7cccfbd69975787c164a2ff9076a06fb6bd43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core child-list reconciliation key encoding; incorrect prefix reuse could cause wrong DOM adoption, though guards and extensive aliasing tests mitigate this.
> 
> **Overview**
> **Reuses a shared encoded wrapper-path prefix** when deriving reconciliation keys for **nested unkeyed** de-opt list siblings, instead of calling `JSON.stringify` on the full `[path, "index", index]` tuple for every leaf.
> 
> The de-opt key path is refactored from `scopedDeoptKey` to **`appendScopedDeoptKey`**, which lazily builds a prefix at the first implicit leaf in a multi-child scope and appends the index for later siblings. Top-level implicit keys stay **numeric**; explicit `k…` keys and full JSON serialization are unchanged when paths are non-primitive, `Array.prototype.toJSON` is customized, or `JSON.stringify` was replaced after init. Single-child scopes and all-explicit lists skip prefix work via `singleDeoptKey` where appropriate.
> 
> **Tests** add nested keyed-wrapper reorders (client + hydration), escaped keys, and a custom array serializer fallback. **Benchmarks** add an opt-in `WORK_MODE=nested` Playwright gate (nested vs flat vs fully explicit 1k-row lists, JSON call counts + timing) and extend the unkeyed gate for `appendScopedDeoptKey`. An Octane **patch** changeset documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94d353e9b581f2b7cc79526f3273e3bd92002bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->