### PR TITLE
fix: scope Strong switch arms independently

### DIFF
--- a/.changeset/strong-switch-arm-scopes.md
+++ b/.changeset/strong-switch-arm-scopes.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Check Strong-mode `@switch` arms in their own lexical scopes so arm-local shadows and functions receive accurate render diagnostics without leaking bindings into sibling arms. Treat instance class field initializers as deferred work when a class is defined during render.

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -178,6 +178,7 @@ function collectHoistedVars(node, functionScope, root = true, bindingsOnly = fal
 	if (
 		bindingsOnly &&
 		(isFunction(node) ||
+			node.type === 'JSXSwitchExpression' ||
 			(!root && node.type === 'StaticBlock') ||
 			node.type === 'ClassDeclaration' ||
 			node.type === 'ClassExpression' ||
@@ -479,7 +480,22 @@ function buildScopes(ast, onlyImported, hookRuntimeModules, bindingsOnly = false
 			return;
 		}
 
-		if (node.type === 'SwitchStatement' || (bindingsOnly && node.type === 'JSXSwitchExpression')) {
+		if (bindingsOnly && node.type === 'JSXSwitchExpression') {
+			// Each template arm is a separate callback. Its `var` declarations
+			// belong to that callback, rather than to the enclosing function or
+			// another arm with a declaration of the same name.
+			walk(node.discriminant, scope);
+			for (const switchCase of node.cases || []) {
+				walk(switchCase.test, scope);
+				const caseScope = createScope(scope, 'function');
+				collectHoistedVars(switchCase.consequent, caseScope, true, true);
+				predeclareDirect(switchCase.consequent, caseScope, hookRuntimeModules, true);
+				for (const statement of switchCase.consequent || []) walk(statement, caseScope);
+			}
+			return;
+		}
+
+		if (node.type === 'SwitchStatement') {
 			// A switch body is one lexical scope shared by every unbraced case.
 			// Predeclare the direct case statements together so let/const/function
 			// captures resolve even when their declaration appears in a case list

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -3421,7 +3421,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'AccessorProperty':
 				visit(node.decorators, scope, phase);
 				if (node.computed) visit(node.key, scope, phase);
-				visit(node.value, scope, phase);
+				visit(
+					node.value,
+					scope,
+					node.type === 'MethodDefinition' || node.static ? phase : 'deferred',
+				);
 				return;
 			case 'BlockStatement':
 			case 'JSXCodeBlock': {
@@ -3546,6 +3550,18 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'LabeledStatement':
 				visit(node.body, scope, phase);
 				return;
+			case 'JSXSwitchExpression': {
+				visit(node.discriminant, scope, phase);
+				let searchPhase = phaseAfter(node.discriminant, phase);
+				for (const branch of node.cases ?? []) {
+					visit(branch.test, scope, searchPhase);
+					searchPhase = phaseAfter(branch.test, searchPhase);
+					const caseScope = createScope(scope, 'function', branch.consequent ?? []);
+					predeclareHoistedVars(branch.consequent, caseScope);
+					visitStatements(branch.consequent, caseScope, searchPhase);
+				}
+				return;
+			}
 			case 'SwitchStatement': {
 				visit(node.discriminant, scope, phase);
 				const initialPhase =

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -4618,6 +4618,156 @@ export function App() {
 	});
 });
 
+describe('Strong mode template switch arms', () => {
+	it('allows an arm-local value to shadow mutable module state', () => {
+		const source = `"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function App(props) @{
+  @switch (props.kind) {
+    @case 'current': {
+      const revision = props.revision;
+      <p>{revision as string}</p>
+    }
+    @default: { <p /> }
+  }
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('checks a case test before entering its arm scope', () => {
+		const source = `"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function App(props) @{
+  @switch (props.kind) {
+    @case revision: {
+      const revision = props.revision;
+      <p>{revision as string}</p>
+    }
+    @default: { <p /> }
+  }
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_MODULE_STATE_READ);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'server', dev: false },
+	])('preserves valid switch output in $mode compilation', (options) => {
+		const source = `let revision = 0;
+function advance() { revision++; }
+export function App(props) @{
+  @switch (props.kind) {
+    @case 'current': {
+      const revision = props.revision;
+      <p>{revision as string}</p>
+    }
+    @default: { <p /> }
+  }
+}`;
+		const ordinary = compile(source, '/src/App.tsrx', options);
+		const strong = compile(source, '/src/App.tsrx', { ...options, strong: true } as any);
+		expect(strong.code).toBe(ordinary.code);
+	});
+
+	it.each([
+		['refs', 'ref', 'const ref = useRef(0);', 'props.other', 'ref.current', RENDER_REF_READ],
+		[
+			'state getters',
+			'getN',
+			'const [, , getN] = useState(0);',
+			'() => 1',
+			'getN()',
+			RENDER_STATE_GETTER_CALL,
+		],
+		[
+			'state setters',
+			'setN',
+			'const [n, setN] = useState(0);',
+			'() => {}',
+			'setN(n + 1)',
+			RENDER_STATE_UPDATE,
+		],
+		[
+			'state arrays',
+			'items',
+			'const [items] = useState([1]);',
+			'[2]',
+			'items.push(3)',
+			RENDER_SNAPSHOT_MUTATION,
+		],
+	])(
+		'keeps %s from one arm visible in a sibling arm',
+		(_shape, name, declaration, other, read, code) => {
+			const source = `"use strong";
+import { useRef, useState } from 'octane';
+export function App(props) @{
+  ${declaration}
+  @switch (props.kind) {
+    @case 'other': {
+      const ${name} = ${other};
+      <p>{String(${name})}</p>
+    }
+    @default: { <p>{String(${read})}</p> }
+  }
+}`;
+			expect(() => compile(source, '/src/App.tsrx')).toThrow(code);
+		},
+	);
+
+	it('does not treat a shadowed ref read as a render ref read', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  @switch (props.kind) {
+    @case 'other': {
+      const ref = props.other;
+      <p>{ref.current as string}</p>
+    }
+    @default: { <p /> }
+  }
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('follows an arm-local function called while rendering', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  @switch (props.kind) {
+    @case 'read': {
+      function read() { return ref.current; }
+      <p>{read() as string}</p>
+    }
+    @default: { <p /> }
+  }
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_READ);
+	});
+
+	it('keeps same-named vars in separate arms when tracing a state updater', () => {
+		const source = `"use strong";
+import { useState } from 'octane';
+export function App(props) @{
+  @switch (props.kind) {
+    @case 'update': {
+      var [n, update] = useState(0);
+      update(n + 1);
+      <p />
+    }
+    @default: {
+      var update = () => {};
+      <p />
+    }
+  }
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+});
+
 describe('Strong mode render-time mutable module state reads', () => {
 	function component(
 		render: string,
@@ -4882,6 +5032,28 @@ export function App() @{
 		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(
 			RENDER_MODULE_STATE_READ,
 		);
+	});
+
+	it('allows an instance field initializer that runs only in an event handler', () => {
+		const source = `"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function App() @{
+  class Entry { value = revision; }
+  <button onClick={() => { const entry = new Entry(); advance(); return entry.value; }} />
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('checks static field initializers when the class is defined during render', () => {
+		const source = `"use strong";
+let revision = 0;
+function advance() { revision++; }
+export function App() @{
+  class Entry { static value = revision; }
+  <p>{Entry.value as string}</p>
+}`;
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_MODULE_STATE_READ);
 	});
 
 	it.each([


### PR DESCRIPTION
## Summary

- Analyze each `@switch` arm in its own function scope, with the case tests in their enclosing scope. This fixes false module/ref diagnostics and missed ref, state getter, setter, and snapshot diagnostics.
- Keep `var` reassignment proofs separate across sibling arms, and classify non-static class field initializers as deferred while preserving checks on static fields and computed keys.

## Why

Addresses the checked Strong mode work in point 2 of #1037. The phase analyzer previously descended into switch arms without creating their scopes, even though the locality walker and emitted arm callbacks already gave each arm its own lifetime.

## Changes

- Add a dedicated `JSXSwitchExpression` visitor and arm-local hoisted-variable scopes.
- Match those scopes in the reassignment pass used by Strong diagnostics.
- Add regressions for arm shadowing, sibling isolation, arm-local functions, class field timing, and unchanged client/server output.
- Add an `octane` patch changeset.

## Validation

- [ ] `pnpm format:check` (scoped check below passed)
- [ ] `pnpm typecheck` (scoped check below passed)
- [ ] `pnpm test` (attempted; unrelated local browser projects failed, so the run was stopped)
- [x] targeted tests: `pnpm exec vitest run --project octane --project octane-prod` (991 files, 17,787 passed, 14 expected failures on the rebased head)
- [x] `pnpm typecheck:files packages/octane/src/compiler/strong-mode.js packages/octane/src/compiler/hook-deps.js packages/octane/tests/compiler/strong-mode.test.ts`
- [x] `pnpm format:files:check packages/octane/src/compiler/strong-mode.js packages/octane/src/compiler/hook-deps.js packages/octane/tests/compiler/strong-mode.test.ts .changeset/strong-switch-arm-scopes.md`
- [x] `pnpm sync` (clean)

## Risk / follow-ups

- This runs only during opt-in Strong compilation. Valid client and server output was byte-identical in the regressions; the existing compiler-throughput benchmark does not enable Strong mode, so it would not measure this analyzer path.
- Object-literal getter/method invocation tracing mentioned as a lower-priority gap in #1037 needs separate property/call-site analysis. Instance fields instantiated synchronously during render also need constructor-aware tracing; this change follows the issue's requested deferred-field treatment.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791658519&installation_model_id=432790&pr_number=1040&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1040&signature=cb9c607e9a3ada2a1d1ff594d8e090f00c7970ecf61edef8aebfafe02fa0f343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes opt-in Strong-mode static analysis and hook binding walks only; emitted code is unchanged in tests, but new per-arm scopes could surface or clear diagnostics in edge cases around template switches and in-render classes.
> 
> **Overview**
> **Strong mode now analyzes each `@switch` arm in its own lexical scope**, matching how the compiler already emits separate arm callbacks. Case discriminants and tests stay in the parent scope; arm bodies get per-arm function scopes in both the render-phase analyzer (`strong-mode.js`) and the reassignment/binding walk used for diagnostics (`hook-deps.js`).
> 
> That fixes **false positives** (e.g. arm-local `const` shadowing module `revision`) and **false negatives** (refs, state getters/setters, and snapshot mutations declared in one arm no longer leak to siblings). Case labels are checked **before** entering the arm scope so reads like `@case revision` still flag module-state use during render.
> 
> **Instance (non-static) class field initializers** are visited in the **`deferred`** execution phase when a class is defined during render, so initializer reads are not treated as synchronous render work; **static** fields and methods keep the prior timing (static initializers still run at class definition time).
> 
> Regression tests cover arm shadowing, sibling isolation, arm-local functions, unchanged client/server codegen under Strong vs ordinary compile, and class field timing. Includes an `octane` patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d797447c3fab99a1f4c0ed2245a8ad9e108e3c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->