### PR TITLE
fix: optimize duplicate inline style properties

### DIFF
--- a/.changeset/fix-duplicate-inline-style.md
+++ b/.changeset/fix-duplicate-inline-style.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Optimize inline style objects with repeated property names using targeted property updates. Preserve every authored value evaluation, the final value of each key, and its original insertion order across client rendering, SSR, and hydration.

--- a/benchmarks/js-framework/README-naive.md
+++ b/benchmarks/js-framework/README-naive.md
@@ -94,7 +94,7 @@ WORK_DIALECT=jsx pnpm --dir benchmarks/js-framework bench:style-work
 ### Fixed-key inline style literals
 
 The separate `style-literals.html` entry keeps the ordinary js-framework app's
-DOM workload and style authoring unchanged. It mounts 1,000 keyed rows in four
+DOM workload and style authoring unchanged. It mounts 1,000 keyed rows in six
 cases:
 
 | case | authored `style` | expected path |
@@ -103,9 +103,15 @@ cases:
 | `multi` | one static declaration and two dynamic values | baked prefix, grouped mount, guarded scalar updates |
 | `generic` | the same three declarations as `multi`, passed through `style={style}` | whole-object diff control |
 | `interleaved` | dynamic `left`, imported `display`, dynamic `right`, then static `opacity` | grouped mount and guarded scalar updates without a static prefix |
+| `duplicateStatic` | dynamic `color`, then static `color`, then dynamic `background` | grouped mount and guarded updates to `background` |
+| `duplicateDynamic` | static `color`, then dynamic `color` and `background` | grouped mount and guarded updates to both final values |
 
 The multi and generic cases produce the same CSS. The interleaved case covers
-the imported value and non-prefix literal order from issue #1048. The gate checks every row's
+the imported value and non-prefix literal order from issue #1048. The duplicate
+cases cover both overwritten-value examples in the issue's follow-up. They
+check that the final value wins, the first insertion determines CSS declaration
+order, and the dynamic color expression is evaluated even when overwritten.
+The gate checks every row's
 style and selection, DOM identity, CSSOM writes, and production helper calls on
 mount, selecting two successive rows, and an unrelated update. It tests work
 separately from correctness suites. The `generic` case must still take the
@@ -131,6 +137,12 @@ To measure an older compiler before grouped lowering, set
 `WORK_EXPECT_MULTI_OPTIMIZED=0` on the final command. Compare that baseline and
 the candidate with the same Node, Vite, `@tsrx/core`, Chromium, machine, and
 sampling settings.
+
+To measure the duplicate-key regression against a compiler that still uses
+whole-object updates for those two cases, set
+`WORK_EXPECT_DUPLICATES_OPTIMIZED=0`. Both duplicate cases require 1,000 generic
+style calls per operation in that baseline and zero after optimization;
+an unrelated update must write no CSS properties in either version.
 
 The naive fixtures also carry the keyed-reorder buttons (mirroring the tuned
 set), so `run-reorder.mjs` can drive them the same way — but the canonical

--- a/benchmarks/js-framework/octane-tsrx-naive/src/StyleLiteralWork.tsrx
+++ b/benchmarks/js-framework/octane-tsrx-naive/src/StyleLiteralWork.tsrx
@@ -1,5 +1,5 @@
 import { useState } from 'octane';
-import { displayValue } from './style-literal-values.js';
+import { displayValue, recordColor } from './style-literal-values.js';
 
 const IDS = Array.from({ length: 1000 }, (_, index) => index);
 
@@ -51,6 +51,30 @@ function InterleavedRow(props) @{
 	</tr>
 }
 
+function DuplicateStaticRow(props) @{
+	<tr class={props.selected ? 'selected' : ''} onClick={props.select}>
+		<td
+			style={{
+				color: recordColor(props.version >= 0 ? props.color : 'transparent'),
+				color: 'red',
+				background: props.background,
+			}}
+		>{String(props.id)}</td>
+	</tr>
+}
+
+function DuplicateDynamicRow(props) @{
+	<tr class={props.selected ? 'selected' : ''} onClick={props.select}>
+		<td
+			style={{
+				color: 'red',
+				color: recordColor(props.version >= 0 ? props.color : 'transparent'),
+				background: props.background,
+			}}
+		>{String(props.id)}</td>
+	</tr>
+}
+
 export function StyleLiteralWork(props) @{
 	const [ids, setIds] = useState([]);
 	const [selected, setSelected] = useState(-1);
@@ -90,12 +114,34 @@ export function StyleLiteralWork(props) @{
 							select={() => setSelected(id)}
 						/>
 					}
-				} @else {
+				} @else if (props.mode === 'interleaved') {
 					@for (const id of ids; key id) {
 						<InterleavedRow
 							id={id}
 							selected={selected === id}
 							version={version}
+							select={() => setSelected(id)}
+						/>
+					}
+				} @else if (props.mode === 'duplicateStatic') {
+					@for (const id of ids; key id) {
+						<DuplicateStaticRow
+							id={id}
+							selected={selected === id}
+							version={version}
+							color={version >= 0 && selected === id ? 'blue' : 'black'}
+							background={version >= 0 && selected === id ? 'yellow' : 'white'}
+							select={() => setSelected(id)}
+						/>
+					}
+				} @else {
+					@for (const id of ids; key id) {
+						<DuplicateDynamicRow
+							id={id}
+							selected={selected === id}
+							version={version}
+							color={version >= 0 && selected === id ? 'blue' : 'black'}
+							background={version >= 0 && selected === id ? 'yellow' : 'white'}
 							select={() => setSelected(id)}
 						/>
 					}

--- a/benchmarks/js-framework/octane-tsrx-naive/src/style-literal-values.js
+++ b/benchmarks/js-framework/octane-tsrx-naive/src/style-literal-values.js
@@ -1,1 +1,8 @@
 export const displayValue = 'block';
+
+export let colorEvaluations = 0;
+
+export function recordColor(value) {
+	colorEvaluations++;
+	return value;
+}

--- a/benchmarks/js-framework/octane-tsrx-naive/src/style-literals-main.js
+++ b/benchmarks/js-framework/octane-tsrx-naive/src/style-literals-main.js
@@ -1,8 +1,13 @@
 import { createRoot, flushSync } from 'octane';
 import { StyleLiteralWork } from './StyleLiteralWork.tsrx';
+import { colorEvaluations } from './style-literal-values.js';
 
 const mode = new URL(location.href).searchParams.get('case') || 'single';
-if (mode !== 'single' && mode !== 'multi' && mode !== 'generic' && mode !== 'interleaved') {
+if (
+	!['single', 'multi', 'generic', 'interleaved', 'duplicateStatic', 'duplicateDynamic'].includes(
+		mode,
+	)
+) {
 	throw new Error(`Unknown inline style benchmark case: ${mode}`);
 }
 const target = document.getElementById('main');
@@ -10,3 +15,4 @@ if (!target) throw new Error('missing #main root');
 
 createRoot(target).render(StyleLiteralWork, { mode });
 window.__benchFlush = () => flushSync(() => {});
+window.__benchColorEvaluations = () => colorEvaluations;

--- a/benchmarks/js-framework/style-literals-work.mjs
+++ b/benchmarks/js-framework/style-literals-work.mjs
@@ -7,8 +7,9 @@ import { chromium } from 'playwright';
 const URL = process.env.TARGET_URL || 'http://127.0.0.1:5233/style-literals.html';
 const ROWS = 1000;
 const OPTIMIZED_MULTI = process.env.WORK_EXPECT_MULTI_OPTIMIZED !== '0';
+const OPTIMIZED_DUPLICATES = process.env.WORK_EXPECT_DUPLICATES_OPTIMIZED !== '0';
 const TIMING_SAMPLES = Number(process.env.WORK_SAMPLES || 0);
-const MODES = ['single', 'multi', 'generic', 'interleaved'];
+const MODES = ['single', 'multi', 'generic', 'interleaved', 'duplicateStatic', 'duplicateDynamic'];
 const OPS = [
 	{ name: 'mount_1k', setup: [], action: 'mount', changedRows: ROWS },
 	{ name: 'select_one', setup: ['mount'], action: 'select4', changedRows: 1 },
@@ -25,6 +26,8 @@ const METRICS = [
 	'MultiRow',
 	'GenericRow',
 	'InterleavedRow',
+	'DuplicateStaticRow',
+	'DuplicateDynamicRow',
 ];
 
 async function invoke(page, action) {
@@ -70,6 +73,7 @@ async function measure(browser, mode, operation) {
 		const observed = await page.evaluate(
 			async ({ action, mode, expectedRows }) => {
 				const before = Array.from(document.querySelectorAll('tbody tr'));
+				const colorEvaluationsBefore = window.__benchColorEvaluations();
 				const writes = { styleSets: 0, styleRemoves: 0, fontStyleWrites: 0 };
 				const set = CSSStyleDeclaration.prototype.setProperty;
 				const remove = CSSStyleDeclaration.prototype.removeProperty;
@@ -119,6 +123,18 @@ async function measure(browser, mode, operation) {
 						) {
 							throw new Error(`${action}: row ${index} lost an interleaved declaration`);
 						}
+					} else if (mode === 'duplicateStatic' || mode === 'duplicateDynamic') {
+						if (
+							cell.style.color !==
+								(mode === 'duplicateStatic' ? 'red' : selected ? 'blue' : 'black') ||
+							cell.style.backgroundColor !== (selected ? 'yellow' : 'white') ||
+							cell.style.cssText !==
+								`color: ${mode === 'duplicateStatic' ? 'red' : selected ? 'blue' : 'black'}; background: ${selected ? 'yellow' : 'white'};`
+						) {
+							throw new Error(
+								`${action}: row ${index} lost the final duplicate value or key order`,
+							);
+						}
 					} else {
 						if (
 							cell.style.fontStyle !== 'normal' ||
@@ -131,7 +147,11 @@ async function measure(browser, mode, operation) {
 						}
 					}
 				}
-				return { rows: rows.length, ...writes };
+				return {
+					rows: rows.length,
+					colorEvaluations: window.__benchColorEvaluations() - colorEvaluationsBefore,
+					...writes,
+				};
 			},
 			{ action: operation.action, mode, expectedRows: ROWS },
 		);
@@ -147,10 +167,15 @@ async function measure(browser, mode, operation) {
 
 function expected(mode, operation) {
 	const changes = operation.changedRows;
+	const duplicate = mode === 'duplicateStatic' || mode === 'duplicateDynamic';
 	const properties = mode === 'single' ? 1 : mode === 'interleaved' ? 3 : 2;
-	const changing = mode === 'interleaved' ? 2 : properties;
+	const changing = mode === 'duplicateStatic' ? 1 : mode === 'interleaved' ? 2 : properties;
 	const generic =
-		mode === 'generic' || ((mode === 'multi' || mode === 'interleaved') && !OPTIMIZED_MULTI);
+		mode === 'generic' ||
+		((mode === 'multi' || mode === 'interleaved') && !OPTIMIZED_MULTI) ||
+		(duplicate && !OPTIMIZED_DUPLICATES);
+	const mountWrites =
+		mode === 'interleaved' ? 4 : generic && !duplicate ? properties + 1 : properties;
 	return {
 		setStyle: generic ? ROWS : 0,
 		setStyleProperty:
@@ -160,22 +185,18 @@ function expected(mode, operation) {
 					? changes * changing
 					: 0,
 		setStyleProperties:
-			(mode === 'multi' || mode === 'interleaved') &&
-			OPTIMIZED_MULTI &&
+			(((mode === 'multi' || mode === 'interleaved') && OPTIMIZED_MULTI) ||
+				(duplicate && OPTIMIZED_DUPLICATES)) &&
 			operation.action === 'mount'
 				? ROWS
 				: 0,
 		applyStyleValue: generic ? ROWS : 0,
-		applyStyleProperty:
-			operation.action === 'mount'
-				? ROWS * (mode === 'interleaved' ? 4 : generic ? properties + 1 : properties)
-				: changes * changing,
-		styleSets:
-			operation.action === 'mount'
-				? ROWS * (mode === 'interleaved' ? 4 : generic ? properties + 1 : properties)
-				: changes * changing,
+		applyStyleProperty: operation.action === 'mount' ? ROWS * mountWrites : changes * changing,
+		styleSets: operation.action === 'mount' ? ROWS * mountWrites : changes * changing,
 		styleRemoves: 0,
-		fontStyleWrites: generic && mode !== 'interleaved' && operation.action === 'mount' ? ROWS : 0,
+		fontStyleWrites:
+			generic && mode !== 'interleaved' && !duplicate && operation.action === 'mount' ? ROWS : 0,
+		colorEvaluations: duplicate ? ROWS : 0,
 		rows: ROWS,
 	};
 }
@@ -266,12 +287,12 @@ try {
 
 const timing = failures.length === 0 ? await measureTiming() : null;
 
-console.log('case    operation        map grouped scalar CSS writes fixed writes rows');
+console.log('case             operation        map grouped scalar CSS writes fixed writes rows');
 for (const mode of MODES) {
 	for (const operation of OPS) {
 		const r = results[mode][operation.name];
 		console.log(
-			`${mode.padEnd(7)} ${operation.name.padEnd(16)} ${String(r.setStyle).padStart(4)} ` +
+			`${mode.padEnd(16)} ${operation.name.padEnd(16)} ${String(r.setStyle).padStart(4)} ` +
 				`${String(r.setStyleProperties).padStart(7)} ${String(r.setStyleProperty).padStart(6)} ` +
 				`${String(r.styleSets).padStart(10)} ${String(r.fontStyleWrites).padStart(12)} ${r.rows}`,
 		);
@@ -283,7 +304,7 @@ if (timing !== null) {
 		for (const operation of OPS) {
 			const t = timing[mode][operation.name];
 			console.log(
-				`${mode.padEnd(7)} ${operation.name.padEnd(16)} ` +
+				`${mode.padEnd(16)} ${operation.name.padEnd(16)} ` +
 					`${t.medianMs.toFixed(2)} [${t.p25Ms.toFixed(2)}, ${t.p75Ms.toFixed(2)}]`,
 			);
 		}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2161,8 +2161,8 @@ function staticObjectToCssString(obj) {
 		properties.set(name, p.value.value);
 	}
 	for (const [name, value] of properties) {
-		if (value == null || value === false || value === '') continue;
-		const cssValue = value === true ? '' : cssStyleValue(name, value);
+		if (value == null || typeof value === 'boolean' || value === '') continue;
+		const cssValue = cssStyleValue(name, value);
 		parts.push(`${hyphenateStyleName(name)}: ${cssValue};`);
 	}
 	return parts.join(' ');
@@ -2205,6 +2205,18 @@ function mixedStaticStyle(obj) {
 		seen.set(normalized, name);
 
 		const value = property.value;
+		const unwrappedValue = unwrapTsExpr(value);
+		// Extracting an anonymous function/class into a temporary changes its
+		// inferred name. A discarded class can observe that name in a static
+		// initializer, so preserve the original object evaluation in this case.
+		if (
+			unwrappedValue?.type === 'ArrowFunctionExpression' ||
+			((unwrappedValue?.type === 'FunctionExpression' ||
+				unwrappedValue?.type === 'ClassExpression') &&
+				!unwrappedValue.id)
+		) {
+			return null;
+		}
 		if (
 			value?.type === 'Literal' &&
 			dynamics.length === 0 &&

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2155,9 +2155,12 @@ function staticStyleObjectNeedsDevValidation(obj) {
 // dynamic styles are byte-identical in innerHTML.
 function staticObjectToCssString(obj) {
 	const parts = [];
+	const properties = new Map();
 	for (const p of obj.properties || []) {
 		const name = p.key.type === 'Identifier' ? p.key.name : p.key.value;
-		const value = p.value.value;
+		properties.set(name, p.value.value);
+	}
+	for (const [name, value] of properties) {
 		if (value == null || value === false || value === '') continue;
 		const cssValue = value === true ? '' : cssStyleValue(name, value);
 		parts.push(`${hyphenateStyleName(name)}: ${cssValue};`);
@@ -2166,13 +2169,14 @@ function staticObjectToCssString(obj) {
 }
 
 // A literal prefix can live in the template when all following properties have
-// fixed, unique names. The values still evaluate together at
-// the authored style attribute, before any DOM writes. Fixed literal values
+// fixed, unique names. The values still evaluate together at the authored
+// style attribute, before any DOM writes. Fixed literal values
 // after the first dynamic property stay in the ordered suffix. Spreads,
 // computed names, and accessors retain ordinary object evaluation and diffing.
 function mixedStaticStyle(obj) {
 	if (obj?.type !== 'ObjectExpression' || obj.properties.length === 0) return null;
-	const seen = new Set();
+	const seen = new Map();
+	let duplicates = false;
 	const prefix = [];
 	const dynamics = [];
 	for (const property of obj.properties) {
@@ -2190,10 +2194,15 @@ function mixedStaticStyle(obj) {
 		}
 		const name = key.type === 'Identifier' ? key.name : key.value;
 		const normalized = hyphenateStyleName(name);
-		if (name === '__proto__' || name === 'dangerouslySetInnerHTML' || seen.has(normalized)) {
+		if (
+			name === '__proto__' ||
+			name === 'dangerouslySetInnerHTML' ||
+			(seen.has(normalized) && seen.get(normalized) !== name)
+		) {
 			return null;
 		}
-		seen.add(normalized);
+		if (seen.has(normalized)) duplicates = true;
+		seen.set(normalized, name);
 
 		const value = property.value;
 		if (
@@ -2206,6 +2215,19 @@ function mixedStaticStyle(obj) {
 		} else {
 			dynamics.push({ name, key, value });
 		}
+	}
+	// A duplicate retains its first insertion position but uses its last value.
+	// Keep every authored evaluation, including overwritten values, and avoid
+	// baking declarations that a later duplicate could replace or remove.
+	if (duplicates) {
+		return {
+			css: '',
+			dynamics: obj.properties.map((property) => ({
+				name: property.key.type === 'Identifier' ? property.key.name : property.key.value,
+				key: property.key,
+				value: property.value,
+			})),
+		};
 	}
 	if (dynamics.length === 0) return null;
 	const css = staticObjectToCssString({ properties: prefix });
@@ -24420,17 +24442,26 @@ function emitBindingMount(bind, elVar, bag) {
 		}
 		case 'styleProperties': {
 			for (let i = 0; i < bind.properties.length; i++) bag.local(`_prev$${bind.id}_${i}`);
+			const entries =
+				bind.properties.length === bind.evaluations.length
+					? V()
+					: b.array(
+							bind.properties.flatMap((property) => [
+								inheritOriginLoc(b.literal(property.name), property.key),
+								b.member(V(), b.literal(property.evaluationIndex * 2 + 1), true),
+							]),
+						);
 			return st(
 				b.block([
 					b.const('_v', bind.expr),
-					b.stmt(b.call(callee(), el(), V(), b.literal(bind.staticCss))),
+					b.stmt(b.call(callee(), el(), entries, b.literal(bind.staticCss))),
 					...mountHost(),
-					...bind.properties.map((_, i) =>
+					...bind.properties.map((property, i) =>
 						b.stmt(
 							b.assignment(
 								'=',
 								local(`_prev$${bind.id}_${i}`),
-								b.member(V(), b.literal(i * 2 + 1), true),
+								b.member(V(), b.literal(property.evaluationIndex * 2 + 1), true),
 							),
 						),
 					),
@@ -24788,15 +24819,16 @@ function emitBindingUpdate(bind, bag, inlineBindingGuards = false) {
 			// Evaluate every authored value before the first CSS write, including
 			// fixed literal suffix values. Mount and hydration compare one complete
 			// style; ordinary updates only call the scalar setter for changed cells.
-			const values = bind.properties.map((property, i) => b.const(`_v${i}`, property.value));
+			const values = bind.evaluations.map((value, i) => b.const(`_v${i}`, value));
+			const valueOf = (property) => b.id(`_v${property.evaluationIndex}`);
 			const entries = b.array(
-				bind.properties.flatMap((property, i) => [
+				bind.properties.flatMap((property) => [
 					inheritOriginLoc(b.literal(property.name), property.key),
-					b.id(`_v${i}`),
+					valueOf(property),
 				]),
 			);
-			const publish = bind.properties.map((_, i) =>
-				b.stmt(b.assignment('=', bagFieldNode(bag, `_prev$${bind.id}_${i}`), b.id(`_v${i}`))),
+			const publish = bind.properties.map((property, i) =>
+				b.stmt(b.assignment('=', bagFieldNode(bag, `_prev$${bind.id}_${i}`), valueOf(property))),
 			);
 			const grouped = [
 				b.stmt(b.call(callee(), F('_el'), entries, b.literal(bind.staticCss))),
@@ -24807,7 +24839,7 @@ function emitBindingUpdate(bind, bag, inlineBindingGuards = false) {
 				attrLoweringToken(b.id(`_$${attrBindingHelper({ kind: 'styleProperty' })}`), bind);
 			const scalar = bind.properties.map((property, i) => {
 				const previous = bagFieldNode(bag, `_prev$${bind.id}_${i}`);
-				const value = b.id(`_v${i}`);
+				const value = valueOf(property);
 				return b.if(
 					b.binary('!==', previous, value),
 					b.block([
@@ -26070,17 +26102,24 @@ function emitElementHtml(
 						});
 					} else {
 						const entries = [];
-						const propertyBindings = [];
+						const propertyBindings = new Map();
+						const evaluations = [];
 						for (const entry of mixed.dynamics) {
 							const value = tsrxExprNode(entry.value, ctx, componentName, inlinedSubs);
 							entries.push(inheritOriginLoc(b.literal(entry.name), entry.key), value);
-							propertyBindings.push({ name: entry.name, key: entry.key, value });
+							propertyBindings.set(entry.name, {
+								name: entry.name,
+								key: entry.key,
+								evaluationIndex: evaluations.length,
+							});
+							evaluations.push(value);
 						}
 						bindings.push({
 							id: bindings.length,
 							kind: 'styleProperties',
 							expr: inheritOriginLoc(b.array(entries), inner),
-							properties: propertyBindings,
+							properties: [...propertyBindings.values()],
+							evaluations,
 							path,
 							ns: hostNs,
 							nameOrigin: attr.name,

--- a/packages/octane/tests/_fixtures/style-object-shorthand.tsrx
+++ b/packages/octane/tests/_fixtures/style-object-shorthand.tsrx
@@ -1,0 +1,18 @@
+interface StyleProps {
+	discarded: string;
+	margin: string | null;
+	top: string | null;
+}
+
+export function ShorthandStyles(props: StyleProps) @{
+	<section>
+		<div
+			id="longhand-first"
+			style={{ marginTop: props.discarded, margin: props.margin, marginTop: props.top }}
+		/>
+		<div
+			id="shorthand-first"
+			style={{ margin: props.discarded, marginTop: props.top, margin: props.margin }}
+		/>
+	</section>
+}

--- a/packages/octane/tests/browser/style-object-literals/index.html
+++ b/packages/octane/tests/browser/style-object-literals/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane inline style hydration</title>
+	</head>
+	<body>
+		<div id="root"><!--octane-ssr--></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/style-object-literals/main.ts
+++ b/packages/octane/tests/browser/style-object-literals/main.ts
@@ -1,0 +1,68 @@
+import { flushSync, hydrateRoot } from '../../../src/index.js';
+import { ShorthandStyles } from '../../_fixtures/style-object-shorthand.tsrx';
+
+const container = document.querySelector('#root') as HTMLElement;
+const ids = ['longhand-first', 'shorthand-first'] as const;
+const elements = ids.map((id) => container.querySelector(`#${id}`) as HTMLElement);
+
+function snapshot() {
+	return ids.map((id, index) => {
+		const element = container.querySelector(`#${id}`) as HTMLElement;
+		return {
+			id,
+			same: element === elements[index],
+			style: element.getAttribute('style'),
+			top: element.style.marginTop,
+			right: element.style.marginRight,
+		};
+	});
+}
+
+const before = snapshot();
+const root = hydrateRoot(container, ShorthandStyles, {
+	discarded: '1px',
+	margin: '4px',
+	top: '8px',
+});
+flushSync(() => {});
+const hydrated = snapshot();
+
+flushSync(() =>
+	root.render(ShorthandStyles, {
+		discarded: '2px',
+		margin: '12px',
+		top: '16px',
+	}),
+);
+const updated = snapshot();
+
+flushSync(() =>
+	root.render(ShorthandStyles, {
+		discarded: '3px',
+		margin: null,
+		top: null,
+	}),
+);
+const removed = snapshot();
+
+window.__styleObjectHydration = {
+	before,
+	hydrated,
+	updated,
+	removed,
+	unmount() {
+		root.unmount();
+	},
+};
+
+declare global {
+	interface Window {
+		__styleObjectHydration: {
+			before: ReturnType<typeof snapshot>;
+			hydrated: ReturnType<typeof snapshot>;
+			updated: ReturnType<typeof snapshot>;
+			removed: ReturnType<typeof snapshot>;
+			unmount(): void;
+		};
+	}
+}

--- a/packages/octane/tests/browser/style-object-literals/style-object-literals.test.ts
+++ b/packages/octane/tests/browser/style-object-literals/style-object-literals.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+import { launchBrowser } from '../../../../../test-utils/playwright-browser.js';
+import { createServer, type Plugin, type ViteDevServer } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { renderToString } from 'octane/server';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadServerFixture } from '../../_server-fixture.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = 'packages/octane/tests/_fixtures/style-object-shorthand.tsrx';
+
+let browser: Browser;
+
+beforeAll(async () => {
+	browser = await launchBrowser({ headless: true });
+});
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+async function openHydratedPage(mode: 'dev' | 'prod'): Promise<{
+	failures: string[];
+	page: Page;
+	server: ViteDevServer;
+}> {
+	const serverModule = loadServerFixture(FIXTURE, {
+		id: `/style-object-shorthand-${mode}.tsrx`,
+		compileOptions: mode === 'prod' ? { hmr: false } : {},
+	});
+	const { html } = renderToString(serverModule.ShorthandStyles, {
+		discarded: '1px',
+		margin: '4px',
+		top: '8px',
+	});
+	const shellPlugin: Plugin = {
+		name: 'style-object-hydration-shell',
+		transformIndexHtml(source) {
+			return source.replace('<!--octane-ssr-->', () => html);
+		},
+	};
+	const server = await createServer({
+		cacheDir: resolve(HERE, `../../../../../node_modules/.vite/octane-style-objects-${mode}`),
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		plugins: [shellPlugin, octane(mode === 'prod' ? { hmr: false } : {})],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	const failures: string[] = [];
+	let page: Page | undefined;
+	try {
+		await server.listen();
+		const address = server.httpServer!.address();
+		if (!address || typeof address === 'string') {
+			throw new Error('Vite did not expose a TCP port');
+		}
+
+		page = await browser.newPage();
+		page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+		page.on('console', (message) => {
+			if (message.type() === 'error' || message.type() === 'warning') {
+				failures.push(`${message.type()}: ${message.text()}`);
+			}
+		});
+		await page.goto(`http://127.0.0.1:${address.port}`);
+		await page.waitForFunction(() => Boolean(window.__styleObjectHydration));
+		return { failures, page, server };
+	} catch (error) {
+		await Promise.allSettled([page?.close(), server.close()]);
+		throw error;
+	}
+}
+
+// Shorthand parsing must run in a browser: jsdom discards a trailing
+// margin-top declaration when parsing a style attribute containing margin.
+describe.sequential('inline style object real-browser hydration', () => {
+	for (const mode of ['dev', 'prod'] as const) {
+		it(`${mode} preserves duplicate shorthand ordering through hydration and updates`, async () => {
+			const { failures, page, server } = await openHydratedPage(mode);
+			try {
+				const state = await page.evaluate(() => window.__styleObjectHydration);
+				expect(state.before).toMatchObject([
+					{ id: 'longhand-first', top: '4px', right: '4px', same: true },
+					{ id: 'shorthand-first', top: '8px', right: '4px', same: true },
+				]);
+				expect(
+					state.before.map((element) =>
+						element
+							.style!.split(';')
+							.filter(Boolean)
+							.map((declaration) => declaration.replace(/\s/g, '')),
+					),
+				).toEqual([
+					['margin-top:8px', 'margin:4px'],
+					['margin:4px', 'margin-top:8px'],
+				]);
+				expect(state.hydrated).toEqual(state.before);
+				expect(state.updated).toMatchObject([
+					{ id: 'longhand-first', top: '12px', right: '12px', same: true },
+					{ id: 'shorthand-first', top: '16px', right: '12px', same: true },
+				]);
+				expect(state.removed).toMatchObject([
+					{ id: 'longhand-first', top: '', right: '', same: true },
+					{ id: 'shorthand-first', top: '', right: '', same: true },
+				]);
+				expect(failures).toEqual([]);
+			} finally {
+				try {
+					await page.evaluate(() => window.__styleObjectHydration.unmount());
+				} finally {
+					await Promise.allSettled([page.close(), server.close()]);
+				}
+			}
+		});
+	}
+});

--- a/packages/octane/tests/style-object-literals.test.ts
+++ b/packages/octane/tests/style-object-literals.test.ts
@@ -22,6 +22,28 @@ export function AllDynamic(props) @{
 }
 `;
 
+const DUPLICATE_SOURCE = `
+export function StaticWinner(props) @{
+	<div id="static-winner" style={{ color: props.color, color: 'red', background: props.background }} />
+}
+
+export function DynamicWinner(props) @{
+	<div id="dynamic-winner" style={{ color: 'red', color: props.color, background: props.background }} />
+}
+
+export function LonghandFirst(props) @{
+	<div id="longhand-first" style={{ marginTop: props.discarded, margin: props.margin, marginTop: props.top }} />
+}
+
+export function ShorthandFirst(props) @{
+	<div id="shorthand-first" style={{ margin: props.discarded, marginTop: props.top, margin: props.margin }} />
+}
+
+export function LiteralDuplicates() @{
+	<div id="literal-duplicates" style={{ marginTop: '1px', margin: '4px', marginTop: '8px', color: 'red', color: null, background: 'blue', background: false, display: 'block', display: '' }} />
+}
+`;
+
 function compiled(source: string, id: string, mode: 'client' | 'server', dev = false) {
 	return loadCompiledFixtureSource(source, {
 		id,
@@ -31,6 +53,213 @@ function compiled(source: string, id: string, mode: 'client' | 'server', dev = f
 }
 
 describe('inline object styles', () => {
+	it.each([false, true])('resolves duplicate literal keys before applying CSS in dev=%s', (dev) => {
+		const client = compiled(DUPLICATE_SOURCE, `duplicate-literals-${dev}.tsrx`, 'client', dev);
+		const root = mount(client.LiteralDuplicates);
+		const element = root.find('#literal-duplicates') as HTMLElement;
+		try {
+			expect(element.style.marginTop).toBe('4px');
+			expect(element.style.marginRight).toBe('4px');
+			expect(element.style.color).toBe('');
+			expect(element.style.backgroundColor).toBe('');
+			expect(element.style.display).toBe('');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([false, true])('uses the final duplicate value on mount and update in dev=%s', (dev) => {
+		const client = compiled(DUPLICATE_SOURCE, `duplicate-values-${dev}.tsrx`, 'client', dev);
+		const fixed = mount(client.StaticWinner, { color: 'blue', background: 'black' });
+		const fixedElement = fixed.find('#static-winner') as HTMLElement;
+		try {
+			expect(fixedElement.style.color).toBe('red');
+			expect(fixedElement.style.backgroundColor).toBe('black');
+			for (const color of ['green', null, undefined, false, '']) {
+				fixed.update(client.StaticWinner, { color, background: 'white' });
+				expect(fixed.find('#static-winner')).toBe(fixedElement);
+				expect(fixedElement.style.color).toBe('red');
+				expect(fixedElement.style.backgroundColor).toBe('white');
+			}
+		} finally {
+			fixed.unmount();
+		}
+
+		const dynamic = mount(client.DynamicWinner, { color: null, background: 'black' });
+		const dynamicElement = dynamic.find('#dynamic-winner') as HTMLElement;
+		try {
+			expect(dynamicElement.style.color).toBe('');
+			expect(dynamicElement.style.backgroundColor).toBe('black');
+			for (const color of ['blue', null, 'green', undefined, 'purple', false, 'yellow', '']) {
+				dynamic.update(client.DynamicWinner, { color, background: 'white' });
+				expect(dynamic.find('#dynamic-winner')).toBe(dynamicElement);
+				expect(dynamicElement.style.color).toBe(typeof color === 'string' ? color : '');
+				expect(dynamicElement.style.backgroundColor).toBe('white');
+			}
+		} finally {
+			dynamic.unmount();
+		}
+	});
+
+	it.each([false, true])(
+		'evaluates overwritten style expressions in authored order in dev=%s',
+		(dev) => {
+			const source = `
+export function App(props) @{
+	<div
+		id="duplicate-order"
+		data-before={props.read('before')}
+		style={{ left: props.read('discarded'), color: props.read('color'), left: props.read('overwritten'), 'left': props.read('winner') }}
+		data-after={props.read('after')}
+	/>
+}`;
+			const client = compiled(source, `duplicate-order-${dev}.tsrx`, 'client', dev);
+			const calls: string[] = [];
+			const values: Record<string, string | number> = {
+				discarded: 5,
+				color: 'red',
+				overwritten: 8,
+				winner: 12,
+			};
+			const read = (key: string) => {
+				calls.push(key);
+				return values[key] ?? key;
+			};
+			const root = mount(client.App, { read });
+			const element = root.find('#duplicate-order') as HTMLElement;
+			try {
+				expect(calls).toEqual(['before', 'discarded', 'color', 'overwritten', 'winner', 'after']);
+				expect(element.style.left).toBe('12px');
+				expect(element.style.color).toBe('red');
+				calls.length = 0;
+				values.discarded = 20;
+				values.color = 'blue';
+				root.update(client.App, { read });
+				expect(calls).toEqual(['before', 'discarded', 'color', 'overwritten', 'winner', 'after']);
+				expect(element.style.left).toBe('12px');
+				expect(element.style.color).toBe('blue');
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it.each([false, true])(
+		'propagates duplicate expression errors before changing styles in dev=%s',
+		(dev) => {
+			const source = `
+export function App(props) @{
+	<div id="duplicate-error" style={{ left: props.read('discarded'), color: props.read('color'), left: props.read('winner') }} />
+}`;
+			const client = compiled(source, `duplicate-error-${dev}.tsrx`, 'client', dev);
+			for (const failure of ['discarded', 'winner']) {
+				const calls: string[] = [];
+				const throwingRead = (key: string) => {
+					calls.push(key);
+					if (key === failure) throw new Error(`failed ${failure}`);
+					return key === 'color' ? 'blue' : 20;
+				};
+				const expectedCalls =
+					failure === 'discarded' ? ['discarded'] : ['discarded', 'color', 'winner'];
+				expect(() => mount(client.App, { read: throwingRead })).toThrow(`failed ${failure}`);
+				expect(calls).toEqual(expectedCalls);
+				const root = mount(client.App, { read: (key: string) => (key === 'color' ? 'red' : 5) });
+				const element = root.find('#duplicate-error') as HTMLElement;
+				try {
+					calls.length = 0;
+					expect(() => root.update(client.App, { read: throwingRead })).toThrow(
+						`failed ${failure}`,
+					);
+					expect(calls).toEqual(expectedCalls);
+					expect(element.style.left).toBe('5px');
+					expect(element.style.color).toBe('red');
+				} finally {
+					root.unmount();
+				}
+			}
+		},
+	);
+
+	it.each([false, true])(
+		'retains the first insertion position of duplicate style keys in dev=%s',
+		(dev) => {
+			const client = compiled(DUPLICATE_SOURCE, `duplicate-position-${dev}.tsrx`, 'client', dev);
+			for (const name of ['LonghandFirst', 'ShorthandFirst']) {
+				const root = mount(client[name], { discarded: '1px', margin: '4px', top: '8px' });
+				const element = root.find('div') as HTMLElement;
+				try {
+					expect(element.style.marginTop).toBe(name === 'LonghandFirst' ? '4px' : '8px');
+					expect(element.style.marginRight).toBe('4px');
+					root.update(client[name], { discarded: '2px', margin: '12px', top: '16px' });
+					expect(root.find('div')).toBe(element);
+					expect(element.style.marginTop).toBe(name === 'LonghandFirst' ? '12px' : '16px');
+					expect(element.style.marginRight).toBe('12px');
+				} finally {
+					root.unmount();
+				}
+			}
+		},
+	);
+
+	it.each([false, true])('hydrates duplicate style values and key order in dev=%s', (dev) => {
+		const id = `duplicate-hydration-${dev}.tsrx`;
+		const server = compiled(DUPLICATE_SOURCE, id, 'server', dev);
+		const client = compiled(DUPLICATE_SOURCE, id, 'client', dev);
+		for (const [name, initialColor, nextColor, initialTop, nextTop] of [
+			['StaticWinner', 'red', 'red', '', ''],
+			['DynamicWinner', '', 'blue', '', ''],
+			['LonghandFirst', '', '', '4px', '12px'],
+			['ShorthandFirst', '', '', '8px', '16px'],
+			['LiteralDuplicates', '', '', '4px', '4px'],
+		]) {
+			const props = {
+				color: null,
+				background: 'black',
+				discarded: '1px',
+				margin: '4px',
+				top: '8px',
+			};
+			const container = document.createElement('div');
+			container.innerHTML = renderToString(server[name], props).html;
+			document.body.appendChild(container);
+			const element = container.querySelector('div') as HTMLElement;
+			const original = element.getAttribute('style');
+			const warnings = vi.spyOn(console, 'error').mockImplementation(() => {});
+			let root: ReturnType<typeof hydrateRoot> | undefined;
+			try {
+				expect(element.style.color).toBe(initialColor);
+				expect(element.style.marginTop).toBe(initialTop);
+				if (name === 'LiteralDuplicates') {
+					expect(element.style.backgroundColor).toBe('');
+					expect(element.style.display).toBe('');
+				}
+				root = hydrateRoot(container, client[name], props);
+				flushSync(() => {});
+				expect(container.querySelector('div')).toBe(element);
+				expect(element.getAttribute('style')).toBe(original);
+				expect(
+					warnings.mock.calls.filter((args) => /hydrat|mismatch/i.test(String(args[0]))),
+				).toEqual([]);
+				flushSync(() =>
+					root!.render(client[name], {
+						color: 'blue',
+						background: 'white',
+						discarded: '2px',
+						margin: '12px',
+						top: '16px',
+					}),
+				);
+				expect(container.querySelector('div')).toBe(element);
+				expect(element.style.color).toBe(nextColor);
+				expect(element.style.marginTop).toBe(nextTop);
+			} finally {
+				root?.unmount();
+				warnings.mockRestore();
+				container.remove();
+			}
+		}
+	});
+
 	it.each([false, true])('updates one and several dynamic values in dev=%s', (dev) => {
 		const client = compiled(SOURCE, `object-literals-${dev}.tsrx`, 'client', dev);
 		const single = mount(client.Single, { color: 'red' });

--- a/packages/octane/tests/style-object-literals.test.ts
+++ b/packages/octane/tests/style-object-literals.test.ts
@@ -40,7 +40,7 @@ export function ShorthandFirst(props) @{
 }
 
 export function LiteralDuplicates() @{
-	<div id="literal-duplicates" style={{ marginTop: '1px', margin: '4px', marginTop: '8px', color: 'red', color: null, background: 'blue', background: false, display: 'block', display: '' }} />
+	<div id="literal-duplicates" style={{ marginTop: '1px', margin: '4px', marginTop: '8px', color: 'red', color: null, background: 'blue', background: false, display: 'block', display: '', '--removed': 'red', '--removed': true }} />
 }
 `;
 
@@ -63,6 +63,7 @@ describe('inline object styles', () => {
 			expect(element.style.color).toBe('');
 			expect(element.style.backgroundColor).toBe('');
 			expect(element.style.display).toBe('');
+			expect(element.style.getPropertyValue('--removed')).toBe('');
 		} finally {
 			root.unmount();
 		}
@@ -145,6 +146,40 @@ export function App(props) @{
 	);
 
 	it.each([false, true])(
+		'preserves inferred names while evaluating overwritten style classes in dev=%s',
+		(dev) => {
+			const source = `
+export function Direct(props) @{
+	<div style={{ color: class { static { props.record(this.name); } }, color: 'red', background: props.background }} />
+}
+
+export function Wrapped(props) @{
+	<div style={{ color: (class { static { props.record(this.name); } } as unknown), color: 'red', background: props.background }} />
+}`;
+			const client = compiled(source, `duplicate-class-names-${dev}.tsrx`, 'client', dev);
+			for (const name of ['Direct', 'Wrapped']) {
+				const names: string[] = [];
+				const record = (value: string) => names.push(value);
+				const root = mount(client[name], { record, background: 'black' });
+				const element = root.find('div') as HTMLElement;
+				try {
+					expect(names).toEqual(['color']);
+					expect(element.style.color).toBe('red');
+					expect(element.style.backgroundColor).toBe('black');
+					names.length = 0;
+					root.update(client[name], { record, background: 'white' });
+					expect(names).toEqual(['color']);
+					expect(root.find('div')).toBe(element);
+					expect(element.style.color).toBe('red');
+					expect(element.style.backgroundColor).toBe('white');
+				} finally {
+					root.unmount();
+				}
+			}
+		},
+	);
+
+	it.each([false, true])(
 		'propagates duplicate expression errors before changing styles in dev=%s',
 		(dev) => {
 			const source = `
@@ -208,8 +243,6 @@ export function App(props) @{
 		for (const [name, initialColor, nextColor, initialTop, nextTop] of [
 			['StaticWinner', 'red', 'red', '', ''],
 			['DynamicWinner', '', 'blue', '', ''],
-			['LonghandFirst', '', '', '4px', '12px'],
-			['ShorthandFirst', '', '', '8px', '16px'],
 			['LiteralDuplicates', '', '', '4px', '4px'],
 		]) {
 			const props = {
@@ -232,11 +265,16 @@ export function App(props) @{
 				if (name === 'LiteralDuplicates') {
 					expect(element.style.backgroundColor).toBe('');
 					expect(element.style.display).toBe('');
+					expect(element.style.getPropertyValue('--removed')).toBe('');
+					expect(original).not.toContain('--removed');
 				}
 				root = hydrateRoot(container, client[name], props);
 				flushSync(() => {});
 				expect(container.querySelector('div')).toBe(element);
 				expect(element.getAttribute('style')).toBe(original);
+				if (name === 'LiteralDuplicates') {
+					expect(element.style.getPropertyValue('--removed')).toBe('');
+				}
 				expect(
 					warnings.mock.calls.filter((args) => /hydrat|mismatch/i.test(String(args[0]))),
 				).toEqual([]);


### PR DESCRIPTION
## Summary

Inline style literals with repeated keys now use grouped mount/hydration and guarded `setStyleProperty` updates. Both examples in https://github.com/octanejs/octane/issues/1048#issuecomment-5638850915 retain their final `color` value while updating `background` without a whole-object style diff.

Closes #1048.

## Why

The fixed-key style optimization rejected every duplicate normalized name. JavaScript duplicates can be optimized by preserving all authored value evaluations while retaining only each key's final value at its first insertion position.

## Changes

- Separate ordered value evaluations from effective property bindings; overwritten expressions still run and can throw before any CSS write.
- Preserve the same duplicate-key semantics in fully static client/SSR styles, including removals and shorthand/longhand order.
- Add dev/prod rendering, exception, SSR, hydration, and update regression coverage.
- Extend the deterministic browser work gate with both reported duplicate orders, semantic controls, and baseline mode.
- Add an Octane patch changeset.

## Validation

Exact candidate: `15473a76c0daacbc6c327d6199a8a25ee889de5e`; baseline: `c8ac7d93a96278b47c5896cba2edff5465c71478`.

[Dedicated validation run](https://github.com/openai-oss-forks/octane/actions/runs/34637618028), using Node 24 and the frozen lockfile:

- [x] `pnpm sync` completed with no generated changes.
- [x] Scoped formatting, JavaScript syntax, and `git diff --check`.
- [x] `style-object-literals.test.ts`: **64/64 passed** across dev/prod projects and compiler modes. The same suite against the baseline compiler reproduced **8 failing assertions** for duplicate static values/removals.
- [x] Real Chromium shorthand hydration: **2/2 passed**, including original SSR declaration order, adoption without mismatch warnings, updates, removals, and DOM identity. These cases use Chromium because jsdom drops a trailing longhand when parsing a shorthand style attribute.
- [x] Deterministic style work gate: **24/24 scenarios passed for both baseline and candidate**, including generic and non-duplicate controls.
- [x] [Pre-merge CI](https://github.com/octanejs/octane/actions/runs/34637518487): full formatting/lint, Chromium integration, package builds, website, publishable-package checks, and example apps passed. The merge cancelled unfinished jobs.
- [ ] [Post-merge CI](https://github.com/octanejs/octane/actions/runs/34638414128) is running for `b7a2c47d108e656191347df5e57d1f4898be9374`, whose Git tree is identical to the validated candidate.

For both reported duplicate orders, `setStyle` / `applyStyleValue` calls fell from **1,000 to 0 per operation**. Candidate mounts use 1,000 grouped calls; selecting one row uses 1 scalar call for the static winner and 2 for the dynamic winner. Unrelated updates use no style setters. Both versions retain 1,000 authored color evaluations, the same CSS writes, final styles, and surviving row identity. These are deterministic work counts; no wall-clock speedup is claimed.

Local installation of two exact dependencies was blocked by the configured registry's recently-published-package policy. Validation used normal hosted Actions with the frozen lockfile; no result relies on substituting older dependencies.

## Risk / follow-ups

The compiler preserves authored evaluation order before CSS writes, last-value/first-position duplicate semantics, and null/boolean/empty-string removals. Spreads, computed keys, accessors, normalized-name aliases, and anonymous function/class values retain generic evaluation; the latter preserves observable inferred names in discarded class initializers.

The separate Three compatibility lane fails after resolving newly released `@types/three@0.186.0` (`testing.ts:250`, `Camera` versus `CameraProps`). The relevant Three sources, workflow, and lockfile are unchanged by this PR; the earlier main run used `@types/three@0.185.4`. This dependency drift is outside the inline-style change.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler lowering for inline styles across client render, SSR, and hydration; behavior is well covered by tests but touches DOM/CSSOM write paths for a common API.
> 
> **Overview**
> Inline `style={{ ... }}` literals that repeat the same property name (including shorthand/longhand pairs like `margin` and `marginTop`) no longer bail out of the fixed-key optimization. The compiler now lowers them to **grouped mount/hydration** plus **guarded per-property updates**, instead of whole-object style diffing.
> 
> Duplicate-key semantics are aligned with JavaScript object literals: **every authored expression still runs in order** (side effects and throws included), **the last value wins** for each key, and **declaration order follows the first occurrence** of each key—including cases where a dynamic `color` is overwritten by a static `color` but the dynamic expression must still run.
> 
> Compiler work splits **ordered value evaluations** from **effective property bindings** so overwritten entries stay evaluated while updates target the final keys. Fully static duplicates are resolved when baking CSS strings. Anonymous class/function values in duplicate objects still force the generic path so inferred names stay correct.
> 
> Coverage adds unit/SSR/hydration tests, a Playwright dev/prod gate for real-browser shorthand parsing, and two new js-framework benchmark cases (`duplicateStatic`, `duplicateDynamic`) with optional `WORK_EXPECT_DUPLICATES_OPTIMIZED=0` baseline mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15473a76c0daacbc6c327d6199a8a25ee889de5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791744762&installation_model_id=432790&pr_number=1053&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1053&signature=76ea798f0ae1b16673bd84dab6cda30e458dd612b782f2b777ac89245258c1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->