### PR TITLE
fix: fold fragment SSR head and production SEO diagnostics

### DIFF
--- a/.changeset/ssr-seo-issue-1037.md
+++ b/.changeset/ssr-seo-issue-1037.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+'@octanejs/seo': patch
+---
+
+Place hoisted SSR metadata inside an authored head at a fragment root, and omit the SEO stray-owner diagnostic from production browser bundles.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -83,8 +83,9 @@ The three buffered renderers return `RenderResult = { html, css }`:
   resolved, an inline `<script type="application/json" data-octane-suspense>`
   seed that hydration consumes. Hoisted `<title>`/`<meta>`/`<link>` (rendered
   anywhere in the tree, each preceded by an adoption marker comment) are folded
-  in by default — spliced into `<head>` when the render produced a document, else
-  prepended (React-19 resource hoisting). `headChannel: 'separate'` withholds
+  in by default — spliced into `<head>` when the render produced a document or a
+  fragment beginning with an authored `<head>`, else prepended (React-19 resource
+  hoisting). `headChannel: 'separate'` withholds
   them and returns them as `head` instead.
 - `head` — the hoisted metadata on its own, present **only** under
   `headChannel: 'separate'` (see `RenderOptions`).
@@ -190,6 +191,10 @@ terminal path as `abort`. Without `injection`, streamed output is unchanged
 apart from that doctype preamble (measured flat on the streaming-ssr
 benchmark).
 
+A streamed fragment that begins with an authored `<head>` receives hoisted
+metadata and renderer-owned leading scoped styles inside that head. It has no
+core-owned doctype and does not enter injection's document-tail mode.
+
 ### `renderToReadableStream(component, props?, options?)` — `octane/server`
 
 The same streaming engine over web streams: resolves with a
@@ -221,9 +226,17 @@ concurrently rather than awaiting `allReady` before reading. Same
   `<head>`-bearing template it owns, rather than rendering the document itself,
   needs `'separate'`: a body-only render has no `</head>` for the fold to target,
   so folding prepends the metadata into the body, where a `<title>` loses to the
-  template's and a canonical or description is ignored. Nothing but the position
-  of the metadata changes: `head + html` under `'separate'` is byte-identical to
-  `html` under `'fold'`.
+  template's and a canonical or description is ignored. For a body-only render,
+  `head + html` under `'separate'` is byte-identical to `html` under `'fold'`;
+  folding into an authored `<head>` instead inserts the metadata inside it.
+
+A fragment beginning with an authored `<head>` is suitable for server-only
+composition when the host supplies `<html>`. It cannot be hydrated with
+`hydrateRoot(document, FragmentPage)` because a Document root expects the
+rendered `<html>` element. To hydrate a host-owned document, render a body-only
+app with `headChannel: 'separate'`, place its metadata in the host's `<head>`,
+and hydrate the app container inside `<body>`. To hydrate an entire Document,
+render an `<html>` root.
 
 ### `setSsrSuspenseTimeout(ms)` / `getSsrSuspenseTimeout()`
 

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -334,7 +334,7 @@ let PERMANENT_STATIC_HYDRATE_DEPTH = 0;
 // active render pass (a mutable container, mirroring CSS's mutable Map, so a
 // per-pass local capture keeps accumulating via `HEAD.html +=` even though
 // strings are immutable). Folded into the result `html` by `spliceHead` (into
-// `<head>` when present, else prepended).
+// a document or leading fragment `<head>`, else prepended).
 interface HeadBuffer {
 	html: string;
 	/**
@@ -6564,8 +6564,9 @@ export function namespaceHeadElement(
  *
  * - `html` — the rendered markup. Hoisted document metadata (`<title>`/`<meta>`/
  *   `<link>`, collected via `ssrHeadEl`) is folded IN: spliced before `</head>`
- *   when the render produced a document, otherwise prepended. (React folds head
- *   resources into the document too, which is why folding is the default.)
+ *   when the render produced a document or a leading fragment `<head>`, otherwise
+ *   prepended. (React folds head resources into the document too, which is why
+ *   folding is the default.)
  * - `head`, the hoisted metadata on its own, present ONLY under
  *   `headChannel: 'separate'`; `html` then excludes it. For hosts that render
  *   into a `<head>`-bearing template they own rather than rendering the
@@ -6614,9 +6615,9 @@ export interface RenderOptions {
 	 * Where hoisted `<title>`/`<meta>`/`<link>` go.
 	 *
 	 * `'fold'` (default) keeps React's resource-hoisting shape: the metadata is
-	 * spliced into `html` before `</head>`, or prepended when the render is not a
-	 * document. `'separate'` withholds it from `html`/the streamed shell and hands
-	 * it over on its own, `RenderResult.head` for the buffered renderers,
+	 * spliced into `html` before `</head>` for a document or leading fragment
+	 * `<head>`, and otherwise prepended. `'separate'` withholds it from `html`/the
+	 * streamed shell and hands it over on its own, `RenderResult.head` for the buffered renderers,
 	 * `StreamOptions.onHeadReady` for the streaming ones.
 	 *
 	 * A host that renders into a `<head>`-bearing template it owns (rather than
@@ -6628,16 +6629,19 @@ export interface RenderOptions {
 	headChannel?: 'fold' | 'separate';
 }
 
-// Insert the hoisted head markup into `body`: before `</head>` when the render
-// produced a document (React-19 resource-hoisting shape), otherwise prepend it so
-// the caller/metaframework can place `html` in a document whose `<head>` then
-// contains the metadata. A document root always gains a `<head>`; any other
-// body with nothing to splice is returned as is, decided from its first bytes so
-// the common fragment response is never scanned for a `</head>`.
-function spliceHead(body: string, head: string): string {
-	if (!isDocumentRoot(body)) return head === '' ? body : head + body;
-	const headClose = body.indexOf('</head>');
+// Fold into a rendered document or a fragment that leads with an authored
+// <head> (the preamble shape used inside a host-owned <html>). Other fragments
+// keep the prepended metadata that a host can place in its own <head>. The
+// common fragment response is classified from its first bytes, never scanned.
+function spliceHead(body: string, head: string, documentRoot = isDocumentRoot(body)): string {
+	if (!documentRoot && (head === '' || !isLeadingHeadRoot(body)))
+		return head === '' ? body : head + body;
+	// A fragment's leading <head> may have an attribute containing "</head>";
+	// begin after its quote-aware opening tag instead of splicing into the attr.
+	const afterOpening = documentRoot ? 0 : documentHeadInsertionPoint(body);
+	const headClose = afterOpening === -1 ? -1 : body.indexOf('</head>', afterOpening);
 	if (headClose !== -1) return body.slice(0, headClose) + head + body.slice(headClose);
+	if (!documentRoot) return head + body;
 	const openingEnd = documentTagEnd(body, body.indexOf('<html') + 5);
 	if (openingEnd !== -1)
 		return body.slice(0, openingEnd) + '<head>' + head + '</head>' + body.slice(openingEnd);
@@ -7608,9 +7612,9 @@ function passToResult(
 	if (pass.serial.length > 0) body += serializeSuspenseSeeds(pass.serial, nonceAttr);
 	if (pass.signals !== undefined) body += serializeNativeSignalSeeds(pass.signals, nonceAttr);
 	// Unclaimed view-transition arm candidates strip at emission (see vtSsrStrip).
-	// Stripping the two channels separately equals stripping the folded string -
-	// no match spans the join, which is what keeps `head + html` byte-identical
-	// to the folded `html`.
+	// Stripping the two channels separately equals stripping the folded string:
+	// no match spans the join. On body-only renders, `head + html` remains
+	// byte-identical to folded output; authored heads change the insertion point.
 	let result: RenderResult;
 	if (separateHead) {
 		result = {
@@ -8822,6 +8826,17 @@ function isDocumentRoot(body: string): boolean {
 	return next === 62 /* > */ || next === 32 || next === 9 || next === 10 || next === 13;
 }
 
+// A fragment can author its own leading <head> even when a surrounding server
+// template supplies <html>. That head receives hoisted metadata, but does not
+// make this an <html> root or cause the streaming doctype to be emitted.
+function isLeadingHeadRoot(body: string): boolean {
+	let i = 0;
+	while (body.startsWith('<!--[-->', i)) i += 8;
+	if (!body.startsWith('<head', i)) return false;
+	const next = body.charCodeAt(i + 5);
+	return next === 62 /* > */ || next === 32 || next === 9 || next === 10 || next === 13;
+}
+
 // Locate the insertion point just inside a document's opening <head> tag —
 // where renderer-owned leading styles and hoisted head elements belong in
 // document mode. Quote-aware so an attribute value containing '>' cannot
@@ -9298,9 +9313,12 @@ async function runStream(
 			shell += spliceHead(pass.body, leadingStyles + shellHead);
 		}
 	} else {
+		const shellPrefix = leadingStyles + shellHead;
 		shell += documentRoot
-			? spliceHead(pass.body, leadingStyles + shellHead)
-			: leadingStyles + shellHead + pass.body;
+			? spliceHead(pass.body, shellPrefix, true)
+			: shellPrefix === ''
+				? pass.body
+				: spliceHead(pass.body, shellPrefix, false);
 	}
 	if (pass.serial.length > 0) shell += serializeSuspenseSeeds(pass.serial, nonceAttr);
 	if (pass.signals !== undefined) shell += serializeNativeSignalSeeds(pass.signals, nonceAttr);

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -6636,10 +6636,9 @@ export interface RenderOptions {
 function spliceHead(body: string, head: string, documentRoot = isDocumentRoot(body)): string {
 	if (!documentRoot && (head === '' || !isLeadingHeadRoot(body)))
 		return head === '' ? body : head + body;
-	// A fragment's leading <head> may have an attribute containing "</head>";
-	// begin after its quote-aware opening tag instead of splicing into the attr.
-	const afterOpening = documentRoot ? 0 : documentHeadInsertionPoint(body);
-	const headClose = afterOpening === -1 ? -1 : body.indexOf('</head>', afterOpening);
+	const headClose = documentRoot
+		? body.indexOf('</head>')
+		: findFragmentHeadClose(body, documentHeadInsertionPoint(body));
 	if (headClose !== -1) return body.slice(0, headClose) + head + body.slice(headClose);
 	if (!documentRoot) return head + body;
 	const openingEnd = documentTagEnd(body, body.indexOf('<html') + 5);
@@ -8863,6 +8862,42 @@ function documentTagEnd(body: string, from: number): number {
 			if (code === quote) quote = 0;
 		} else if (code === 34 /* " */ || code === 39 /* ' */) quote = code;
 		else if (code === 62 /* > */) return i + 1;
+	}
+	return -1;
+}
+
+// Only a leading fragment <head> takes this path. Quoted attributes, comments,
+// and raw script/style text can contain "</head>" without closing the element.
+// Walk markup tags (quote-aware via documentTagEnd) rather than searching raw
+// bytes; ordinary fragments never pay for a body scan.
+function findFragmentHeadClose(body: string, from: number): number {
+	while (from !== -1) {
+		const start = body.indexOf('<', from);
+		if (start === -1) return -1;
+		if (body.startsWith('<!--', start)) {
+			const end = body.indexOf('-->', start + 4);
+			if (end === -1) return -1;
+			from = end + 3;
+			continue;
+		}
+		if (body.startsWith('</head>', start)) return start;
+		const end = documentTagEnd(body, start + 1);
+		if (end === -1) return -1;
+		let rawClose: string | null = null;
+		if (body.startsWith('<script', start)) {
+			const next = body.charCodeAt(start + 7);
+			if (next === 62 || next === 32 || next === 9 || next === 10 || next === 13)
+				rawClose = '</script>';
+		} else if (body.startsWith('<style', start)) {
+			const next = body.charCodeAt(start + 6);
+			if (next === 62 || next === 32 || next === 9 || next === 10 || next === 13)
+				rawClose = '</style>';
+		}
+		if (rawClose !== null) {
+			const rawEnd = body.indexOf(rawClose, end);
+			if (rawEnd === -1) return -1;
+			from = rawEnd + rawClose.length;
+		} else from = end;
 	}
 	return -1;
 }

--- a/packages/octane/tests/hydration/head-hydrate.test.ts
+++ b/packages/octane/tests/hydration/head-hydrate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 import { compile } from 'octane/compiler';
@@ -264,6 +264,38 @@ describe('hoisted document metadata — SSR', () => {
 });
 
 describe('hoisted document metadata — hydration', () => {
+	it('adopts separate metadata in a host-owned document with a body app root', () => {
+		const id = '/src/hosted-head.tsrx';
+		const serverPage = ownershipModule(id, 'server');
+		const clientPage = ownershipModule(id, 'client');
+		const { html, head } = ServerRT.renderToString(
+			serverPage.Page,
+			{ label: 'server' },
+			{ headChannel: 'separate' },
+		);
+		const parsed = new DOMParser().parseFromString(
+			`<!doctype html><html><head>${head}</head><body><div id="app">${html}</div></body></html>`,
+			'text/html',
+		);
+		const title = parsed.head.querySelector('title');
+		const main = parsed.querySelector('main');
+		const app = parsed.getElementById('app')!;
+		expect(title?.textContent).toBe('server');
+		expect(main?.textContent).toBe('server');
+		const onRecoverableError = vi.fn();
+		const root = hydrateRoot(app, clientPage.Page, { label: 'server' }, { onRecoverableError });
+		expect(parsed.head.querySelector('title')).toBe(title);
+		expect(app.querySelector('main')).toBe(main);
+		flushSync(() => root.render(clientPage.Page, { label: 'client' }));
+		expect(parsed.head.querySelector('title')).toBe(title);
+		expect(title?.textContent).toBe('client');
+		expect(app.querySelector('main')).toBe(main);
+		expect(main?.textContent).toBe('client');
+		expect(onRecoverableError).not.toHaveBeenCalled();
+		root.unmount();
+		expect(title?.isConnected).toBe(false);
+	});
+
 	it('adopts the server head and single-root body, then removes owned nodes on unmount', () => {
 		const { html } = ServerRT.renderToString(server.Page, { params: {} });
 		// html folds head metadata to the front + body after. A document places the

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -1075,6 +1075,51 @@ describe('SSR, hoisted head channel', () => {
 		`,
 		'head-fragment-comment.tsrx',
 	);
+	const fragmentWithAuthoredHead = evalServer(
+		`
+		export function Page() @{
+			<>
+				<head data-page="fragment" data-note="keep </head> here">
+					<meta charSet="utf-8" />
+				</head>
+				<body>
+					<title>Fragment document</title>
+					<main>body text</main>
+				</body>
+			</>
+		}
+		`,
+		'head-fragment-document.tsrx',
+	);
+	const fragmentWithNestedHead = evalServer(
+		`
+		export function Page() @{
+			<div>
+				<head><meta name="fragment-nested" content="kept" /></head>
+				<title>Nested head</title>
+				<main>body text</main>
+			</div>
+		}
+		`,
+		'head-fragment-nested.tsrx',
+	);
+	const fragmentWithStyledHead = evalServer(
+		`
+		export function Page() @{
+			<>
+				<head data-page="styled" />
+				<body>
+					<title>Styled fragment</title>
+					<main class="styled">
+						body text
+						<style>.styled { color: rebeccapurple; }</style>
+					</main>
+				</body>
+			</>
+		}
+		`,
+		'head-fragment-styled.tsrx',
+	);
 	const documentPages = evalServer(
 		`
 		export function WithHead() @{
@@ -1144,6 +1189,70 @@ describe('SSR, hoisted head channel', () => {
 			expect(separate.html).toContain('<main><!-- </head> --></main>');
 			expect(separate.head! + separate.html).toBe(folded.html);
 		}
+	});
+
+	it('folds hoisted metadata inside a leading authored head in a fragment root', async () => {
+		for (const render of [RT.renderToString, RT.renderToStaticMarkup, prerender]) {
+			const { html } = await render(fragmentWithAuthoredHead.Page);
+			const headOpen = html.indexOf('<head data-page="fragment"');
+			const charset = html.indexOf('charSet="utf-8"');
+			const title = html.indexOf('<title>Fragment document</title>');
+			const headClose = html.lastIndexOf('</head>');
+			const bodyOpen = html.indexOf('<body>');
+			expect(headOpen).toBeGreaterThan(-1);
+			expect(charset).toBeGreaterThan(headOpen);
+			expect(title).toBeGreaterThan(charset);
+			expect(title).toBeLessThan(headClose);
+			expect(headClose).toBeLessThan(bodyOpen);
+			const parsed = new DOMParser().parseFromString(
+				`<!doctype html><html>${html}</html>`,
+				'text/html',
+			);
+			expect(parsed.head.querySelector('meta[charset]')?.getAttribute('charset')).toBe('utf-8');
+			expect(parsed.head.getAttribute('data-note')).toBe('keep </head> here');
+			expect(parsed.title).toBe('Fragment document');
+		}
+	});
+
+	it('folds metadata inside a leading fragment head in streamed output', async () => {
+		const stream = await RT.renderToReadableStream(fragmentWithAuthoredHead.Page);
+		const html = await new Response(stream).text();
+		const headOpen = html.indexOf('<head data-page="fragment"');
+		const title = html.indexOf('<title>Fragment document</title>');
+		const headClose = html.lastIndexOf('</head>');
+		expect(title).toBeGreaterThan(headOpen);
+		expect(title).toBeLessThan(headClose);
+		expect(html).not.toContain('<!DOCTYPE html>');
+	});
+
+	it('keeps a nested head from capturing fragment metadata', async () => {
+		for (const render of [RT.renderToString, RT.renderToStaticMarkup, prerender]) {
+			const { html } = await render(fragmentWithNestedHead.Page);
+			expect(html.indexOf('<title>Nested head</title>')).toBeLessThan(html.indexOf('<div>'));
+			expect(html.indexOf('name="fragment-nested"')).toBeLessThan(html.indexOf('<div>'));
+		}
+		const stream = await RT.renderToReadableStream(fragmentWithNestedHead.Page);
+		const html = await new Response(stream).text();
+		expect(html.indexOf('<title>Nested head</title>')).toBeLessThan(html.indexOf('<div>'));
+	});
+
+	it('folds streamed scoped styles with metadata inside a leading authored head', async () => {
+		const stream = await RT.renderToReadableStream(fragmentWithStyledHead.Page);
+		const html = await new Response(stream).text();
+		const headOpen = html.indexOf('<head data-page="styled">');
+		const style = html.indexOf('<style data-octane=');
+		const title = html.indexOf('<title>Styled fragment</title>');
+		const headClose = html.indexOf('</head>');
+		expect(style).toBeGreaterThan(headOpen);
+		expect(style).toBeLessThan(headClose);
+		expect(title).toBeGreaterThan(headOpen);
+		expect(title).toBeLessThan(headClose);
+		const parsed = new DOMParser().parseFromString(
+			`<!doctype html><html>${html}</html>`,
+			'text/html',
+		);
+		expect(parsed.head.querySelector('style[data-octane]')?.textContent).toContain('rebeccapurple');
+		expect(parsed.title).toBe('Styled fragment');
 	});
 
 	it('places metadata inside an authored or synthesized document head', async () => {

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -1091,6 +1091,31 @@ describe('SSR, hoisted head channel', () => {
 		`,
 		'head-fragment-document.tsrx',
 	);
+	const fragmentWithHeadChildMarkup = evalServer(
+		`
+		export function Page() @{
+			<>
+				<head>
+					<script data-note="</head>" dangerouslySetInnerHTML={{ __html: 'const marker = "</head>";' }} />
+					<meta charSet="utf-8" />
+				</head>
+				<body><title>Head child markup</title><main>body text</main></body>
+			</>
+		}
+		`,
+		'head-fragment-child-markup.tsrx',
+	);
+	const fragmentWithHeadComment = evalServer(
+		`
+		export function Page() @{
+			<>
+				<head dangerouslySetInnerHTML={{ __html: '<!-- </head> -->' }} />
+				<body><title>Comment in head</title><main>body text</main></body>
+			</>
+		}
+		`,
+		'head-fragment-comment-inside-head.tsrx',
+	);
 	const fragmentWithNestedHead = evalServer(
 		`
 		export function Page() @{
@@ -1223,6 +1248,75 @@ describe('SSR, hoisted head channel', () => {
 		expect(title).toBeGreaterThan(headOpen);
 		expect(title).toBeLessThan(headClose);
 		expect(html).not.toContain('<!DOCTYPE html>');
+	});
+
+	it('folds metadata after a head child containing closing-tag text', async () => {
+		for (const render of [RT.renderToString, RT.renderToStaticMarkup, prerender]) {
+			const { html } = await render(fragmentWithHeadChildMarkup.Page);
+			const parsed = new DOMParser().parseFromString(
+				`<!doctype html><html>${html}</html>`,
+				'text/html',
+			);
+			expect(parsed.head.querySelector('script')?.getAttribute('data-note')).toBe('</head>');
+			expect(parsed.head.querySelector('script')?.textContent).toContain('"</head>"');
+			expect(parsed.head.querySelector('meta[charset]')?.getAttribute('charset')).toBe('utf-8');
+			expect(parsed.title).toBe('Head child markup');
+			expect(parsed.body.querySelector('main')?.textContent).toBe('body text');
+		}
+		const stream = await RT.renderToReadableStream(fragmentWithHeadChildMarkup.Page);
+		const html = await new Response(stream).text();
+		const parsed = new DOMParser().parseFromString(
+			`<!doctype html><html>${html}</html>`,
+			'text/html',
+		);
+		expect(parsed.head.querySelector('script')?.getAttribute('data-note')).toBe('</head>');
+		expect(parsed.head.querySelector('meta[charset]')?.getAttribute('charset')).toBe('utf-8');
+		expect(parsed.title).toBe('Head child markup');
+	});
+
+	it('folds metadata after a comment containing closing-tag text in the head', async () => {
+		for (const render of [RT.renderToString, RT.renderToStaticMarkup, prerender]) {
+			const { html } = await render(fragmentWithHeadComment.Page);
+			const parsed = new DOMParser().parseFromString(
+				`<!doctype html><html>${html}</html>`,
+				'text/html',
+			);
+			expect(
+				[...parsed.head.childNodes].some(
+					(node) => node.nodeType === 8 && node.textContent?.includes('</head>'),
+				),
+			).toBe(true);
+			expect(parsed.title).toBe('Comment in head');
+			expect(parsed.body.querySelector('main')?.textContent).toBe('body text');
+		}
+	});
+
+	it('folds metadata after raw style text in a fragment head', () => {
+		const fragment = RT.createElement(
+			RT.Fragment,
+			null,
+			RT.createElement(
+				'head',
+				null,
+				RT.createElement('style', {
+					dangerouslySetInnerHTML: { __html: '/* </head> */ .safe { color: red }' },
+				}),
+			),
+			RT.createElement(
+				'body',
+				null,
+				RT.createElement('title', null, 'Style in head'),
+				RT.createElement('main', null, 'body text'),
+			),
+		);
+		const { html } = RT.renderToString(fragment);
+		const parsed = new DOMParser().parseFromString(
+			`<!doctype html><html>${html}</html>`,
+			'text/html',
+		);
+		expect(parsed.head.querySelector('style')?.textContent).toContain('/* </head> */');
+		expect(parsed.title).toBe('Style in head');
+		expect(parsed.body.querySelector('main')?.textContent).toBe('body text');
 	});
 
 	it('keeps a nested head from capturing fragment metadata', async () => {

--- a/packages/seo/src/useStrayOwnerDiagnostic.ts
+++ b/packages/seo/src/useStrayOwnerDiagnostic.ts
@@ -16,41 +16,42 @@
  */
 import { useEffect } from 'octane';
 
-// This package publishes source, so a browser application compiles the file
-// below with its own tsconfig and runs it in a host that has neither
-// `@types/node` nor a `process` global. The reference is therefore declared
-// here and guarded at runtime; without the guard every `<Head>` render throws a
-// ReferenceError in any host that does not define one.
-//
-// The read stays spelled out as `process.env.NODE_ENV` because that is the
-// expression bundlers substitute with a literal. Where the identifier also
-// survives, Node and SSR, the production branch is exact. Where only the value
-// is substituted the guard reads false and the diagnostic behaves as it does in
-// development: one counter and one effect per owning `<Head>`, which is the
-// price of not throwing.
-declare const process: { readonly env: { readonly NODE_ENV?: string } } | undefined;
+// This package publishes source, so consumers need no Node types. Bundlers
+// replace the direct `process.env.NODE_ENV` read in both development and
+// production browser builds. An unbundled browser host without `process`
+// cannot identify its mode, so the catch below skips the diagnostic safely.
+declare const process: { readonly env: { readonly NODE_ENV?: string } };
 
 let liveOwners = 0;
 let reported = false;
 
 export function useStrayOwnerDiagnostic(owns: boolean): void {
-	if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') return;
-	useEffect(() => {
-		if (!owns) return;
-		liveOwners++;
-		if (liveOwners > 1 && !reported) {
-			reported = true;
-			console.error(
-				'[@octanejs/seo] Two <Head> elements are mounted with neither containing the ' +
-					'other, so each emits its own merged set: the document will carry duplicate ' +
-					'tags and the FIRST in document order will win, which makes the other ' +
-					"component's metadata silently ineffective. Wrap the app in a single " +
-					'<Head> so every other <Head> block merges into it.',
-			);
+	let checkedEnvironment = false;
+	try {
+		if (process.env.NODE_ENV !== 'production') {
+			checkedEnvironment = true;
+			useEffect(() => {
+				if (!owns) return;
+				liveOwners++;
+				if (liveOwners > 1 && !reported) {
+					reported = true;
+					console.error(
+						'[@octanejs/seo] Two <Head> elements are mounted with neither containing the ' +
+							'other, so each emits its own merged set: the document will carry duplicate ' +
+							'tags and the FIRST in document order will win, which makes the other ' +
+							"component's metadata silently ineffective. Wrap the app in a single " +
+							'<Head> so every other <Head> block merges into it.',
+					);
+				}
+				return () => {
+					liveOwners--;
+					if (liveOwners <= 1) reported = false;
+				};
+			});
 		}
-		return () => {
-			liveOwners--;
-			if (liveOwners <= 1) reported = false;
-		};
-	});
+	} catch (error) {
+		// Only an unresolved environment probe may fail closed. A hook error
+		// must still reach its caller, including in a development browser.
+		if (checkedEnvironment || typeof process !== 'undefined') throw error;
+	}
 }

--- a/packages/seo/tests/_fixtures/production-bundle-consumer.ts
+++ b/packages/seo/tests/_fixtures/production-bundle-consumer.ts
@@ -1,0 +1,7 @@
+import { createRoot, drainPassiveEffects, flushSync } from 'octane';
+import { StrayOwners } from './misuse.tsrx';
+
+createRoot(document.getElementById('root')!).render(StrayOwners);
+flushSync(() => {});
+drainPassiveEffects();
+flushSync(() => {});

--- a/packages/seo/tests/production-bundle.test.ts
+++ b/packages/seo/tests/production-bundle.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { build, transform } from 'esbuild';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error This shared JavaScript build helper has no declaration file.
+import { createOctaneSourcePlugin } from '../../../scripts/packed-source-compiler.mjs';
+
+const require = createRequire(import.meta.url);
+const { JSDOM } = require('jsdom') as {
+	JSDOM: new (
+		markup: string,
+		options: { runScripts: 'dangerously'; pretendToBeVisual: boolean },
+	) => { window: Window & typeof globalThis & { eval(source: string): void; close(): void } };
+};
+const packageDirectory = resolve(import.meta.dirname, '..');
+const consumerEntry = resolve(import.meta.dirname, '_fixtures/production-bundle-consumer.ts');
+
+async function runBrowserBundle(mode: 'development' | 'production') {
+	const result = await build({
+		entryPoints: [consumerEntry],
+		plugins: [await createOctaneSourcePlugin(packageDirectory)],
+		bundle: true,
+		define: {
+			__OCTANE_PROFILE_ENABLED__: 'false',
+			'process.env.NODE_ENV': JSON.stringify(mode),
+		},
+		format: 'iife',
+		logLevel: 'silent',
+		minify: true,
+		platform: 'browser',
+		treeShaking: true,
+		write: false,
+	});
+	const browser = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+		runScripts: 'dangerously',
+		pretendToBeVisual: true,
+	});
+	const errors: string[] = [];
+
+	try {
+		browser.window.console.error = (...args: unknown[]) => errors.push(args.map(String).join(' '));
+		expect('process' in browser.window).toBe(false);
+		browser.window.eval(result.outputFiles[0].text);
+		expect(browser.window.document.querySelector('main')?.textContent).toBe('stray');
+		return { errors, code: result.outputFiles[0].text };
+	} finally {
+		browser.window.close();
+	}
+}
+
+describe('@octanejs/seo browser bundles', () => {
+	it('reports stray <Head> owners in a development bundle without process', async () => {
+		expect((await runBrowserBundle('development')).errors.join('\n')).toContain(
+			'Wrap the app in a single',
+		);
+	}, 30_000);
+
+	it('stays silent in a production bundle without process', async () => {
+		const { errors, code } = await runBrowserBundle('production');
+		expect(errors).toEqual([]);
+		expect(code).not.toContain('Two <Head> elements are mounted');
+	}, 30_000);
+
+	it('does not throw when an unbundled browser host has no process', async () => {
+		const source = readFileSync(
+			resolve(packageDirectory, 'src/useStrayOwnerDiagnostic.ts'),
+			'utf8',
+		);
+		const compiled = await transform(source, { format: 'cjs', loader: 'ts' });
+		const module: { exports: { useStrayOwnerDiagnostic?: (owns: boolean) => void } } = {
+			exports: {},
+		};
+
+		runInNewContext(compiled.code, {
+			exports: module.exports,
+			module,
+			require: (name: string) => {
+				if (name !== 'octane') throw new Error(`Unexpected import: ${name}`);
+				return {
+					useEffect: () => {
+						throw new Error('An unbundled host cannot schedule this diagnostic.');
+					},
+				};
+			},
+		});
+
+		expect(() => module.exports.useStrayOwnerDiagnostic!(true)).not.toThrow();
+	});
+});

--- a/scripts/check-package-packs.mjs
+++ b/scripts/check-package-packs.mjs
@@ -475,6 +475,7 @@ async function validatePackedConsumer(tempRoot, archives) {
 				devDependencies: {
 					'@tsrx/typescript-plugin': tsrxTypeScriptPluginVersion,
 					'@types/node': nodeTypesVersion,
+					postcss: '^8.5.28',
 					typescript: typescriptVersion,
 					vite: viteVersion,
 				},
@@ -482,13 +483,6 @@ async function validatePackedConsumer(tempRoot, archives) {
 			null,
 			2,
 		) + '\n',
-	);
-	// postcss 8.5.28 makes DeclarationProps extend NodeProps, but tsrx-tsc
-	// cannot resolve that named export from node.d.ts (TS2304). pnpm 11 reads
-	// overrides from pnpm-workspace.yaml, matching the other packed consumers.
-	writeFileSync(
-		path.join(consumerDirectory, 'pnpm-workspace.yaml'),
-		'overrides:\n  postcss: "8.5.26"\n',
 	);
 	writeFileSync(
 		path.join(sourceDirectory, 'App.tsrx'),
@@ -873,9 +867,7 @@ export function renderProbe() {
 
 	const consumerRequire = createRequire(path.join(consumerDirectory, 'package.json'));
 	const installedPostcss = consumerRequire('postcss/package.json').version;
-	if (installedPostcss !== '8.5.26') {
-		throw new Error(`packed consumer resolved postcss ${installedPostcss}; expected 8.5.26`);
-	}
+	console.log(`packed consumer resolved postcss ${installedPostcss}`);
 	const directRuntime = realpathSync(consumerRequire.resolve('octane'));
 	// Resolve through real ESM package specifiers from the installed consumer,
 	// not a CommonJS-resolved file URL, so conditional `import` branches remain


### PR DESCRIPTION
## Summary

- Address items 5 and 6 of #1037 in their owning packages.
- Fold hoisted SSR metadata into a fragment root's leading authored `<head>`, including streamed scoped styles.
- Remove the SEO stray-owner diagnostic from production browser bundles and retire the packed-consumer PostCSS override.

## Why

- Fragment preambles previously emitted hoisted metadata ahead of their authored `<head>`.
- The SEO environment guard kept a development diagnostic in browser production output.
- The PostCSS type error was in 8.5.27 and is fixed in 8.5.28 ([upstream issue #2154](https://github.com/postcss/postcss/issues/2154)); the 8.5.26 smoke override obscured the current consumer result.

## Changes

- Detect a leading fragment `<head>` after SSR block markers, locate its closing tag past quoted child attributes, comments, and script/style text, and preserve the existing document doctype behavior.
- Document the SSR preamble and the supported separate-head, body-root hydration route; test buffered, static, prerendered, streamed, nested-head, scoped-style, and hydration behavior.
- Guard the SEO diagnostic so bundlers eliminate its effect and counter in production, while development browser builds still report misuse and unbundled hosts without `process` fail safely.
- Exercise packed consumers with `postcss: ^8.5.28` and report the resolved version, without a workspace override.

## Validation

- [x] `pnpm sync` (no generated diff)
- [x] Scoped `pnpm format:files:check` and core/SEO source typechecks
- [x] SSR and hydration suites in development and production modes: 464 tests; focused SSR regression rerun on the final scanner: 152 tests
- [x] SEO and SEO SSR suites: 108 tests; production bundle regression passed again after final integration
- [x] Package-pack canaries: 30 tests; independent strict `tsc` and `tsrx-tsc` consumer reproduction fails on PostCSS 8.5.27 and passes on 8.5.28
- [x] Current-head CI `validate publishable packages`, including the packed-consumer phase. The local run packed all tarballs but could not install consumers because this host's npm mirror lacks several versions already required by `main` (`@tsrx/typescript-plugin@0.3.135`, `@tsrx/core@0.1.69`, `cn@0.2.6`).
- [ ] Repository-wide `pnpm test`, `pnpm typecheck`, and `pnpm format:check` (targeted alternatives above)

## Risk / follow-ups

- A fragment `<head>`/`<body>` preamble composed into a host-owned `<html>` is an SSR-only shape; hydrating that fragment as the `Document` root is not supported. The documented body-root/separate-head path adopts and updates metadata in the hydration regression.
- Production streaming benchmark output bytes and chunk counts were unchanged. A same-process 100-sample paired comparison measured about 1.9% higher median CPU-800 time, small relative to observed run-order variation; no speed claim is made.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791674519&installation_model_id=432790&pr_number=1045&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1045&signature=3e995e3726d16d08f9070e3c64f8813b3182ded947ed72e0b39b9b2bde58820e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core SSR head insertion and streaming shell assembly change markup shape for fragment preambles; incorrect `</head>` detection could misplace title/meta/link, though new edge-case tests mitigate that.
> 
> **Overview**
> **SSR hoisted metadata** now splices into a **leading authored `<head>`** on fragment roots (not only full `<html>` documents), for buffered and streaming renders. Streaming also places **leading scoped styles** inside that head; fragment preambles still skip the streaming doctype and injection document-tail mode. Closing `</head>` is found with a quote-aware scan so false matches inside scripts, styles, and comments do not break folding.
> 
> **`@octanejs/seo`** restructures the stray `<Head>` diagnostic so **`useEffect` runs only when `NODE_ENV !== 'production'`**, letting production browser bundles drop the warning; hosts without `process` skip safely via try/catch. **Docs** describe fragment-head SSR vs hydrating with `headChannel: 'separate'` on a body root.
> 
> **Packed-consumer tooling** drops the PostCSS 8.5.26 pin and relies on **^8.5.28**. New SSR, hydration, and esbuild production-bundle tests cover the above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006531f4b490e20835fdc7fb6a89cae0843b6207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->