### PR TITLE
fix: stabilize main CI failures

### DIFF
--- a/.changeset/three-testing-camera-props.md
+++ b/.changeset/three-testing-camera-props.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/three': patch
+---
+
+Align the test renderer's camera option with the root camera configuration type so constructed and declarative cameras remain compatible with current Three declarations.

--- a/packages/input-otp/audit/pristine-runtime-crosswalk.json
+++ b/packages/input-otp/audit/pristine-runtime-crosswalk.json
@@ -41,7 +41,7 @@
   ],
   "rewrittenExecution": {
     "path": "packages/input-otp/tests/pristine/upstream.browser.test.ts",
-    "sha256": "f9257765451998e0b6103c0b014f39680dce85ec9637411126ba3bf17a671f3a"
+    "sha256": "e7fdfc659200c780071b325792a13a26b3a6e3bc9e81c6df195334d56145cf08"
   },
   "identityCrosswalk": [
     {

--- a/packages/input-otp/audit/react-parity.json
+++ b/packages/input-otp/audit/react-parity.json
@@ -10,7 +10,10 @@
     "integrity": "sha256:62112dac2d8eea337fb8bafb5c9ce5a5d3574f03e06adfe1411ae40e3cc84d97",
     "verification": "verified"
   },
-  "upstreamSuites": { "runtime": "present", "types": "absent" },
+  "upstreamSuites": {
+    "runtime": "present",
+    "types": "absent"
+  },
   "adaptedRoots": {
     "source": {
       "roots": ["packages/input-otp/src"],
@@ -66,7 +69,7 @@
         {
           "path": "packages/input-otp/audit/pristine-runtime-crosswalk.json",
           "role": "support",
-          "sha256": "79e436f2f9415119037b98b63d7a6ffb308d623b055e89f427e69816588e43a3"
+          "sha256": "fb1073b5e138bbeb15d48331b6c6d7c4f21452749e4db2d5166b039dabf2ed0f"
         },
         {
           "path": "packages/input-otp/audit/pristine-adaptation-ledger.json",
@@ -76,7 +79,7 @@
         {
           "path": "packages/input-otp/tests/pristine/upstream.browser.test.ts",
           "role": "support",
-          "sha256": "f9257765451998e0b6103c0b014f39680dce85ec9637411126ba3bf17a671f3a"
+          "sha256": "e7fdfc659200c780071b325792a13a26b3a6e3bc9e81c6df195334d56145cf08"
         },
         {
           "path": "packages/input-otp/upstream/apps/playground/src/tests/base.delete-word.spec.ts",

--- a/packages/input-otp/tests/browser/upstream/base.selections.spec.ts
+++ b/packages/input-otp/tests/browser/upstream/base.selections.spec.ts
@@ -7,6 +7,7 @@ async function expectMirrorSelection(start: number, end: number): Promise<void> 
 	const input = page.getByRole('textbox');
 	await expect.poll(async () => input.getAttribute('data-input-otp-mss')).toBe(String(start));
 	await expect.poll(async () => input.getAttribute('data-input-otp-mse')).toBe(String(end));
+	await expectSelection(input, [start, end]);
 }
 
 async function pressAndExpectSelection(key: string, start: number, end: number): Promise<void> {
@@ -14,7 +15,6 @@ async function pressAndExpectSelection(key: string, start: number, end: number):
 	await input.press(key);
 	await input.evaluate(() => document.dispatchEvent(new Event('selectionchange')));
 	await expectMirrorSelection(start, end);
-	await expectSelection(input, [start, end]);
 }
 
 it('should replace selected char if another is pressed', async () => {

--- a/packages/input-otp/tests/pristine/upstream.browser.test.ts
+++ b/packages/input-otp/tests/pristine/upstream.browser.test.ts
@@ -9,6 +9,14 @@ async function expectMirrorSelection(start: number, end: number): Promise<void> 
 	const target = input();
 	await expect.poll(async () => target.getAttribute('data-input-otp-mss')).toBe(String(start));
 	await expect.poll(async () => target.getAttribute('data-input-otp-mse')).toBe(String(end));
+	await expect
+		.poll(async () =>
+			target.evaluate((element: HTMLInputElement) => [
+				element.selectionStart,
+				element.selectionEnd,
+			]),
+		)
+		.toEqual([start, end]);
 }
 
 async function setSelectionAndWait(start: number, end: number): Promise<void> {

--- a/packages/octane/tests/compiler/volar.test.ts
+++ b/packages/octane/tests/compiler/volar.test.ts
@@ -981,7 +981,7 @@ export function Chart<T extends Octane.SVGProps<SVGTextElement>>(props: T) {
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
-	});
+	}, 15_000);
 
 	it('handles @if / @for / @try / @switch directives', () => {
 		const src =

--- a/packages/solana-kit/tests/internal.test.ts
+++ b/packages/solana-kit/tests/internal.test.ts
@@ -1,14 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { subSlot } from '../src/internal';
 
 describe('subSlot', () => {
-	beforeEach(() => {
-		vi.resetModules();
-	});
-
 	it('preserves derived identities across module re-evaluation', async () => {
 		const parent = Symbol.for('solana-kit:test-parent');
-		const first = await import('../src/internal');
-		const firstChild = first.subSlot(parent, 'client');
+		const firstChild = subSlot(parent, 'client');
 
 		vi.resetModules();
 		const second = await import('../src/internal');
@@ -17,8 +13,7 @@ describe('subSlot', () => {
 		expect(Symbol.keyFor(firstChild)).toBe('solana-kit:test-parent:client');
 	});
 
-	it('keeps distinct tags in distinct hook cells', async () => {
-		const { subSlot } = await import('../src/internal');
+	it('keeps distinct tags in distinct hook cells', () => {
 		const parent = Symbol.for('solana-kit:distinct-tags');
 
 		expect(subSlot(parent, 'client')).not.toBe(subSlot(parent, 'capability'));

--- a/packages/three/audit/react-parity.json
+++ b/packages/three/audit/react-parity.json
@@ -299,7 +299,7 @@
         {
           "path": "packages/three/typetests/subpath-api.test.ts",
           "role": "support",
-          "sha256": "58f2908e4ddf4595b35335de27c907b4ab60bc31357d79fefa7aad1ad4b99ce5"
+          "sha256": "9e83adc4cc2fef155fa32f24a193ca453736a2a70348a5badc2f5f3d0875a1de"
         }
       ]
     }

--- a/packages/three/src/testing.ts
+++ b/packages/three/src/testing.ts
@@ -14,7 +14,7 @@ import {
 	getThreeEventStore,
 	runThreeEventScope,
 } from './core/driver.js';
-import { createRoot, type CanvasLike, type ThreeRoot } from './core/root.js';
+import { createRoot, type CameraProps, type CanvasLike, type ThreeRoot } from './core/root.js';
 import type { Renderer, RootStore } from './core/store.js';
 
 const DEFAULT_WIDTH = 1280;
@@ -26,7 +26,7 @@ export interface CreateThreeTestRendererOptions {
 	/** Logical canvas height. Defaults to 800. */
 	readonly height?: number;
 	/** Optional camera used by the configured root. Defaults to a perspective camera. */
-	readonly camera?: THREE.Camera;
+	readonly camera?: CameraProps;
 }
 
 /** Renderer recorder injected into a deterministic Three test root. */

--- a/packages/three/typetests/subpath-api.test.ts
+++ b/packages/three/typetests/subpath-api.test.ts
@@ -23,6 +23,7 @@ import testing, {
 } from '@octanejs/three/testing';
 import type { JSX as IntrinsicJSX } from '@octanejs/three/intrinsics';
 import type { JSX as RuntimeJSX } from '@octanejs/three/intrinsics/jsx-runtime';
+import * as THREE from 'three';
 
 type IntrinsicMesh = IntrinsicJSX.IntrinsicElements['mesh'];
 type RuntimeMesh = RuntimeJSX.IntrinsicElements['mesh'];
@@ -43,6 +44,12 @@ const intrinsicMesh: IntrinsicMesh = { position: [1, 2, 3] };
 const runtimeMesh: RuntimeMesh = intrinsicMesh;
 const rootMesh: RootMesh = runtimeMesh;
 const intrinsicMeshAgain: IntrinsicMesh = rootMesh;
+const constructedCameraOptions: CreateThreeTestRendererOptions = {
+	camera: new THREE.PerspectiveCamera(),
+};
+const declarativeCameraOptions: CreateThreeTestRendererOptions = {
+	camera: { position: [1, 2, 3] },
+};
 
 void rootCreate;
 void coreState;
@@ -55,7 +62,8 @@ void threeRenderer;
 void threeRendererBoundaries;
 void threeRendererRules;
 void intrinsicMeshAgain;
-void (undefined as unknown as CreateThreeTestRendererOptions);
+void constructedCameraOptions;
+void declarativeCameraOptions;
 void (undefined as unknown as MockEventData);
 void (undefined as unknown as MockSyntheticEvent);
 void (undefined as unknown as TestingRenderer);

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -654,6 +654,7 @@ describe('CI workflow aggregation', () => {
 			parityVitestModule.default.test.projects.map((project) => project.test.name).sort(),
 			requiredVitestProjects.sort(),
 		);
+		assert.equal(parityVitestModule.default.test.maxWorkers, process.env.CI ? 2 : undefined);
 		const inputOtpBrowser = parityVitestModule.default.test.projects.find(
 			(project) => project.test.name === 'input-otp-browser',
 		);

--- a/test-utils/vitest-browser-collection.test.ts
+++ b/test-utils/vitest-browser-collection.test.ts
@@ -24,8 +24,10 @@ export default { test: {
 		join(root, 'mocked.test.mjs'),
 		`
 import { it, vi } from 'vitest';
-import { value } from './dependency.mjs';
 vi.mock('./dependency.mjs', () => ({ value: 'mocked' }));
+// Import after registration so this test isolates mock cleanup between files;
+// it does not also depend on browser-transform timing for static-import hoisting.
+const { value } = await import('./dependency.mjs');
 if (value !== 'mocked') throw new Error('The first file must see its own mock');
 it('mocked', () => { throw new Error('Collection must not execute test bodies'); });
 `,

--- a/vitest.react-parity.config.js
+++ b/vitest.react-parity.config.js
@@ -11,6 +11,10 @@ export default {
 	...baseConfig,
 	test: {
 		...baseConfig.test,
+		// The four CI shards already provide process-level parallelism. Capping
+		// each 4-vCPU runner leaves enough headroom for Vite, browser, and jsdom
+		// workers instead of intermittently losing an otherwise healthy test file.
+		...(process.env.CI ? { maxWorkers: 2 } : {}),
 		projects: buildParityVitestProjects({
 			baseProjects: baseConfig.test.projects,
 			lanes,

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -203,13 +203,16 @@ async function loadRoute(
 	options: {
 		beforeNavigation?: (page: import('playwright').Page, errors: string[]) => Promise<void>;
 		waitForNetworkIdle?: boolean;
+		viewport?: { width: number; height: number };
 		// Deliberate outlier for a caller that knowingly pays a cold dev server's
 		// on-demand compile, which is not an ordinary "wait for this to appear".
 		timeout?: number;
 	} = {},
 ) {
 	const actionTimeout = options.timeout ?? PLAYWRIGHT_ACTION_TIMEOUT;
-	const page = await browser!.newPage();
+	const page = await browser!.newPage(
+		options.viewport === undefined ? undefined : { viewport: options.viewport },
+	);
 	page.setDefaultTimeout(actionTimeout);
 	page.setDefaultNavigationTimeout(options.timeout ?? PLAYWRIGHT_NAVIGATION_TIMEOUT);
 	const errors: string[] = [];
@@ -1001,19 +1004,22 @@ describe('website dev-SSR → hydration (real browser)', { concurrent: false }, 
 		'keeps command-palette results readable in a constrained viewport',
 		{ timeout: 30_000 },
 		async () => {
-			const context = await browser.newContext({ viewport: { width: 746, height: 374 } });
-			const page = await context.newPage();
-			const errors: string[] = [];
-			page.on('console', (message) => {
-				if (message.type() === 'error') errors.push(message.text());
+			const { page, errors } = await loadRoute(`http://localhost:${DEV_PORT}`, '/docs/bindings', {
+				viewport: { width: 746, height: 374 },
 			});
-			page.on('pageerror', (error) => errors.push('pageerror: ' + String(error)));
 			try {
-				await page.goto(`http://localhost:${DEV_PORT}/docs/bindings`, {
-					waitUntil: 'networkidle',
-				});
-				await page.keyboard.press('Control+K');
-				await page.locator('.search-input').fill('tanstack');
+				const trigger = page.locator('.search-trigger');
+				const searchInput = page.locator('.search-input');
+				// SSR exposes the trigger before hydration attaches its event. Opening is
+				// idempotent, so retry the observable interaction until the dialog exists.
+				await expect
+					.poll(async () => {
+						if (await searchInput.isVisible()) return true;
+						await trigger.click();
+						return searchInput.isVisible();
+					})
+					.toBe(true);
+				await searchInput.fill('tanstack');
 				const firstResult = page.locator('.search-entity').first();
 				await firstResult.waitFor();
 
@@ -1032,7 +1038,7 @@ describe('website dev-SSR → hydration (real browser)', { concurrent: false }, 
 				expect(geometry.cardBottom).toBeGreaterThanOrEqual(geometry.contentBottom);
 				expect(errors.filter((error) => !error.includes('Failed to load resource'))).toEqual([]);
 			} finally {
-				await context.close();
+				await page.close();
 			}
 		},
 	);

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1013,11 +1013,14 @@ describe('website dev-SSR → hydration (real browser)', { concurrent: false }, 
 				// SSR exposes the trigger before hydration attaches its event. Opening is
 				// idempotent, so retry the observable interaction until the dialog exists.
 				await expect
-					.poll(async () => {
-						if (await searchInput.isVisible()) return true;
-						await trigger.click();
-						return searchInput.isVisible();
-					})
+					.poll(
+						async () => {
+							if (await searchInput.isVisible()) return true;
+							await trigger.click();
+							return searchInput.isVisible();
+						},
+						{ timeout: PLAYWRIGHT_ACTION_TIMEOUT },
+					)
 					.toBe(true);
 				await searchInput.fill('tanstack');
 				const firstResult = page.locator('.search-entity').first();


### PR DESCRIPTION
## Summary

- fix the deterministic Three 0.186 compatibility failure by aligning the testing renderer camera option with the root's `CameraProps`
- remove redundant timed module loading from the Solana identity test and give the genuinely heavy Volar type-program test a bounded 15-second budget
- wait for real DOM selection in both Input OTP browser oracles, make the website command-palette geometry case wait for an interactive trigger, and isolate the nested Vitest mock-cleanup assertion from static-import transform timing
- cap each React-parity CI shard at two workers so four 4-vCPU runners retain headroom for Vite, jsdom, and browser work

## Why

Recent `main` failures split into a deterministic dependency-compatibility break and resource-sensitive test races. The newest `main` run failed only Three compatibility after `@types/three@0.186.0`; earlier failures repeatedly hit the same 5-second Solana/Volar ceilings, stale Input OTP selection in both the pristine and adapted browser lanes, random parity worker loss, and readiness-sensitive website/browser-tooling checks. The broad Playwright-install failure was an external Ubuntu package-mirror outage and is intentionally not encoded as a product workaround.

## Validation

- [x] `pnpm format:files:check`
- [ ] `pnpm format:check` (full CI)
- [ ] `pnpm typecheck` (full CI)
- [ ] `pnpm test` (full CI)
- [x] `pnpm sync`
- [x] `pnpm react-parity:validate` (stable 5,345 cases; canary 5,413 cases)
- [x] `node --test scripts/ci-workflow.test.mjs` (62 tests)
- [x] Three r156: `tsgo`, public type program, and 137 compatibility tests
- [x] Three r186: `tsgo`, public type program, and 137 compatibility tests
- [x] Input OTP parity audit/negative controls and 41 pristine/adapted Chromium cases
- [x] command-palette dev-SSR/hydration case (pre-fix local failure at interactive readiness; post-fix pass in 1.6s)
- [x] nested Vitest browser collection, 8 consecutive Chromium passes
- [x] Solana module re-evaluation, 3 simultaneous default-timeout passes (17–25ms test bodies)
- [x] Volar host-spread type program under contention (4.8s within explicit 15s budget)

`pnpm typecheck:files` selects the full pre-existing Volar test module and reports existing errors at lines 11/312/314/365/366; the changed test is at line 981. The package-specific Three type programs above pass, and full CI remains the authoritative aggregate gate.

## Risk / follow-ups

- Full and repeated CI runs are required to assess flake-rate improvement; this PR will remain under observation through multiple complete workflow executions.
- The binding-audit collector marks the legacy Three status release string incomplete because it combines version and commit identity; provenance itself remains recorded in `packages/three/UPSTREAM.md` and is outside this CI-fix scope.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test types, timeouts, worker caps, and e2e wait logic; the Three camera option is a typing alignment for the test renderer only.
> 
> **Overview**
> Targets flaky and deterministic **main** CI failures with test-harness and typing fixes rather than product behavior changes.
> 
> **`@octanejs/three`:** `createThreeTestRenderer`’s optional `camera` is typed as root **`CameraProps`** (constructed `THREE.PerspectiveCamera` or declarative `{ position: [...] }`), fixing the break after newer `@types/three`; typetests and a patch changeset document the contract.
> 
> **Test stability:** React-parity Vitest caps **`maxWorkers: 2` on CI** (config + workflow assertion). Input OTP browser/pristine helpers assert **real `selectionStart`/`selectionEnd`** alongside mirror attributes; adapted selection tests centralize that in `expectMirrorSelection`. Solana **`subSlot`** test drops redundant module churn; Volar’s heavy type-program case gets a **15s** budget. Vitest browser collection uses **dynamic import after `vi.mock`** so mock cleanup does not race static hoisting.
> 
> **Website e2e:** `loadRoute` accepts an optional **viewport**; the constrained command-palette case uses it and **polls trigger clicks** until the search input is interactive after hydration. Parity audit JSON hashes update from touched test files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a230a9638ecf99ab55cad8c52c37cf9b94ece7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791752819&installation_model_id=432790&pr_number=1056&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1056&signature=9ad28bbff276cc19f8120f05d56ab8a2ba0cd41c23c1f35a0c2b7df1766807b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->