### PR TITLE
feat: reject ambient browser reads in Strong renders

### DIFF
--- a/.changeset/strong-render-ambient-reads.md
+++ b/.changeset/strong-render-ambient-reads.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/mcp-server': patch
+---
+
+Reject known ambient browser-state reads during Strong renders with `OCTANE_STRONG_RENDER_AMBIENT_READ`, including browser handle aliases and `globalThis` property reads outside known standard language builtins. Preserve shadowing, events, effects, external-store snapshot callbacks, and lazy state initialization, and document how to render subscribed snapshots safely across server and client.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -516,6 +516,26 @@ non-idempotent globals such as `Date.now()` and `Math.random()`
 synchronous helpers; they do not prove arbitrary method bodies or imported code
 pure. Lazy state initialization may obtain an initial timestamp or random value.
 
+Reading unshadowed `window`, `document`, `localStorage`, `sessionStorage`,
+`navigator`, `location`, or `matchMedia` during render reports
+`OCTANE_STRONG_RENDER_AMBIENT_READ`. This includes `typeof` guards and constant
+aliases of those browser handles. Reading a `globalThis` property also reports
+the error, including computed properties whose names are unknown, except for
+known standard language builtins such as `globalThis.JSON`. Reading the
+`globalThis` object itself remains supported.
+Shadowed local names and scalar snapshots captured at module initialization are
+not browser-handle reads. The analysis does not generally prove aliases obtained
+through defaults, returned values, containers, arbitrary deeper properties, or
+imports. Those values still have to satisfy the render-snapshot contract.
+
+For changing browser state, use `useSyncExternalStore` with a server snapshot
+and render its returned snapshot. Browser reads in its snapshot callbacks,
+events, effects, and deferred callbacks remain supported. Lazy `useState` and
+`useReducer` initializers may also read browser state for an initial value. They
+still run during server rendering: guard unavailable browser APIs and ensure the
+server and client agree on initial output. A `typeof window` guard inside an
+ordinary render calculation does not make the calculation snapshot-safe.
+
 The directive is also an author assertion for production memoization, not just a
 request for diagnostics. Render output must not observe changing data through a
 stable ref, state getter, module variable, external store object, or hidden hook.

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -747,6 +747,12 @@ These patterns become compile errors:
 - Reading a reassigned module-scope `let` or `var` during render
   (`OCTANE_STRONG_RENDER_MODULE_STATE_READ`). Move the changing value into
   state or context, or pass an immutable snapshot as a prop.
+- Reading unshadowed `window`, `document`, `localStorage`, `sessionStorage`,
+  `navigator`, `location`, or `matchMedia` during render
+  (`OCTANE_STRONG_RENDER_AMBIENT_READ`), including `typeof` guards and known
+  browser handle aliases. Reading `globalThis` properties also reports this
+  error, except for known standard language builtins. Read a subscribed snapshot
+  or move the read into an event, effect, or lazy state initializer.
 - Assigning to a `useRef` object's `current` during render.
 - Reading a `useRef` object's `current` during render
   (`OCTANE_STRONG_RENDER_REF_READ`). Pass the ref to a `ref` prop as usual; read
@@ -768,6 +774,47 @@ These patterns become compile errors:
   uses it (`OCTANE_STRONG_HOOK_LOCALITY`).
 - Declaring a named callback outside the sole nested `@{…}` block containing
   its native `onX` event (`OCTANE_STRONG_EVENT_HANDLER_LOCALITY`).
+
+### Read browser state through a snapshot
+
+Use `useSyncExternalStore` for browser values that can change. Its snapshot
+callbacks may read browser state; render from the snapshot returned by the hook.
+Supply a server snapshot for server rendering and hydration:
+
+```jsx
+"use strong";
+
+import { useSyncExternalStore } from 'octane';
+
+function subscribeResize(notify) {
+  window.addEventListener('resize', notify);
+  return () => window.removeEventListener('resize', notify);
+}
+
+export function ViewportWidth() @{
+  const width = useSyncExternalStore(
+    subscribeResize,
+    () => window.innerWidth,
+    () => 0,
+  );
+  <p>Viewport width: {width as string}</p>
+}
+```
+
+Browser reads in event handlers, effects, and deferred callbacks remain valid.
+Lazy `useState` and `useReducer` initializers may capture an initial browser
+value, but they still run during server rendering. Guard browser APIs there and
+ensure server and client initial output agrees. A `typeof window` guard in an
+ordinary render expression still reads ambient state and is rejected.
+
+The browser check respects local shadowing and follows constant aliases of
+known browser handles. It does not reject scalar snapshots captured at module
+initialization, the `globalThis` object itself, or known standard language
+builtins such as `globalThis.JSON`. Other `globalThis` property reads, including
+computed properties whose names are unknown, are rejected. The analysis does
+not generally prove aliases obtained through defaults, returned values,
+containers, arbitrary deeper properties, or imports. The render-snapshot
+contract still applies to those values.
 
 ### Keep work with its nested template block
 

--- a/packages/octane-mcp-server/skills/react-divergences.md
+++ b/packages/octane-mcp-server/skills/react-divergences.md
@@ -47,6 +47,25 @@ state or context, or pass an immutable snapshot as a prop. Read the ref or call
 the getter in an event, effect, or deferred callback.
 Compatibility modules keep their existing behavior.
 
+Reading unshadowed `window`, `document`, `localStorage`, `sessionStorage`,
+`navigator`, `location`, or `matchMedia` while rendering reports
+`OCTANE_STRONG_RENDER_AMBIENT_READ`. This includes `typeof` guards, constant
+browser handle aliases, and `globalThis` property reads except known standard
+language builtins. Computed `globalThis` properties whose names are unknown also
+report the error. Local shadowing, scalar module snapshots, the `globalThis`
+object itself, and standard language builtins such as `globalThis.JSON` remain valid.
+The analysis does not generally prove aliases obtained through defaults,
+returned values, containers, arbitrary deeper properties, or imports. Those
+values still have to satisfy the render-snapshot contract.
+
+Use `useSyncExternalStore` with a server snapshot for changing browser state;
+browser reads inside its snapshot callbacks remain legal. Events, effects,
+deferred callbacks, and lazy `useState` or `useReducer` initializers may also
+read browser state. Lazy initialization still runs during server rendering:
+guard unavailable browser APIs there and ensure server and client initial
+output agrees. A guard in an ordinary render calculation still reads ambient
+state and is rejected.
+
 ## Controlled inputs match React — on native events
 
 Controlled `value`/`checked` follow React's semantics exactly: the prop drives

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -65,6 +65,86 @@ const ARRAY_STATE_TUPLE_BINDING = {
 	getter: STATE_GETTER_BINDING,
 };
 const UNDEFINED_BINDING = { kind: 'constant', value: UNDEFINED_VALUE, primitive: undefined };
+const GLOBAL_OBJECT_BINDING = { kind: 'global-object' };
+const AMBIENT_GLOBAL_BINDINGS = new Map(
+	[
+		'window',
+		'document',
+		'localStorage',
+		'sessionStorage',
+		'navigator',
+		'location',
+		'matchMedia',
+	].map((name) => [name, { kind: 'ambient', name }]),
+);
+// Reading a standard language builtin is permitted here. Its calls still
+// follow the separate clock/randomness rules; this is not a purity whitelist.
+const LANGUAGE_GLOBALS = new Set([
+	'undefined',
+	'NaN',
+	'Infinity',
+	'globalThis',
+	'Object',
+	'Function',
+	'Boolean',
+	'Symbol',
+	'Error',
+	'AggregateError',
+	'EvalError',
+	'RangeError',
+	'ReferenceError',
+	'SyntaxError',
+	'TypeError',
+	'URIError',
+	'Number',
+	'BigInt',
+	'Math',
+	'Date',
+	'String',
+	'RegExp',
+	'Array',
+	'Int8Array',
+	'Uint8Array',
+	'Uint8ClampedArray',
+	'Int16Array',
+	'Uint16Array',
+	'Int32Array',
+	'Uint32Array',
+	'BigInt64Array',
+	'BigUint64Array',
+	'Float16Array',
+	'Float32Array',
+	'Float64Array',
+	'Map',
+	'Set',
+	'WeakMap',
+	'WeakSet',
+	'ArrayBuffer',
+	'SharedArrayBuffer',
+	'DataView',
+	'Atomics',
+	'JSON',
+	'Promise',
+	'Reflect',
+	'Proxy',
+	'WeakRef',
+	'FinalizationRegistry',
+	'Intl',
+	'Iterator',
+	'AsyncIterator',
+	'DisposableStack',
+	'AsyncDisposableStack',
+	'isFinite',
+	'isNaN',
+	'parseFloat',
+	'parseInt',
+	'decodeURI',
+	'decodeURIComponent',
+	'encodeURI',
+	'encodeURIComponent',
+	'escape',
+	'unescape',
+]);
 const SKIP_KEYS = new Set([
 	'type',
 	'start',
@@ -83,6 +163,7 @@ const SKIP_KEYS = new Set([
 export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 export const STRONG_RENDER_STATE_GETTER_CALL = 'OCTANE_STRONG_RENDER_STATE_GETTER_CALL';
 export const STRONG_RENDER_MODULE_STATE_READ = 'OCTANE_STRONG_RENDER_MODULE_STATE_READ';
+export const STRONG_RENDER_AMBIENT_READ = 'OCTANE_STRONG_RENDER_AMBIENT_READ';
 export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
 export const STRONG_RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
@@ -1214,6 +1295,21 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	const moduleScope = createScope(null, 'module', ast.body ?? [], [], isReassigned);
 	const mutableModuleDeclarations = new Map();
 	const reassignedModuleNames = new Map();
+	const moduleAmbientAliases = new Map();
+	const activeAmbientAliases = new Set();
+	function recordModuleAmbientAliases(pattern, initializer, properties = []) {
+		if (pattern?.type === 'Identifier') {
+			moduleAmbientAliases.set(pattern.name, { initializer, properties });
+		} else if (pattern?.type === 'AssignmentPattern') {
+			recordModuleAmbientAliases(pattern.left, initializer, properties);
+		} else if (pattern?.type === 'ObjectPattern') {
+			for (const property of pattern.properties ?? []) {
+				if (property.type === 'Property') {
+					recordModuleAmbientAliases(property.value, initializer, [...properties, property]);
+				}
+			}
+		}
+	}
 	function recordMutableModulePattern(pattern) {
 		if (pattern?.type === 'Identifier') {
 			let declarations = mutableModuleDeclarations.get(pattern.name);
@@ -1288,6 +1384,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				}
 			}
 			for (const binding of declaration.declarations ?? []) {
+				const initial = unwrap(binding.init);
+				if (
+					declaration.kind === 'const' &&
+					(initial?.type === 'Identifier' ||
+						initial?.type === 'MemberExpression' ||
+						initial?.type === 'Literal' ||
+						initial?.type === 'TemplateLiteral' ||
+						initial?.type === 'BinaryExpression')
+				) {
+					recordModuleAmbientAliases(binding.id, initial);
+				}
 				if (binding.id?.type === 'Identifier') {
 					addNamedRenderRoot(unwrap(binding.init), binding.id.name);
 				}
@@ -1382,6 +1489,116 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			node,
 			'Strong mode does not allow reading a reassigned module variable during render. Move the value into state or context, or pass an immutable snapshot as a prop.',
 		);
+	}
+
+	function reportAmbientRead(node) {
+		report(
+			STRONG_RENDER_AMBIENT_READ,
+			node,
+			'Strong mode does not allow reading browser globals during render. Use useSyncExternalStore with a server snapshot for live browser state, or read it in an effect or a lazy state initializer. Lazy initializers still need to handle server rendering.',
+		);
+	}
+
+	function ambientMemberBinding(object, key) {
+		if (object === GLOBAL_OBJECT_BINDING || object === AMBIENT_GLOBAL_BINDINGS.get('window')) {
+			if (key === 'globalThis') return GLOBAL_OBJECT_BINDING;
+			return AMBIENT_GLOBAL_BINDINGS.get(key) ?? null;
+		}
+		return null;
+	}
+
+	function ambientKeyValue(expression, scope) {
+		const node = unwrap(expression);
+		if (node?.type !== 'Identifier' || resolveScope(scope, node.name) !== moduleScope)
+			return UNKNOWN_PRIMITIVE;
+		const alias = moduleAmbientAliases.get(node.name);
+		if (
+			alias === undefined ||
+			alias.properties.length !== 0 ||
+			activeAmbientAliases.has(node.name)
+		) {
+			return UNKNOWN_PRIMITIVE;
+		}
+		// A render root can appear before the module constant used as its key.
+		activeAmbientAliases.add(node.name);
+		try {
+			return staticPrimitiveValue(alias.initializer, moduleScope, true);
+		} finally {
+			activeAmbientAliases.delete(node.name);
+		}
+	}
+
+	function ambientPropertyKey(property, scope) {
+		const key = property.type === 'Property' ? property.key : property.property;
+		return property.computed ? staticPrimitiveValue(key, scope, true) : (key?.name ?? key?.value);
+	}
+
+	function ambientReference(expression, scope) {
+		const node = unwrap(expression);
+		if (node?.type === 'Identifier' || node?.type === 'JSXIdentifier') {
+			const binding = resolve(scope, node.name);
+			if (binding?.kind === 'ambient' || binding === GLOBAL_OBJECT_BINDING) return binding;
+			if (binding === null) {
+				return node.name === 'globalThis'
+					? GLOBAL_OBJECT_BINDING
+					: (AMBIENT_GLOBAL_BINDINGS.get(node.name) ?? null);
+			}
+			const alias = moduleAmbientAliases.get(node.name);
+			if (
+				alias !== undefined &&
+				resolveScope(scope, node.name) === moduleScope &&
+				!activeAmbientAliases.has(node.name)
+			) {
+				// Module functions can precede their const aliases. Resolve only
+				// browser handles, never taint a copied scalar module snapshot.
+				activeAmbientAliases.add(node.name);
+				try {
+					let value = ambientReference(alias.initializer, moduleScope);
+					for (const property of alias.properties) {
+						value = ambientMemberBinding(value, ambientPropertyKey(property, moduleScope));
+					}
+					return value;
+				} finally {
+					activeAmbientAliases.delete(node.name);
+				}
+			}
+			return null;
+		}
+		if (node?.type === 'MemberExpression' || node?.type === 'JSXMemberExpression') {
+			const object = ambientReference(node.object, scope);
+			return object === GLOBAL_OBJECT_BINDING || object === AMBIENT_GLOBAL_BINDINGS.get('window')
+				? ambientMemberBinding(object, ambientPropertyKey(node, scope))
+				: null;
+		}
+		return null;
+	}
+
+	function isAmbientMemberRead(node, scope) {
+		const value = unwrap(node);
+		if (value?.type !== 'MemberExpression' && value?.type !== 'JSXMemberExpression') return false;
+		return (
+			ambientReference(value.object, scope) === GLOBAL_OBJECT_BINDING &&
+			!LANGUAGE_GLOBALS.has(ambientPropertyKey(value, scope))
+		);
+	}
+
+	function bindAmbientPattern(pattern, value, scope, bind) {
+		if (value !== GLOBAL_OBJECT_BINDING && value?.kind !== 'ambient') return;
+		if (pattern?.type === 'Identifier') {
+			bind(pattern, value);
+		} else if (pattern?.type === 'AssignmentPattern') {
+			bindAmbientPattern(pattern.left, value, scope, bind);
+		} else if (pattern?.type === 'ObjectPattern') {
+			for (const property of pattern.properties ?? []) {
+				if (property.type !== 'Property') continue;
+				bindAmbientPattern(
+					property.value,
+					ambientMemberBinding(value, ambientPropertyKey(property, scope)),
+					scope,
+					bind,
+				);
+			}
+		}
 	}
 
 	function mutableModuleRead(name, scope) {
@@ -1890,6 +2107,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	}
 
 	function definitelyDefined(value) {
+		if (value === GLOBAL_OBJECT_BINDING) return true;
 		if (value?.kind === 'constant' && value.primitive !== UNKNOWN_PRIMITIVE) {
 			return value.primitive !== undefined;
 		}
@@ -1931,7 +2149,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						? defaultValue
 						: definitelyDefined(value)
 							? value
-							: defaultValue?.kind === 'getter' || defaultValue?.kind === 'state-tuple'
+							: defaultValue?.kind === 'getter' ||
+								  defaultValue?.kind === 'state-tuple' ||
+								  defaultValue === GLOBAL_OBJECT_BINDING ||
+								  defaultValue?.kind === 'ambient'
 								? defaultValue
 								: OTHER_BINDING;
 				visitPatternExpressions(
@@ -1941,12 +2162,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					parameter.left.type === 'ObjectPattern' &&
 						(value?.kind === 'ref' ||
 							(usesDefault && isRefObject(parameter.right, parameterScope))),
+					value,
 				);
 				bindStateGetterPattern(parameter.left, value, parameterScope, bindGetter);
+				bindAmbientPattern(parameter.left, value, parameterScope, bindGetter);
 				parameter = parameter.left;
 			} else {
-				visitPatternExpressions(parameter, parameterScope, phase, value?.kind === 'ref');
+				visitPatternExpressions(parameter, parameterScope, phase, value?.kind === 'ref', value);
 				bindStateGetterPattern(parameter, value, parameterScope, bindGetter);
+				bindAmbientPattern(parameter, value, parameterScope, bindGetter);
 			}
 			if (parameter.type === 'Identifier' && !isReassigned(parameter)) {
 				parameterScope.bindings.set(parameter.name, value);
@@ -1999,14 +2223,20 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
-	function visitPatternExpressions(pattern, scope, phase, refSource = false) {
+	function visitPatternExpressions(pattern, scope, phase, refSource = false, ambientSource = null) {
 		let executionPhase = phase;
 		if (pattern?.type === 'TSParameterProperty') {
-			return visitPatternExpressions(pattern.parameter, scope, phase);
+			return visitPatternExpressions(pattern.parameter, scope, phase, refSource, ambientSource);
 		} else if (pattern?.type === 'Identifier') {
 			if (executionPhase === 'render') reportRetainedRowMutation(pattern, scope);
 		} else if (pattern?.type === 'AssignmentPattern') {
-			executionPhase = visitPatternExpressions(pattern.left, scope, executionPhase);
+			executionPhase = visitPatternExpressions(
+				pattern.left,
+				scope,
+				executionPhase,
+				refSource,
+				ambientSource,
+			);
 			visit(pattern.right, scope, executionPhase);
 		} else if (pattern?.type === 'ArrayPattern') {
 			for (const element of pattern.elements ?? []) {
@@ -2018,6 +2248,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (property.computed) {
 					visit(property.key, scope, executionPhase);
 					executionPhase = phaseAfter(property.key, executionPhase);
+				}
+				if (
+					ambientSource === GLOBAL_OBJECT_BINDING &&
+					executionPhase === 'render' &&
+					currentFunctionChecksImpureCalls &&
+					(property.type === 'RestElement' ||
+						!LANGUAGE_GLOBALS.has(ambientPropertyKey(property, scope)))
+				) {
+					reportAmbientRead(property.type === 'RestElement' ? property : property.key);
 				}
 				const currentProperty =
 					refSource &&
@@ -2038,6 +2277,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					property.argument ?? property.value,
 					scope,
 					executionPhase,
+					false,
+					ambientSource === null
+						? null
+						: ambientMemberBinding(ambientSource, ambientPropertyKey(property, scope)),
 				);
 			}
 		} else if (pattern?.type === 'RestElement') {
@@ -2082,6 +2325,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				identifier.name,
 				declarationKind === 'const' || !isReassigned(identifier) ? value : OTHER_BINDING,
 			);
+		}
+		const ambient = ambientReference(initial, scope);
+		if (ambient !== null) {
+			bindAmbientPattern(declaration.id, ambient, scope, bind);
+			return;
 		}
 		const stateTuple = stateTupleBinding(initial, scope);
 		const snapshot =
@@ -2226,6 +2474,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			scope,
 			phaseAfter(declaration.init, phase),
 			declaration.id?.type === 'ObjectPattern' && isRefObject(declaration.init, scope),
+			declaration.id?.type === 'ObjectPattern' ? ambientReference(declaration.init, scope) : null,
 		);
 	}
 
@@ -2261,7 +2510,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		);
 	}
 
-	function staticPrimitiveValue(value, scope) {
+	function staticPrimitiveValue(value, scope, moduleConstantKeys = false) {
 		const expression = unwrap(value);
 		if (expression?.type === 'CallExpression') {
 			const result = callResult(expression, scope);
@@ -2273,7 +2522,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			if (binding?.kind === 'linked-key') return binding.value;
 			if (binding?.kind === 'constant') return binding.primitive;
 			if (binding == null && expression.name === 'undefined') return undefined;
-			return UNKNOWN_PRIMITIVE;
+			return moduleConstantKeys ? ambientKeyValue(expression, scope) : UNKNOWN_PRIMITIVE;
 		}
 		if (expression?.type === 'TemplateLiteral') {
 			let result = '';
@@ -2282,7 +2531,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (text == null) return UNKNOWN_PRIMITIVE;
 				result += text;
 				if (index < (expression.expressions?.length ?? 0)) {
-					const part = staticPrimitiveValue(expression.expressions[index], scope);
+					const part = staticPrimitiveValue(
+						expression.expressions[index],
+						scope,
+						moduleConstantKeys,
+					);
 					if (
 						part === UNKNOWN_PRIMITIVE ||
 						(part !== null && typeof part === 'object') ||
@@ -2297,8 +2550,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			return result;
 		}
 		if (expression?.type === 'BinaryExpression' && expression.operator === '+') {
-			const left = staticPrimitiveValue(expression.left, scope);
-			const right = staticPrimitiveValue(expression.right, scope);
+			const left = staticPrimitiveValue(expression.left, scope, moduleConstantKeys);
+			const right = staticPrimitiveValue(expression.right, scope, moduleConstantKeys);
 			if (
 				left === UNKNOWN_PRIMITIVE ||
 				right === UNKNOWN_PRIMITIVE ||
@@ -2323,7 +2576,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 		if (expression?.type === 'UnaryExpression') {
 			if (expression.operator === 'void') return undefined;
-			const argument = staticPrimitiveValue(expression.argument, scope);
+			const argument = staticPrimitiveValue(expression.argument, scope, moduleConstantKeys);
 			if (expression.operator === '!') {
 				if (argument !== UNKNOWN_PRIMITIVE) return !argument;
 				const value = staticExpressionValue(expression.argument, scope);
@@ -2349,22 +2602,22 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 		if (expression?.type === 'SequenceExpression') {
 			const expressions = expression.expressions ?? [];
-			return staticPrimitiveValue(expressions[expressions.length - 1], scope);
+			return staticPrimitiveValue(expressions[expressions.length - 1], scope, moduleConstantKeys);
 		}
 		if (expression?.type === 'ConditionalExpression') {
 			const branches = conditionalExpressionBranches(expression, scope);
 			return branches === 1
-				? staticPrimitiveValue(expression.consequent, scope)
+				? staticPrimitiveValue(expression.consequent, scope, moduleConstantKeys)
 				: branches === 2
-					? staticPrimitiveValue(expression.alternate, scope)
+					? staticPrimitiveValue(expression.alternate, scope, moduleConstantKeys)
 					: UNKNOWN_PRIMITIVE;
 		}
 		if (expression?.type === 'LogicalExpression') {
 			const branches = logicalExpressionBranches(expression, scope);
 			return branches === 1
-				? staticPrimitiveValue(expression.left, scope)
+				? staticPrimitiveValue(expression.left, scope, moduleConstantKeys)
 				: branches === 2
-					? staticPrimitiveValue(expression.right, scope)
+					? staticPrimitiveValue(expression.right, scope, moduleConstantKeys)
 					: UNKNOWN_PRIMITIVE;
 		}
 		return UNKNOWN_PRIMITIVE;
@@ -2701,6 +2954,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 	function expressionBinding(expression, scope) {
 		const node = unwrap(expression);
+		const ambient = ambientReference(node, scope);
+		if (ambient !== null) return ambient;
 		if (node?.type === 'Identifier') {
 			const binding = resolve(scope, node.name);
 			if (
@@ -2891,7 +3146,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 	function visitSynchronousHookCallback(value, scope, phase, stateInitializer = false) {
 		const checkImpureCalls = currentFunctionChecksImpureCalls;
-		// Lazy state initialization may read a clock or randomness. Keep its
+		// Lazy state initialization may read a clock, randomness, or browser state. Keep its
 		// existing state/ref/Effect Event checks at the synchronous render phase.
 		if (stateInitializer) currentFunctionChecksImpureCalls = false;
 		try {
@@ -3084,6 +3339,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				if (
 					readAccess &&
 					phase === 'render' &&
+					currentFunctionChecksImpureCalls &&
+					ambientReference(node, scope)?.kind === 'ambient'
+				) {
+					reportAmbientRead(node);
+				}
+				if (
+					readAccess &&
+					phase === 'render' &&
 					currentFunctionChecksRenderReads &&
 					mutableModuleRead(node.name, scope)
 				) {
@@ -3093,7 +3356,28 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'JSXOpeningElement': {
 				let name = node.name;
 				const member = name?.type === 'JSXMemberExpression';
-				while (name?.type === 'JSXMemberExpression') name = name.object;
+				let ambientMember;
+				while (name?.type === 'JSXMemberExpression') {
+					if (
+						phase === 'render' &&
+						currentFunctionChecksImpureCalls &&
+						isAmbientMemberRead(name, scope)
+					) {
+						ambientMember = name;
+					}
+					name = name.object;
+				}
+				if (
+					name?.type === 'JSXIdentifier' &&
+					(member || (!/^[a-z]/.test(name.name) && !name.name.includes('-'))) &&
+					phase === 'render' &&
+					currentFunctionChecksImpureCalls
+				) {
+					const reference = ambientReference(name, scope);
+					if (reference?.kind === 'ambient' || ambientMember) {
+						reportAmbientRead(ambientMember ?? name);
+					}
+				}
 				if (
 					name?.type === 'JSXIdentifier' &&
 					(member || (!/^[a-z]/.test(name.name) && !name.name.includes('-'))) &&
@@ -3105,6 +3389,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				}
 				break;
 			}
+			case 'JSXSpreadAttribute':
+				visit(node.argument, scope, phase);
+				if (
+					currentFunctionChecksImpureCalls &&
+					phaseAfter(node.argument, phase) === 'render' &&
+					ambientReference(node.argument, scope) === GLOBAL_OBJECT_BINDING
+				) {
+					reportAmbientRead(node);
+				}
+				return;
 			case 'ExportNamedDeclaration':
 			case 'ExportDefaultDeclaration':
 				visit(node.declaration, scope, phase);
@@ -3180,6 +3474,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						const spreadPhase = phaseAfter(property.argument, executionPhase);
 						if (
 							spreadPhase === 'render' &&
+							currentFunctionChecksImpureCalls &&
+							ambientReference(property.argument, scope) === GLOBAL_OBJECT_BINDING
+						) {
+							reportAmbientRead(property);
+						}
+						if (
+							spreadPhase === 'render' &&
 							currentFunctionChecksRenderReads &&
 							isRefObject(property.argument, scope)
 						) {
@@ -3228,6 +3529,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					phaseAfter(node.object, phase, true, node.optional === true) === 'render'
 				) {
 					reportRefRead(node);
+				}
+				if (
+					readAccess &&
+					phase === 'render' &&
+					currentFunctionChecksImpureCalls &&
+					isAmbientMemberRead(node, scope)
+				) {
+					const propertyPhase = phaseAfter(node.object, phase, true, node.optional === true);
+					if (phaseAfter(node.computed ? node.property : null, propertyPhase) === 'render') {
+						reportAmbientRead(node);
+					}
 				}
 				return;
 			}
@@ -3482,11 +3794,22 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						scope,
 						phaseAfter(node.right, phase),
 						node.left.type === 'ObjectPattern' && isRefObject(node.right, scope),
+						node.left.type === 'ObjectPattern' ? ambientReference(node.right, scope) : null,
 					);
 					return;
 				}
 				visit(node.left, scope, phase, false);
 				const rightPhase = phaseAfter(node.left, phase, true);
+				if (
+					node.operator !== '=' &&
+					rightPhase === 'render' &&
+					currentFunctionChecksImpureCalls &&
+					(isAmbientMemberRead(node.left, scope) ||
+						(unwrap(node.left)?.type === 'Identifier' &&
+							ambientReference(node.left, scope)?.kind === 'ambient'))
+				) {
+					reportAmbientRead(unwrap(node.left));
+				}
 				visit(node.right, scope, rightPhase);
 				const executionPhase = phaseAfter(node.right, rightPhase);
 				if (executionPhase === 'render') {
@@ -3517,6 +3840,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				return;
 			}
 			case 'UpdateExpression':
+				if (
+					phaseAfter(node.argument, phase) === 'render' &&
+					currentFunctionChecksImpureCalls &&
+					(isAmbientMemberRead(node.argument, scope) ||
+						(unwrap(node.argument)?.type === 'Identifier' &&
+							ambientReference(node.argument, scope)?.kind === 'ambient'))
+				) {
+					reportAmbientRead(unwrap(node.argument));
+				}
 				if (
 					phase === 'render' &&
 					currentFunctionChecksRenderReads &&

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -6,6 +6,7 @@ import { compileToVolarMappings } from '../../src/compiler/volar.js';
 const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 const RENDER_STATE_GETTER_CALL = 'OCTANE_STRONG_RENDER_STATE_GETTER_CALL';
 const RENDER_MODULE_STATE_READ = 'OCTANE_STRONG_RENDER_MODULE_STATE_READ';
+const RENDER_AMBIENT_READ = 'OCTANE_STRONG_RENDER_AMBIENT_READ';
 const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
 const RENDER_REF_READ = 'OCTANE_STRONG_RENDER_REF_READ';
@@ -4958,6 +4959,374 @@ function advance() { revision++; }
 export function App() { return <p>{revision}</p>; }`;
 		expect(() => slotHooks(plain, '/src/useRevision.ts')).toThrow(RENDER_MODULE_STATE_READ);
 		expect(() => compile(tsx, '/src/App.tsx')).toThrow(RENDER_MODULE_STATE_READ);
+	});
+});
+
+describe('Strong mode render-time ambient browser state reads', () => {
+	function component(render: string, moduleSetup = '') {
+		return `${moduleSetup}
+export function App(props) @{
+  ${render}
+}`;
+	}
+
+	it('rejects ambient browser state during render while compatibility remains legal', () => {
+		const source = 'export function App() @{ <p>{window.innerWidth as string}</p> }';
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it.each([
+		'window.innerWidth',
+		'document.visibilityState',
+		'localStorage.getItem("theme")',
+		'sessionStorage.getItem("theme")',
+		'navigator.language',
+		'location.pathname',
+		'matchMedia("(min-width: 600px)").matches',
+		'globalThis.window.innerWidth',
+		'globalThis.document.visibilityState',
+		'globalThis.localStorage.getItem("theme")',
+		'globalThis.sessionStorage.getItem("theme")',
+		'globalThis.navigator.language',
+		'globalThis.location.pathname',
+		'globalThis.matchMedia("(min-width: 600px)").matches',
+		'window["innerWidth"]',
+		'globalThis["localStorage"].getItem("theme")',
+		'window?.innerWidth',
+		'globalThis?.["document"]?.visibilityState',
+		'matchMedia?.("(min-width: 600px)")?.matches',
+		'globalThis[props.key]',
+		'typeof window',
+		'(window as Window).innerWidth',
+	])('rejects the ambient read %s', (expression) => {
+		const source = component(`<p>{${expression} as string}</p>`);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it.each([
+		['a local alias', 'const browser = window; <p>{browser.innerWidth as string}</p>'],
+		[
+			'destructuring during render',
+			'const { localStorage: storage } = globalThis; <p>{storage.getItem("theme") as string}</p>',
+		],
+		[
+			'an object shorthand value',
+			'const environment = { navigator }; <p>{environment.navigator.language}</p>',
+		],
+		[
+			'a computed object key',
+			'const entries = { [location.pathname]: true }; <p>{Object.keys(entries)[0]}</p>',
+		],
+		[
+			'an object spread',
+			'const environment = { ...window }; <p>{environment.innerWidth as string}</p>',
+		],
+		[
+			'a rest destructuring read',
+			'const { Math, ...environment } = globalThis; <p>{environment.innerWidth as string}</p>',
+		],
+		['a global property update', 'globalThis.innerWidth++; <p />'],
+		['a compound global property assignment', 'globalThis.innerWidth += 1; <p />'],
+		[
+			'an immediate callback',
+			'const width = (() => window.innerWidth)(); <p>{width as string}</p>',
+		],
+		[
+			'a memo calculation',
+			'const width = useMemo(() => window.innerWidth, []); <p>{width as string}</p>',
+		],
+	])('rejects ambient browser state through %s', (_shape, render) => {
+		const source = component(render, 'import { useMemo } from "octane";');
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it.each([
+		['a browser handle alias', 'const browser = window;', 'browser.innerWidth'],
+		[
+			'an alias of an alias',
+			'const browser = window; const environment = browser;',
+			'environment.innerWidth',
+		],
+		[
+			'a destructured browser handle',
+			'const { localStorage: storage } = globalThis;',
+			'storage.getItem("theme")',
+		],
+		[
+			'a browser function alias',
+			'const query = window.matchMedia;',
+			'query("(min-width: 600px)").matches',
+		],
+		[
+			'a global object alias',
+			'const environment = globalThis;',
+			'environment.document.visibilityState',
+		],
+		[
+			'a synchronous module helper',
+			'function readWidth() { return window.innerWidth; }',
+			'readWidth()',
+		],
+	])('follows %s into render', (_shape, setup, expression) => {
+		const source = component(`<p>{${expression} as string}</p>`, setup);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it('follows a module browser alias declared after the render root', () => {
+		const source = `${component('<p>{browser.innerWidth as string}</p>')}\nconst browser = window;`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it('follows a computed module browser alias when its constant key follows the render root', () => {
+		const source = `${component('<p>{browser.innerWidth as string}</p>')}
+const key = "window";
+const browser = globalThis[key];`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it('allows a standard globalThis builtin when its constant key follows the render root', () => {
+		const source = `${component('<p>{globalThis[key].max(1, 2) as string}</p>')}\nconst key = "Math";`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['a concatenated key before render', 'const key = "JS" + "ON";', true],
+		['a concatenated key after render', 'const key = "JS" + "ON";', false],
+		['a template key before render', 'const part = "SON"; const key = `J${part}`;', true],
+		['a template key after render', 'const part = "SON"; const key = `J${part}`;', false],
+	])('allows a standard globalThis builtin through %s', (_shape, setup, before) => {
+		const render = component('<p>{globalThis[key].stringify(props.value)}</p>');
+		const source = before ? `${setup}\n${render}` : `${render}\n${setup}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('checks an ambient helper default when its argument may be undefined', () => {
+		const helper = 'function read(root = globalThis) { return root.mutableCache; }';
+		const source = component('<p>{read(props.root) as string}</p>', helper);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+		const defined = component('<p>{read({ mutableCache: props.value }) as string}</p>', helper);
+		expect(() => compile(`"use strong";\n${defined}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('allows a globalThis optional member read after await while checking window before await', () => {
+		const source =
+			'"use strong"; export async function useData() { return globalThis?.[await Promise.resolve("JSON")]; }';
+		expect(() => slotHooks(source, '/src/useData.ts')).not.toThrow();
+		expect(() => slotHooks(source.replace('globalThis?', 'window?'), '/src/useData.ts')).toThrow(
+			RENDER_AMBIENT_READ,
+		);
+	});
+
+	it.each([
+		[
+			'nested globalThis destructuring',
+			'const { globalThis: { document: page } } = globalThis; <p>{page.title}</p>',
+		],
+		[
+			'helper parameter destructuring',
+			'function title({ document: page }) { return page.title; } <p>{title(globalThis)}</p>',
+		],
+		['a JSX spread', '<p {...globalThis} />'],
+		['a nested globalThis JSX spread', '<p {...globalThis.globalThis} />'],
+		['a nested globalThis component tag', '<globalThis.globalThis.Widget />'],
+	])('rejects ambient browser state through %s', (_shape, render) => {
+		const source = component(render);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it('checks a compound assignment before its awaited value while allowing an awaited target', () => {
+		const eager = component(
+			'(async () => { globalThis.innerWidth += await props.value; })(); <p />',
+		);
+		const deferred = component('(async () => { globalThis[await props.key] += 1; })(); <p />');
+		expect(() => compile(eager, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${eager}`, '/src/App.tsrx')).toThrow(RENDER_AMBIENT_READ);
+		expect(() => compile(`"use strong";\n${deferred}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps ambient reads in events, effects, cleanup, and deferred work legal', () => {
+		const source = `"use strong";
+import { useEffect } from 'octane';
+const browser = window;
+function readWidth() { return browser.innerWidth; }
+export function App(props) @{
+  useEffect(() => {
+    props.record(document.visibilityState, readWidth());
+    return () => props.record(location.pathname);
+  }, []);
+  setTimeout(() => props.record(navigator.language), 0);
+  Promise.resolve().then(() => props.record(localStorage.getItem("theme")));
+  (async () => { await Promise.resolve(); props.record(sessionStorage.getItem("theme")); })();
+  <button onClick={() => props.record(readWidth(), matchMedia("(min-width: 600px)").matches)}>Check</button>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('allows lazy state and reducer initializers while checking eager arguments and memo callbacks', () => {
+		const source = `"use strong";
+import { useState, useReducer, useMemo } from 'octane';
+function initialWidth() { return window.innerWidth; }
+export function App() @{
+  const [width] = useState(initialWidth);
+  const [theme] = useState(() => localStorage.getItem("theme"));
+  const [language] = useReducer((value) => value, null, () => navigator.language);
+  <p>{width as string}{theme as string}{language as string}</p>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() =>
+			compile(
+				source.replace('useState(initialWidth)', 'useState(initialWidth())'),
+				'/src/App.tsrx',
+			),
+		).toThrow(RENDER_AMBIENT_READ);
+		expect(() =>
+			compile(
+				source.replace('useState(initialWidth)', 'useMemo(initialWidth, [])'),
+				'/src/App.tsrx',
+			),
+		).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it('allows subscribed browser snapshots with a server snapshot', () => {
+		const source = `"use strong";
+import { useSyncExternalStore } from 'octane';
+function subscribe(notify) {
+  window.addEventListener('resize', notify);
+  return () => window.removeEventListener('resize', notify);
+}
+function readWidth() { return window.innerWidth; }
+export function App() @{
+  const width = useSyncExternalStore(subscribe, readWidth, () => 0);
+  <p>{width as string}</p>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() =>
+			compile(
+				source.replace('subscribe, readWidth, () => 0', 'subscribe, window.readWidth, () => 0'),
+				'/src/App.tsrx',
+			),
+		).toThrow(RENDER_AMBIENT_READ);
+	});
+
+	it.each([
+		[
+			'parameter shadows',
+			'export function App({ window, document, localStorage, sessionStorage, navigator, location, matchMedia, globalThis }) @{ <p>{window.innerWidth + document.title + localStorage.value + sessionStorage.value + navigator.language + location.pathname + matchMedia() + globalThis.value as string}</p> }',
+		],
+		[
+			'local shadows',
+			component(
+				'const window = props.window; const globalThis = props.environment; <p>{window.innerWidth + globalThis.navigator.language as string}</p>',
+			),
+		],
+		[
+			'a shadowed globalThis component namespace',
+			'export function App({ globalThis }) @{ <globalThis.globalThis.Widget /> }',
+		],
+		[
+			'imported shadows',
+			component('<p>{location.pathname}</p>', 'import { location } from "./config";'),
+		],
+		[
+			'catch binding shadows',
+			component(
+				'let title = ""; try { throw props.error; } catch (document) { title = document.message; } <p>{title}</p>',
+			),
+		],
+		[
+			'plain property, class, and label names',
+			component(
+				'const entry = { window: props.value }; class Entry { document = 1; location() { return 2; } } navigator: { break navigator; } <p data-window={entry.window}>{new Entry().document as string}</p>',
+			),
+		],
+		[
+			'a module scalar snapshot',
+			component('<p>{width as string}</p>', 'const width = window.innerWidth;'),
+		],
+		[
+			'standard globalThis builtins',
+			component(
+				'const value = globalThis.JSON.stringify(globalThis.Math.max(props.value, 0)); <p>{value}</p>',
+			),
+		],
+		['a plain global property assignment', component('globalThis.innerWidth = props.width; <p />')],
+		[
+			'an unused cyclic module alias',
+			component('<p />', 'const first = second; const second = first;'),
+		],
+		[
+			'a statically skipped optional key and argument',
+			component('null?.[window.innerWidth]; (null?.read)?.(document.title); <p />'),
+		],
+	])('allows %s', (_shape, source) => {
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each(['client', 'server'] as const)(
+		'enforces ambient reads and preserves valid %s output',
+		(mode) => {
+			const invalid = component('<p>{window.innerWidth as string}</p>');
+			expect(() => compile(invalid, '/src/App.tsrx', { mode, strong: true } as any)).toThrow(
+				RENDER_AMBIENT_READ,
+			);
+			const source = component(
+				'<button onClick={() => props.record(window.innerWidth)}>Check</button>',
+			);
+			const ordinary = compile(source, '/src/App.tsrx', { mode });
+			const strong = compile(source, '/src/App.tsrx', { mode, strong: true } as any);
+			expect(strong.code).toBe(ordinary.code);
+			expect(strong.diagnostics).toEqual(ordinary.diagnostics);
+		},
+	);
+
+	it('locates the ambient browser read in compiler and Volar diagnostics', () => {
+		const source = `"use strong";\n${component('<p>{window.innerWidth as string}</p>')}`;
+		const offset = source.lastIndexOf('window');
+		try {
+			compile(source, '/src/App.tsrx');
+			throw new Error('expected a Strong render-time ambient read diagnostic');
+		} catch (error: any) {
+			expect(error).toMatchObject({ code: RENDER_AMBIENT_READ, filename: '/src/App.tsrx' });
+		}
+		const mapped = compileToVolarMappings(source, '/src/App.tsrx');
+		expect(mapped.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_AMBIENT_READ,
+				severity: 'error',
+				filename: '/src/App.tsrx',
+				start: expect.objectContaining({ offset }),
+			}),
+		);
+		expect(mapped.errors).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_AMBIENT_READ,
+				type: 'usage',
+				fileName: '/src/App.tsrx',
+				pos: offset,
+			}),
+		);
+	});
+
+	it('rejects ambient reads in plain custom hooks and Octane TSX components', () => {
+		const plain = '"use strong"; export function useViewportWidth() { return window.innerWidth; }';
+		const tsx =
+			'/** @jsxImportSource octane */\n"use strong"; export function App() { return <p>{document.visibilityState}</p>; }';
+		expect(() => slotHooks(plain, '/src/useViewportWidth.ts')).toThrow(RENDER_AMBIENT_READ);
+		expect(() => compile(tsx, '/src/App.tsx')).toThrow(RENDER_AMBIENT_READ);
+		expect(compileToVolarMappings(tsx, '/src/App.tsx').diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_AMBIENT_READ, severity: 'error' }),
+		);
 	});
 });
 

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -232,6 +232,14 @@ A Strong module cannot:
 - Read a reassigned module-scope `let` or `var` while rendering
   (`OCTANE_STRONG_RENDER_MODULE_STATE_READ`). Put changing values in state or
   context, or pass an immutable snapshot as a prop.
+- Read unshadowed `window`, `document`, `localStorage`, `sessionStorage`,
+  `navigator`, `location`, or `matchMedia` while rendering
+  (`OCTANE_STRONG_RENDER_AMBIENT_READ`). This includes `typeof` guards, known
+  browser handle aliases, and `globalThis` property reads except known standard
+  language builtins. Computed `globalThis` properties whose names are unknown
+  also report the error. Render a snapshot from
+  `useSyncExternalStore` with a server snapshot, or read browser state in an
+  event, effect, or lazy state initializer.
 - Assign to a ref's `current` value while rendering.
 - Read a `useRef` object's `current` while rendering
   (`OCTANE_STRONG_RENDER_REF_READ`). Keep refs as `ref` props and read them in
@@ -252,6 +260,16 @@ A Strong module cannot:
   `@{…}` block that uses it (`OCTANE_STRONG_HOOK_LOCALITY`).
 - Declare a named native event handler outside the sole deeper nested `@{…}`
   block containing its direct `onX` use (`OCTANE_STRONG_EVENT_HANDLER_LOCALITY`).
+
+Browser reads in external-store snapshot callbacks, events, effects, deferred
+callbacks, and lazy `useState` or `useReducer` initializers remain supported.
+Lazy initializers still run during server rendering: guard browser APIs and
+ensure server and client initial output agrees. The check respects shadowed
+names, scalar module snapshots, the `globalThis` object itself, and known
+standard language builtins such as `globalThis.JSON`. It does not generally
+prove aliases obtained through defaults, returned values, containers, arbitrary
+deeper properties, or imports safe; those still need to satisfy the snapshot
+contract.
 
 A nested `@{…}` can place hooks and named event handlers beside the JSX that
 uses them:


### PR DESCRIPTION
## Summary

- Add `OCTANE_STRONG_RENDER_AMBIENT_READ` for render-time browser-global reads in Strong modules.
- Preserve compatibility mode, shadowing, deferred work, subscribed snapshots, and lazy state initialization.
- Add compiler/Volar regressions, public guidance, and patch changesets for `octane` and `@octanejs/mcp-server`.

Part of #1027 (ambient globals item).

## Why

Reading live browser state during a cached render can produce stale output and break server rendering. The diagnostic points to `useSyncExternalStore` with a server snapshot, an effect, or a lazy initializer with server-rendering guards.

## Changes

- Recognize unshadowed `window`, `document`, `localStorage`, `sessionStorage`, `navigator`, `location`, and `matchMedia`, including `typeof` reads and known browser-handle aliases.
- Check `globalThis` properties, destructuring, object/JSX spreads, JSX member tags, and compound/update reads. Permit the global object identity and known standard JavaScript language builtins.
- Reuse the existing render phase and lazy-initializer exemption. Respect optional-chain and `await` evaluation order, local shadowing, and module constant declaration order.
- Document subscribed viewport state and the bounded nature of alias analysis.

## Validation

- [x] Full `pnpm typecheck`.
- [x] Compiler suite: `pnpm exec vitest run packages/octane/tests/compiler --silent=passed-only` — 55 files passed, 2,047 tests passed and 14 expected failures at the final source revision; six further regression cases then passed in the targeted run.
- [x] Final ambient diagnostic suite — 72/72 passed, including client/server emission parity and source-located Volar diagnostics.
- [x] Prettier check on all seven changed files; `git diff --check`.
- [x] `pnpm sync` — no additional generated changes.
- [x] Final paired compiler-throughput benchmark against `afdc3618a`: 100/1,000-component normal, legal ambient-callback, and module-alias workloads in Strong and compatibility modes. All 24 client/server output comparisons matched bytes and SHA256.

### Compiler throughput

Node v26.4.0 on Apple M5 Max; one process alternated baseline/candidate order with 3 warmups and 17 pairs (100 components) or 11 pairs (1,000). Final candidate `90c024d3d`, analyzer SHA256 `a3eb2c64d86e26d93fe15715dc70de1b5168c6d2ca2144c9ca6a228ab63ff387`.

| Strong workload | 100 components, baseline → candidate | 1,000 components, baseline → candidate |
| --- | --- | --- |
| Normal | 38.02 → 38.78 ms (+2.0%) | 408.49 → 416.89 ms (+2.1%) |
| Legal ambient callbacks | 32.48 → 33.04 ms (+1.7%) | 394.98 → 399.06 ms (+1.0%) |
| Module aliases | 52.72 → 54.92 ms (+4.2%) | 461.38 → 456.04 ms (−1.2%) |

Paired median ratios were 0.972–1.036. Compatibility control medians ranged from −5.8% to +1.8%; sample tails were noisier than the observed deltas. No material throughput regression was established; small compiler overhead remains plausible. Generated runtime code was identical in the measured legal programs.

Local reproduction artifacts: `/private/tmp/octane-ambient-paired.mjs` and `/private/tmp/octane-ambient-paired-final.json`; command: `node /private/tmp/octane-ambient-paired.mjs /private/tmp/octane-ambient-paired-final.json`.

- [x] Current-head [CI run 34502442267](https://github.com/octanejs/octane/actions/runs/34502442267) passed on `90c024d3d`: all test and React parity shards, browser and website integration, package validation, examples, lint, typecheck, and provenance. Cursor Bugbot passed with no findings. The PR is ready for review; maintainer approval is still required.

The full repository `pnpm test` and repository-wide format scan were not run locally; the compiler suite and changed-file formatting cover this change, and full relevant CI will be checked before handoff.

## Risk / follow-ups

- This intentionally adds Strong errors to previously accepted browser-state reads. Compatibility behavior and valid emitted client/server code are preserved.
- This remains bounded static analysis: arbitrary imported code, deeper properties, returned/container values, and destructuring defaults with unknown inputs are not generally proven. Only known direct module `const` aliases are resolved independently of declaration order.
- Standard global builtin access is not a purity guarantee for arbitrary calls through those objects; the existing separate clock/randomness detector remains bounded.
- Lazy initializers still execute during SSR and must preserve matching initial output. The diagnostic does not make an unsafe initializer server-safe.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791649592&installation_model_id=432790&pr_number=1036&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1036&signature=14e5db906383e6cf4caeb92b9abcc6581ccfe77e64826c7ed1fe139a38990971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Strong modules that previously read browser APIs during render will now fail at compile time; alias analysis is intentionally bounded and may miss or over-approximate some patterns.
> 
> **Overview**
> Strong mode now fails compile when render code reads live browser globals, with a new **`OCTANE_STRONG_RENDER_AMBIENT_READ`** diagnostic.
> 
> The Strong compiler pass tracks unshadowed **`window`**, **`document`**, storage, **`navigator`**, **`location`**, **`matchMedia`**, and most **`globalThis`** property access (including **`typeof`**, aliases, destructuring, spreads, and JSX), while still allowing shadowed names, module-level scalar snapshots, the **`globalThis`** object itself, and standard language builtins. Lazy **`useState`** / **`useReducer`** initializers, **`useSyncExternalStore`** snapshot callbacks, and deferred work stay exempt.
> 
> Docs, MCP skill text, a changeset, and a large **`strong-mode.test.ts`** suite document **`useSyncExternalStore`** with a server snapshot and pin client/server emission parity plus Volar source locations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c024d3d14da9876ac75bc5a2bf287ffe6bfbfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->