### PR TITLE
perf: reuse nested implicit SSR descriptor key prefixes

### DIFF
--- a/.changeset/ssr-nested-implicit-prefix.md
+++ b/.changeset/ssr-nested-implicit-prefix.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reuse nested implicit descriptor key prefixes during server rendering while preserving Suspense retry identities and hydration output.

--- a/benchmarks/ssr-throughput/README.md
+++ b/benchmarks/ssr-throughput/README.md
@@ -128,6 +128,73 @@ EXPECTED_HTML_SHA=YOUR_BASELINE_SHA node benchmarks/ssr-throughput/unkeyed-work.
 Timing deltas within process-to-process variance are inconclusive; the
 serialization count is the deterministic work gate.
 
+### Nested descriptor identity work gate (opt-in)
+
+`nested-work.mjs` builds a separate minified production SSR entry into ignored
+`dist/nested-work-{label}/`. It renders 1,000 implicit component children and an
+adjacent explicit key `"0"` under one nested array. A flat list and a fully
+explicit nested list provide controls. Descriptors are prepared before rendering
+so the timed operation measures their traversal and serialization.
+
+The observer runs in its own process and installs its `JSON.stringify` wrapper
+before importing the built runtime. A second process imports the same artifact
+without the observer, checks complete HTML/CSS hashes and row order, then times
+rendering with 350 ms warmup per mode. Every timed render materializes its HTML
+with `Buffer.byteLength`. Reported calls describe serialization work, not V8
+allocation counts.
+
+At the baseline revision, freeze and measure its bundle:
+
+```bash
+NESTED_BUILD_LABEL=baseline node benchmarks/ssr-throughput/nested-work.mjs 0 --build-only
+NESTED_BUILD_LABEL=baseline EXPECT_NESTED_IMPLICIT_JSON=1000 EXPECT_NESTED_PATH_JSON=0 BENCH_JSON=/tmp/ssr-nested-baseline.json node benchmarks/ssr-throughput/nested-work.mjs 2 --no-build
+```
+
+After changing the runtime, preserve a separate candidate bundle. Set
+`EXPECTED_RESPONSE_SHA` to the baseline's `responseSha`; it combines the complete
+HTML and CSS hashes for all three modes:
+
+```bash
+NESTED_BUILD_LABEL=candidate node benchmarks/ssr-throughput/nested-work.mjs 0 --build-only
+NESTED_BUILD_LABEL=candidate EXPECTED_RESPONSE_SHA=YOUR_BASELINE_SHA BENCH_JSON=/tmp/ssr-nested-candidate.json node benchmarks/ssr-throughput/nested-work.mjs 2 --no-build
+```
+
+The candidate gate requires zero full nested implicit key serializations and
+one shared path serialization, while flat and fully explicit controls require
+zero shared paths. Zero seconds performs only semantic/work checks. Keep the
+built artifacts fixed and repeat the identical `--no-build` commands in
+A–B–B–A order to compare timing distributions. Output includes Node version,
+artifact SHA, raw/gzip bundle bytes, per-mode work counts, HTML/CSS hashes, and
+median/p95 render latency. The existing `unkeyed-work.mjs` gate is unchanged.
+
+#### Nested prefix reuse — 2026-09-10
+
+Compared merged main `afdc3618a` with nested implicit prefix reuse on Node
+26.4.0 / Darwin 25.6.0 / Apple M5 Max (arm64). Frozen minified production
+artifacts ran in A–B–B–A–A–B–B–A order, four fresh processes per variant, with
+350 ms warmup and two seconds of timing per mode. Values are the median and
+range of the four per-process medians:
+
+| Mode | Main ms, median [range] | Candidate ms, median [range] | JSON work, main → candidate |
+| --- | --- | --- | --- |
+| Nested implicit siblings | 2.168 [1.984–3.665] | 2.033 [1.982–2.132] | 1,000 full implicit keys → one shared path |
+| Flat siblings | 1.881 [1.744–3.266] | 1.843 [1.803–1.867] | Zero implicit/path serializations in both |
+| Fully explicit nested siblings | 2.184 [2.112–2.345] | 2.156 [2.112–2.180] | 1,001 explicit keys; zero shared paths in both |
+
+Every mode preserves all 1,001 rows and byte-identical HTML/CSS. The combined
+response checksum is `a88626f3f1917242e578e43611410e6aa8f542365572844f68286f72d8e10534`.
+The minified fixture bundle grows from 58,519 to 59,043 raw bytes and 20,021 to
+20,198 gzip bytes (+524 / +177). These are complete fixture bundle sizes.
+
+An initial version routed flat leaves through the larger helper and showed a
+17.1% median flat-list slowdown with separated ranges. Keeping the original
+small key helper for flat and singleton containers removed that separation in
+the final comparison above. One baseline process was slow across nested and
+flat modes; it remains included in the reported ranges. Final distributions
+overlap, so these runs establish reduced serialization work without a
+throughput claim. The final candidate artifact checksum is
+`de43e3e23ae90e3033249b19ef1dd8272ae5d56a05941624183bcb676910cf91`.
+
 ### Private loop HTML carriers — 2026-09-03
 
 Compared merged main `44d50dbc0` with private loop bodies returning serialized

--- a/benchmarks/ssr-throughput/fixtures/src/entry-nested-server.ts
+++ b/benchmarks/ssr-throughput/fixtures/src/entry-nested-server.ts
@@ -1,0 +1,31 @@
+import { createElement } from 'octane/server';
+import { prerender } from 'octane/static';
+
+const h = createElement as (type: any, props?: any, ...children: any[]) => any;
+type ListKind = 'nested' | 'flat' | 'explicit';
+
+function Row(props: { id: number | 'explicit' }) {
+	return h('li', { 'data-index': props.id }, `row ${props.id}`);
+}
+
+function makeRows(explicit: boolean) {
+	const rows = Array.from({ length: 1000 }, (_, id) =>
+		h(Row, explicit ? { id, key: `row-${id}` } : { id }),
+	);
+	// A string key "0" must remain distinct from implicit position zero.
+	rows.splice(1, 0, h(Row, { id: 'explicit', key: '0' }));
+	return rows;
+}
+
+// Reuse descriptors across renders so timing isolates traversal and SSR work.
+// Component leaves force the identity path; pure host leaves would bypass it.
+const rows = makeRows(false);
+const children = { nested: [rows], flat: rows, explicit: [makeRows(true)] };
+
+function NestedDescriptorPage(props: { kind: ListKind }) {
+	return h('ul', { id: `${props.kind}-descriptors` }, children[props.kind]);
+}
+
+export async function renderNestedDescriptors(kind: ListKind) {
+	return prerender(NestedDescriptorPage as any, { kind });
+}

--- a/benchmarks/ssr-throughput/nested-work.mjs
+++ b/benchmarks/ssr-throughput/nested-work.mjs
@@ -1,0 +1,205 @@
+// Opt-in SSR nested-key work gate. Observed and timed production modules load
+// in separate processes; the JSON observer is installed before module loading.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const seconds = Math.max(0, Number(process.argv[2] ?? 2));
+const kinds = ['nested', 'flat', 'explicit'];
+const hash = (value) => createHash('sha256').update(value).digest('hex');
+const worker = process.argv.find((arg) => arg.startsWith('--worker='))?.slice(9);
+
+function checkResponse(kind, first, second) {
+	assert.equal(second.html, first.html, `${kind}: repeated HTML`);
+	assert.equal(second.css, first.css, `${kind}: repeated CSS`);
+	assert.equal(first.css, '', `${kind}: fixture has no styles`);
+	const ids = [...first.html.matchAll(/<li data-index="([^"]+)">/g)].map((match) => match[1]);
+	assert.deepEqual(ids, ['0', 'explicit', ...Array.from({ length: 999 }, (_, i) => String(i + 1))]);
+	return {
+		rows: ids.length,
+		htmlSha: hash(first.html),
+		cssSha: hash(first.css),
+		htmlBytes: Buffer.byteLength(first.html),
+		cssBytes: Buffer.byteLength(first.css),
+	};
+}
+
+async function runWorker() {
+	const counts = {
+		nestedImplicitJson: 0,
+		nestedExplicitJson: 0,
+		flatImplicitJson: 0,
+		flatExplicitJson: 0,
+		pathOnlyJson: 0,
+	};
+	const original = JSON.stringify;
+	try {
+		if (worker === 'observe') {
+			JSON.stringify = function (value, ...args) {
+				if (Array.isArray(value) && value.length === 3 && Array.isArray(value[0])) {
+					if (value[1] === 'index' && Number.isInteger(value[2])) {
+						counts[value[0].length === 0 ? 'flatImplicitJson' : 'nestedImplicitJson']++;
+					} else if (value[1] === 'key') {
+						counts[value[0].length === 0 ? 'flatExplicitJson' : 'nestedExplicitJson']++;
+					}
+				} else if (
+					Array.isArray(value) &&
+					value.length === 2 &&
+					value[0] === 'wrapper' &&
+					value[1] === 0
+				) {
+					counts.pathOnlyJson++;
+				}
+				return Reflect.apply(original, this, [value, ...args]);
+			};
+		}
+		const { renderNestedDescriptors: render } = await import(
+			pathToFileURL(process.env.NESTED_WORK_BUNDLE).href
+		);
+		const result = {};
+		for (const kind of kinds) {
+			const first = await render(kind);
+			for (const key of Object.keys(counts)) counts[key] = 0;
+			const second = await render(kind);
+			result[kind] = { ...checkResponse(kind, first, second) };
+			if (worker === 'observe') {
+				result[kind].work = { ...counts };
+				continue;
+			}
+			if (seconds === 0) continue;
+			const now = () => process.hrtime.bigint();
+			const warmEnd = now() + 350_000_000n;
+			let warmRenders = 0;
+			while (warmRenders < 3 || now() < warmEnd) {
+				Buffer.byteLength((await render(kind)).html);
+				warmRenders++;
+			}
+			const samples = [];
+			const end = now() + BigInt(Math.round(seconds * 1e9));
+			do {
+				const start = now();
+				Buffer.byteLength((await render(kind)).html);
+				samples.push(Number(now() - start) / 1e6);
+			} while (now() < end);
+			samples.sort((a, b) => a - b);
+			result[kind].timing = {
+				warmRenders,
+				samples: samples.length,
+				medianMs: samples[Math.floor(samples.length / 2)],
+				p95Ms: samples[Math.floor(samples.length * 0.95)],
+			};
+		}
+		return result;
+	} finally {
+		JSON.stringify = original;
+	}
+}
+
+if (worker !== undefined) {
+	assert.ok(worker === 'observe' || worker === 'clean', 'known worker mode');
+	console.log(JSON.stringify(await runWorker()));
+} else {
+	const label = process.env.NESTED_BUILD_LABEL ?? 'candidate';
+	assert.match(label, /^[a-zA-Z0-9-]+$/, 'build label is a directory suffix');
+	const output = path.join(here, 'dist', `nested-work-${label}`);
+	const bundle = path.join(output, 'entry-nested-server.js');
+	if (!process.argv.includes('--no-build')) {
+		const { build } = await import('vite');
+		await build({
+			root: path.join(here, 'fixtures'),
+			logLevel: 'warn',
+			build: {
+				ssr: 'src/entry-nested-server.ts',
+				outDir: output,
+				emptyOutDir: true,
+				minify: 'esbuild',
+			},
+			ssr: { noExternal: ['@tsrx/react'] },
+		});
+	}
+	const source = fs.readFileSync(bundle);
+	const meta = {
+		node: process.version,
+		label,
+		bundleSha: hash(source),
+		bundleBytes: source.length,
+		bundleGzipBytes: gzipSync(source).length,
+	};
+	if (process.argv.includes('--build-only')) {
+		console.log(JSON.stringify(meta, null, 2));
+	} else {
+		const run = (kind) =>
+			JSON.parse(
+				execFileSync(
+					process.execPath,
+					[fileURLToPath(import.meta.url), String(seconds), `--worker=${kind}`],
+					{
+						env: { ...process.env, NESTED_WORK_BUNDLE: bundle },
+						encoding: 'utf8',
+					},
+				),
+			);
+		const observed = run('observe');
+		const clean = run('clean');
+		for (const kind of kinds) {
+			const { work, ...response } = observed[kind];
+			const { timing, ...cleanResponse } = clean[kind];
+			assert.deepEqual(response, cleanResponse, `${kind}: observer preserves all response bytes`);
+			assert.equal(work.flatImplicitJson, 0, `${kind}: top-level implicit keys stay numeric`);
+		}
+		assert.deepEqual(
+			observed.flat.work,
+			{
+				nestedImplicitJson: 0,
+				nestedExplicitJson: 0,
+				flatImplicitJson: 0,
+				flatExplicitJson: 1,
+				pathOnlyJson: 0,
+			},
+			'flat control',
+		);
+		assert.deepEqual(
+			observed.explicit.work,
+			{
+				nestedImplicitJson: 0,
+				nestedExplicitJson: 1001,
+				flatImplicitJson: 0,
+				flatExplicitJson: 0,
+				pathOnlyJson: 0,
+			},
+			'fully explicit control',
+		);
+		assert.deepEqual(
+			observed.nested.work,
+			{
+				nestedImplicitJson: Number(process.env.EXPECT_NESTED_IMPLICIT_JSON ?? 0),
+				nestedExplicitJson: 1,
+				flatImplicitJson: 0,
+				flatExplicitJson: 0,
+				pathOnlyJson: Number(process.env.EXPECT_NESTED_PATH_JSON ?? 1),
+			},
+			'nested implicit identity work',
+		);
+		const responses = Object.fromEntries(
+			kinds.map((kind) => [kind, { htmlSha: clean[kind].htmlSha, cssSha: clean[kind].cssSha }]),
+		);
+		const responseSha = hash(JSON.stringify(responses));
+		if (process.env.EXPECTED_RESPONSE_SHA)
+			assert.equal(
+				responseSha,
+				process.env.EXPECTED_RESPONSE_SHA,
+				'baseline/candidate HTML and CSS bytes',
+			);
+		const result = { ...meta, responseSha, observed, clean };
+		if (process.env.BENCH_JSON)
+			fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(result, null, 2) + '\n');
+		console.log(JSON.stringify(result, null, 2));
+	}
+}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1152,6 +1152,45 @@ function scopedSsrDeoptKey(
 	return JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]);
 }
 
+const SSR_DEOPT_KEY_STRINGIFY = JSON.stringify;
+
+function nestedImplicitSsrKeyPrefix(path: readonly (string | number)[]): string | null {
+	// Match the client's prefix optimization only for inert wrapper paths. A
+	// serializer replaced after import or toJSON hook still sees the full tuple.
+	if (JSON.stringify !== SSR_DEOPT_KEY_STRINGIFY || 'toJSON' in path) return null;
+	for (let i = 0; i < path.length; i++) {
+		const type = typeof path[i];
+		if (type !== 'string' && type !== 'number') return null;
+	}
+	return '[' + JSON.stringify(path) + ',"index",';
+}
+
+function appendNestedSsrDeoptKey(
+	outKeys: any[],
+	path: readonly (string | number)[],
+	item: any,
+	index: number,
+	key: any,
+	implicitPrefix: string | null | undefined,
+): string | null | undefined {
+	const explicit = isElementDescriptor(item) && item.key != null;
+	if (!explicit) {
+		// Reuse only within this synchronous container walk; retries and nested
+		// wrappers each build their own prefix. Fully keyed lists never need one.
+		if (implicitPrefix === undefined) implicitPrefix = nestedImplicitSsrKeyPrefix(path);
+		if (
+			implicitPrefix !== null &&
+			JSON.stringify === SSR_DEOPT_KEY_STRINGIFY &&
+			!('toJSON' in path)
+		) {
+			outKeys.push(implicitPrefix + index + ']');
+			return implicitPrefix;
+		}
+	}
+	outKeys.push(JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]));
+	return implicitPrefix;
+}
+
 // Mirror the client runtime's flattenReactChildContainer exactly: array and
 // Fragment wrappers disappear from the rendered leaf list, while their nesting,
 // kind, and explicit keys remain encoded into each leaf identity. Markup then has
@@ -1164,12 +1203,24 @@ function flattenSsrChildContainer(
 	path: readonly (string | number)[],
 ): void {
 	const count = children.length;
+	let implicitPrefix: string | null | undefined;
 	for (let i = 0; i < count; i++) {
 		const item = children[i];
 		if (isFragmentDescriptor(item)) {
 			if (item.ref != null || hasOwnProp.call(item.props, 'ref')) {
 				outItems.push(fragmentRefDescriptor(item));
-				outKeys.push(scopedSsrDeoptKey(path, item, i, ssrDeoptKey(item, i)));
+				if (path.length === 0 || count === 1) {
+					outKeys.push(scopedSsrDeoptKey(path, item, i, ssrDeoptKey(item, i)));
+				} else {
+					implicitPrefix = appendNestedSsrDeoptKey(
+						outKeys,
+						path,
+						item,
+						i,
+						ssrDeoptKey(item, i),
+						implicitPrefix,
+					);
+				}
 				continue;
 			}
 			const nested = fragmentDescriptorChildren(item);
@@ -1202,7 +1253,20 @@ function flattenSsrChildContainer(
 			continue;
 		}
 		outItems.push(item);
-		outKeys.push(scopedSsrDeoptKey(path, item, i, ssrDeoptKey(item, i)));
+		// Keep flat lists on the small original helper; routing every leaf
+		// through the nested-prefix helper regresses production SSR throughput.
+		if (path.length === 0 || count === 1) {
+			outKeys.push(scopedSsrDeoptKey(path, item, i, ssrDeoptKey(item, i)));
+		} else {
+			implicitPrefix = appendNestedSsrDeoptKey(
+				outKeys,
+				path,
+				item,
+				i,
+				ssrDeoptKey(item, i),
+				implicitPrefix,
+			);
+		}
 	}
 }
 

--- a/packages/octane/tests/ssr-deopt-list-identity.test.ts
+++ b/packages/octane/tests/ssr-deopt-list-identity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createElement, Fragment, renderToPipeableStream, use } from 'octane/server';
+import {
+	createElement,
+	Fragment,
+	positionalChildren,
+	renderToPipeableStream,
+	use,
+} from 'octane/server';
 import { prerender } from 'octane/static';
 import { loadCompiledFixtureSource } from './_server-fixture';
 import {
@@ -94,7 +100,113 @@ function StreamingPage(props: { scenario: ListScenario }) {
 	]);
 }
 
+interface NestedSiblingScenario {
+	reverse: boolean;
+	values: Map<string, Promise<string>>;
+}
+
+function nestedSiblingOrder(reverse: boolean): string[] {
+	return (reverse ? ['second', 'first'] : ['first', 'second']).flatMap((group) =>
+		['outer-0', 'keyed', 'outer-1', 'inner-0', 'inner-1'].map((row) => `${group}-${row}`),
+	);
+}
+
+function nestedSiblingChildren(scenario: NestedSiblingScenario, component: typeof Row) {
+	return (scenario.reverse ? ['second', 'first'] : ['first', 'second']).map((group) => {
+		const row = (name: string, key?: string) => {
+			const kind = `${group}-${name}`;
+			return createElement(component, { kind, value: scenario.values.get(kind)!, key });
+		};
+		return createElement(
+			Fragment,
+			{ key: `quote"\\slash\n\u0000\ud800:${group}` },
+			row('outer-0'),
+			row('keyed', '0'),
+			row('outer-1'),
+			positionalChildren([row('inner-0'), row('inner-1')]),
+		);
+	});
+}
+
+function NestedSiblingsPage(props: { scenario: NestedSiblingScenario }) {
+	return createElement('ul', null, nestedSiblingChildren(props.scenario, Row));
+}
+
+function NestedStreamingSiblingsPage(props: { scenario: NestedSiblingScenario }) {
+	return createElement('ul', null, nestedSiblingChildren(props.scenario, StreamingRow));
+}
+
+function nestedSiblingRequest(reverse: boolean) {
+	const pending = new Map(nestedSiblingOrder(false).map((name) => [name, deferred<string>()]));
+	const scenario: NestedSiblingScenario = {
+		reverse,
+		values: new Map([...pending].map(([name, value]) => [name, value.promise])),
+	};
+	return { pending, scenario };
+}
+
 describe('server descriptor lists across async retries', () => {
+	it('keeps nested sibling results with their keyed wrappers across interleaved retries', async () => {
+		const first = nestedSiblingRequest(false);
+		const second = nestedSiblingRequest(true);
+		const firstResult = prerender(NestedSiblingsPage, { scenario: first.scenario });
+		const secondResult = prerender(NestedSiblingsPage, { scenario: second.scenario });
+
+		// Both requests suspend before their wrapper order changes. Each row must
+		// receive its own settled value when the complete page renders again.
+		first.scenario.reverse = true;
+		second.scenario.reverse = false;
+		for (const name of nestedSiblingOrder(true)) {
+			second.pending.get(name)!.resolve(`B-${name}`);
+			first.pending.get(name)!.resolve(`A-${name}`);
+		}
+
+		const [firstHtml, secondHtml] = await Promise.all([firstResult, secondResult]);
+		expect(rows(firstHtml.html)).toEqual(
+			nestedSiblingOrder(true).map((name) => `${name}:A-${name}`),
+		);
+		expect(rows(secondHtml.html)).toEqual(
+			nestedSiblingOrder(false).map((name) => `${name}:B-${name}`),
+		);
+	});
+
+	it('reveals nested implicit siblings independently when their stream resolves out of order', async () => {
+		const request = nestedSiblingRequest(false);
+		const output = createPipeableCollector();
+		const errors: unknown[] = [];
+		const stream = renderToPipeableStream(
+			NestedStreamingSiblingsPage,
+			{ scenario: request.scenario },
+			{ onError: (error) => errors.push(error) },
+		);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		try {
+			stream.pipe(output.destination);
+			await vi.waitFor(() => {
+				expect(rows(output.chunks.join(''))).toEqual(
+					nestedSiblingOrder(false).map((name) => `${name}:waiting`),
+				);
+			});
+
+			for (const name of ['second-inner-1', 'first-outer-1']) {
+				request.pending.get(name)!.resolve(`VALUE-${name}`);
+				await vi.waitFor(() => expect(output.chunks.join('')).toContain(`VALUE-${name}`));
+			}
+			for (const [name, value] of request.pending) value.resolve(`VALUE-${name}`);
+			container.innerHTML = await output.ended;
+			activateStreamedMarkup(container);
+			expect(rows(container.innerHTML)).toEqual(
+				nestedSiblingOrder(false).map((name) => `${name}:VALUE-${name}`),
+			);
+			expect(errors).toEqual([]);
+		} finally {
+			stream.abort();
+			container.remove();
+			resetStreamRuntimeGlobals();
+		}
+	});
+
 	it("does not reuse a nested unkeyed child's result for a new top-level position", async () => {
 		const plain = deferred<string>();
 		const keyed = deferred<string>();


### PR DESCRIPTION
## Summary

- Reuse one serialized wrapper path for nested implicit SSR descriptor siblings, preserving the exact identity key bytes, async retry behavior, and hydration output.
- Keep flat and singleton lists on their original small key helper. Prefix state is local to a synchronous container walk; explicit keys and exotic serialization use the existing tuple encoding.
- Add public SSR retry/streaming regressions, an isolated minified production work gate with flat and explicit controls, benchmark evidence, and a patch changeset.

Continues #981 after #1034; the combined list-key item remains open.

## Performance evidence

Compared with merged main `afdc3618a` on Node 26.4.0 / Apple M5 Max, using frozen minified production bundles:

- 1,000 full nested implicit key JSON calls become **zero**, plus **one shared path JSON call**.
- Flat implicit calls stay zero; the adjacent explicit key stays one. Fully explicit nested lists retain 1,001 explicit calls and create no shared prefix.
- All 1,001 rows and complete HTML/CSS bytes match baseline in all three modes. The observer imports its runtime in a separate process before clean timing.
- Fixture bundle grows by **524 raw / 177 gzip bytes** (58,519 → 59,043 / 20,021 → 20,198).
- Four fresh processes per variant, ABBAABBA order, 350 ms warmup + 2 seconds per mode: final timing ranges overlap; **no throughput improvement claimed**. A slow baseline process is retained in the published ranges.

Self-review caught a 17.1% flat-list slowdown in the initial larger-helper design. Restoring the original flat/singleton helper removed the separated control distributions. Final rebuilt artifact matches the measured SHA. Full numbers and reproduction commands are in `benchmarks/ssr-throughput/README.md`.

## Validation

- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34501455107): **26/26 jobs passed** at `cfc786198fd14d64bdb970deaa36930e673d16d4`. Cursor Bugbot completed successfully with no findings; there are no unresolved review threads. The PR contains live main `afdc3618a` and has no merge conflicts.

- [x] Targeted dev/prod SSR, streaming, async retries, descriptor identity, and hydration tests: **28 files / 550 tests passed**.
- [x] Deliberate wrapper-path removal made the new reorder case fail in both modes with another wrapper's settled value; restored implementation passed.
- [x] `tsrx-tsc --noEmit -p packages/octane/tsconfig.json`
- [x] Scoped Prettier checks, `git diff --check`, changeset/release-plan checks, and `pnpm sync`
- [x] Final minified nested work/HTML/CSS gate; existing `unkeyed-work.mjs` gate
- [x] Final rebuilt benchmark artifact equals the timed artifact.
- [ ] `pnpm format:check` (scoped checks run locally)
- [ ] `pnpm typecheck` (core program checked locally)
- [ ] `pnpm test` (targeted core suites run locally; repository coverage runs in CI)

## Risk / follow-ups

Nested leaf key strings still exist; this removes repeated wrapper-path serialization. Explicit coercion, the per-list key callback, and other #981 items remain open. The local prefix adds a small bundle cost; timing does not establish a throughput gain. No state is retained across retries, requests, or aborts.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791649184&installation_model_id=432790&pr_number=1035&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1035&signature=075c2103f60609f183f77454350228e5899c44cd61119a0787fad1d035898006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SSR child-list identity key generation used by Suspense retries and hydration; behavior is heavily tested but mistakes could mis-associate async row results.
> 
> **Overview**
> Server rendering now **reuses one serialized wrapper-path prefix** for siblings inside nested implicit descriptor lists, appending each position index instead of calling `JSON.stringify` on the full `[path,"index",i]` tuple every time. **Flat top-level lists and single-child containers** still use the original `scopedSsrDeoptKey` fast path so common cases are not slowed down.
> 
> The optimization is scoped to a synchronous `flattenSsrChildContainer` walk: prefix state does not carry across retries, explicit keys still use the full tuple encoding, and patched `JSON.stringify` / exotic paths fall back to the prior behavior so identity bytes stay compatible with hydration and async Suspense retries.
> 
> Adds **SSR regressions** for nested sibling ordering under interleaved retries and out-of-order streaming, plus an opt-in **`nested-work.mjs`** production gate (nested vs flat vs fully explicit controls) and benchmark notes documenting reduced JSON work without claiming throughput wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc786198fd14d64bdb970deaa36930e673d16d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->