### PR TITLE
fix: require signal imports for native reads

### DIFF
--- a/.changeset/native-reads-require-signal-import.md
+++ b/.changeset/native-reads-require-signal-import.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Require a runtime `octane/signals` import to enable native signal reads in a module. Unrelated `$`-suffixed names no longer change DOM compilation or reject non-DOM renderers; components receiving signal handles or readers through props can import `octane/signals` directly.

--- a/benchmarks/scoped-signals/README.md
+++ b/benchmarks/scoped-signals/README.md
@@ -228,7 +228,7 @@ evidence, not compiled `.tsrx`, browser, CI, or heap evidence.
 current compiler. It measures production synchronous mount, prop update, signal
 update, unmount, and server-render work. The two unread controls use an ordinary module and a module containing native
 capabilities, without importing the signal engine into either final bundle.
-Current compilers select tracking automatically; archived experimental compilers
+Current compilers select tracking from the fixture's explicit signals import; archived experimental compilers
 receive their original option. Both revisions compile identical source per case.
 Read cases cover one source, 16 reads of one source, and 16 distinct sources.
 Both `@{}` output and ordinary return-JSX output are included. Each case has its

--- a/benchmarks/scoped-signals/native-costs.tsrx
+++ b/benchmarks/scoped-signals/native-costs.tsrx
@@ -1,5 +1,6 @@
 import { use } from 'octane';
 import type { SignalHandle } from 'octane/signals';
+import 'octane/signals';
 import { make$ } from './native-cost-factory.mjs';
 
 interface ValueProps {

--- a/benchmarks/scoped-signals/run-native-costs.mjs
+++ b/benchmarks/scoped-signals/run-native-costs.mjs
@@ -328,11 +328,16 @@ async function buildCase(target, scenario, nativeReads, mode) {
 		}
 	}
 	if (!scenario.reads) {
+		const bundledInputs = Object.values(output.metafile.outputs).flatMap(({ inputs }) =>
+			Object.entries(inputs)
+				.filter(([, entry]) => entry.bytesInOutput > 0)
+				.map(([input]) => input),
+		);
 		assert.ok(
-			inputs.every(
-				(input) => !/alien-signals|\/signals\/(?:engine|graph|requests)\.ts/.test(input.path),
+			bundledInputs.every(
+				(input) => !/alien-signals|\/signals\/(?:engine|graph|requests)\.ts/.test(input),
 			),
-			'Unread control imported a signal engine',
+			'Unread control bundled a signal engine',
 		);
 	}
 	const codeMinified = transformSync(result.code, { minify: true }).code;

--- a/benchmarks/scoped-signals/run-native-props.mjs
+++ b/benchmarks/scoped-signals/run-native-props.mjs
@@ -327,11 +327,16 @@ async function buildCase(target, scenario, nativeReads, mode) {
 		}
 	}
 	if (!scenario.reads) {
+		const bundledInputs = Object.values(output.metafile.outputs).flatMap(({ inputs }) =>
+			Object.entries(inputs)
+				.filter(([, entry]) => entry.bytesInOutput > 0)
+				.map(([input]) => input),
+		);
 		assert.ok(
-			inputs.every(
-				(input) => !/alien-signals|\/signals\/(?:engine|graph|requests)\.ts/.test(input.path),
+			bundledInputs.every(
+				(input) => !/alien-signals|\/signals\/(?:engine|graph|requests)\.ts/.test(input),
 			),
-			'Unread control imported a signal engine',
+			'Unread control bundled a signal engine',
 		);
 	}
 	const codeMinified = transformSync(result.code, { minify: true }).code;

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,6 +1,6 @@
 # Signals
 
-`octane/signals` is Octane's stable, renderer-independent API for scoped state, derived values, async resources, and streams. Native component reads and `useSignal$` work with the standard Octane compiler; no signal-specific compiler option is needed. The compiler recognizes signal imports and `$` capability names, including handles passed through props and helpers imported from other modules.
+`octane/signals` is Octane's stable, renderer-independent API for scoped state, derived values, async resources, and streams. Native component reads and `useSignal$` work with the standard Octane compiler; no signal-specific compiler option is needed. Each module that consumes native reads needs a runtime import from `octane/signals`, `octane/signals/client`, or `octane/signals/server`, including modules that receive handles through props or call imported helpers. A `$` name alone does not enable native reads.
 
 The [website guide](https://octanejs.dev/docs/signals) introduces the API. This reference describes ownership, availability, and hydration in more detail. The [original implementation evidence](experimental-scoped-signals-evidence.md) and [implementation plan](plans/2026-08-27-experimental-scoped-async-signals-plan.md) are historical records.
 
@@ -106,11 +106,25 @@ export function Counter() @{
 }
 ```
 
+When a component receives its signal reader through props and has no signal API binding to import, import the signals module for its native-read compilation:
+
+```tsrx
+import { useMemo } from 'octane';
+import 'octane/signals';
+
+export function Reader(props: { read$: () => string }) @{
+	const value = useMemo(() => props.read$());
+	<output>{value as string}</output>
+}
+```
+
+The import must be a runtime import; `import type` does not enable native reads.
+
 Native reads use Octane's existing component scopes, blocks, scheduling, and acceptance machinery. The compiler carries read evidence through its own memoization and deferred values. A stable signal handle alone is not evidence that its value is unchanged. Committed subscriptions remain alive until replacement work is accepted, and discarded work releases its provisional subscriptions.
 
 Signal-consuming renderer modules activate a versioned private runtime capability before rendering. The runtime then collects reads around the actual component invocation, before parameter defaults and destructuring execute. Setup reads also remain tracked when a function returns an intermediate JSX variable or an explicit `createElement` result. Compiler body brackets join that same invocation; they do not create a second subscription owner. Compile native consumers and their custom hooks through the standard Octane toolchain so inferred memo caches carry native read evidence.
 
-Use `$` for signal bindings and functions that return native signals or hide live native reads. The naming diagnostics recognize the branded API, statically known native-capability aliases and helpers, and optional TypeScript facts. They do not rename old bindings or ordinary properties merely because they end in `$`. Opaque imported functions can exceed static naming analysis; compiler-owned caches must still preserve reads observed at runtime.
+Use `$` for signal bindings and functions that return native signals or hide live native reads. In a module with a runtime signals import, compiler naming diagnostics recognize the branded API and statically known native-capability aliases and helpers. Optional TypeScript name validation is separate and can diagnose imported signal types without enabling native reads. Neither check renames old bindings or ordinary properties merely because they end in `$`. Opaque imported functions can exceed static naming analysis; compiler-owned caches must still preserve reads observed at runtime.
 
 An inferred memo tracks its lexical dependencies and the native reads made while computing its result. A cache hit replays that read evidence so the component remains subscribed:
 

--- a/packages/octane/src/compiler/native-read-diagnostics.js
+++ b/packages/octane/src/compiler/native-read-diagnostics.js
@@ -1,4 +1,4 @@
-import { createLexicalAnalysis, forEachRuntimeAstChild } from './compile-universal.js';
+import { createLexicalAnalysis } from './compile-universal.js';
 import { analyzeRendererBoundaries } from './renderer-boundaries.js';
 import { NATIVE_SIGNAL_NAME, NATIVE_MEMO_READ, nativeReadDiagnostic } from './native-read-facts.js';
 export { NATIVE_SIGNAL_NAME, NATIVE_MEMO_READ } from './native-read-facts.js';
@@ -65,40 +65,19 @@ function propertyName(node, computed = false) {
 }
 
 /**
- * Signal capabilities are part of authored source, not build configuration.
- * A `$` capability can arrive through props, a namespace, or an imported helper;
- * do not require a direct signals import or proof of the eventual read target.
- * Once selected, the entire module captures actual reads, including opaque calls.
- * Inspect runtime syntax rather than text so erased types, comments, and string
- * contents do not opt an ordinary module into native memoization and its adapter.
+ * Native reads are an explicit module capability. A runtime signals import,
+ * including a bare import for opaque readers, opts the entire module into
+ * capturing actual reads. Type-only imports and `$` names alone do not.
  */
 export function nativeReadOptions(ast, options) {
-	let nativeReads = false;
-	function visit(node) {
-		if (nativeReads || !node || typeof node !== 'object') return;
-		if (node.importKind === 'type' || node.exportKind === 'type') return;
-		if (
+	const nativeReads = ast.body.some(
+		(node) =>
 			node.type === 'ImportDeclaration' &&
-			node.specifiers.length > 0 &&
-			node.specifiers.every((specifier) => specifier.importKind === 'type')
-		) {
-			return;
-		}
-		if (
-			((node.type === 'Identifier' || node.type === 'JSXIdentifier') && node.name.endsWith('$')) ||
-			(node.type === 'ImportDeclaration' &&
-				(node.source?.value === SIGNALS_MODULE || LOCAL_MODULES.has(node.source?.value))) ||
-			((node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') &&
-				String(propertyName(node.property, node.computed) ?? '').endsWith('$')) ||
-			(node.type === 'Property' &&
-				String(propertyName(node.key, node.computed) ?? '').endsWith('$'))
-		) {
-			nativeReads = true;
-			return;
-		}
-		forEachRuntimeAstChild(node, visit);
-	}
-	visit(ast);
+			node.importKind !== 'type' &&
+			(node.source?.value === SIGNALS_MODULE || LOCAL_MODULES.has(node.source?.value)) &&
+			(node.specifiers.length === 0 ||
+				node.specifiers.some((specifier) => specifier.importKind !== 'type')),
+	);
 	return { ...options, nativeReads };
 }
 

--- a/packages/octane/tests/_fixtures/native-read-collection.tsrx
+++ b/packages/octane/tests/_fixtures/native-read-collection.tsrx
@@ -1,5 +1,6 @@
 import { createElement, useLayoutEffect, useRef, useState } from 'octane';
 import type { Resource, SignalHandle } from 'octane/signals';
+import 'octane/signals';
 
 export interface CollectionProps {
 	count$: SignalHandle<number>;

--- a/packages/octane/tests/_fixtures/native-reads-ordinary-dollar.tsrx
+++ b/packages/octane/tests/_fixtures/native-reads-ordinary-dollar.tsrx
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'octane';
+
+export function Ticker() @{
+	const [count, setCount] = useState(0);
+	useEffect(() => {
+		const tick$ = setInterval(() => setCount((value) => value + 1), 1000);
+		return () => clearInterval(tick$);
+	}, []);
+	<div>{String(count)}</div>
+}

--- a/packages/octane/tests/_fixtures/signals-deferred-values.tsrx
+++ b/packages/octane/tests/_fixtures/signals-deferred-values.tsrx
@@ -7,6 +7,7 @@ import {
 	type OctaneNode,
 } from 'octane';
 import type { SignalHandle } from 'octane/signals';
+import 'octane/signals';
 
 export function FiveInputs(props: { a: string; b: string; c: string; d: string; e: string }) {
 	const values = [props.a, props.b, props.c, props.d, props.e];

--- a/packages/octane/tests/_fixtures/signals-hydration.tsrx
+++ b/packages/octane/tests/_fixtures/signals-hydration.tsrx
@@ -1,6 +1,7 @@
 import { Hydrate, useLayoutEffect, useRef } from 'octane';
 import type { HydrateWhen } from 'octane/hydration';
 import type { Resource, Scope, WritableSignal } from 'octane/signals';
+import 'octane/signals';
 
 export interface NativeHydrationState {
 	scope: Scope;

--- a/packages/octane/tests/_fixtures/signals-memos.tsrx
+++ b/packages/octane/tests/_fixtures/signals-memos.tsrx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useMemo, useMemo as memo } from 'octane';
 import * as Octane from 'octane';
+import 'octane/signals';
 
 export interface MemoReaderProps {
 	read$: () => string;

--- a/packages/octane/tests/_fixtures/signals-parallel-use.tsrx
+++ b/packages/octane/tests/_fixtures/signals-parallel-use.tsrx
@@ -1,4 +1,5 @@
 import { use } from 'octane';
+import 'octane/signals';
 
 export interface NativeCreationProps {
 	make$: () => Promise<string>;

--- a/packages/octane/tests/_server-fixture.ts
+++ b/packages/octane/tests/_server-fixture.ts
@@ -16,6 +16,7 @@ import * as HydrationRuntime from 'octane/hydration';
 import * as InternalClientRuntime from 'octane/internal/client';
 import * as InternalServerRuntime from 'octane/internal/server';
 import * as ClientRuntime from '../src/index.js';
+import 'octane/signals';
 
 export type CompiledFixtureModule = Record<string, any>;
 
@@ -125,6 +126,8 @@ export function evaluateCompiledFixtureCode<T extends CompiledFixtureModule>(
 		(_match: string, names: string) =>
 			importBinding(`const {${names.replace(/\s+as\s+/g, ': ')}} = __hydrationRuntime;`),
 	);
+	// The signals entrypoint was initialized by this loader's own bare import.
+	code = code.replace(/import\s*['"]octane\/signals['"];?/g, '');
 	code = code.replace(
 		/import\s+(\*\s+as\s+[\w$]+|\{[^}]*\}|[\w$]+)\s+from\s*['"]([^'"]+)['"];?/g,
 		(match: string, binding: string, request: string) => {

--- a/packages/octane/tests/browser/signals-native-collection/native.tsrx
+++ b/packages/octane/tests/browser/signals-native-collection/native.tsrx
@@ -1,5 +1,6 @@
 import { useMemo } from 'octane';
 import type { SignalHandle, WritableSignal } from 'octane/signals';
+import 'octane/signals';
 
 interface ReadProps {
 	count$: SignalHandle<number>;

--- a/packages/octane/tests/compiler/native-reads.test.ts
+++ b/packages/octane/tests/compiler/native-reads.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { compile } from '../../src/compiler/compile.js';
 import { compileToVolarMappings } from '../../src/compiler/volar.js';
@@ -7,6 +9,10 @@ import { slotHooks } from '../../src/compiler/slot-hooks.js';
 const NAMING = 'OCTANE_NATIVE_SIGNAL_NAME';
 const MEMO_READ = 'OCTANE_NATIVE_MEMO_READ';
 const FILENAME = '/src/native-reads.tsrx';
+const ORDINARY_DOLLAR = readFileSync(
+	resolve(import.meta.dirname, '../_fixtures/native-reads-ordinary-dollar.tsrx'),
+	'utf8',
+);
 const PREFIX = `import { createScope } from 'octane/signals';
 const scope = createScope();
 const count$ = scope.signal$('count', 0);
@@ -28,6 +34,37 @@ const modes = [
 ] as const;
 
 describe('automatic native signal compilation', () => {
+	it.each(['universal', 'valdi'])(
+		'compiles ordinary $ names on the %s renderer without a signals import',
+		(target) => {
+			const renderer = { id: 'scene', module: 'scene-runtime', target } as const;
+			if (target === 'universal') {
+				expect(() => compile(ORDINARY_DOLLAR, FILENAME, { renderer })).not.toThrow();
+			}
+			expect(() =>
+				compile(
+					`import $ from 'jquery';
+export function App(props) @{
+  const tick$ = props.delay;
+  const bag = { 'delay$': tick$ };
+  <group value={bag['delay$']} reader={props.reader$} library={$} />
+}`,
+					FILENAME,
+					{ renderer },
+				),
+			).not.toThrow();
+		},
+	);
+
+	it.each([{ dev: true }, { dev: false, hmr: false }])(
+		'keeps the ordinary DOM compile path for $ names in %j',
+		(options) => {
+			const plain = ORDINARY_DOLLAR.replaceAll('tick$', 'tick');
+			const compiled = compile(ORDINARY_DOLLAR, FILENAME, options).code;
+			expect(compiled.replaceAll('tick$', 'tick')).toBe(compile(plain, FILENAME, options).code);
+		},
+	);
+
 	it.each(modes)('compiles local signals without configuration in %j', (options) => {
 		const source = `import { useSignal$ } from 'octane/signals/client';
 export function Counter() @{ const count$ = useSignal$(0); <output>{String(count$.get())}</output> }`;
@@ -100,6 +137,7 @@ export function useCounter$() { return useSignal$(0); }`;
 			for (const component of [
 				'export function App() @{ <group /> }',
 				'export function App() { return <group />; }',
+				'export function App(props) @{ const tick$ = props.value; <group value={tick$} /> }',
 			]) {
 				const source = `${types}\n${component}`;
 				const options = {
@@ -108,13 +146,21 @@ export function useCounter$() { return useSignal$(0); }`;
 					renderer: { id: 'scene', module: 'scene-runtime', target: 'universal' as const },
 				};
 				expect(() => compile(source, FILENAME, options)).not.toThrow();
-				expect(compileToVolarMappings(source, FILENAME, options).diagnostics).toEqual([]);
+				expect(
+					compileToVolarMappings(source, FILENAME, {
+						renderers: {
+							registry: { scene: { module: 'scene-runtime', target: 'universal' } },
+							rules: [{ include: '**/*.tsrx', renderer: 'scene' }],
+						},
+					}).diagnostics,
+				).toEqual([]);
 			}
 		}
 	});
 
 	it('rejects an active non-DOM renderer boundary inside a DOM module', () => {
-		const source = `import { Canvas } from '@scene/bridge';
+		const source = `import 'octane/signals';
+import { Canvas } from '@scene/bridge';
 export function App(props) @{ <Canvas><mesh value={props.value$.get()} /></Canvas> }`;
 		expect(() =>
 			compile(source, FILENAME, {

--- a/packages/octane/tests/signals-memos.test.ts
+++ b/packages/octane/tests/signals-memos.test.ts
@@ -12,9 +12,10 @@ import { deferred } from './_server-stream';
 import * as client from './_fixtures/signals-memos.tsrx';
 
 describe('native reads in inferred memos', () => {
-	it('tracks a quoted reader property without a direct signals import or compiler option', () => {
+	it('tracks a quoted reader property with an explicit signals import', () => {
 		const { Reader } = loadCompiledFixtureSource(
 			`import { useMemo } from 'octane';
+import 'octane/signals';
 export function Reader(props) @{
   const { 'read$': read } = props;
   const value = useMemo(read);
@@ -170,6 +171,7 @@ export function Reader(props) @{
 		it(`tracks inferred memos in plain modules (inline=${inlineHookMemo})`, () => {
 			const plain = loadPlainHookFixtureSource(
 				`import { createElement, useMemo } from 'octane';
+import 'octane/signals';
 export function App(props) {
   const value = useMemo(() => props.read$());
   const sampled = useMemo(() => props.label, [props.label]);


### PR DESCRIPTION
## Summary

- Activate native signal reads only when the compiled module has a runtime import from `octane/signals`, `octane/signals/client`, or `octane/signals/server`.
- Keep ordinary `$` names on the normal DOM path and allow them in universal renderers, including jQuery-style imports and RxJS-style timer names.
- Make the signal reader fixtures and scoped signal benchmark import explicitly, document the contract, and add a patch changeset.

Addresses point 1 of #1037. The remaining points in that tracking issue are outside this PR.

## Validation

- [ ] `pnpm format:check` (scoped formatting check below)
- [ ] `pnpm typecheck` (scoped `pnpm typecheck:files` passed)
- [ ] `pnpm test` (targeted suites below)
- [x] targeted tests: compiler suite (1,985 passed; 14 expected failures), signal suites (562 passed), real browser native collection (4 passed in dev/prod)
- [x] scoped native costs benchmark smoke with semantic controls (`--quick --samples=1 --updates=10 --mounts=2 --ssr=2 --collector=10`)
- [x] `pnpm format:files:check` on all changed source, tests, fixtures, docs, and changeset
- [x] `pnpm sync`

## Risk / follow-ups

Modules that receive signal readers only through props must now import `octane/signals` at runtime to opt into native subscriptions. The affected fixtures and documentation show this explicitly. The compiler no longer infers signal behavior from `$` spelling alone.

The focused native props benchmark requires an immutable archived baseline and was not run locally; its unread bundle control mirrors the native costs benchmark validated above.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791655006&installation_model_id=432790&pr_number=1039&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1039&signature=fd8d879c49aef50899b9647b1270983061a324f68a048edb5f12f53ea2f1b85d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking compiler contract change: modules that relied on `$` spelling or prop-only handles without a runtime signals import will stop collecting native reads until they add an import.
> 
> **Overview**
> Native signal read collection is now **opt-in per module** via a runtime import from `octane/signals`, `octane/signals/client`, or `octane/signals/server`. **`import type` alone does not enable it**, and unrelated identifiers ending in `$` no longer flip the compiler into native-read mode or block universal/non-DOM renderers.
> 
> The compiler’s `nativeReadOptions` detection was narrowed accordingly: it scans only for qualifying import declarations instead of inferring capability from `$`-suffixed names across the AST. Docs explain the contract (including prop-passed readers via a bare `import 'octane/signals'`), signal fixtures and benchmarks add explicit imports, and benchmark unread controls assert the **bundled** output—not merely resolved inputs—excludes the signal engine. Tests cover ordinary `$` names (e.g. `tick$` for intervals) staying on the normal DOM path and type-only signal imports compiling on universal renderers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5206fb9c2e04efba8a6e833e7beccb055a291f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->