### PR TITLE
fix: preserve deferred imports in TSRX output

### DIFF
--- a/.changeset/deferred-module-imports.md
+++ b/.changeset/deferred-module-imports.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Preserve `import defer` and `import.defer()` syntax in compiled TSRX modules so supported loaders can defer dependency evaluation.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -37,6 +37,7 @@ import {
 	createStyleClassMapFromStylesheet,
 	clone_ast_node as cloneAstNode,
 	strongHash,
+	withDeferredImports,
 } from '@tsrx/core';
 import { parseModule } from '#octane/compiler-parser';
 import { createStyleScopePass } from './style-scopes.js';
@@ -9922,7 +9923,11 @@ function compileInternal(
 				}).nodes,
 			);
 			if (hmrEnabled) hmrComponents.push({ name: node.declaration.id.name, exportKind: 'default' });
-		} else if (node.type === 'ImportDeclaration' && node.source.value === 'octane') {
+		} else if (
+			node.type === 'ImportDeclaration' &&
+			node.source.value === 'octane' &&
+			node.phase !== 'defer'
+		) {
 			// Preserve ALL user-imported names from octane (Portal, createContext,
 			// use, custom helpers, etc.) — merged into the single prelude import.
 			addUserImportSpecifiers(ctx, node);
@@ -10572,8 +10577,16 @@ function compileServer(
 					: compileServerComponent({ ...node.declaration, default: true }, ctx)),
 			);
 		} else if (node.type === 'ImportDeclaration' && node.source.value === 'octane') {
-			// User imports from 'octane' resolve to the server runtime instead.
-			addUserImportSpecifiers(ctx, node);
+			// Preserve the authored deferred namespace while routing it to the server runtime.
+			// Other user imports are merged into the eager server runtime prelude.
+			if (node.phase === 'defer') {
+				bodyNodes.push({
+					...node,
+					source: { ...node.source, value: 'octane/server', raw: '"octane/server"' },
+				});
+			} else {
+				addUserImportSpecifiers(ctx, node);
+			}
 		} else if (
 			(node.type === 'ImportDeclaration' ||
 				node.type === 'ExportNamedDeclaration' ||
@@ -29464,7 +29477,7 @@ const esrapCommentOptions = {
 function printNodeWithMap(node, ctx) {
 	const printable = stripTsOnlyWrappers(escapeMultilineStringLiterals(node));
 	if (assertPrintedLocs()) assertNodeLocs(printable);
-	const { code, map } = esrapPrint(printable, esrapTsx(esrapCommentOptions), {
+	const { code, map } = esrapPrint(printable, withDeferredImports(esrapTsx(esrapCommentOptions)), {
 		sourceMapSource: ctx.mapSourceName,
 		sourceMapContent: ctx.mapSource,
 		sourceMapEncodeMappings: false,

--- a/packages/octane/tests/_fixtures/deferred-module-imports.tsrx
+++ b/packages/octane/tests/_fixtures/deferred-module-imports.tsrx
@@ -1,0 +1,9 @@
+import defer * as slow from './basic.tsrx';
+import * as eager from './actions.tsrx';
+
+export const loadLater = import.defer('./activity.tsrx');
+export const readModules = () => [slow.Hello, eager.ActionForm];
+
+export function App() @{
+	<p>{'Ready'}</p>
+}

--- a/packages/octane/tests/compiler/module-import-phases.test.ts
+++ b/packages/octane/tests/compiler/module-import-phases.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseModule } from 'oxc-tsrx/tsrx-core-compat';
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+
+const source = readFileSync(
+	join(process.cwd(), 'packages/octane/tests/_fixtures/deferred-module-imports.tsrx'),
+	'utf8',
+);
+
+describe('compiled module imports', () => {
+	for (const [label, options] of [
+		['client development', { dev: true, hmr: 'vite' }],
+		['client production', { dev: false, hmr: false }],
+		['server development', { mode: 'server', dev: true }],
+		['server production', { mode: 'server', dev: false }],
+	] as const) {
+		it(`preserves deferred imports in ${label}`, () => {
+			const { code } = compile(source, 'deferred-module-imports.tsrx', options);
+			const statements = parseModule(code, 'deferred-module-imports.js').body;
+			const imports = statements.filter((statement) => statement.type === 'ImportDeclaration');
+			const deferred = imports.find((statement) => statement.source.value === './basic.tsrx');
+			const eager = imports.find((statement) => statement.source.value === './actions.tsrx');
+			const loadLater = statements.find(
+				(statement) =>
+					statement.type === 'ExportNamedDeclaration' &&
+					statement.declaration?.type === 'VariableDeclaration' &&
+					statement.declaration.declarations[0]?.id?.type === 'Identifier' &&
+					statement.declaration.declarations[0]?.id.name === 'loadLater',
+			);
+			const dynamicImport =
+				loadLater?.type === 'ExportNamedDeclaration' &&
+				loadLater.declaration?.type === 'VariableDeclaration'
+					? loadLater.declaration.declarations[0]?.init
+					: undefined;
+
+			expect(deferred?.phase).toBe('defer');
+			expect(deferred?.specifiers[0]?.type).toBe('ImportNamespaceSpecifier');
+			expect(eager?.phase).not.toBe('defer');
+			expect(dynamicImport).toMatchObject({
+				type: 'ImportExpression',
+				phase: 'defer',
+				source: { value: './activity.tsrx' },
+			});
+		});
+	}
+
+	for (const [label, options, runtimeModule] of [
+		['client', { hmr: false }, 'octane'],
+		['server', { mode: 'server' }, 'octane/server'],
+	] as const) {
+		it(`preserves deferred imports from the ${label} runtime`, () => {
+			const { code } = compile(
+				"import defer * as runtime from 'octane'; export const getHook = () => runtime.useState;",
+				'deferred-runtime-import.tsrx',
+				options,
+			);
+			const runtimeImport = parseModule(code, 'deferred-runtime-import.js').body.find(
+				(statement) =>
+					statement.type === 'ImportDeclaration' && statement.source.value === runtimeModule,
+			);
+
+			expect(runtimeImport?.type === 'ImportDeclaration' ? runtimeImport.phase : undefined).toBe(
+				'defer',
+			);
+		});
+	}
+});


### PR DESCRIPTION
## Summary
- Preserve authored `import defer * as ns` and `import.defer(...)` in TSRX compiler output.
- Keep deferred `octane` namespace imports intact when the client/server runtime prelude is built.
- Add a patch changeset and compiler regression coverage for client/server and dev/prod output.

## Why
The TSRX parser records the import phase, but esrap's default TSX visitors omit it when Octane prints the final module. The emitted static import evaluated eagerly, and the dynamic form became an ordinary `import(...)`.

## Changes
- Use `@tsrx/core`'s deferred import visitor wrapper at the single generated program print.
- Leave a deferred runtime namespace outside the eager import merge; route it to `octane/server` in server output.
- Assert parsed emitted phases, including an ordinary eager import control.

## Validation
- [ ] `pnpm format:check` (scoped check below)
- [ ] `pnpm typecheck` (full workspace install locally blocked by registry 403 for pinned TSRX packages)
- [ ] `pnpm test` (same dependency limit)
- [x] `pnpm format:files:check` for the changed files
- [x] `pnpm sync` (no generated changes)
- [x] focused compiler tests: 80 passed across four files with frozen AST and source-location assertions
- [x] focused strict TypeScript check of the new test
- [x] same-environment eager compile control: byte-identical output, median 0.538 ms before / 0.539 ms after (nine interleaved samples of 250 compiles; ranges overlap)

## Risk / follow-ups
The emitted syntax requires loader/bundler support for deferred imports. This compiler change does not transform that syntax for loaders that only parse it. No runtime hot path changes; local timing variation is larger than the observed compile difference.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791738437&installation_model_id=432790&pr_number=1050&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1050&signature=70a94bfa83d797bc5ffb2f19415664236a4aac2dffcebb4141d34783d0dee0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compiler-only output fix with no runtime hot-path changes; emitted defer syntax still depends on downstream loader/bundler support.
> 
> **Overview**
> Fixes the TSRX compiler dropping **deferred import** metadata when emitting JavaScript: authored `import defer * as …` and `import.defer(...)` now keep their `defer` phase in the printed module via `@tsrx/core`'s `withDeferredImports` wrapper around the esrap TSX printer.
> 
> **Octane runtime prelude handling** is updated so deferred `octane` namespace imports are no longer folded into the eager prelude merge (client) and instead emit as a separate import routed to `octane/server` on server builds, while ordinary `octane` imports behave as before.
> 
> Adds a patch changeset, a fixture, and compiler tests across client/server and dev/prod that parse emitted output and assert defer phases on static and dynamic imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc51f1b6d4b23d5ddc193a27f064c9117927c175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->