### PR TITLE
perf: bring native hover allocations close to Solid

### DIFF
--- a/.changeset/native-host-bindings.md
+++ b/.changeset/native-host-bindings.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Add opt-in `universalHostBinding` for local direct native roots. A subscribed source can update selected host properties in one accepted batch without rebuilding the component tree on each change.

--- a/.changeset/release-native-effect-history.md
+++ b/.changeset/release-native-effect-history.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Release earlier effect hooks after accepted universal renderer updates. Repeated native renders with unchanged effect dependencies no longer retain the callback history until unmount.

--- a/benchmarks/universal-native-hover/README.md
+++ b/benchmarks/universal-native-hover/README.md
@@ -83,7 +83,7 @@ OCTANE_NATIVE_DIST="$OCTANE_ROOT/packages/octane/dist/universal-native.js" \
 ```
 
 On Hermes 1.0.0 (HBC 98, Hades), the patched 2,000-hover run allocated
-11,564,392 bytes for Octane and 5,823,776 bytes for Solid 2.0.0-rc.6. Mounted
+9,182,120 bytes for Octane and 5,823,776 bytes for Solid 2.0.0-rc.6. Mounted
 live JS after GC was about 0.94 MB versus 0.37 MB; both ended with an 8 MiB
 heap capacity, and Octane collected 7 times versus Solid's 6. Both produced
 101 hosts, 3,999 property changes, 2,000 events, 80 view effect creations and

--- a/benchmarks/universal-native-hover/README.md
+++ b/benchmarks/universal-native-hover/README.md
@@ -7,6 +7,12 @@ public `octane/universal/native` renderer and uses the public object host driver
 An 80-row variant checks the cost of increasing the same component depth and
 number of hosts fourfold.
 
+The reporter's [Hermes reproduction](https://github.com/Josema/octane-and-solid-core-memory-reproduction)
+uses hand-authored universal plans and an empty-dependency effect in each view.
+Use that harness when investigating the issue's cumulative allocation, mounted
+heap, and garbage collection; this compiled Node suite exercises a different
+render path and has no view effects.
+
 Each sample keeps the tree mounted, dispatches 2,000 native host events, and
 flushes the resulting state update. The harness verifies the original 101 or
 401 host identities, four view layers per row, correct selected props, exactly

--- a/benchmarks/universal-native-hover/README.md
+++ b/benchmarks/universal-native-hover/README.md
@@ -13,6 +13,86 @@ Use that harness when investigating the issue's cumulative allocation, mounted
 heap, and garbage collection; this compiled Node suite exercises a different
 render path and has no view effects.
 
+## Opt-in native host bindings
+
+Updating a selection through `useState` in the root component still rerenders
+that component and its descendants. For an external `{ get, subscribe }` source,
+`universalHostBinding` connects its selected value directly to an ordinary host
+property on a local direct universal root. One source notification can update
+multiple bound hosts in one accepted driver batch. An aborted prepare leaves
+the accepted source connected; accepting a replacement or unmounting releases
+the previous subscriptions.
+
+```ts
+import {
+  createObjectContainer,
+  createObjectDriver,
+  createUniversalRoot,
+  defineUniversalComponent,
+  flushUniversalSync,
+  universalHostBinding,
+  universalPlan,
+  universalValue,
+} from 'octane/universal/native';
+import { createScope } from 'octane/signals';
+
+const scope = createScope({ scopeKey: 'native-hover' });
+const selected$ = scope.signal$('selected', 0);
+const row = universalPlan('object', {
+  kind: 'host', type: 'row', bindings: [['active', 0]],
+});
+const Rows = defineUniversalComponent('object', () =>
+  [0, 1].map((id) =>
+    universalValue(row, [universalHostBinding(selected$, (current) => current === id)], id),
+  ),
+);
+const container = createObjectContainer();
+const root = createUniversalRoot(container, createObjectDriver());
+root.render(Rows, undefined);
+flushUniversalSync(() => selected$.set(1));
+console.log(container.children.map((child) => child.props.active)); // [false, true]
+root.unmount();
+scope.dispose();
+```
+
+This opt-in route currently requires a local direct driver and properties that
+can be updated in place. Binding descriptors in a specialized compact
+`universalFor` leaf plan are rejected; use ordinary host values when building
+an ownerless list. The benchmark below exercises root `useState` and does not
+measure this binding route. Measure cumulative allocation with the reporter's
+Hermes harness before comparing the two approaches.
+
+The committed [reporter patch](./reporter-host-binding.patch) changes only the
+Octane side of the reporter's reproduction and adds a local build alias to its
+runner. From this worktree, the following commands reproduce that comparison
+with the reporter's bundled macOS Hermes binary. The package symlink supplies
+metadata for the runner; esbuild uses the built local Octane files selected by
+`OCTANE_NATIVE_DIST`.
+
+```bash
+OCTANE_ROOT="$(pwd)"
+REPRO_DIR=/private/tmp/octane-1007-reporter
+git clone https://github.com/Josema/octane-and-solid-core-memory-reproduction "$REPRO_DIR"
+git -C "$REPRO_DIR" checkout c9fda17b6f50798475b358149875962707d1d7f9
+patch -p1 -d "$REPRO_DIR" < "$OCTANE_ROOT/benchmarks/universal-native-hover/reporter-host-binding.patch"
+(cd "$REPRO_DIR" && npm pkg delete dependencies.octane && npm install --no-save --package-lock=false)
+ln -s "$OCTANE_ROOT/packages/octane" "$REPRO_DIR/node_modules/octane"
+node packages/octane/scripts/build.mjs
+OCTANE_NATIVE_DIST="$OCTANE_ROOT/packages/octane/dist/universal-native.js" \
+  OCTANE_RAW_RESULTS=1 node "$REPRO_DIR/run.mjs"
+```
+
+On Hermes 1.0.0 (HBC 98, Hades), the patched 2,000-hover run allocated
+11,564,392 bytes for Octane and 5,823,776 bytes for Solid 2.0.0-rc.6. Mounted
+live JS after GC was about 0.94 MB versus 0.37 MB; both ended with an 8 MiB
+heap capacity, and Octane collected 7 times versus Solid's 6. Both produced
+101 hosts, 3,999 property changes, 2,000 events, 80 view effect creations and
+cleanups, and zero hosts after unmount. The reporter's original root `useState`
+implementation still reconstructs the whole hand-authored tree on each hover;
+the opt-in binding keeps its App, Row, and View render counts at 1, 20, and 80.
+
+## Compiled Node workload
+
 Each sample keeps the tree mounted, dispatches 2,000 native host events, and
 flushes the resulting state update. The harness verifies the original 101 or
 401 host identities, four view layers per row, correct selected props, exactly

--- a/benchmarks/universal-native-hover/reporter-host-binding.patch
+++ b/benchmarks/universal-native-hover/reporter-host-binding.patch
@@ -1,0 +1,42 @@
+--- a/octane.js
++++ b/octane.js
+@@ -8 +8 @@
+-  useState,
++  universalHostBinding,
+@@ -11,0 +12 @@
++import { createScope } from 'octane/signals';
+@@ -78,0 +80,2 @@
++  const scope = createScope({ scopeKey: 'native-hover-test' });
++  const selected$ = scope.signal$('selected', -1);
+@@ -119 +121,0 @@
+-    const [activeRow, setActiveRow] = useState(-1);
+@@ -125 +127 @@
+-        active: index === activeRow,
++        active: universalHostBinding(selected$, value => value === index),
+@@ -128 +130 @@
+-          setActiveRow(index);
++          selected$.set(index);
+@@ -147,0 +150 @@
++      scope.dispose();
+--- a/run.mjs
++++ b/run.mjs
+@@ -179,0 +180 @@
++  const nativeDist = process.env.OCTANE_NATIVE_DIST && path.resolve(process.env.OCTANE_NATIVE_DIST);
+@@ -190 +191,6 @@
+-      { name: 'octane', label: 'Octane', version: octaneVersion, variant: `published-${octaneVersion}` },
++      {
++        name: 'octane',
++        label: nativeDist === undefined ? 'Octane' : 'Octane local',
++        version: octaneVersion,
++        variant: nativeDist === undefined ? `published-${octaneVersion}` : `local-dist-${octaneVersion}`,
++      },
+@@ -194 +200,6 @@
+-      'octane/universal/native': path.join(octaneDirectory, 'universal-native.js'),
++      'octane/universal/native': nativeDist ?? path.join(octaneDirectory, 'universal-native.js'),
++      ...(nativeDist === undefined ? {} : {
++        'octane/signals': path.resolve(
++          process.env.OCTANE_SIGNALS_DIST ?? path.join(path.dirname(nativeDist), 'signals/index.js'),
++        ),
++      }),
+@@ -232,0 +244 @@
++  if (process.env.OCTANE_RAW_RESULTS === '1') console.log(`RAW_RESULT ${JSON.stringify(stats)}`);

--- a/docs/universal-renderer-architecture.md
+++ b/docs/universal-renderer-architecture.md
@@ -942,6 +942,19 @@ host scheduler boundary. The Three package composes that drain with Octane's
 DOM `flushSync`/`act`, so direct Three roots and DOM-owned `Canvas` boundaries
 settle under one public scheduling call without making DOM scheduling part of
 the universal ABI.
+
+For fine-grained native host updates, `universalHostBinding(source, select)`
+accepts a source with `get()` and `subscribe(notify)` methods as an ordinary host
+property value. A scoped `signal$` from `octane/signals` is one such source.
+The root shares one subscription per source, reads a notified source once for
+its bound hosts, and publishes changed selected properties in an accepted host batch. This
+updates the host without rerunning the component or its effects; a later
+component render reads the latest source value. Bindings are released when
+their host is replaced, hidden, or unmounted. They are opt-in for local direct
+roots and host properties the driver can update in place. Transported roots,
+DOM-owned bridges, event props, and specialized compact `universalFor` leaf
+descriptors do not support this path.
+
 Transition/deferred/action/form compatibility APIs currently execute without a
 separate lane scheduler, and `memo` does not yet provide a render bailout;
 those timing/optimization gaps do not weaken transactional ownership.

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -35,6 +35,38 @@ const UNIVERSAL_CHILDREN = Symbol.for('octane.universal.children');
 const UNIVERSAL_IF = Symbol.for('octane.universal.if');
 const UNIVERSAL_SWITCH = Symbol.for('octane.universal.switch');
 const UNIVERSAL_FOR = Symbol.for('octane.universal.for');
+const UNIVERSAL_HOST_BINDING = Symbol('octane.universal.host-binding');
+
+export interface UniversalHostBinding<T> {
+	readonly $$kind: typeof UNIVERSAL_HOST_BINDING;
+	readonly source: {
+		get(): unknown;
+		subscribe(notify: () => void): () => void;
+	};
+	readonly select: (value: unknown) => T;
+	readonly getSnapshot: () => T;
+}
+
+/** Exploratory local-host binding; this is not a general component subscription. */
+export function universalHostBinding<T, U>(
+	source: { get(): T; subscribe(notify: () => void): () => void },
+	select: (value: T) => U,
+): UniversalHostBinding<U> {
+	return {
+		$$kind: UNIVERSAL_HOST_BINDING,
+		source,
+		select: select as (value: unknown) => U,
+		getSnapshot: () => select(source.get()),
+	};
+}
+
+function isUniversalHostBinding(value: unknown): value is UniversalHostBinding<unknown> {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		(value as UniversalHostBinding<unknown>).$$kind === UNIVERSAL_HOST_BINDING
+	);
+}
 const UNIVERSAL_TRY = Symbol.for('octane.universal.try');
 const UNIVERSAL_CONTEXT = Symbol.for('octane.universal.context');
 const UNIVERSAL_ACTIVITY = Symbol.for('octane.universal.activity');
@@ -864,6 +896,7 @@ interface BlueprintHost {
 	key: UniversalKey | null;
 	type: string;
 	props: Record<string, unknown>;
+	hostBindings?: Map<string, UniversalHostBinding<unknown>>;
 	ref: unknown;
 	owner: UniversalOwnerRecord;
 	events: Map<string, BlueprintEvent>;
@@ -1173,6 +1206,7 @@ const UNIVERSAL_TREE_LIFECYCLE = 1 << 3;
 const UNIVERSAL_TREE_LOCAL_CALLBACK = 1 << 4;
 const UNIVERSAL_TREE_REF = 1 << 5;
 const UNIVERSAL_TREE_HIDDEN = 1 << 6;
+const UNIVERSAL_TREE_HOST_BINDING = 1 << 7;
 
 interface DraftOwner {
 	record: UniversalOwnerRecord;
@@ -2950,9 +2984,21 @@ function materializeOwnerlessLeafValue(
 	let events: Map<string, BlueprintEvent> | null = null;
 	let lifecycles: Map<string, BlueprintHostCallback> | null = null;
 	let localCallbacks: Map<string, BlueprintHostCallback> | null = null;
+	let hostBindings: Map<string, UniversalHostBinding<unknown>> | null = null;
 	const attempt = currentAttempt();
 	for (const name of Object.keys(props)) {
 		const handler = props[name];
+		if (isUniversalHostBinding(handler)) {
+			if (attempt.root.hasHostBindingUnsupportedConfiguration() || name.startsWith('on')) {
+				throw new Error(
+					'Experimental host bindings require an ordinary prop on a local direct root.',
+				);
+			}
+			markUniversalTreeFeature(UNIVERSAL_TREE_HOST_BINDING);
+			(hostBindings ??= new Map()).set(name, handler);
+			props[name] = attempt.root.encodeHostProp(node.type, name, handler.getSnapshot());
+			continue;
+		}
 		if (compilerLeafProps) {
 			if (isRendererRegion(handler)) markUniversalTreeFeature(UNIVERSAL_TREE_REGION);
 			props[name] = attempt.root.encodeHostProp(node.type, name, handler);
@@ -3029,6 +3075,7 @@ function materializeOwnerlessLeafValue(
 		key: null,
 		type: node.type,
 		props,
+		...(hostBindings === null ? null : { hostBindings }),
 		ref: null,
 		owner: owner.record,
 		events: events ?? EMPTY_BLUEPRINT_EVENTS,
@@ -3300,6 +3347,11 @@ function materializeValue(
 				const host = compactHost!;
 				if (itemIndex === 0 && host.props !== undefined) {
 					for (const name of Object.keys(host.props)) {
+						if (isUniversalHostBinding(host.props[name])) {
+							throw new Error(
+								'Experimental host bindings cannot be used in compact universal leaf lists.',
+							);
+						}
 						if (isRendererRegion(host.props[name])) {
 							markUniversalTreeFeature(UNIVERSAL_TREE_REGION);
 						}
@@ -3309,6 +3361,11 @@ function materializeValue(
 				if (bindings !== undefined) {
 					for (let bindingIndex = 0; bindingIndex < bindings.length; bindingIndex++) {
 						const binding = values[bindings[bindingIndex][1]];
+						if (isUniversalHostBinding(binding)) {
+							throw new Error(
+								'Experimental host bindings cannot be used in compact universal leaf lists.',
+							);
+						}
 						if (typeof binding === 'object' && binding !== null && isRendererRegion(binding)) {
 							markUniversalTreeFeature(UNIVERSAL_TREE_REGION);
 						}
@@ -3806,6 +3863,13 @@ function materializeNode(
 		propsValue = normalizePropsValue(values[node.propsSlot] as any);
 		Object.assign(props, propsValue.props);
 	}
+	if (
+		isUniversalHostBinding(props.ref) ||
+		isUniversalHostBinding(props.key) ||
+		isUniversalHostBinding(props.children)
+	) {
+		throw new Error('Experimental host bindings require an ordinary host property.');
+	}
 	const hasKey = staticProps === null && (propsValue?.hasKey || hasOwnProp.call(props, 'key'));
 	const hostKey = normalizeUniversalKey(
 		propsValue?.hasKey ? propsValue.key : hasKey ? props.key : null,
@@ -3821,8 +3885,20 @@ function materializeNode(
 	let events: Map<string, BlueprintEvent> | null = null;
 	let lifecycles: Map<string, BlueprintHostCallback> | null = null;
 	let localCallbacks: Map<string, BlueprintHostCallback> | null = null;
+	let hostBindings: Map<string, UniversalHostBinding<unknown>> | null = null;
 	for (const name of staticProps === null ? Object.keys(props) : EMPTY_STATIC_PROP_NAMES) {
 		const handler = props[name];
+		if (isUniversalHostBinding(handler)) {
+			if (root.hasHostBindingUnsupportedConfiguration() || name.startsWith('on')) {
+				throw new Error(
+					'Experimental host bindings require an ordinary prop on a local direct root.',
+				);
+			}
+			markUniversalTreeFeature(UNIVERSAL_TREE_HOST_BINDING);
+			(hostBindings ??= new Map()).set(name, handler);
+			props[name] = root.encodeHostProp(node.type, name, handler.getSnapshot());
+			continue;
+		}
 		const lifecycle = root.classifyLifecycle(name, handler);
 		if (lifecycle !== null) {
 			delete props[name];
@@ -3906,6 +3982,7 @@ function materializeNode(
 			key: hostKey,
 			type: node.type,
 			props,
+			...(hostBindings === null ? null : { hostBindings }),
 			ref,
 			owner: CURRENT_OWNER!.record,
 			events: events ?? EMPTY_BLUEPRINT_EVENTS,
@@ -4006,6 +4083,7 @@ function materializeCollapsedTemplate(value: UniversalPlanValue): BlueprintHost 
 		for (const name of Object.keys(props)) {
 			const current = props[name];
 			if (
+				isUniversalHostBinding(current) ||
 				root.classifyLifecycle(name, current) !== null ||
 				root.classifyLocalCallback(name, current) !== null ||
 				isRendererRegion(current)
@@ -4085,6 +4163,7 @@ function prepareCollapsedTemplateValues(
 	for (let index = 0; index < prepared.values.length; index++) {
 		const binding = prepared.values[index];
 		const source = value.values[binding.slot];
+		if (isUniversalHostBinding(source)) return null;
 		if (binding.text) {
 			if (typeof source !== 'string' && typeof source !== 'number' && typeof source !== 'bigint') {
 				return null;
@@ -7074,6 +7153,22 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		PreparedCollapsedTemplateProgram | null
 	> | null = null;
 	private localCallbacks = new Map<number, CommittedHostCallback>();
+	private boundHosts: Map<
+		LogicalRecord,
+		{ name: string; binding: UniversalHostBinding<unknown> }[]
+	> | null = null;
+	private readonly boundSources = new Map<
+		UniversalHostBinding<unknown>['source'],
+		{
+			records: LogicalRecord[];
+			unsubscribe: () => void;
+		}
+	>();
+	private dirtyBoundHosts: LogicalRecord[] = [];
+	private readonly dirtyBoundHostSet = new Set<LogicalRecord>();
+	private dirtyBoundSources: UniversalHostBinding<unknown>['source'][] = [];
+	private readonly dirtyBoundSourceSet = new Set<UniversalHostBinding<unknown>['source']>();
+	private boundHostScheduled = false;
 	private readonly publishedListeners = new Set<number>();
 	private pending: UniversalTransactionImpl<Container, PublicInstance> | null = null;
 	private suspended: UniversalSuspendedAttemptImpl | null = null;
@@ -7378,6 +7473,260 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 
 	private hasAsyncTransport(): boolean {
 		return this.transport?.mode === 'async';
+	}
+
+	hasHostBindingUnsupportedConfiguration(): boolean {
+		return this.transport !== null || this.bridge !== null;
+	}
+
+	private dropHostBindings(record: LogicalRecord): unknown {
+		const attached = this.boundHosts?.get(record);
+		if (attached === undefined) return NO_PENDING_PASSIVE_ERROR;
+		this.boundHosts!.delete(record);
+		this.dirtyBoundHostSet.delete(record);
+		const dirtyIndex = this.dirtyBoundHosts.indexOf(record);
+		if (dirtyIndex !== -1) this.dirtyBoundHosts.splice(dirtyIndex, 1);
+		let unsubscribeError: unknown = NO_PENDING_PASSIVE_ERROR;
+		for (let index = 0; index < attached.length; index++) {
+			const source = attached[index].binding.source;
+			const group = this.boundSources.get(source);
+			if (group === undefined) continue;
+			const position = group.records.indexOf(record);
+			if (position >= 0) group.records.splice(position, 1);
+			if (group.records.length === 0) {
+				this.boundSources.delete(source);
+				try {
+					group.unsubscribe();
+				} catch (error) {
+					if (unsubscribeError === NO_PENDING_PASSIVE_ERROR) unsubscribeError = error;
+				}
+			}
+		}
+		return unsubscribeError;
+	}
+
+	private commitHostBindings(record: LogicalRecord, next: BlueprintHost): unknown {
+		const bindings = next.hostBindings;
+		if (bindings === undefined || next.visibility !== 'visible') {
+			return this.dropHostBindings(record);
+		}
+		const previous = this.boundHosts?.get(record);
+		if (previous !== undefined && previous.length === bindings.size) {
+			let unchanged = true;
+			let index = 0;
+			for (const [name, binding] of bindings) {
+				const current = previous[index++];
+				if (current.name !== name || current.binding !== binding) {
+					unchanged = false;
+					break;
+				}
+			}
+			if (unchanged) return NO_PENDING_PASSIVE_ERROR;
+		}
+		const unsubscribeError = this.dropHostBindings(record);
+		const connected: { name: string; binding: UniversalHostBinding<unknown> }[] = [];
+		(this.boundHosts ??= new Map()).set(record, connected);
+		try {
+			for (const [name, binding] of bindings) {
+				connected.push({ name, binding });
+				let group = this.boundSources.get(binding.source);
+				if (group === undefined) {
+					group = { records: [], unsubscribe: () => {} };
+					this.boundSources.set(binding.source, group);
+					group.records.push(record);
+					try {
+						group.unsubscribe = binding.source.subscribe(() =>
+							this.queueHostBindingSource(binding.source),
+						);
+					} catch (error) {
+						this.boundSources.delete(binding.source);
+						throw error;
+					}
+				} else if (!group.records.includes(record)) group.records.push(record);
+				const value = this.encodeHostProp(next.type, name, binding.getSnapshot());
+				if (!sameUniversalHostPropValue(record.props[name], value)) {
+					this.queueHostBindingUpdate(record);
+				}
+			}
+		} catch (error) {
+			this.dropHostBindings(record);
+			throw error;
+		}
+		return unsubscribeError;
+	}
+
+	private queueHostBindingUpdate(record: LogicalRecord): void {
+		if (this.unmounted || this.unmounting || !this.boundHosts?.has(record)) return;
+		if (!this.dirtyBoundHostSet.has(record)) {
+			this.dirtyBoundHostSet.add(record);
+			this.dirtyBoundHosts.push(record);
+		}
+		this.scheduleHostBindingUpdate();
+	}
+
+	private queueHostBindingSource(source: UniversalHostBinding<unknown>['source']): void {
+		if (this.unmounted || this.unmounting || !this.boundSources.has(source)) return;
+		if (!this.dirtyBoundSourceSet.has(source)) {
+			this.dirtyBoundSourceSet.add(source);
+			this.dirtyBoundSources.push(source);
+		}
+		this.scheduleHostBindingUpdate();
+	}
+
+	private scheduleHostBindingUpdate(): void {
+		SCHEDULED_UNIVERSAL_ROOTS.add(this);
+		if (this.boundHostScheduled) return;
+		this.boundHostScheduled = true;
+		this.__scheduleMicrotask(() => {
+			if (this.boundHostScheduled) this.flushHostBindingUpdates();
+		});
+	}
+
+	private restoreDirtyHostBindings(records: readonly LogicalRecord[]): void {
+		this.boundHostScheduled = false;
+		if (!this.scheduled) SCHEDULED_UNIVERSAL_ROOTS.delete(this);
+		for (let index = 0; index < records.length; index++) {
+			const record = records[index];
+			if (this.boundHosts?.has(record) && !this.dirtyBoundHostSet.has(record)) {
+				this.dirtyBoundHostSet.add(record);
+				this.dirtyBoundHosts.push(record);
+			}
+		}
+	}
+
+	private flushHostBindingUpdates(): void {
+		if (
+			(this.dirtyBoundHosts.length === 0 && this.dirtyBoundSources.length === 0) ||
+			this.unmounted ||
+			this.unmounting
+		) {
+			this.boundHostScheduled = false;
+			if (!this.scheduled) SCHEDULED_UNIVERSAL_ROOTS.delete(this);
+			return;
+		}
+		if (this.pending !== null || this.scheduled) {
+			// The queued microtask has been consumed; the pending transaction or
+			// scheduled render will arrange the next drain once it settles.
+			this.boundHostScheduled = false;
+			return;
+		}
+		this.boundHostScheduled = false;
+		SCHEDULED_UNIVERSAL_ROOTS.delete(this);
+		let records = this.dirtyBoundHosts;
+		const sources = this.dirtyBoundSources;
+		this.dirtyBoundHosts = [];
+		this.dirtyBoundHostSet.clear();
+		this.dirtyBoundSources = [];
+		this.dirtyBoundSourceSet.clear();
+		if (sources.length === 1 && records.length === 0) {
+			records = this.boundSources.get(sources[0])?.records.slice() ?? [];
+		} else if (sources.length !== 0) {
+			const seen = new Set(records);
+			for (let index = 0; index < sources.length; index++) {
+				const group = this.boundSources.get(sources[index]);
+				if (group === undefined) continue;
+				for (let recordIndex = 0; recordIndex < group.records.length; recordIndex++) {
+					const record = group.records[recordIndex];
+					if (!seen.has(record)) {
+						seen.add(record);
+						records.push(record);
+					}
+				}
+			}
+		}
+		const updates: { record: LogicalRecord; props: Record<string, unknown> }[] = [];
+		const commands: UniversalHostCommand[] = [];
+		const soleSource = sources.length === 1 ? sources[0] : null;
+		let soleSourceRead = false;
+		let soleSourceSnapshot: unknown;
+		const otherSourceSnapshots =
+			sources.length > 1 ? new Map<UniversalHostBinding<unknown>['source'], unknown>() : null;
+		try {
+			for (let recordIndex = 0; recordIndex < records.length; recordIndex++) {
+				const record = records[recordIndex];
+				const connected = this.boundHosts?.get(record);
+				if (connected === undefined || record.visibility !== 'visible') continue;
+				let next: Record<string, unknown> | null = null;
+				for (let bindingIndex = 0; bindingIndex < connected.length; bindingIndex++) {
+					const { name, binding } = connected[bindingIndex];
+					let raw: unknown;
+					if (binding.source === soleSource) {
+						if (!soleSourceRead) {
+							soleSourceSnapshot = binding.source.get();
+							soleSourceRead = true;
+						}
+						raw = soleSourceSnapshot;
+					} else if (otherSourceSnapshots !== null && sources.includes(binding.source)) {
+						if (!otherSourceSnapshots.has(binding.source)) {
+							otherSourceSnapshots.set(binding.source, binding.source.get());
+						}
+						raw = otherSourceSnapshots.get(binding.source);
+					} else {
+						raw = binding.source.get();
+					}
+					const selected = binding.select(raw);
+					const current = (next ?? record.props)[name];
+					if (this.driver.props === undefined && sameUniversalHostPropValue(current, selected))
+						continue;
+					const value = this.encodeHostProp(record.type!, name, selected);
+					if (sameUniversalHostPropValue(current, value)) continue;
+					(next ??= { ...record.props })[name] = value;
+				}
+				if (next === null) continue;
+				const kind = this.driver.updates?.classify(record.type!, record.props, next) ?? 'update';
+				if (kind !== 'update' || record.lifecycles.size !== 0) {
+					throw new Error(
+						'Experimental host bindings require update-only hosts without lifecycle callbacks.',
+					);
+				}
+				Object.freeze(next);
+				updates.push({ record, props: next });
+				commands.push({ op: 'update', id: record.id, props: next });
+			}
+		} catch (error) {
+			this.restoreDirtyHostBindings(records);
+			throw error;
+		}
+		if (commands.length === 0) return;
+		const batch = freezeUniversalHostBatch(this.renderer, this.nextBatchVersion++, commands);
+		let prepared: UniversalPreparedHostBatch;
+		try {
+			prepared = this.driver.prepareBatch(this.container, batch, {
+				invokeLocalCallback: (listener, args) => this.invokeLocalCallback(listener, args),
+			});
+		} catch (error) {
+			this.restoreDirtyHostBindings(records);
+			throw error;
+		}
+		if (!isValidPreparedHostBatch(prepared)) {
+			this.restoreDirtyHostBindings(records);
+			throw new TypeError('Invalid host binding batch token.');
+		}
+		const transaction = new UniversalTransactionImpl(
+			this,
+			batch,
+			() => prepared.apply(),
+			null,
+			this.transportIdentity(batch.version),
+			() => {
+				for (let index = 0; index < updates.length; index++) {
+					updates[index].record.props = updates[index].props;
+				}
+			},
+			() => prepared.afterAccept?.(),
+			noopUniversalCommitTask,
+			noopUniversalCommitTask,
+			noopUniversalCommitTask,
+			null,
+			() => prepared.abort(),
+			() => {
+				for (let index = 0; index < records.length; index++)
+					this.queueHostBindingUpdate(records[index]);
+			},
+			EMPTY_UNIVERSAL_TRANSITION_BATCHES,
+		);
+		this.pending = transaction;
+		transaction.commit();
 	}
 
 	private enqueueAsyncWork(work: () => Promise<void>): void {
@@ -8123,14 +8472,20 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 	}
 
 	flushScheduledWork(): void {
-		if (!this.scheduled) return;
+		if (!this.scheduled) {
+			this.flushHostBindingUpdates();
+			return;
+		}
 		// A transported teardown is provisional until acknowledgement. Keep work
 		// raised by the still-accepted listener table queued so rejection can resume
 		// it against the accepted tree.
 		if (this.unmounting) return;
 		this.scheduled = false;
 		SCHEDULED_UNIVERSAL_ROOTS.delete(this);
-		if (this.unmounted || this.owner?.disposed || this.lastComponent === null) return;
+		if (this.unmounted || this.owner?.disposed || this.lastComponent === null) {
+			this.flushHostBindingUpdates();
+			return;
+		}
 		if (this.bridge !== null) {
 			this.bridge.invalidate();
 		} else if (this.hasAsyncTransport()) {
@@ -8173,7 +8528,10 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			});
 		} else {
 			const input = this.scheduledRenderInput();
-			if (input === null) return;
+			if (input === null) {
+				this.flushHostBindingUpdates();
+				return;
+			}
 			let attempt: UniversalPreparedAttempt;
 			try {
 				attempt = this.__prepareScheduled(input[0], input[1]);
@@ -8182,10 +8540,27 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 				// handler it escapes into the host's microtask channel. A root created
 				// with onUncaughtError consumes its own report; the failed attempt is
 				// already discarded and recovery is unchanged.
-				if (!reportUniversalUncaughtError(this, error)) throw error;
+				try {
+					if (!reportUniversalUncaughtError(this, error)) throw error;
+				} finally {
+					// A binding notification may have deferred its own microtask while
+					// this scheduled render was active. Drain it even if rendering failed.
+					this.flushHostBindingUpdates();
+				}
 				return;
 			}
-			if (attempt.status === 'prepared') attempt.commit();
+			let commitError: unknown = NO_PENDING_PASSIVE_ERROR;
+			try {
+				if (attempt.status === 'prepared') attempt.commit();
+			} catch (error) {
+				commitError = error;
+			}
+			try {
+				this.flushHostBindingUpdates();
+			} catch (error) {
+				if (commitError === NO_PENDING_PASSIVE_ERROR) throw error;
+			}
+			if (commitError !== NO_PENDING_PASSIVE_ERROR) throw commitError;
 		}
 	}
 
@@ -9955,28 +10330,37 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		component: UniversalComponent<any>,
 		props: any,
 	): UniversalTransactionImpl<Container, PublicInstance> {
-		const compactTemplateUpdate = this.tryCreateCompactTemplateUpdateTransaction(
-			blueprint,
-			attempt,
-			component,
-			props,
-		);
-		if (compactTemplateUpdate !== null) return compactTemplateUpdate;
-		const compactLeafUpdate = this.tryCreateCompactLeafUpdateTransaction(
-			blueprint,
-			attempt,
-			component,
-			props,
-		);
-		if (compactLeafUpdate !== null) return compactLeafUpdate;
+		// Compact publications update host props without publishing host binding
+		// subscriptions. Bound trees use the general accepted transaction path.
+		const hasHostBindings =
+			(this.boundHosts?.size ?? 0) !== 0 ||
+			(attempt.treeFeatures & UNIVERSAL_TREE_HOST_BINDING) !== 0;
+		if (!hasHostBindings) {
+			const compactTemplateUpdate = this.tryCreateCompactTemplateUpdateTransaction(
+				blueprint,
+				attempt,
+				component,
+				props,
+			);
+			if (compactTemplateUpdate !== null) return compactTemplateUpdate;
+			const compactLeafUpdate = this.tryCreateCompactLeafUpdateTransaction(
+				blueprint,
+				attempt,
+				component,
+				props,
+			);
+			if (compactLeafUpdate !== null) return compactLeafUpdate;
+		}
 		this.expandCompactLeafLists(blueprint);
-		const stableLeafUpdate = this.tryCreateStableLeafUpdateTransaction(
-			blueprint,
-			attempt,
-			component,
-			props,
-		);
-		if (stableLeafUpdate !== null) return stableLeafUpdate;
+		if (!hasHostBindings) {
+			const stableLeafUpdate = this.tryCreateStableLeafUpdateTransaction(
+				blueprint,
+				attempt,
+				component,
+				props,
+			);
+			if (stableLeafUpdate !== null) return stableLeafUpdate;
+		}
 		const stagedPortalRegistrations = new Set<UniversalPortalTargetRegistration>();
 		if (((this.treeFeatures | attempt.treeFeatures) & UNIVERSAL_TREE_PORTAL) === 0) {
 			return this.createPreparedTransaction(
@@ -11793,6 +12177,23 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					deactivatedRegionCells.add(cell);
 					previous.deactivate();
 				}
+				// Publish bindings after the logical host and owner state has accepted.
+				let bindingUnsubscribeError: unknown = NO_PENDING_PASSIVE_ERROR;
+				for (const record of removedHosts) {
+					const error = this.dropHostBindings(record);
+					if (bindingUnsubscribeError === NO_PENDING_PASSIVE_ERROR) bindingUnsubscribeError = error;
+				}
+				try {
+					for (const draft of hostDrafts) {
+						const error = this.commitHostBindings(draft.record, draft.blueprint as BlueprintHost);
+						if (bindingUnsubscribeError === NO_PENDING_PASSIVE_ERROR)
+							bindingUnsubscribeError = error;
+					}
+				} catch (error) {
+					for (const draft of hostDrafts) this.dropHostBindings(draft.record);
+					throw error;
+				}
+				if (bindingUnsubscribeError !== NO_PENDING_PASSIVE_ERROR) throw bindingUnsubscribeError;
 				if (portalReleaseError !== NO_PENDING_PASSIVE_ERROR) throw portalReleaseError;
 			},
 			() => (preparedHost ?? preparedAsyncHost)?.afterAccept?.(),
@@ -11908,6 +12309,12 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			}
 			if (this.hostAttachments !== null) this.queueHostAttachmentFlush();
 			this.ensureScheduledTransitionWork();
+			if (
+				(this.dirtyBoundHosts.length !== 0 || this.dirtyBoundSources.length !== 0) &&
+				!this.boundHostScheduled
+			) {
+				this.scheduleHostBindingUpdate();
+			}
 		}
 	}
 
@@ -12164,6 +12571,19 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		return {
 			batch,
 			finalize: (acceptedHostError) => {
+				let bindingUnsubscribeError: unknown = NO_PENDING_PASSIVE_ERROR;
+				if (this.boundHosts !== null) {
+					for (const record of [...this.boundHosts.keys()]) {
+						const error = this.dropHostBindings(record);
+						if (bindingUnsubscribeError === NO_PENDING_PASSIVE_ERROR)
+							bindingUnsubscribeError = error;
+					}
+				}
+				this.dirtyBoundHosts = [];
+				this.dirtyBoundHostSet.clear();
+				this.dirtyBoundSources = [];
+				this.dirtyBoundSourceSet.clear();
+				this.boundHostScheduled = false;
 				this.scheduled = false;
 				this.scheduledUrgent = false;
 				this.scheduledFullRoot = false;
@@ -12253,6 +12673,11 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					});
 				}
 				const syncTasks = [...insertionTasks, ...layoutTasks, ...refTasks];
+				if (bindingUnsubscribeError !== NO_PENDING_PASSIVE_ERROR) {
+					syncTasks.unshift(() => {
+						throw bindingUnsubscribeError;
+					});
+				}
 				if (attachmentUnsubscribeError !== NO_PENDING_PASSIVE_ERROR) {
 					syncTasks.unshift(() => {
 						throw attachmentUnsubscribeError;

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -836,6 +836,11 @@ export interface UniversalTransaction {
 	abort(): void;
 }
 
+interface UniversalRootPendingTransaction extends UniversalTransaction {
+	readonly transitionBatches: ReadonlySet<UniversalTransitionBatch>;
+	isAwaitingTransportAcknowledgement(): boolean;
+}
+
 export interface UniversalSuspendedAttempt {
 	readonly status: 'suspended' | 'aborted';
 	readonly thenable: PromiseLike<unknown>;
@@ -7170,7 +7175,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 	private readonly dirtyBoundSourceSet = new Set<UniversalHostBinding<unknown>['source']>();
 	private boundHostScheduled = false;
 	private readonly publishedListeners = new Set<number>();
-	private pending: UniversalTransactionImpl<Container, PublicInstance> | null = null;
+	private pending: UniversalRootPendingTransaction | null = null;
 	private suspended: UniversalSuspendedAttemptImpl | null = null;
 	private urgentBoundarySuspension: UniversalSuspendedAttemptImpl | null = null;
 	private awaitingReplay: SuspendedMemoReplay | null = null;
@@ -7535,9 +7540,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					this.boundSources.set(binding.source, group);
 					group.records.push(record);
 					try {
-						group.unsubscribe = binding.source.subscribe(() =>
-							this.queueHostBindingSource(binding.source),
-						);
+						group.unsubscribe = this.subscribeHostBindingSource(binding.source);
 					} catch (error) {
 						this.boundSources.delete(binding.source);
 						throw error;
@@ -7553,6 +7556,12 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			throw error;
 		}
 		return unsubscribeError;
+	}
+
+	private subscribeHostBindingSource(source: UniversalHostBinding<unknown>['source']): () => void {
+		// The listener survives individual bound hosts. Do not close over the
+		// first host's binding, which can retain its removed selector and payload.
+		return source.subscribe(() => this.queueHostBindingSource(source));
 	}
 
 	private queueHostBindingUpdate(record: LogicalRecord): void {
@@ -7594,6 +7603,11 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		}
 	}
 
+	/** @internal Restore a binding-only batch abandoned before host acceptance. */
+	restoreAbortedHostBindingRecords(records: readonly LogicalRecord[]): void {
+		this.restoreDirtyHostBindings(records);
+	}
+
 	private flushHostBindingUpdates(): void {
 		if (
 			(this.dirtyBoundHosts.length === 0 && this.dirtyBoundSources.length === 0) ||
@@ -7608,6 +7622,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			// The queued microtask has been consumed; the pending transaction or
 			// scheduled render will arrange the next drain once it settles.
 			this.boundHostScheduled = false;
+			if (!this.scheduled) SCHEDULED_UNIVERSAL_ROOTS.delete(this);
 			return;
 		}
 		this.boundHostScheduled = false;
@@ -7634,7 +7649,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 				}
 			}
 		}
-		const updates: { record: LogicalRecord; props: Record<string, unknown> }[] = [];
+		const changedRecords: LogicalRecord[] = [];
 		const commands: UniversalHostCommand[] = [];
 		const soleSource = sources.length === 1 ? sources[0] : null;
 		let soleSourceRead = false;
@@ -7680,7 +7695,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					);
 				}
 				Object.freeze(next);
-				updates.push({ record, props: next });
+				changedRecords.push(record);
 				commands.push({ op: 'update', id: record.id, props: next });
 			}
 		} catch (error) {
@@ -7702,28 +7717,12 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			this.restoreDirtyHostBindings(records);
 			throw new TypeError('Invalid host binding batch token.');
 		}
-		const transaction = new UniversalTransactionImpl(
+		const transaction = new UniversalBoundHostTransaction(
 			this,
 			batch,
-			() => prepared.apply(),
-			null,
-			this.transportIdentity(batch.version),
-			() => {
-				for (let index = 0; index < updates.length; index++) {
-					updates[index].record.props = updates[index].props;
-				}
-			},
-			() => prepared.afterAccept?.(),
-			noopUniversalCommitTask,
-			noopUniversalCommitTask,
-			noopUniversalCommitTask,
-			null,
-			() => prepared.abort(),
-			() => {
-				for (let index = 0; index < records.length; index++)
-					this.queueHostBindingUpdate(records[index]);
-			},
-			EMPTY_UNIVERSAL_TRANSITION_BATCHES,
+			prepared,
+			changedRecords,
+			records,
 		);
 		this.pending = transaction;
 		transaction.commit();
@@ -8555,12 +8554,22 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			} catch (error) {
 				commitError = error;
 			}
+			let bindingError: unknown = NO_PENDING_PASSIVE_ERROR;
 			try {
 				this.flushHostBindingUpdates();
 			} catch (error) {
-				if (commitError === NO_PENDING_PASSIVE_ERROR) throw error;
+				bindingError = error;
+			}
+			if (commitError !== NO_PENDING_PASSIVE_ERROR && bindingError !== NO_PENDING_PASSIVE_ERROR) {
+				throw typeof AggregateError === 'function'
+					? new AggregateError(
+							[commitError, bindingError],
+							'Universal host commit and binding update both failed.',
+						)
+					: commitError;
 			}
 			if (commitError !== NO_PENDING_PASSIVE_ERROR) throw commitError;
+			if (bindingError !== NO_PENDING_PASSIVE_ERROR) throw bindingError;
 		}
 	}
 
@@ -12178,22 +12187,25 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					previous.deactivate();
 				}
 				// Publish bindings after the logical host and owner state has accepted.
-				let bindingUnsubscribeError: unknown = NO_PENDING_PASSIVE_ERROR;
+				let bindingPublicationError: unknown = NO_PENDING_PASSIVE_ERROR;
 				for (const record of removedHosts) {
 					const error = this.dropHostBindings(record);
-					if (bindingUnsubscribeError === NO_PENDING_PASSIVE_ERROR) bindingUnsubscribeError = error;
+					if (bindingPublicationError === NO_PENDING_PASSIVE_ERROR) bindingPublicationError = error;
 				}
-				try {
-					for (const draft of hostDrafts) {
+				for (const draft of hostDrafts) {
+					try {
 						const error = this.commitHostBindings(draft.record, draft.blueprint as BlueprintHost);
-						if (bindingUnsubscribeError === NO_PENDING_PASSIVE_ERROR)
-							bindingUnsubscribeError = error;
+						if (bindingPublicationError === NO_PENDING_PASSIVE_ERROR)
+							bindingPublicationError = error;
+					} catch (error) {
+						// Host acceptance is already final. A failed source cleans up
+						// its own record; keep other accepted hosts subscribed and
+						// continue connecting the remaining hosts.
+						if (bindingPublicationError === NO_PENDING_PASSIVE_ERROR)
+							bindingPublicationError = error;
 					}
-				} catch (error) {
-					for (const draft of hostDrafts) this.dropHostBindings(draft.record);
-					throw error;
 				}
-				if (bindingUnsubscribeError !== NO_PENDING_PASSIVE_ERROR) throw bindingUnsubscribeError;
+				if (bindingPublicationError !== NO_PENDING_PASSIVE_ERROR) throw bindingPublicationError;
 				if (portalReleaseError !== NO_PENDING_PASSIVE_ERROR) throw portalReleaseError;
 			},
 			() => (preparedHost ?? preparedAsyncHost)?.afterAccept?.(),
@@ -12299,7 +12311,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		return transaction;
 	}
 
-	finish(transaction: UniversalTransactionImpl<Container, PublicInstance>): void {
+	finish(transaction: UniversalRootPendingTransaction): void {
 		if (this.pending === transaction) {
 			this.pending = null;
 			if (transaction.status === 'committed') {
@@ -12721,6 +12733,116 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 				}
 			},
 		};
+	}
+}
+
+/** Local binding-only batches keep the same acceptance and error ordering with less per-event state. */
+class UniversalBoundHostTransaction<
+	Container,
+	PublicInstance,
+> implements UniversalRootPendingTransaction {
+	private state: 'prepared' | 'committed' | 'aborted' = 'prepared';
+	private hostAccepted = false;
+	readonly transitionBatches = EMPTY_UNIVERSAL_TRANSITION_BATCHES;
+
+	constructor(
+		private readonly root: UniversalRootImpl<Container, PublicInstance>,
+		readonly batch: UniversalHostBatch,
+		private readonly prepared: UniversalPreparedHostBatch,
+		private readonly changedRecords: readonly LogicalRecord[],
+		private readonly records: readonly LogicalRecord[],
+	) {}
+
+	get status(): 'prepared' | 'committed' | 'aborted' {
+		return this.state;
+	}
+
+	isAwaitingTransportAcknowledgement(): boolean {
+		return false;
+	}
+
+	commit(): void {
+		if (this.state !== 'prepared' || this.hostAccepted) return;
+		// Like the general transaction, an apply error is post-accept: finish
+		// version and logical publication, then report the first failure.
+		this.hostAccepted = true;
+		let failure: unknown = NO_PENDING_PASSIVE_ERROR;
+		UNIVERSAL_COMMIT_TASK_DEPTH++;
+		try {
+			try {
+				this.prepared.apply();
+			} catch (error) {
+				failure = error;
+			}
+			try {
+				this.root.markBatchAccepted(this.batch.version);
+			} catch (error) {
+				if (failure === NO_PENDING_PASSIVE_ERROR) failure = error;
+			}
+			try {
+				// Binding-only batches contain update commands in changed-record order.
+				for (let index = 0; index < this.changedRecords.length; index++) {
+					this.changedRecords[index].props = (
+						this.batch.commands[index] as Extract<UniversalHostCommand, { op: 'update' }>
+					).props;
+				}
+			} catch (error) {
+				if (failure === NO_PENDING_PASSIVE_ERROR) failure = error;
+			}
+			try {
+				this.prepared.afterAccept?.();
+			} catch (error) {
+				if (failure === NO_PENDING_PASSIVE_ERROR) failure = error;
+			}
+		} finally {
+			UNIVERSAL_COMMIT_TASK_DEPTH--;
+			this.state = 'committed';
+			try {
+				this.root.finish(this);
+			} catch (error) {
+				if (failure === NO_PENDING_PASSIVE_ERROR) failure = error;
+			}
+		}
+		if (failure !== NO_PENDING_PASSIVE_ERROR) throw failure;
+	}
+
+	commitAsync(): Promise<void> {
+		try {
+			this.commit();
+			return Promise.resolve();
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	abort(): void {
+		if (this.state !== 'prepared') return;
+		if (this.hostAccepted) {
+			throw new Error('A universal transaction cannot be aborted after its host batch committed.');
+		}
+		this.state = 'aborted';
+		let failure: unknown = NO_PENDING_PASSIVE_ERROR;
+		UNIVERSAL_COMMIT_TASK_DEPTH++;
+		try {
+			try {
+				this.prepared.abort();
+			} catch (error) {
+				failure = error;
+			}
+			try {
+				this.root.restoreAbortedHostBindingRecords(this.records);
+			} catch (error) {
+				if (failure === NO_PENDING_PASSIVE_ERROR) failure = error;
+			}
+		} finally {
+			UNIVERSAL_COMMIT_TASK_DEPTH--;
+			try {
+				this.root.finish(this);
+			} catch (error) {
+				if (failure === NO_PENDING_PASSIVE_ERROR) failure = error;
+			}
+		}
+		if (failure !== NO_PENDING_PASSIVE_ERROR) throw failure;
 	}
 }
 

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -9669,6 +9669,11 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			record.parent = draft.parent?.record ?? null;
 			record.hooks = draft.hooks;
 			record.effectOrder = [...draft.seenEffects];
+			// Stable leaf updates have already checked predecessor effects before
+			// acceptance; keep only the hooks needed for future renders.
+			for (let index = 0; index < draft.seenEffects.length; index++) {
+				draft.seenEffects[index].previous = null;
+			}
 			record.children = draft.children.map((child) => child.record);
 			record.contextValues = draft.contextValues;
 			record.isBoundary = draft.isBoundary;
@@ -11679,6 +11684,11 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					}
 					record.hooks = draft.hooks;
 					record.effectOrder = [...draft.seenEffects];
+					// Staging has already compared predecessor effects and captured any
+					// cleanups. A committed hook must not retain every prior render.
+					for (let index = 0; index < draft.seenEffects.length; index++) {
+						draft.seenEffects[index].previous = null;
+					}
 					if (draft.retainedChildren === null) {
 						record.children = draft.children.map((child) => child.record);
 					} else {

--- a/packages/octane/tests/universal-effect-retention.test.ts
+++ b/packages/octane/tests/universal-effect-retention.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { build } from 'esbuild';
+import { expect, it } from 'vitest';
+
+it('releases skipped effect callbacks while their native tree remains mounted', async () => {
+	const source = `
+import assert from 'node:assert/strict';
+import { setImmediate } from 'node:timers/promises';
+import {
+  createObjectContainer,
+  createObjectDriver,
+  createUniversalRoot,
+  defineUniversalComponent,
+  universalComponent,
+  universalPlan,
+  universalValue,
+  useEffect,
+} from 'octane/universal/native';
+
+const renderer = 'native-effect-retention';
+const plan = universalPlan(renderer, {
+  kind: 'host',
+  type: 'view',
+  bindings: [['version', 0]],
+});
+const eventPlan = universalPlan(renderer, {
+  kind: 'host',
+  type: 'view',
+  bindings: [['version', 0], ['onPress', 1]],
+});
+async function checkEffectCallbackRetention(nested) {
+  const container = createObjectContainer(renderer);
+  const root = createUniversalRoot(container, createObjectDriver(renderer));
+  let weakIntermediate;
+  let creates = 0;
+  let cleanups = 0;
+  let presses = 0;
+  const onPress = () => { presses++; };
+  const View = defineUniversalComponent(renderer, ({ version }) => {
+    const marker = { version };
+    if (version === 1) weakIntermediate = new WeakRef(marker);
+    useEffect(() => {
+      creates++;
+      return () => {
+        assert.equal(marker.version, 0);
+        cleanups++;
+      };
+    }, [], 'view-effect');
+    return nested
+      ? universalValue(eventPlan, [version, onPress])
+      : universalValue(plan, [version]);
+  });
+  const App = defineUniversalComponent(renderer, ({ version }) =>
+    universalComponent(renderer, View, { version }),
+  );
+  const entry = nested ? App : View;
+
+  root.render(entry, { version: 0 }).commitPassive();
+  const host = container.children[0];
+  assert.equal(creates, 1);
+  root.render(entry, { version: 1 }).commitPassive();
+  root.render(entry, { version: 2 }).commitPassive();
+  assert.equal(container.children[0], host);
+  assert.equal(host.props.version, 2);
+  assert.equal(creates, 1);
+  assert.equal(cleanups, 0);
+
+  // A WeakRef keeps a dereferenced target alive for the rest of its JS job.
+  // Move to another turn before collecting a callback that never ran.
+  await setImmediate();
+  for (let attempt = 0; attempt < 3; attempt++) {
+    gc();
+    await setImmediate();
+  }
+  assert.equal(weakIntermediate.deref(), undefined,
+    'an ignored effect callback from an earlier render remains reachable (' +
+    (nested ? 'nested' : 'root') + ')');
+  assert.equal(container.children[0], host);
+  assert.equal(host.props.version, 2);
+  if (nested) {
+    container.dispatchEvent(host, 'press', {});
+    assert.equal(presses, 1);
+  }
+  root.unmount();
+  root.flushPassiveTasks();
+  assert.equal(cleanups, 1);
+  assert.equal(container.children.length, 0);
+}
+
+await checkEffectCallbackRetention(false);
+await checkEffectCallbackRetention(true);
+`;
+	const result = await build({
+		stdin: {
+			contents: source,
+			resolveDir: resolve(import.meta.dirname, '..'),
+			sourcefile: 'native-effect-retention-consumer.mjs',
+		},
+		bundle: true,
+		define: { __OCTANE_PROFILE_ENABLED__: 'false' },
+		format: 'esm',
+		minify: true,
+		platform: 'node',
+		target: 'node22',
+		write: false,
+	});
+	const directory = mkdtempSync(join(tmpdir(), 'octane-native-effect-retention-'));
+	try {
+		const entry = join(directory, 'consumer.mjs');
+		writeFileSync(entry, result.outputFiles[0].text);
+		const run = spawnSync(process.execPath, ['--expose-gc', entry], {
+			encoding: 'utf8',
+			timeout: 30_000,
+		});
+		expect(run.error).toBeUndefined();
+		expect(run.status, run.stderr).toBe(0);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});

--- a/packages/octane/tests/universal-host-binding-retention.test.ts
+++ b/packages/octane/tests/universal-host-binding-retention.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { build } from 'esbuild';
+import { expect, it } from 'vitest';
+
+it('releases a removed selector while another host shares its source', async () => {
+	const source = `
+import assert from 'node:assert/strict';
+import { setImmediate } from 'node:timers/promises';
+import {
+  createObjectContainer,
+  createObjectDriver,
+  createUniversalRoot,
+  defineUniversalComponent,
+  flushUniversalSync,
+  universalHostBinding,
+  universalPlan,
+  universalValue,
+} from 'octane/universal/native';
+
+let current = 0;
+const listeners = new Set();
+const source = {
+  get() { return current; },
+  subscribe(notify) {
+    listeners.add(notify);
+    return () => listeners.delete(notify);
+  },
+  set(value) {
+    current = value;
+    for (const notify of [...listeners]) notify();
+  },
+};
+const plan = universalPlan('object', {
+  kind: 'host',
+  type: 'row',
+  bindings: [['active', 0]],
+});
+const survivingBinding = universalHostBinding(source, value => value);
+let removedSelectorCapture;
+const Scene = defineUniversalComponent('object', ({ includeFirst }) => [
+  includeFirst ? (() => {
+    const capture = { offset: 0, payload: new Uint8Array(1024 * 1024) };
+    removedSelectorCapture = new WeakRef(capture);
+    return universalValue(plan, [
+      universalHostBinding(source, value => value + capture.offset),
+    ], 'first');
+  })() : null,
+  universalValue(plan, [survivingBinding], 'second'),
+]);
+
+const container = createObjectContainer();
+const root = createUniversalRoot(container, createObjectDriver());
+root.render(Scene, { includeFirst: true });
+assert.equal(listeners.size, 1);
+const survivor = container.children[1];
+root.render(Scene, { includeFirst: false });
+assert.deepEqual(container.children, [survivor]);
+assert.equal(listeners.size, 1);
+
+// Move to another turn before collecting an object only held by a WeakRef.
+await setImmediate();
+for (let attempt = 0; attempt < 5; attempt++) {
+  gc();
+  await setImmediate();
+}
+assert.equal(removedSelectorCapture.deref() === undefined, true,
+  'a removed selector remains reachable while a shared source is subscribed');
+flushUniversalSync(() => source.set(2));
+assert.equal(survivor.props.active, 2);
+root.unmount();
+assert.equal(listeners.size, 0);
+`;
+	const result = await build({
+		stdin: {
+			contents: source,
+			resolveDir: resolve(import.meta.dirname, '..'),
+			sourcefile: 'native-host-binding-retention-consumer.mjs',
+		},
+		bundle: true,
+		define: { __OCTANE_PROFILE_ENABLED__: 'false' },
+		format: 'esm',
+		minify: true,
+		platform: 'node',
+		target: 'node22',
+		write: false,
+	});
+	const directory = mkdtempSync(join(tmpdir(), 'octane-native-host-binding-retention-'));
+	try {
+		const entry = join(directory, 'consumer.mjs');
+		writeFileSync(entry, result.outputFiles[0].text);
+		const run = spawnSync(process.execPath, ['--expose-gc', entry], {
+			encoding: 'utf8',
+			timeout: 30_000,
+		});
+		expect(run.error).toBeUndefined();
+		expect(run.status, run.stderr).toBe(0);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});

--- a/packages/octane/tests/universal-host-bindings.test.ts
+++ b/packages/octane/tests/universal-host-bindings.test.ts
@@ -1,0 +1,708 @@
+import { describe, expect, it } from 'vitest';
+import { createScope } from 'octane/signals';
+import {
+	createObjectContainer,
+	createObjectDriver,
+	createUniversalRoot,
+	defineUniversalComponent,
+	flushUniversalSync,
+	memo,
+	universalActivity,
+	universalComponent,
+	universalFor,
+	universalHostBinding,
+	universalPlan,
+	universalProps,
+	universalValue,
+	useState,
+} from '../src/universal-native.js';
+
+function createSource<T>(initial: T) {
+	let value = initial;
+	let subscriptionCount = 0;
+	let unsubscriptionCount = 0;
+	const listeners = new Set<() => void>();
+	return {
+		get() {
+			return value;
+		},
+		subscribe(notify: () => void) {
+			subscriptionCount++;
+			listeners.add(notify);
+			return () => {
+				unsubscriptionCount++;
+				listeners.delete(notify);
+			};
+		},
+		set(next: T) {
+			value = next;
+			for (const notify of [...listeners]) notify();
+		},
+		get listenerCount() {
+			return listeners.size;
+		},
+		get subscriptionCount() {
+			return subscriptionCount;
+		},
+		get unsubscriptionCount() {
+			return unsubscriptionCount;
+		},
+		captureListener() {
+			return [...listeners][0];
+		},
+	};
+}
+
+const rowPlan = universalPlan('object', {
+	kind: 'host',
+	type: 'row',
+	bindings: [
+		['active', 0],
+		['label', 1],
+	],
+});
+
+describe('universal host bindings', () => {
+	it('binds a scoped signal to native row properties', () => {
+		const scope = createScope({ scopeKey: 'native-host-binding' });
+		const selected$ = scope.signal$('selected', 0);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Rows = defineUniversalComponent('object', () =>
+			[0, 1].map((id) =>
+				universalValue(
+					rowPlan,
+					[universalHostBinding(selected$, (selected) => selected === id), `row:${id}`],
+					id,
+				),
+			),
+		);
+
+		try {
+			root.render(Rows, undefined);
+			expect(container.children.map((row) => row.props.active)).toEqual([true, false]);
+			flushUniversalSync(() => selected$.set(1));
+			expect(container.children.map((row) => row.props.active)).toEqual([false, true]);
+		} finally {
+			root.unmount();
+			scope.dispose();
+		}
+	});
+
+	it('changes both selected rows in one accepted host update', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const accepted: Array<[unknown, unknown]> = [];
+		const driver = {
+			...baseDriver,
+			prepareBatch(
+				target: typeof container,
+				batch: (typeof container.commits)[number],
+				context: Parameters<typeof baseDriver.prepareBatch>[2],
+			) {
+				const prepared = baseDriver.prepareBatch(target, batch, context);
+				return {
+					...prepared,
+					apply() {
+						prepared.apply();
+						if (target.children.length === 2) {
+							accepted.push([target.children[0].props.active, target.children[1].props.active]);
+						}
+					},
+				};
+			},
+		};
+		const root = createUniversalRoot(container, driver);
+		const Rows = defineUniversalComponent('object', () => [
+			universalValue(rowPlan, [universalHostBinding(source, (active) => active === 0), 'first']),
+			universalValue(rowPlan, [universalHostBinding(source, (active) => active === 1), 'second']),
+		]);
+
+		root.render(Rows, undefined);
+		const [first, second] = container.children;
+		try {
+			expect(accepted).toEqual([[true, false]]);
+			flushUniversalSync(() => source.set(1));
+			expect(accepted).toEqual([
+				[true, false],
+				[false, true],
+			]);
+			expect(container.children).toEqual([first, second]);
+			expect([first.props.label, second.props.label]).toEqual(['first', 'second']);
+		} finally {
+			root.unmount();
+		}
+		expect(source.listenerCount).toBe(0);
+	});
+
+	it('keeps the accepted source connected across an aborted replacement', () => {
+		const first = createSource(1);
+		const second = createSource(10);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent(
+			'object',
+			(props: { source: ReturnType<typeof createSource<number>>; label: string }) =>
+				universalValue(rowPlan, [
+					universalHostBinding(props.source, (value) => value),
+					props.label,
+				]),
+		);
+
+		root.render(Scene, { source: first, label: 'accepted' });
+		const row = container.children[0];
+		expect([first.subscriptionCount, first.unsubscriptionCount]).toEqual([1, 0]);
+		try {
+			const abandoned = root.prepare(Scene, { source: second, label: 'abandoned' });
+			expect(abandoned.status).toBe('prepared');
+			expect(row.props).toMatchObject({ active: 1, label: 'accepted' });
+			abandoned.abort();
+			expect(second.listenerCount).toBe(0);
+			expect([first.subscriptionCount, first.unsubscriptionCount]).toEqual([1, 0]);
+			expect([second.subscriptionCount, second.unsubscriptionCount]).toEqual([0, 0]);
+			flushUniversalSync(() => first.set(2));
+			expect(row.props).toMatchObject({ active: 2, label: 'accepted' });
+
+			root.render(Scene, { source: second, label: 'next' });
+			expect(container.children[0]).toBe(row);
+			expect(row.props).toMatchObject({ active: 10, label: 'next' });
+			expect(first.listenerCount).toBe(0);
+			expect([first.subscriptionCount, first.unsubscriptionCount]).toEqual([1, 1]);
+			expect([second.subscriptionCount, second.unsubscriptionCount]).toEqual([1, 0]);
+			flushUniversalSync(() => first.set(3));
+			expect(row.props.active).toBe(10);
+			flushUniversalSync(() => second.set(11));
+			expect(row.props.active).toBe(11);
+		} finally {
+			root.unmount();
+		}
+		expect(second.listenerCount).toBe(0);
+		expect([second.subscriptionCount, second.unsubscriptionCount]).toEqual([1, 1]);
+	});
+
+	it('applies two source changes to one host in the same accepted event update', () => {
+		const active = createSource(false);
+		const label = createSource('before');
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const accepted: Array<[unknown, unknown]> = [];
+		const driver = {
+			...baseDriver,
+			prepareBatch(
+				target: typeof container,
+				batch: (typeof container.commits)[number],
+				context: Parameters<typeof baseDriver.prepareBatch>[2],
+			) {
+				const prepared = baseDriver.prepareBatch(target, batch, context);
+				return {
+					...prepared,
+					apply() {
+						prepared.apply();
+						if (target.children.length !== 0) {
+							accepted.push([target.children[0].props.active, target.children[0].props.label]);
+						}
+					},
+				};
+			},
+		};
+		const root = createUniversalRoot(container, driver);
+		const buttonPlan = universalPlan('object', { kind: 'host', type: 'button', propsSlot: 0 });
+		const Scene = defineUniversalComponent('object', () => [
+			universalValue(rowPlan, [
+				universalHostBinding(active, (value) => value),
+				universalHostBinding(label, (value) => value),
+			]),
+			universalValue(buttonPlan, [
+				universalProps([
+					[
+						'set',
+						'onSelect',
+						() => {
+							active.set(true);
+							label.set('after');
+						},
+					],
+				]),
+			]),
+		]);
+
+		root.render(Scene, undefined);
+		const row = container.children[0];
+		try {
+			expect(accepted).toEqual([[false, 'before']]);
+			flushUniversalSync(() => container.dispatchEvent(container.children[1], 'select', undefined));
+			expect(accepted).toEqual([
+				[false, 'before'],
+				[true, 'after'],
+			]);
+			expect(container.children[0]).toBe(row);
+			expect([active.subscriptionCount, label.subscriptionCount]).toEqual([1, 1]);
+		} finally {
+			root.unmount();
+		}
+		expect([active.unsubscriptionCount, label.unsubscriptionCount]).toEqual([1, 1]);
+	});
+
+	it('connects a bound host property inside an ownerless list', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const root = createUniversalRoot(container, {
+			...baseDriver,
+			capabilities: { ...baseDriver.capabilities, compilerLeafProps: true },
+		});
+		const Rows = defineUniversalComponent('object', () =>
+			universalFor(
+				[0, 1],
+				(id) => id,
+				(id) =>
+					universalValue(rowPlan, [
+						universalHostBinding(source, (active) => active === id),
+						`row:${id}`,
+					]),
+				null,
+				true,
+			),
+		);
+
+		root.render(Rows, undefined);
+		const [first, second] = container.children;
+		try {
+			expect([first.props.active, second.props.active]).toEqual([true, false]);
+			flushUniversalSync(() => source.set(1));
+			expect([first.props.active, second.props.active]).toEqual([false, true]);
+			expect(source.listenerCount).toBe(1);
+		} finally {
+			root.unmount();
+		}
+		expect(source.listenerCount).toBe(0);
+	});
+
+	it('reconnects a hidden bound host with the latest source value on reveal', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent('object', (props: { mode: 'visible' | 'hidden' }) =>
+			universalActivity(props.mode, () =>
+				universalValue(rowPlan, [universalHostBinding(source, (value) => value), 'bound']),
+			),
+		);
+
+		root.render(Scene, { mode: 'visible' });
+		const row = container.children[0];
+		try {
+			expect(row.props.active).toBe(0);
+			expect(source.listenerCount).toBe(1);
+			const abandoned = root.prepare(Scene, { mode: 'hidden' });
+			abandoned.abort();
+			expect(row.visible).toBe(true);
+			expect(source.listenerCount).toBe(1);
+
+			root.render(Scene, { mode: 'hidden' });
+			expect(row.visible).toBe(false);
+			expect(source.listenerCount).toBe(0);
+			expect([source.subscriptionCount, source.unsubscriptionCount]).toEqual([1, 1]);
+			flushUniversalSync(() => source.set(2));
+			expect(row.props.active).toBe(0);
+
+			root.render(Scene, { mode: 'visible' });
+			expect(container.children[0]).toBe(row);
+			expect(row.visible).toBe(true);
+			expect(row.props.active).toBe(2);
+			expect([source.subscriptionCount, source.unsubscriptionCount]).toEqual([2, 1]);
+			flushUniversalSync(() => source.set(3));
+			expect(row.props.active).toBe(3);
+		} finally {
+			root.unmount();
+		}
+		expect([source.listenerCount, source.unsubscriptionCount]).toEqual([0, 2]);
+	});
+
+	it('rejects a bound ref before accepting a host or subscribing', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const plan = universalPlan('object', {
+			kind: 'host',
+			type: 'row',
+			propsSlot: 0,
+		});
+		const Scene = defineUniversalComponent('object', () =>
+			universalValue(plan, [
+				universalProps([['set', 'ref', universalHostBinding(source, (value) => value)]]),
+			]),
+		);
+
+		expect(() => root.render(Scene, undefined)).toThrow(/ordinary host property/i);
+		expect(container.commits).toHaveLength(0);
+		expect(container.children).toEqual([]);
+		expect(container.instanceCount).toBe(0);
+		expect(source.listenerCount).toBe(0);
+		root.unmount();
+	});
+
+	it('rejects unsupported compact leaf bindings before accepting a host', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const root = createUniversalRoot(container, {
+			...baseDriver,
+			capabilities: { ...baseDriver.capabilities, compilerLeafProps: true },
+		});
+		const leafPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'row',
+			bindings: [['active', 0]],
+		});
+		const Rows = defineUniversalComponent('object', () =>
+			universalFor(
+				[0],
+				(id) => id,
+				// The compiler's specialized leaf path passes its raw value slots.
+				(id) =>
+					[universalHostBinding(source, (active) => active === id)] as unknown as ReturnType<
+						typeof universalValue
+					>,
+				null,
+				true,
+				true,
+				undefined,
+				leafPlan,
+			),
+		);
+
+		expect(() => root.render(Rows, undefined)).toThrow(/compact.*binding|binding.*compact/i);
+		expect(container.children).toEqual([]);
+		expect(container.commits).toHaveLength(0);
+		expect(container.instanceCount).toBe(0);
+		expect(source.listenerCount).toBe(0);
+		root.unmount();
+	});
+
+	it('reads the latest source in an explicit render and disconnects on unmount', () => {
+		const source = createSource(1);
+		const container = createObjectContainer();
+		const pending: Array<() => void> = [];
+		const root = createUniversalRoot(container, createObjectDriver(), {
+			scheduleMicrotask: (callback) => pending.push(callback),
+		});
+		const Scene = defineUniversalComponent('object', (props: { label: string }) =>
+			universalValue(rowPlan, [universalHostBinding(source, (value) => value), props.label]),
+		);
+
+		root.render(Scene, { label: 'before' });
+		const row = container.children[0];
+		const retiredListener = source.captureListener();
+		source.set(2);
+		root.render(Scene, { label: 'after' });
+		expect(row.props).toMatchObject({ active: 2, label: 'after' });
+		for (const callback of pending.splice(0)) callback();
+		expect(row.props).toMatchObject({ active: 2, label: 'after' });
+
+		root.unmount();
+		expect(container.children).toEqual([]);
+		expect(source.listenerCount).toBe(0);
+		const accepted = container.commits.length;
+		flushUniversalSync(() => {
+			source.set(3);
+			retiredListener?.();
+		});
+		for (const callback of pending.splice(0)) callback();
+		expect(container.children).toEqual([]);
+		expect(container.commits).toHaveLength(accepted);
+	});
+
+	it('allows a surviving row to update after a queued row was removed', () => {
+		const first = createSource(0);
+		const second = createSource(0);
+		const container = createObjectContainer();
+		const pending: Array<() => void> = [];
+		const root = createUniversalRoot(container, createObjectDriver(), {
+			scheduleMicrotask: (callback) => pending.push(callback),
+		});
+		const Scene = defineUniversalComponent('object', (props: { showFirst: boolean }) => [
+			props.showFirst
+				? universalValue(rowPlan, [universalHostBinding(first, (value) => value), 'first'], 'first')
+				: null,
+			universalValue(rowPlan, [universalHostBinding(second, (value) => value), 'second'], 'second'),
+		]);
+		const drain = () => {
+			for (let index = 0; index < 20 && pending.length !== 0; index++) pending.shift()!();
+			expect(pending).toEqual([]);
+		};
+
+		root.render(Scene, { showFirst: true });
+		const surviving = container.children[1];
+		first.set(1);
+		root.render(Scene, { showFirst: false });
+		expect(container.children).toEqual([surviving]);
+		expect(first.listenerCount).toBe(0);
+		drain();
+
+		second.set(2);
+		drain();
+		expect(surviving.props).toMatchObject({ active: 2, label: 'second' });
+		root.unmount();
+		expect(second.listenerCount).toBe(0);
+	});
+
+	it('keeps bound properties responsive after a scheduled component render fails', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const pending: Array<() => void> = [];
+		const errors: unknown[] = [];
+		const root = createUniversalRoot(container, createObjectDriver(), {
+			scheduleMicrotask: (callback) => pending.push(callback),
+			onUncaughtError: (error) => errors.push(error),
+		});
+		let fail!: () => void;
+		const Scene = defineUniversalComponent('object', () => {
+			const [broken, setBroken] = useState(false, 'broken');
+			fail = () => setBroken(true);
+			if (broken) throw new Error('component render failed');
+			return universalValue(rowPlan, [universalHostBinding(source, (value) => value), 'accepted']);
+		});
+		const drain = () => {
+			for (let index = 0; index < 20 && pending.length !== 0; index++) pending.shift()!();
+			expect(pending).toEqual([]);
+		};
+
+		root.render(Scene, undefined);
+		const row = container.children[0];
+		try {
+			source.set(1);
+			fail();
+			drain();
+			expect(errors).toHaveLength(1);
+			expect(errors[0]).toMatchObject({ message: 'component render failed' });
+			expect(row.props).toMatchObject({ active: 1, label: 'accepted' });
+			source.set(2);
+			drain();
+			expect(row.props.active).toBe(2);
+		} finally {
+			root.unmount();
+		}
+		expect(source.listenerCount).toBe(0);
+	});
+
+	it('publishes a bound value and ordinary state change together for one event', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const buttonPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'button',
+			propsSlot: 0,
+		});
+		const Scene = defineUniversalComponent('object', () => {
+			const [changed, setChanged] = useState(false, 'changed');
+			return [
+				universalValue(rowPlan, [
+					universalHostBinding(source, (value) => value),
+					changed ? 'after' : 'before',
+				]),
+				universalValue(buttonPlan, [
+					universalProps([
+						[
+							'set',
+							'onSelect',
+							() => {
+								source.set(1);
+								setChanged(true);
+							},
+						],
+					]),
+				]),
+			];
+		});
+
+		root.render(Scene, undefined);
+		const row = container.children[0];
+		const before = container.commits.length;
+		flushUniversalSync(() => container.dispatchEvent(container.children[1], 'select', undefined));
+		expect(row.props).toMatchObject({ active: 1, label: 'after' });
+		expect(container.commits).toHaveLength(before + 1);
+		root.unmount();
+	});
+
+	it('disposes earlier subscriptions if a later source fails during publication', () => {
+		const first = createSource(1);
+		const second = {
+			get() {
+				return 2;
+			},
+			subscribe(_notify: () => void): () => void {
+				throw new Error('source subscription failed');
+			},
+		};
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent('object', () => [
+			universalValue(rowPlan, [universalHostBinding(first, (value) => value), 'first']),
+			universalValue(rowPlan, [universalHostBinding(second, (value) => value), 'second']),
+		]);
+
+		expect(() => root.render(Scene, undefined)).toThrow('source subscription failed');
+		const activeListeners = first.listenerCount;
+		root.unmount();
+		expect(activeListeners).toBe(0);
+		expect(first.listenerCount).toBe(0);
+	});
+
+	it('disconnects after a source read fails following subscription', () => {
+		let subscribed = false;
+		const listeners = new Set<() => void>();
+		const source = {
+			get() {
+				if (subscribed) throw new Error('source read failed');
+				return 1;
+			},
+			subscribe(notify: () => void) {
+				listeners.add(notify);
+				subscribed = true;
+				return () => listeners.delete(notify);
+			},
+		};
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent('object', () =>
+			universalValue(rowPlan, [universalHostBinding(source, (value) => value), 'first']),
+		);
+
+		expect(() => root.render(Scene, undefined)).toThrow('source read failed');
+		expect(listeners.size).toBe(0);
+		root.unmount();
+	});
+
+	it('disconnects every removed host when one source cleanup throws', () => {
+		const fault = new Error('first source cleanup failed');
+		const firstListeners = new Set<() => void>();
+		let staleListener: () => void = () => {};
+		let firstCleanups = 0;
+		const first = {
+			get: () => 0,
+			subscribe(notify: () => void) {
+				firstListeners.add(notify);
+				staleListener = notify;
+				return () => {
+					firstListeners.delete(notify);
+					firstCleanups++;
+					notify();
+					throw fault;
+				};
+			},
+		};
+		const second = createSource(1);
+		const third = createSource(2);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Rows = defineUniversalComponent('object', () => [
+			universalValue(rowPlan, [universalHostBinding(first, (value) => value), 'first'], 'first'),
+			universalValue(rowPlan, [universalHostBinding(second, (value) => value), 'second'], 'second'),
+			universalValue(rowPlan, [universalHostBinding(third, (value) => value), 'third'], 'third'),
+		]);
+
+		root.render(Rows, undefined);
+		expect(() => root.unmount()).toThrow(fault);
+		expect(container.children).toEqual([]);
+		expect(container.instanceCount).toBe(0);
+		expect(firstListeners.size).toBe(0);
+		expect(firstCleanups).toBe(1);
+		expect([second.listenerCount, third.listenerCount]).toEqual([0, 0]);
+		expect([second.unsubscriptionCount, third.unsubscriptionCount]).toEqual([1, 1]);
+		const accepted = container.commits.length;
+		flushUniversalSync(() => {
+			staleListener();
+			second.set(3);
+			third.set(4);
+		});
+		expect(container.commits).toHaveLength(accepted);
+		root.unmount();
+		expect(firstCleanups).toBe(1);
+	});
+
+	it('publishes a queued binding after an accepted scheduled host commit fails', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const fault = new Error('host apply failed after acceptance');
+		let failOnce = true;
+		const driver = {
+			...baseDriver,
+			prepareBatch(
+				target: typeof container,
+				batch: (typeof container.commits)[number],
+				context: Parameters<typeof baseDriver.prepareBatch>[2],
+			) {
+				const prepared = baseDriver.prepareBatch(target, batch, context);
+				if (
+					!batch.commands.some(
+						(command) => command.op === 'update' && command.props.value === 'after',
+					)
+				) {
+					return prepared;
+				}
+				return {
+					...prepared,
+					apply() {
+						prepared.apply();
+						if (failOnce) {
+							failOnce = false;
+							throw fault;
+						}
+					},
+				};
+			},
+		};
+		const pending: Array<() => void> = [];
+		const thrown: unknown[] = [];
+		const root = createUniversalRoot(container, driver, {
+			scheduleMicrotask: (callback) => pending.push(callback),
+		});
+		const stagePlan = universalPlan('object', {
+			kind: 'host',
+			type: 'stage',
+			bindings: [['value', 0]],
+		});
+		const Bound = memo(
+			defineUniversalComponent('object', () =>
+				universalValue(rowPlan, [universalHostBinding(source, (value) => value), 'bound']),
+			),
+		);
+		let updateStage!: () => void;
+		const Scene = defineUniversalComponent('object', () => {
+			const [stage, setStage] = useState('before', 'stage');
+			updateStage = () => setStage('after');
+			return [universalComponent('object', Bound), universalValue(stagePlan, [stage])];
+		});
+		const drain = () => {
+			for (let index = 0; index < 20 && pending.length !== 0; index++) {
+				try {
+					pending.shift()!();
+				} catch (error) {
+					thrown.push(error);
+				}
+			}
+			expect(pending).toEqual([]);
+		};
+
+		root.render(Scene, undefined);
+		const row = container.children[0];
+		try {
+			source.set(1);
+			updateStage();
+			drain();
+			expect(thrown).toEqual([fault]);
+			expect(container.children[0]).toBe(row);
+			expect(container.children[1].props.value).toBe('after');
+			expect(row.props.active).toBe(1);
+			source.set(2);
+			drain();
+			expect(row.props.active).toBe(2);
+		} finally {
+			root.unmount();
+		}
+		expect(source.listenerCount).toBe(0);
+	});
+});

--- a/packages/octane/tests/universal-host-bindings.test.ts
+++ b/packages/octane/tests/universal-host-bindings.test.ts
@@ -181,6 +181,56 @@ describe('universal host bindings', () => {
 		expect([second.subscriptionCount, second.unsubscriptionCount]).toEqual([1, 1]);
 	});
 
+	it('defers a source notification while a host transaction is prepared', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent('object', (props: { label: string }) =>
+			universalValue(rowPlan, [universalHostBinding(source, (value) => value), props.label]),
+		);
+
+		root.render(Scene, { label: 'old' });
+		const row = container.children[0];
+		try {
+			const pending = root.prepare(Scene, { label: 'new' });
+			expect(pending.status).toBe('prepared');
+			expect(() => flushUniversalSync(() => source.set(1))).not.toThrow();
+			expect(row.props).toMatchObject({ active: 0, label: 'old' });
+			pending.commit();
+			flushUniversalSync(() => {});
+			expect(container.children[0]).toBe(row);
+			expect(row.props).toMatchObject({ active: 1, label: 'new' });
+		} finally {
+			root.unmount();
+		}
+		expect(source.listenerCount).toBe(0);
+	});
+
+	it('replays a deferred source notification after aborting a host transaction', () => {
+		const source = createSource(0);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent('object', (props: { label: string }) =>
+			universalValue(rowPlan, [universalHostBinding(source, (value) => value), props.label]),
+		);
+
+		root.render(Scene, { label: 'old' });
+		const row = container.children[0];
+		try {
+			const pending = root.prepare(Scene, { label: 'discarded' });
+			expect(pending.status).toBe('prepared');
+			flushUniversalSync(() => source.set(1));
+			expect(row.props).toMatchObject({ active: 0, label: 'old' });
+			pending.abort();
+			flushUniversalSync(() => {});
+			expect(container.children[0]).toBe(row);
+			expect(row.props).toMatchObject({ active: 1, label: 'old' });
+		} finally {
+			root.unmount();
+		}
+		expect(source.listenerCount).toBe(0);
+	});
+
 	it('applies two source changes to one host in the same accepted event update', () => {
 		const active = createSource(false);
 		const label = createSource('before');
@@ -526,7 +576,7 @@ describe('universal host bindings', () => {
 		root.unmount();
 	});
 
-	it('disposes earlier subscriptions if a later source fails during publication', () => {
+	it('keeps earlier accepted hosts responsive if a later new source fails', () => {
 		const first = createSource(1);
 		const second = {
 			get() {
@@ -544,10 +594,46 @@ describe('universal host bindings', () => {
 		]);
 
 		expect(() => root.render(Scene, undefined)).toThrow('source subscription failed');
-		const activeListeners = first.listenerCount;
+		expect(container.children).toHaveLength(2);
+		expect(first.listenerCount).toBe(1);
+		flushUniversalSync(() => first.set(3));
+		expect(container.children[0].props.active).toBe(3);
 		root.unmount();
-		expect(activeListeners).toBe(0);
 		expect(first.listenerCount).toBe(0);
+	});
+
+	it('keeps a previously mounted bound host connected if another source fails', () => {
+		const healthy = createSource(0);
+		const stableBinding = universalHostBinding(healthy, (value) => value);
+		const failing = {
+			get: () => 0,
+			subscribe(_notify: () => void): () => void {
+				throw new Error('new source subscription failed');
+			},
+		};
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const Scene = defineUniversalComponent('object', (props: { add: boolean }) => [
+			universalValue(rowPlan, [stableBinding, 'existing'], 'existing'),
+			props.add
+				? universalValue(rowPlan, [universalHostBinding(failing, (value) => value), 'new'], 'new')
+				: null,
+		]);
+
+		root.render(Scene, { add: false });
+		const existing = container.children[0];
+		expect(healthy.listenerCount).toBe(1);
+		try {
+			expect(() => root.render(Scene, { add: true })).toThrow('new source subscription failed');
+			expect(container.children).toHaveLength(2);
+			expect(container.children[0]).toBe(existing);
+			expect(healthy.listenerCount).toBe(1);
+			flushUniversalSync(() => healthy.set(1));
+			expect(existing.props.active).toBe(1);
+		} finally {
+			root.unmount();
+		}
+		expect(healthy.listenerCount).toBe(0);
 	});
 
 	it('disconnects after a source read fails following subscription', () => {
@@ -704,5 +790,88 @@ describe('universal host bindings', () => {
 			root.unmount();
 		}
 		expect(source.listenerCount).toBe(0);
+	});
+
+	it('reports both an accepted host failure and a queued source read failure', () => {
+		const backing = createSource(0);
+		const hostError = new Error('accepted host apply failed');
+		const sourceError = new Error('bound source read failed');
+		let failNextRead = false;
+		const source = {
+			get() {
+				if (failNextRead) {
+					failNextRead = false;
+					throw sourceError;
+				}
+				return backing.get();
+			},
+			subscribe(notify: () => void) {
+				return backing.subscribe(notify);
+			},
+		};
+		const container = createObjectContainer();
+		const baseDriver = createObjectDriver();
+		const driver = {
+			...baseDriver,
+			prepareBatch(
+				target: typeof container,
+				batch: (typeof container.commits)[number],
+				context: Parameters<typeof baseDriver.prepareBatch>[2],
+			) {
+				const prepared = baseDriver.prepareBatch(target, batch, context);
+				if (
+					!batch.commands.some(
+						(command) => command.op === 'update' && command.props.value === 'after',
+					)
+				) {
+					return prepared;
+				}
+				return {
+					...prepared,
+					apply() {
+						prepared.apply();
+						failNextRead = true;
+						backing.set(1);
+						throw hostError;
+					},
+				};
+			},
+		};
+		const root = createUniversalRoot(container, driver);
+		const stagePlan = universalPlan('object', {
+			kind: 'host',
+			type: 'stage',
+			bindings: [['value', 0]],
+		});
+		const bound = universalHostBinding(source, (value) => value);
+		const Bound = memo(
+			defineUniversalComponent('object', () => universalValue(rowPlan, [bound, 'bound'])),
+		);
+		let updateStage!: () => void;
+		const Scene = defineUniversalComponent('object', () => {
+			const [stage, setStage] = useState('before', 'stage');
+			updateStage = () => setStage('after');
+			return [universalComponent('object', Bound), universalValue(stagePlan, [stage])];
+		});
+
+		root.render(Scene, undefined);
+		const row = container.children[0];
+		try {
+			let reported: unknown;
+			try {
+				flushUniversalSync(() => updateStage());
+			} catch (error) {
+				reported = error;
+			}
+			expect(reported).toBeInstanceOf(AggregateError);
+			expect((reported as AggregateError).errors).toEqual([hostError, sourceError]);
+			expect(container.children[1].props.value).toBe('after');
+			expect(row.props.active).toBe(0);
+			flushUniversalSync(() => backing.set(2));
+			expect(row.props.active).toBe(2);
+		} finally {
+			root.unmount();
+		}
+		expect(backing.listenerCount).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

- Add opt-in `universalHostBinding(source, select)` for ordinary properties on local direct native roots. A root shares one source subscription and publishes changed properties together without rerendering the component tree.
- Release superseded effect callbacks after accepted universal commits so a mounted tree does not retain earlier render closures.
- Include a patch against the reporter's Hermes reproduction and public regression tests for batching, aborts, hidden hosts, cleanup, scheduler failures, and selector collection.

## Why

The [reporter's issue](https://github.com/octanejs/octane/issues/1007) and [reproduction](https://github.com/Josema/octane-and-solid-core-memory-reproduction) distinguish mounted retention from cumulative allocations. Releasing effect history fixes the mounted retention, but the hand-authored root `useState` route still reconstructs 20 rows and 80 view layers on every hover. The new binding route lets that source update the two changed host properties in an accepted batch.

## Changes

- Host bindings subscribe after host acceptance, use the latest source value, and publish changed host props through a specialized local transaction with the same acceptance and abort behavior. They unsubscribe on replacement, hide, and unmount. Unsupported transport, bridge, event, and compact leaf cases fail explicitly.
- A failed new source subscription leaves healthy accepted hosts connected; shared listeners do not retain removed selectors; source notifications during a prepared transaction drain after commit or abort. Simultaneous scheduled host and bound source errors are both reported.
- The checked-in reporter patch changes the Octane `useState` source to a scoped signal and bound `active` props; the original Solid workload and host/effect assertions remain intact. Reproduction commands are in `benchmarks/universal-native-hover/README.md`.

## Validation

- [x] Focused universal renderer tests, development and production projects: 42 files, 766 tests passed.
- [x] Full `pnpm typecheck`; scoped `tsgo --noEmit -p packages/octane/tsconfig.json` on the final core.
- [x] Repository-wide `prettier --check .` (the `pnpm format:check` command) and changed-file formatting checks.
- [x] Original Hermes 1.0.0 Hades harness with the reporter's host driver and a real scoped signal, 2,000 hovers: Octane 9,182,120 B cumulative allocations, 0.94 MB mounted live after GC, 7 collections; Solid 5,823,776 B, 0.37 MB, 6 collections. Both produce 101 hosts, 3,999 property changes, 2,000 events, 80 effect creates/cleanups, and zero hosts after unmount.
- [ ] `pnpm test` — attempted locally; broad browser and unrelated package suites failed in this macOS environment. Current-head CI is the gate for the full matrix.

## Risk / follow-ups

- The fine-grained route is opt-in. Existing root `useState` updates still rebuild the hand-authored tree and retain their cumulative allocation cost. The measured opt-in path is about 1.58× Solid's cumulative bytes and 2.57× its mounted live bytes, with the same 8 MiB heap capacity. Controlled diagnostic substitutions attribute about 1.24 MB to the scoped signal versus a minimal source and about 0.90 MB to the reporter's host property traversal; neither substitution is in the final comparison.
- Bindings currently support local direct roots and ordinary update-only host properties. Transported roots, DOM-owned bridges, event props, and specialized compact leaf descriptors need separate designs.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791672393&installation_model_id=432790&pr_number=1044&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1044&signature=9b195b0aa03bcec503df5f55a3dc413a6c557d8a26acc6bf89a877555ca7c309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches universal root commit/scheduling, subscription lifetimes, and effect hook retention in core `universal-core.ts`; behavior is opt-in but errors and partial-failure paths are intricate.
> 
> **Overview**
> Adds **opt-in `universalHostBinding(source, select)`** so local direct native roots can push `{ get, subscribe }` changes (e.g. scoped signals) straight to ordinary host props in **one accepted driver batch**, without rerunning the component tree. The root deduplicates subscriptions per source, wires bindings after host acceptance, uses a dedicated binding transaction path, and tears down on replace/hide/unmount; transported/bridge/event/compact-leaf cases are rejected.
> 
> Separately, **accepted universal commits clear superseded effect hook `previous` links**, so stable native renders with unchanged effect deps no longer keep old callback closures alive while mounted.
> 
> Docs and the native-hover benchmark README document the binding API, Hermes repro steps, and a reporter patch; large regression and GC retention tests cover batching, aborts, scheduler failures, and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5fced2596a48d1e1b7a535dc53314bf479eaef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
