### PR TITLE
perf: avoid per-list key callback wrappers

### DIFF
--- a/.changeset/deopt-list-key-sources.md
+++ b/.changeset/deopt-list-key-sources.md
@@ -3,3 +3,5 @@
 ---
 
 Read descriptor list keys directly during reconciliation without creating a key callback for each list render, while preserving keyed identity and hydration behavior.
+
+Keep mapped component slots compatible when rendering switches between native array mapping and a custom map implementation, preserving hydrated inputs and component identity.

--- a/.changeset/deopt-list-key-sources.md
+++ b/.changeset/deopt-list-key-sources.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Read descriptor list keys directly during reconciliation without creating a key callback for each list render, while preserving keyed identity and hydration behavior.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -303,6 +303,24 @@ gzip bytes (+107 / +38). Asset-set SHA-256 values are
 `6a5fca951bdd27d1e1eb3dad0d9372b69859daaa0e29d0336af7da7de40372b9` (baseline)
 and `6b19ce09eb24956a00c0da2bdb26557b3bba227ed65aa1b4c2e3492e549522a8` (candidate).
 
+#### Guarded component-map compatibility check
+
+The hydration regression also exposed an existing compiler mismatch: native map
+item roots could use a lite scope, while a later custom-map result needs a full
+component slot. Guarded component-map roots now use compatible slots in both
+modes. The unchanged regression failed before this correction and passes in dev
+and production afterwards.
+
+For both a simple hookless mapped component and the nested-input fixture,
+standard production and server output were byte-identical. Dev output grew by
+5 bytes and production with `autoMemo: false` by 17 bytes as the call changed
+from a lite scope to a full component slot. Those modes pay the additional slot
+bookkeeping required to preserve identity across dispatch changes; these byte
+counts are not a heap-allocation measurement. Ordinary component `@for` output
+was unchanged in all four modes. Rebuilding the production work gate after the
+compiler correction reproduced the exact candidate bundle and readable-source
+checksums above, so its recorded work and timing evidence remains applicable.
+
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 
 The canonical suite only ever reorders two rows (`swap`). `run-reorder.mjs`

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -213,6 +213,96 @@ how much general browser load changes between runs. Absolute timing differences 
 control's variation are inconclusive; the untimed JSON call counts and
 observable state are deterministic gates.
 
+### List key callback work (opt-in)
+
+`WORK_MODE=key-callback` builds and serves a separate fixture with three cases:
+512 four-row descriptor lists, 512 four-row native mapped lists, and a compiled
+2,048-row `@for` control. Equivalent descriptor/data generations are prepared
+before timing. The compiled control retains its row objects across distinct
+array generations to exercise pure survivor walks. Mapped generations alternate
+numeric and equivalent string keys to protect normalization. Mount, unrelated
+update, keyed reorder, and restore must preserve row order, complete inner HTML,
+survivor nodes, typed inputs, and focus.
+
+The work observer parses readable production output to locate the two key
+callback expressions in the list renderer. Jitless Chromium precise **parent
+block** coverage counts executions of those expressions; callback invocation
+counts would instead scale with rows and are not a creation count. This gate
+reports executed source construction sites, not V8 heap allocations. A second
+browser without coverage runs the same semantic checks and timing against a
+minified production bundle. The compiled `@for` case guards cost added to the
+shared reconciler.
+
+Freeze the baseline's readable and minified artifacts before changing runtime
+code; the label selects an ignored `octane-tsrx/dist/key-callback-{label}/`
+directory. Run these commands from the repository root:
+
+```bash
+WORK_MODE=key-callback WORK_BUILD_LABEL=baseline node benchmarks/js-framework/style-work.mjs 0 --build-only
+WORK_MODE=key-callback WORK_BUILD_LABEL=baseline WORK_EXPECT_CALLBACKS=512 WORK_JSON=/tmp/key-callback-baseline.json node benchmarks/js-framework/style-work.mjs 30 --no-build
+```
+
+Build the candidate separately, then pass the baseline's `semanticSha` to check
+all phases' complete markup. The candidate gate requires zero key callback
+constructions in each list case:
+
+```bash
+WORK_MODE=key-callback WORK_BUILD_LABEL=candidate node benchmarks/js-framework/style-work.mjs 0 --build-only
+WORK_MODE=key-callback WORK_BUILD_LABEL=candidate WORK_EXPECTED_HTML_SHA=YOUR_BASELINE_SHA WORK_JSON=/tmp/key-callback-candidate.json node benchmarks/js-framework/style-work.mjs 30 --no-build
+```
+
+Zero samples run only semantic/work checks. Once both full gates pass, add
+`--timing-only` to skip repeating the jitless observer while retaining all clean
+semantic checks. Keep artifacts fixed and compare identical `--no-build` runs
+in A–B–B–A order. Update and reorder cases have 16 warmup operations and 30
+samples of eight operations, except the very cheap pure compiled update uses
+256 operations per sample for timer resolution. `--compiled-update-only` isolates
+that timing while retaining every semantic case. Override
+`WORK_COMPILED_UPDATE_BATCH=8` to examine the shorter warmup run. Mount has four
+warmups and 30 single-mount samples, with unmount cleanup outside timing. Output includes median/p95 latency,
+Node/Chromium versions, artifact checksums, and minified raw/gzip JS bytes.
+Differences within control or process variance are inconclusive.
+
+Measured on 2026-09-11 against frozen baseline
+`2a667f91b538d028c30ba198b807ed5db373ebb3`, Node 26.4.0, Chromium
+149.0.7827.55, Darwin 25.6.0 arm64. Four fresh processes per revision ran in
+A–B–B–A–A–B–B–A order without concurrent tests. Ranges below are the per-process
+median latencies in milliseconds; the pure compiled update uses the separate
+256-operation comparison. Other cells use the original eight-operation run.
+
+| Case | Operation | Baseline median range (ms) | Candidate median range (ms) |
+| --- | --- | --- | --- |
+| 512 descriptor lists | Mount | 5.200–6.000 | 5.400–5.600 |
+| 512 descriptor lists | Update | 1.325–1.637 | 1.325–1.450 |
+| 512 descriptor lists | Reorder | 14.613–15.875 | 14.513–14.888 |
+| 512 mapped lists | Mount | 3.900–4.200 | 3.700–4.100 |
+| 512 mapped lists | Update | 0.475–0.588 | 0.487–0.488 |
+| 512 mapped lists | Reorder | 13.750–15.425 | 13.638–14.100 |
+| Compiled 2,048-row control | Mount | 3.000–3.500 | 2.800–3.100 |
+| Compiled 2,048-row control | Pure update (256 per sample) | 0.0090–0.0102 | 0.0094–0.0102 |
+| Compiled 2,048-row control | Reorder | 14.625–15.938 | 14.625–16.125 |
+
+All ranges overlap, so these timings support no throughput claim. The original
+short compiled-update run had quantized medians of 0.0125 ms baseline versus
+0.0250 ms candidate. Increasing the batch also increases optimization exposure,
+so the steady result does not rule out an early-run cost. A focused three-way
+comparison found identical approximately 0.0082 ms steady medians for baseline,
+the shared helper, and an inline-dispatch alternative. The inline alternative's
+short-run medians ranged from 0.0125 to 0.0250 ms and added another 226 raw / 78
+gzip bytes, providing no consistent benefit for the extra duplication.
+
+Deterministic work fell from 512 to zero executed callback constructions for
+**each** descriptor-list phase and independently for **each** mapped-list phase.
+Only one of the two source branches executes per list. The compiled control
+executes neither branch. Both revisions pass every order, identity, input, focus,
+and observed/minified parity gate; the combined complete-markup SHA-256 is
+`d07aceedd3930d72653bfc9a08da00722199d3a8ea61f69325c470172a3b01a4`.
+
+Minified fixture JS changed from 176,950 to 177,057 raw bytes and 56,488 to 56,526
+gzip bytes (+107 / +38). Asset-set SHA-256 values are
+`6a5fca951bdd27d1e1eb3dad0d9372b69859daaa0e29d0336af7da7de40372b9` (baseline)
+and `6b19ce09eb24956a00c0da2bdb26557b3bba227ed65aa1b4c2e3492e549522a8` (candidate).
+
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 
 The canonical suite only ever reorders two rows (`swap`). `run-reorder.mjs`

--- a/benchmarks/js-framework/key-callback-work.mjs
+++ b/benchmarks/js-framework/key-callback-work.mjs
@@ -1,0 +1,393 @@
+// Production work gate for the two selected per-list key callback sites.
+// Precise coverage observes closure-expression execution in readable output;
+// timings and bundle sizes use a separate, clean minified production build.
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
+import { chromium } from 'playwright';
+import ts from 'typescript';
+import { build } from 'vite';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.join(here, 'octane-tsrx');
+const label = process.env.WORK_BUILD_LABEL ?? 'candidate';
+assert.match(label, /^[a-zA-Z0-9-]+$/);
+const output = path.join(fixture, 'dist', `key-callback-${label}`);
+const samples = Math.max(0, Number(process.argv[2] ?? 30));
+const compiledUpdateOnly = process.argv.includes('--compiled-update-only');
+const compiledUpdateBatch = Number(process.env.WORK_COMPILED_UPDATE_BATCH ?? 256);
+assert.ok(
+	Number.isInteger(compiledUpdateBatch) && compiledUpdateBatch > 0 && compiledUpdateBatch % 2 === 0,
+	'compiled update batch must be a positive even integer',
+);
+const kinds = ['many', 'mapped', 'compiled'];
+const groups = 512;
+const rows = groups * 4;
+const hash = (value) => createHash('sha256').update(value).digest('hex');
+
+if (!process.argv.includes('--no-build')) {
+	for (const mode of ['observed', 'timing']) {
+		await build({
+			root: fixture,
+			configFile: path.join(fixture, 'vite.config.key-callback.js'),
+			logLevel: 'warn',
+			build: {
+				outDir: path.join(output, mode),
+				emptyOutDir: true,
+				minify: mode === 'timing' ? 'esbuild' : false,
+			},
+		});
+	}
+}
+
+function assets(mode) {
+	const directory = path.join(output, mode, 'assets');
+	return fs
+		.readdirSync(directory)
+		.filter((name) => name.endsWith('.js'))
+		.map((name) => ({
+			name,
+			source: fs.readFileSync(path.join(directory, name), 'utf8'),
+		}));
+}
+
+const minified = assets('timing');
+const bundle = {
+	bytes: minified.reduce((total, asset) => total + Buffer.byteLength(asset.source), 0),
+	gzipBytes: minified.reduce((total, asset) => total + gzipSync(asset.source).length, 0),
+	sha: hash(minified.map(({ name, source }) => `${name}\n${source}`).join('\n')),
+};
+
+function findKeySites() {
+	const matches = [];
+	for (const asset of assets('observed')) {
+		const ast = ts.createSourceFile(asset.name, asset.source, ts.ScriptTarget.Latest, true);
+		function visit(node) {
+			if (ts.isFunctionDeclaration(node) && node.name?.text === 'renderPreparedChildList') {
+				const sites = [];
+				function closure(child) {
+					if (
+						(ts.isArrowFunction(child) ||
+							ts.isFunctionExpression(child) ||
+							ts.isFunctionDeclaration(child)) &&
+						child.parameters.length === 2 &&
+						child.parameters.every((parameter) => ts.isIdentifier(parameter.name))
+					) {
+						let body = child.body;
+						if (
+							body &&
+							ts.isBlock(body) &&
+							body.statements.length === 1 &&
+							ts.isReturnStatement(body.statements[0])
+						)
+							body = body.statements[0].expression;
+						while (body && ts.isParenthesizedExpression(body)) body = body.expression;
+						const names = child.parameters.map((parameter) => parameter.name.text);
+						const parameter = (value, index) =>
+							value && ts.isIdentifier(value) && value.text === names[index];
+						const descriptor =
+							body && ts.isElementAccessExpression(body) && parameter(body.argumentExpression, 1);
+						const mapped =
+							body &&
+							ts.isBinaryExpression(body) &&
+							body.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+							ts.isStringLiteral(body.left) &&
+							body.left.text === 'k' &&
+							ts.isCallExpression(body.right) &&
+							ts.isIdentifier(body.right.expression) &&
+							body.right.expression.text === 'String' &&
+							body.right.arguments.length === 1 &&
+							ts.isCallExpression(body.right.arguments[0]) &&
+							body.right.arguments[0].arguments.length === 2 &&
+							body.right.arguments[0].arguments.every((argument, index) =>
+								parameter(argument, index),
+							);
+						if (descriptor || mapped)
+							sites.push({
+								kind: descriptor ? 'descriptor' : 'mapped',
+								start: child.getStart(ast),
+								end: child.end,
+							});
+					}
+					ts.forEachChild(child, closure);
+				}
+				closure(node.body);
+				matches.push({ name: asset.name, sourceSha: hash(asset.source), sites });
+			}
+			ts.forEachChild(node, visit);
+		}
+		visit(ast);
+	}
+	assert.equal(matches.length, 1, 'one readable production list renderer');
+	assert.ok(
+		matches[0].sites.length === 0 || matches[0].sites.length === 2,
+		'review changed callback source shape',
+	);
+	return matches[0];
+}
+
+const source = findKeySites();
+if (process.argv.includes('--build-only')) {
+	console.log(JSON.stringify({ label, bundle, source }, null, 2));
+} else {
+	const server = createServer((request, response) => {
+		const url = new URL(request.url, 'http://127.0.0.1');
+		const parts = url.pathname.split('/').filter(Boolean);
+		const mode = parts.shift();
+		if ((mode !== 'observed' && mode !== 'timing') || parts.some((part) => part === '..')) {
+			response.writeHead(404).end();
+			return;
+		}
+		const file = path.join(output, mode, ...parts);
+		if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+			response.writeHead(404).end();
+			return;
+		}
+		response.setHeader('content-type', file.endsWith('.js') ? 'text/javascript' : 'text/html');
+		response.end(fs.readFileSync(file));
+	});
+	await new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', resolve);
+	});
+	const origin = `http://127.0.0.1:${server.address().port}`;
+	const invoke = (page, operation) =>
+		page.evaluate((name) => window.__keyCallbackWork(name), operation);
+	async function verify(page, kind, phase) {
+		return page.evaluate(
+			({ kind, phase, count }) => {
+				const main = document.querySelector(`[data-kind="${kind}"]`);
+				if (!main) throw new Error('missing work root');
+				const elements = Array.from(main.querySelectorAll('li'));
+				if (elements.length !== count) throw new Error(`wrong row count ${elements.length}`);
+				const reordered = phase === 'reorder';
+				const expected = Array.from({ length: count }, (_, index) => {
+					if (!reordered) return index;
+					return kind === 'compiled'
+						? count - index - 1
+						: Math.floor(index / 4) * 4 + [0, 3, 1, 2][index % 4];
+				});
+				const version = phase === 'mount' ? '0' : '1';
+				if (main.getAttribute('data-version') !== version) throw new Error('update did not commit');
+				let before = window.__keyCallbackBefore;
+				if (phase === 'mount') before = window.__keyCallbackBefore = new Map();
+				for (let index = 0; index < count; index++) {
+					const id = expected[index];
+					const row = elements[index];
+					const input = row.querySelector('input');
+					if (
+						row.getAttribute('data-row') !== String(id) ||
+						!input ||
+						input.getAttribute('aria-label') !== `row ${id}`
+					) {
+						throw new Error(`incorrect row content/order at ${index}`);
+					}
+					if (phase === 'mount') {
+						if (input.value !== `row ${id}`) throw new Error('wrong initial input value');
+						before.set(id, { row, input });
+						if (id % 257 === 0) input.value = `typed ${id}`;
+					} else {
+						const previous = before.get(id);
+						if (row !== previous.row || input !== previous.input)
+							throw new Error(`row ${id} lost identity`);
+						if (input.value !== (id % 257 === 0 ? `typed ${id}` : `row ${id}`))
+							throw new Error(`row ${id} lost input state`);
+					}
+				}
+				if (phase === 'mount') before.get(0).input.focus();
+				else if (document.activeElement !== before.get(0).input)
+					throw new Error('focused input was replaced');
+				return { rows: elements.length, html: main.innerHTML };
+			},
+			{ kind, phase, count: rows },
+		);
+	}
+	function creationWork(coverage) {
+		const script = coverage.result.find((entry) => entry.url.endsWith(`/assets/${source.name}`));
+		assert.ok(script, 'observed production asset coverage');
+		const render = script.functions.find((fn) => fn.functionName === 'renderPreparedChildList');
+		const work = { listCalls: render?.ranges[0]?.count ?? 0, descriptor: 0, mapped: 0 };
+		for (const site of source.sites) {
+			const ranges =
+				render?.ranges.filter(
+					(range) => range.startOffset <= site.start && range.endOffset >= site.end,
+				) ?? [];
+			ranges.sort((a, b) => a.endOffset - a.startOffset - (b.endOffset - b.startOffset));
+			work[site.kind] += ranges[0]?.count ?? 0;
+		}
+		return work;
+	}
+	async function runCase(browser, mode, kind) {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		const errors = [];
+		page.on('pageerror', (error) => errors.push(error.message));
+		let cdp;
+		try {
+			await page.goto(`${origin}/${mode}/key-callback-work.html`);
+			await page.waitForFunction(() => window.__ready === true);
+			if (mode === 'observed') {
+				cdp = await context.newCDPSession(page);
+				await cdp.send('Profiler.enable');
+				await cdp.send('Profiler.startPreciseCoverage', { callCount: true, detailed: true });
+			}
+			const phases = {};
+			for (const phase of ['mount', 'update', 'reorder', 'restore']) {
+				if (cdp) await cdp.send('Profiler.takePreciseCoverage');
+				await invoke(page, `${phase}-${kind}`);
+				const work = cdp ? creationWork(await cdp.send('Profiler.takePreciseCoverage')) : undefined;
+				const visible = await verify(page, kind, phase);
+				phases[phase] = {
+					rows: visible.rows,
+					htmlSha: hash(visible.html),
+					...(work ? { work } : {}),
+				};
+			}
+			let timing;
+			if (mode === 'timing' && samples > 0 && (!compiledUpdateOnly || kind === 'compiled')) {
+				timing = await page.evaluate(
+					({ kind, samples, compiledUpdateOnly, compiledUpdateBatch }) => {
+						const result = {};
+						for (const operation of compiledUpdateOnly ? ['update'] : ['update', 'reorder']) {
+							const batch = kind === 'compiled' && operation === 'update' ? compiledUpdateBatch : 8;
+							let reordered = false;
+							const step = () => {
+								const action =
+									operation === 'update'
+										? 'update'
+										: (reordered = !reordered)
+											? 'reorder'
+											: 'restore';
+								window.__keyCallbackWork(`${action}-${kind}`);
+							};
+							for (let i = 0; i < 16; i++) step();
+							const times = [];
+							for (let i = 0; i < samples; i++) {
+								const start = performance.now();
+								for (let j = 0; j < batch; j++) step();
+								times.push((performance.now() - start) / batch);
+							}
+							times.sort((a, b) => a - b);
+							result[operation] = {
+								samples,
+								operationsPerSample: batch,
+								medianMs: times[Math.floor(samples / 2)],
+								p95Ms: times[Math.floor(samples * 0.95)],
+							};
+						}
+						return result;
+					},
+					{ kind, samples, compiledUpdateOnly, compiledUpdateBatch },
+				);
+				await verify(page, kind, 'restore');
+				if (!compiledUpdateOnly) {
+					timing.mount = await page.evaluate(
+						({ kind, samples }) => {
+							const mount = () => window.__keyCallbackWork(`mount-${kind}`);
+							const unmount = () => window.__keyCallbackWork(`unmount-${kind}`);
+							unmount();
+							for (let i = 0; i < 4; i++) {
+								mount();
+								unmount();
+							}
+							const times = [];
+							for (let i = 0; i < samples; i++) {
+								const start = performance.now();
+								mount();
+								times.push(performance.now() - start);
+								unmount();
+							}
+							times.sort((a, b) => a - b);
+							mount();
+							return {
+								samples,
+								operationsPerSample: 1,
+								medianMs: times[Math.floor(samples / 2)],
+								p95Ms: times[Math.floor(samples * 0.95)],
+							};
+						},
+						{ kind, samples },
+					);
+					await verify(page, kind, 'mount');
+				}
+			}
+			assert.deepEqual(errors, [], `${kind}: browser errors`);
+			await invoke(page, `unmount-${kind}`);
+			assert.equal(
+				await page.locator(`[data-kind="${kind}"]`).count(),
+				0,
+				'unmount removes work root',
+			);
+			return { phases, ...(timing ? { timing } : {}) };
+		} finally {
+			if (cdp) await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});
+			await context.close();
+		}
+	}
+	let browser;
+	try {
+		let observed;
+		if (!process.argv.includes('--timing-only')) {
+			browser = await chromium.launch({
+				headless: true,
+				args: ['--no-sandbox', '--js-flags=--jitless'],
+			});
+			observed = {};
+			for (const kind of kinds) observed[kind] = await runCase(browser, 'observed', kind);
+			await browser.close();
+		}
+		browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+		const environment = { node: process.version, chromium: browser.version() };
+		const clean = {};
+		for (const kind of kinds) clean[kind] = await runCase(browser, 'timing', kind);
+		const callbacks = Number(process.env.WORK_EXPECT_CALLBACKS ?? 0);
+		for (const kind of observed ? kinds : []) {
+			for (const phase of ['mount', 'update', 'reorder', 'restore']) {
+				const { work, ...semantic } = observed[kind].phases[phase];
+				assert.deepEqual(
+					semantic,
+					clean[kind].phases[phase],
+					`${kind}/${phase}: observed/clean HTML`,
+				);
+				assert.deepEqual(
+					work,
+					{
+						listCalls: kind === 'compiled' ? 0 : groups,
+						descriptor: kind === 'many' ? callbacks : 0,
+						mapped: kind === 'mapped' ? callbacks : 0,
+					},
+					`${kind}/${phase}: executed key callback construction sites`,
+				);
+			}
+		}
+		const semanticSha = hash(
+			JSON.stringify(Object.fromEntries(kinds.map((kind) => [kind, clean[kind].phases]))),
+		);
+		if (process.env.WORK_EXPECTED_HTML_SHA)
+			assert.equal(
+				semanticSha,
+				process.env.WORK_EXPECTED_HTML_SHA,
+				'baseline/candidate complete HTML',
+			);
+		const result = {
+			suite: 'js-framework-style-work/key-callback',
+			label,
+			environment,
+			bundle,
+			source,
+			semanticSha,
+			observed,
+			clean,
+		};
+		if (process.env.WORK_JSON)
+			fs.writeFileSync(process.env.WORK_JSON, JSON.stringify(result, null, 2) + '\n');
+		console.log(JSON.stringify(result, null, 2));
+	} finally {
+		await browser?.close();
+		await new Promise((resolve) => server.close(resolve));
+	}
+}

--- a/benchmarks/js-framework/octane-tsrx/key-callback-work.html
+++ b/benchmarks/js-framework/octane-tsrx/key-callback-work.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Descriptor list key work</title>
+	</head>
+	<body>
+		<script type="module" src="/src/key-callback-work-main.js"></script>
+	</body>
+</html>

--- a/benchmarks/js-framework/octane-tsrx/src/KeyCallbackRows.tsrx
+++ b/benchmarks/js-framework/octane-tsrx/src/KeyCallbackRows.tsrx
@@ -1,0 +1,50 @@
+import type { OctaneNode } from 'octane';
+
+type Group = { id: number; rows: OctaneNode[] };
+type Row = { id: number; label: string };
+type MappedGroup = { id: number; rows: (Row & { key: string | number })[] };
+
+function DescriptorList(props: { group: Group }) @{
+	<section data-group={props.group.id}>
+		<ul>{props.group.rows}</ul>
+	</section>
+}
+
+export function ManyDescriptorLists(props: { groups: Group[]; version: number }) @{
+	<main data-kind="many" data-version={props.version}>
+		@for (const group of props.groups; key group.id) {
+			<DescriptorList group={group} />
+		}
+	</main>
+}
+
+function MappedList(props: { group: MappedGroup }) @{
+	<section data-group={props.group.id}>
+		<ul>{props.group.rows.map(
+			(row) => <li key={row.key} data-row={row.id}>
+				<input defaultValue={row.label} aria-label={row.label} />
+			</li>,
+		)}</ul>
+	</section>
+}
+
+export function ManyMappedLists(props: { groups: MappedGroup[]; version: number }) @{
+	<main data-kind="mapped" data-version={props.version}>
+		@for (const group of props.groups; key group.id) {
+			<MappedList group={group} />
+		}
+	</main>
+}
+
+// The same total number of rows, with keys read by the compiled @for path.
+export function CompiledRows(props: { rows: Row[]; version: number }) @{
+	<main data-kind="compiled" data-version={props.version}>
+		<ul>
+			@for (const row of props.rows; key row.id) {
+				<li data-row={row.id}>
+					<input defaultValue={row.label} aria-label={row.label} />
+				</li>
+			}
+		</ul>
+	</main>
+}

--- a/benchmarks/js-framework/octane-tsrx/src/key-callback-work-main.js
+++ b/benchmarks/js-framework/octane-tsrx/src/key-callback-work-main.js
@@ -1,0 +1,4 @@
+import { runKeyCallbackWork } from './key-callback-work';
+
+window.__keyCallbackWork = runKeyCallbackWork;
+window.__ready = true;

--- a/benchmarks/js-framework/octane-tsrx/src/key-callback-work.ts
+++ b/benchmarks/js-framework/octane-tsrx/src/key-callback-work.ts
@@ -1,0 +1,100 @@
+import { createElement, createRoot, flushSync, type OctaneNode } from 'octane';
+import { CompiledRows, ManyDescriptorLists, ManyMappedLists } from './KeyCallbackRows.tsrx';
+
+type Kind = 'many' | 'mapped' | 'compiled';
+const GROUPS = 512;
+const ROWS = GROUPS * 4;
+
+function descriptor(group: number, row: number): OctaneNode {
+	const id = group * 4 + row;
+	return createElement(
+		'li',
+		{ key: row === 0 ? undefined : row === 1 ? '0' : `row-${row}`, 'data-row': id },
+		createElement('input', { defaultValue: `row ${id}`, 'aria-label': `row ${id}` }),
+	);
+}
+
+function groups(reordered: boolean) {
+	return Array.from({ length: GROUPS }, (_, id) => ({
+		id,
+		rows: (reordered ? [0, 3, 1, 2] : [0, 1, 2, 3]).map((row) => descriptor(id, row)),
+	}));
+}
+
+function rows(reordered: boolean) {
+	const values = Array.from({ length: ROWS }, (_, id) => ({ id, label: `row ${id}` }));
+	return reordered ? values.toReversed() : values;
+}
+
+function mappedGroups(reordered: boolean, stringKeys: boolean = false) {
+	return Array.from({ length: GROUPS }, (_, group) => ({
+		id: group,
+		rows: (reordered ? [0, 3, 1, 2] : [0, 1, 2, 3]).map((index) => ({
+			id: group * 4 + index,
+			key: stringKeys ? String(group * 4 + index) : group * 4 + index,
+			label: `row ${group * 4 + index}`,
+		})),
+	}));
+}
+
+// Two equivalent generations force list traversal on unrelated updates. A
+// third generation checks reorder identity; all construction precedes timing.
+const prepared = {
+	many: [groups(false), groups(false), groups(true)],
+	// Numeric and string forms must retain the same mapped identity.
+	mapped: [mappedGroups(false), mappedGroups(false, true), mappedGroups(true)],
+	// Distinct outer arrays retain the same rows. This keeps the compiled
+	// control on the pure survivor path where key-read overhead is exposed.
+	compiled: (() => {
+		const stable = rows(false);
+		return [stable.slice(), stable.slice(), stable.toReversed()];
+	})(),
+};
+const roots: Partial<Record<Kind, ReturnType<typeof createRoot>>> = {};
+const containers: Partial<Record<Kind, HTMLElement>> = {};
+const versions: Record<Kind, number> = { many: 0, mapped: 0, compiled: 0 };
+
+function render(kind: Kind, generation: number): void {
+	const root = roots[kind];
+	if (root === undefined) throw new Error(`${kind} is not mounted`);
+	if (kind === 'many') {
+		root.render(ManyDescriptorLists, {
+			groups: prepared.many[generation],
+			version: versions[kind],
+		});
+	} else if (kind === 'mapped') {
+		root.render(ManyMappedLists, { groups: prepared.mapped[generation], version: versions[kind] });
+	} else {
+		root.render(CompiledRows, { rows: prepared.compiled[generation], version: versions[kind] });
+	}
+	flushSync(() => {});
+}
+
+export function runKeyCallbackWork(operation: string): void {
+	const [action, kind] = operation.split('-') as [string, Kind];
+	if (kind !== 'many' && kind !== 'mapped' && kind !== 'compiled')
+		throw new Error(`unknown kind ${kind}`);
+	if (action === 'mount') {
+		if (roots[kind] !== undefined) throw new Error(`${kind} is already mounted`);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		containers[kind] = container;
+		roots[kind] = createRoot(container);
+		versions[kind] = 0;
+		render(kind, 0);
+	} else if (action === 'update') {
+		versions[kind] = 1 - versions[kind];
+		render(kind, versions[kind]);
+	} else if (action === 'reorder') {
+		render(kind, 2);
+	} else if (action === 'restore') {
+		render(kind, versions[kind]);
+	} else if (action === 'unmount') {
+		roots[kind]?.unmount();
+		containers[kind]?.remove();
+		delete roots[kind];
+		delete containers[kind];
+	} else {
+		throw new Error(`unknown operation ${operation}`);
+	}
+}

--- a/benchmarks/js-framework/octane-tsrx/vite.config.key-callback.js
+++ b/benchmarks/js-framework/octane-tsrx/vite.config.key-callback.js
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mergeConfig } from 'vite';
+import base from './vite.config.js';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export default mergeConfig(base, {
+	base: './',
+	build: {
+		outDir: 'dist/key-callback-work',
+		rollupOptions: { input: resolve(root, 'key-callback-work.html') },
+	},
+});

--- a/benchmarks/js-framework/style-work.mjs
+++ b/benchmarks/js-framework/style-work.mjs
@@ -15,6 +15,10 @@ if (process.env.WORK_MODE === 'nested') {
 	await import('./nested-work.mjs');
 	process.exit(process.exitCode ?? 0);
 }
+if (process.env.WORK_MODE === 'key-callback') {
+	await import('./key-callback-work.mjs');
+	process.exit(process.exitCode ?? 0);
+}
 if (process.env.WORK_MODE === 'literals') {
 	await import('./style-literals-work.mjs');
 	process.exit(process.exitCode ?? 0);

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14336,6 +14336,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			mountCallbackSinks,
 			options?.keyedSelection ?? null,
 			options?.inlineBindingGuards === true,
+			options?.mappedItem === true,
 		);
 	}
 	ctx.currentInvariantLocals = prevInvariantLocals;
@@ -22242,6 +22243,7 @@ function planJsx(
 	mountCallbackSinks = null,
 	keyedSelection = null,
 	inlineBindingGuards = false,
+	mappedItem = false,
 ) {
 	// DEV ONLY: per-element source-location map for THIS body (path-key → [line, col]),
 	// populated at the top of emitElementHtml and read in the binding mount loop to emit
@@ -22420,6 +22422,17 @@ function planJsx(
 			}
 		}
 		appendTemplateIr(rootTemplate, part);
+		if (mappedItem && jsxNodes.length === 1 && nodeIsComp) {
+			// A guarded map can switch to authored component descriptors on its
+			// next render. Both modes must own the same full component slot; a
+			// lite scope cannot be reconciled as that descriptor's component.
+			const rootComp = compCalls[compCalls.length - 1];
+			if (rootComp.liteEligible || rootComp.autoMemoLite) {
+				rootComp.singleRoot = ctx.componentInfo?.get(rootComp.compNode.name)?.singleRoot === true;
+			}
+			rootComp.liteEligible = false;
+			rootComp.autoMemoLite = false;
+		}
 		// M3 inherit-range: stamp the sole comp-call root's cc. Its own entry is
 		// the LAST one its emitNodeHtml pushed (nested children/prop ccs are
 		// pushed first, before makeCompCall returns to the root push).
@@ -27051,6 +27064,7 @@ function hoistBodyHelper(
 	idOrigin = null,
 	keyedSelection = null,
 	inlineBindingGuards = false,
+	mappedItem = false,
 ) {
 	const helperName = `${prefix}$${ctx.nextHelperId++}`;
 	const ownEnvNames = envNames === null ? null : helperCaptures(ctx, stmts, params);
@@ -27098,7 +27112,9 @@ function hoistBodyHelper(
 		fakeOrigin,
 	);
 	const helperOptions =
-		inlineBindingGuards || keyedSelection !== null ? { keyedSelection, inlineBindingGuards } : null;
+		inlineBindingGuards || keyedSelection !== null || mappedItem
+			? { keyedSelection, inlineBindingGuards, mappedItem }
+			: null;
 	if (envNames == null) {
 		inlinedSubs.push(compileFunctionBody(fake, ctx, helperName, parentNs, cssHash, helperOptions));
 		return helperName;
@@ -28842,6 +28858,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		directiveKeywordOrigin(ctx, node),
 		keyedSelection,
 		hostMountSafe,
+		node.nativeArrayMap != null,
 	);
 
 	const mapCall = node.nativeArrayMap || null;

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -25317,9 +25317,8 @@ function renderPreparedChildList(
 	const { items, keys } = preparedList;
 	const markerlessMappedFallback =
 		mappedFallback === true && hydration !== null && !hydration.isOpen(hydration.node);
-	const getKey = compiledMapKey
-		? (item: any, index: number) => 'k' + String(compiledMapKey(item, index))
-		: (_item: any, i: number) => keys![i];
+	const keySource = compiledMapKey || keys!;
+	const normalizeKey = !!compiledMapKey;
 	const wasMappedNative = state.forSlot.mappedNative === true;
 	let body =
 		compiledMapBody || (mappedFallback === true ? mappedDeoptItemBody : (deoptItemBody as any));
@@ -25327,7 +25326,7 @@ function renderPreparedChildList(
 		for (let index = 0; index < items.length; index++) {
 			const item = items[index];
 			if (!isHostDescriptor(item)) continue;
-			const block = state.forSlot.items.get(getKey(item, index));
+			const block = state.forSlot.items.get(readListKey(keySource, item, index, normalizeKey));
 			if (
 				block !== undefined &&
 				block.startMarker !== null &&
@@ -25437,23 +25436,25 @@ function renderPreparedChildList(
 			parentBlock,
 			state.forSlot,
 			items,
-			getKey,
+			keySource,
 			body,
 			compiledMapBody === undefined ? 2 : (fastFlags & 2) !== 0,
 			ssrMarkerless,
+			normalizeKey,
 		);
 	} else {
 		reconcileKeyed(
 			parentBlock,
 			state.forSlot,
 			items,
-			getKey,
+			keySource,
 			body,
 			pure,
 			compiledMapBody === undefined ? 2 : (fastFlags & 2) !== 0,
 			lite,
 			(fastFlags & 8) !== 0,
 			ssrMarkerless,
+			normalizeKey,
 		);
 	}
 	// Upgrade adoption: nodes the empty→fill mount didn't consume (old
@@ -33598,6 +33599,22 @@ function consumeAdoptQueuePrefix(adopt: Array<{ key: any; node: Node }>, count: 
 	adopt.length -= count;
 }
 
+type ListKeySource<T> = readonly any[] | ((item: T, index: number) => any);
+
+// Prepared descriptor keys already have their reconciliation encoding. Compiled
+// maps normalize each callback result at the original read site; ordinary @for
+// callbacks retain their raw key identity and receive exactly two arguments.
+// The source stays local to this call so nested item renders cannot replace it.
+function readListKey<T>(
+	keySource: ListKeySource<T>,
+	item: T,
+	index: number,
+	normalizeKey: boolean,
+): any {
+	if (typeof keySource !== 'function') return keySource[index];
+	return normalizeKey ? 'k' + String(keySource(item, index)) : keySource(item, index);
+}
+
 /**
  * Linear first-fill of an EMPTY keyed list — the hydration-adopt / first-mount
  * path: append (or adopt) each item in order and build the survivor machinery
@@ -33611,12 +33628,13 @@ function consumeAdoptQueuePrefix(adopt: Array<{ key: any; node: Node }>, count: 
 // Validate keys as the existing reconciler reads them. Never invoke a key
 // expression twice for diagnostics; repeated reads of the same index are legal.
 function checkedListKey<T>(
-	getKey: (item: T, index: number) => any,
+	keySource: ListKeySource<T>,
+	normalizeKey: boolean,
 ): (item: T, index: number) => any {
 	const seen = new Map<any, number>();
 	let warned = false;
 	return (item, index) => {
-		const key = getKey(item, index);
+		const key = readListKey(keySource, item, index, normalizeKey);
 		if (!warned && seen.has(key) && seen.get(key) !== index) {
 			warned = true;
 			const label =
@@ -33633,14 +33651,18 @@ function mountItemsLinear<T>(
 	parentBlock: Block,
 	state: ForSlot,
 	items: ArrayLike<T>,
-	getKey: (item: T, index: number) => any,
+	keySource: ListKeySource<T>,
 	itemBody: (item: T, scope: Scope) => void,
 	singleRoot: boolean | 2,
 	ssrMarkerless: boolean,
+	normalizeKey: boolean = false,
 ): void {
 	const newLen = items.length;
 	if (newLen === 0) return;
-	if (process.env.NODE_ENV !== 'production') getKey = checkedListKey(getKey);
+	if (process.env.NODE_ENV !== 'production') {
+		keySource = checkedListKey(keySource, normalizeKey);
+		normalizeKey = false;
+	}
 	// Every 0 -> N fill funnels through here (forBlock, the value-position array
 	// path, and reconcileKeyed's own empty branch). An empty list is still a
 	// shape to go back to: a fill during a render that may yet hold must come
@@ -33662,7 +33684,7 @@ function mountItemsLinear<T>(
 	try {
 		for (let i = 0; i < newLen; i++) {
 			const item = items[i];
-			const key = getKey(item, i);
+			const key = readListKey(keySource, item, i, normalizeKey);
 			let adoptNode: Node | null = null;
 			let anchor: Node = state.end;
 			if (adopt !== null && adoptIndex < adopt.length) {
@@ -33726,7 +33748,7 @@ function reconcileKeyed<T>(
 	parentBlock: Block,
 	state: ForSlot,
 	items: ArrayLike<T>,
-	getKey: (item: T, index: number) => any,
+	keySource: ListKeySource<T>,
 	itemBody: (item: T, scope: Scope) => void,
 	pure: boolean,
 	// true / false = compiler-static (compiled @for); 2 = de-opt per-item
@@ -33738,6 +33760,7 @@ function reconcileKeyed<T>(
 	// item's hydration pair. Kept separate from singleRoot because sole-component
 	// and conditional roots are markerless only on fresh client mounts today.
 	ssrMarkerless: boolean = false,
+	normalizeKey: boolean = false,
 ): void {
 	const oldItems = state.items;
 	const oldSize = state.size;
@@ -33751,10 +33774,22 @@ function reconcileKeyed<T>(
 	// Fast path: empty → fill — the linear first-fill pass (callers on the
 	// first-mount path dispatch to it directly and skip this function entirely).
 	if (oldSize === 0) {
-		mountItemsLinear(parentBlock, state, items, getKey, itemBody, singleRoot, ssrMarkerless);
+		mountItemsLinear(
+			parentBlock,
+			state,
+			items,
+			keySource,
+			itemBody,
+			singleRoot,
+			ssrMarkerless,
+			normalizeKey,
+		);
 		return;
 	}
-	if (process.env.NODE_ENV !== 'production') getKey = checkedListKey(getKey);
+	if (process.env.NODE_ENV !== 'production') {
+		keySource = checkedListKey(keySource, normalizeKey);
+		normalizeKey = false;
+	}
 	// Fast path: clear all.
 	if (newLen === 0) {
 		const ownedRootClear = journalShape && canDeferRootOwnedListClear(state);
@@ -33775,7 +33810,7 @@ function reconcileKeyed<T>(
 	let oldFirst: Block | null = state.head;
 	let prefixLen = 0;
 	while (oldFirst !== null && prefixLen < newLen) {
-		const newKey = getKey(items[prefixLen], prefixLen);
+		const newKey = readListKey(keySource, items[prefixLen], prefixLen, normalizeKey);
 		if (oldFirst.key !== newKey) break;
 		const block = oldFirst;
 		updateSurvivor(
@@ -33800,7 +33835,7 @@ function reconcileKeyed<T>(
 	let newEnd = newLen - 1;
 	let oldRemain = oldSize - prefixLen;
 	while (oldLast !== null && oldRemain > 0 && newEnd >= prefixLen) {
-		const newKey = getKey(items[newEnd], newEnd);
+		const newKey = readListKey(keySource, items[newEnd], newEnd, normalizeKey);
 		if (oldLast.key !== newKey) break;
 		const block = oldLast;
 		updateSurvivor(block, items[newEnd], newEnd, itemBody, pure, lite, indexIndependent, state.env);
@@ -33831,7 +33866,7 @@ function reconcileKeyed<T>(
 		let prev: Block | null = beforeMiddle;
 		for (let i = prefixLen; i <= newEnd; i++) {
 			const item = items[i];
-			const key = getKey(item, i);
+			const key = readListKey(keySource, item, i, normalizeKey);
 			const block = mountItem(
 				parentBlock,
 				parentNode,
@@ -33883,7 +33918,7 @@ function reconcileKeyed<T>(
 	const newKeys: any[] = new Array(newMidLen);
 	const newKeysToIdx = new Map<any, number>(); // key → MIDDLE-RELATIVE index (0..newMidLen-1)
 	for (let i = 0; i < newMidLen; i++) {
-		const key = getKey(items[prefixLen + i], prefixLen + i);
+		const key = readListKey(keySource, items[prefixLen + i], prefixLen + i, normalizeKey);
 		newKeys[i] = key;
 		newKeysToIdx.set(key, i);
 	}

--- a/packages/octane/tests/_fixtures/deopt-child-keys.tsrx
+++ b/packages/octane/tests/_fixtures/deopt-child-keys.tsrx
@@ -6,3 +6,14 @@
 export function RowsHole(props) @{
 	<ul class="rows">{props.rows}</ul>
 }
+
+function MappedInputRow(props) @{
+	<li data-row={props.row.id}>
+		<input data-input={props.row.id} defaultValue={props.row.label} />
+		{props.row.children}
+	</li>
+}
+
+export function MappedInputRows(props) @{
+	<ul class="mapped-rows">{props.rows.map((row) => <MappedInputRow key={row.id} row={row} />)}</ul>
+}

--- a/packages/octane/tests/deopt-child-key-aliasing.test.ts
+++ b/packages/octane/tests/deopt-child-key-aliasing.test.ts
@@ -12,7 +12,7 @@ import {
 import { renderToString } from 'octane/server';
 import { mount } from './_helpers';
 import { loadServerFixture } from './_server-fixture';
-import { RowsHole } from './_fixtures/deopt-child-keys.tsrx';
+import { MappedInputRows, RowsHole } from './_fixtures/deopt-child-keys.tsrx';
 
 // Descriptors handed to a template HOLE reach the de-opt keyed list, which
 // derives an internal reconciliation key per child from its wrapper path plus
@@ -34,6 +34,135 @@ const server = loadServerFixture('packages/octane/tests/_fixtures/deopt-child-ke
 function TextHost({ value }: { value: OctaneNode }) {
 	return createElement('p', { 'data-testid': 'text' }, value);
 }
+
+function InputRow({ id }: { id: string }) {
+	return createElement(
+		'li',
+		{ 'data-row': id },
+		createElement('input', { 'data-input': id, defaultValue: id }),
+	);
+}
+
+function NestedInputGroup({ id, reverse }: { id: string; reverse: boolean }) {
+	const keyed = ['0', 'last'].map((key) => createElement(InputRow, { key, id: `${id}-${key}` }));
+	return createElement(
+		'li',
+		{ 'data-group': id },
+		createElement('ul', null, [
+			createElement(InputRow, { id: `${id}-plain` }),
+			...(reverse ? keyed.reverse() : keyed),
+		]),
+	);
+}
+
+describe('lists rendered inside list items', () => {
+	it('keeps independent input state while outer and inner descriptor lists reorder', () => {
+		const rows = (order: string[], reverse: boolean) => [
+			createElement(InputRow, { id: 'plain' }),
+			...order.map((id) => createElement(NestedInputGroup, { key: id, id, reverse })),
+			createElement(InputRow, { id: 'tail' }),
+		];
+		const view = mount(RowsHole, { rows: rows(['0', 'b', 'c'], false) });
+		try {
+			const inputs = new Map(
+				(view.findAll('input') as HTMLInputElement[]).map((input) => [input.dataset.input!, input]),
+			);
+			for (const [id, input] of inputs) input.value = `typed:${id}`;
+			for (const [order, reverse] of [
+				[['c', '0', 'b'], true],
+				[['0', 'b', 'c'], false],
+			] as const) {
+				view.update(RowsHole, { rows: rows([...order], reverse) });
+				expect(view.findAll('[data-group]').map((node) => node.getAttribute('data-group'))).toEqual(
+					order,
+				);
+				expect(view.findAll('input').map((node) => node.getAttribute('data-input'))).toEqual([
+					'plain',
+					...order.flatMap((id) =>
+						(reverse ? ['plain', 'last', '0'] : ['plain', '0', 'last']).map(
+							(key) => `${id}-${key}`,
+						),
+					),
+					'tail',
+				]);
+				for (const [id, input] of inputs) {
+					expect(view.find(`[data-input="${id}"]`)).toBe(input);
+					expect(input.value).toBe(`typed:${id}`);
+				}
+			}
+		} finally {
+			view.unmount();
+		}
+	});
+
+	it.each(['native map', 'custom map'] as const)(
+		'adopts mapped inputs through %s and retains them across map modes and nested reorders',
+		(mode) => {
+			const rows = (order: string[], reverse: boolean, custom: boolean) => {
+				const values = order.map((id) => ({
+					id,
+					label: id,
+					children: createElement('ul', null, [
+						createElement(NestedInputGroup, { key: 'nested', id: `${id}-nested`, reverse }),
+					]),
+				}));
+				if (custom) {
+					Object.defineProperty(values, 'map', {
+						value(callback: (value: (typeof values)[number], index: number) => unknown) {
+							return Array.prototype.map.call(this, callback);
+						},
+					});
+				}
+				return values;
+			};
+			const initial = ['0', 'b', 'c'];
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.innerHTML = renderToString(server.MappedInputRows, {
+				rows: rows(initial, false, false),
+			}).html;
+			const inputs = new Map(
+				Array.from(container.querySelectorAll<HTMLInputElement>('input'), (input) => [
+					input.dataset.input!,
+					input,
+				]),
+			);
+			for (const [id, input] of inputs) input.value = `typed:${id}`;
+			const errors: unknown[] = [];
+			const root = hydrateRoot(
+				container,
+				MappedInputRows,
+				{ rows: rows(initial, false, mode === 'custom map') },
+				{ onRecoverableError: (error) => errors.push(error) },
+			);
+			try {
+				flushSync(() => {});
+				for (const [order, reverse, custom] of [
+					[initial, false, mode === 'custom map'],
+					[['c', '0', 'b'], true, mode === 'native map'],
+					[initial, false, mode === 'custom map'],
+				] as const) {
+					flushSync(() =>
+						root.render(MappedInputRows, { rows: rows([...order], reverse, custom) }),
+					);
+					expect(
+						Array.from(container.querySelectorAll('.mapped-rows > li'), (node) =>
+							node.getAttribute('data-row'),
+						),
+					).toEqual(order);
+					for (const [id, input] of inputs) {
+						expect(container.querySelector(`[data-input="${id}"]`)).toBe(input);
+						expect(input.value).toBe(`typed:${id}`);
+					}
+				}
+				expect(errors).toEqual([]);
+			} finally {
+				root.unmount();
+				container.remove();
+			}
+		},
+	);
+});
 
 describe('scalar host children', () => {
 	it('updates strings and numbers without replacing the surviving text node', () => {

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as ServerRuntime from 'octane/server';
-import { createElement, flushSync, hydrateRoot, use, type OctaneNode } from '../src/index.js';
+import {
+	createElement,
+	flushSync,
+	forBlock,
+	hostComponent,
+	hydrateRoot,
+	use,
+	type ComponentBody,
+	type OctaneNode,
+} from '../src/index.js';
 import { act, mount } from './_helpers';
 import { loadServerFixture } from './_server-fixture';
 import {
@@ -71,6 +80,70 @@ import {
 import { SnapshotMappedList } from './_fixtures/for-strong.js';
 
 const labels = (r: ReturnType<typeof mount>) => r.findAll('li').map((li) => li.textContent);
+
+describe('manual keyed lists', () => {
+	it('preserves object keys and callback arguments, and discards a failed list before retry', () => {
+		type Row = { id: string; label: string };
+		type Props = { items: Row[]; getKey: (item: Row, index: number) => Row };
+		const ManualList: ComponentBody<Props> = (props, scope) => {
+			const parent = hostComponent(scope, 0, 'ul', null);
+			forBlock(scope, 1, parent, props.items, props.getKey, (item, rowScope) => {
+				hostComponent(
+					rowScope,
+					0,
+					'li',
+					{ 'data-id': item.id },
+					createElement('input', { defaultValue: item.label }),
+				);
+			});
+		};
+		const initial = ['a', 'b', 'c'].map((id) => ({ id, label: id }));
+		let current: Row[] = [];
+		let failKey = false;
+		const failure = new Error('key unavailable');
+		const calls: unknown[][] = [];
+		function getKey(this: void, item: Row, index: number): Row {
+			calls.push([...arguments]);
+			expect(this).toBeUndefined();
+			expect(item).toBe(current[index]);
+			if (failKey && item.id === 'new') throw failure;
+			return item;
+		}
+		const view = mount(ManualList, { items: current, getKey });
+		try {
+			current = initial;
+			view.update(ManualList, { items: current, getKey });
+			const inputs = view.findAll('input') as HTMLInputElement[];
+			for (const input of inputs) input.value = `typed:${input.value}`;
+			current = initial.toReversed();
+			view.update(ManualList, { items: current, getKey });
+			expect(view.findAll('input')).toEqual(inputs.toReversed());
+
+			current = [initial[2], { id: 'new', label: 'new' }, initial[0]];
+			failKey = true;
+			expect(() => view.update(ManualList, { items: current, getKey })).toThrow(failure);
+			expect(view.findAll('input')).toEqual([]);
+			expect(inputs.every((input) => !input.isConnected)).toBe(true);
+
+			failKey = false;
+			view.update(ManualList, { items: current, getKey });
+			expect(view.findAll('li').map((row) => row.getAttribute('data-id'))).toEqual([
+				'c',
+				'new',
+				'a',
+			]);
+			expect((view.findAll('input') as HTMLInputElement[]).map((input) => input.value)).toEqual([
+				'c',
+				'new',
+				'a',
+			]);
+			expect(calls.length).toBeGreaterThan(0);
+			expect(calls.every((args) => args.length === 2)).toBe(true);
+		} finally {
+			view.unmount();
+		}
+	});
+});
 
 describe('forBlock — mount', () => {
 	it('mounts an empty list', () => {

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -82,7 +82,7 @@ import { SnapshotMappedList } from './_fixtures/for-strong.js';
 const labels = (r: ReturnType<typeof mount>) => r.findAll('li').map((li) => li.textContent);
 
 describe('manual keyed lists', () => {
-	it('preserves object keys and callback arguments, and discards a failed list before retry', () => {
+	it('preserves object keys and callback arguments, and unmounts the root after an unhandled key error', () => {
 		type Row = { id: string; label: string };
 		type Props = { items: Row[]; getKey: (item: Row, index: number) => Row };
 		const ManualList: ComponentBody<Props> = (props, scope) => {
@@ -122,10 +122,12 @@ describe('manual keyed lists', () => {
 			current = [initial[2], { id: 'new', label: 'new' }, initial[0]];
 			failKey = true;
 			expect(() => view.update(ManualList, { items: current, getKey })).toThrow(failure);
+			// An unhandled render error unmounts the entire failed root.
 			expect(view.findAll('input')).toEqual([]);
 			expect(inputs.every((input) => !input.isConnected)).toBe(true);
 
 			failKey = false;
+			// The public root remains reusable; retry mounts fresh inputs.
 			view.update(ManualList, { items: current, getKey });
 			expect(view.findAll('li').map((row) => row.getAttribute('data-id'))).toEqual([
 				'c',


### PR DESCRIPTION
## Summary

Remove the per-list key callback selected by `renderPreparedChildList`: reconciliation now reads the prepared key array directly or calls the existing compiled-map key function with normalization at the original read site.

Partial follow-up to #981. Explicit/nested key encoding and keyed component-slot coercion remain open.

## Changes

- Keep each key source local to its reconciliation call, preserving nested/reentrant rendering without retained caches.
- Preserve raw `@for` key identity, the public callback's two arguments and receiver, key/coercion evaluation order, development duplicate-key diagnostics, and empty-fill/error cleanup.
- Add behavioral coverage for nested descriptor reorders, mapped hydration and map-mode transitions, object keys, callback arguments, and failed-list retry.
- Correct a pre-existing compiler mismatch exposed by that regression: guarded-map component roots now retain full component-slot ownership across native/custom dispatch, including compatible single-root boundaries. Ordinary `@for` output remains unchanged.
- Add an opt-in production browser work gate with descriptor, native mapped, and compiled `@for` controls, plus a patch changeset.

## Performance evidence

- 512 small descriptor lists: selected callback construction executions **512 → 0** per mount/update/reorder/restore.
- 512 native mapped lists: selected normalizing callback construction executions **512 → 0** per phase.
- Compiled 2,048-row `@for` control: **0 → 0**. All cases preserve full markup, survivor nodes, typed input values, and focus.
- Final minified fixture bundle: **176,950 → 177,057 bytes**; gzip **56,488 → 56,526 bytes** (+107/+38).
- Paired warm timing distributions overlap; no throughput or V8 heap-allocation improvement is claimed. Short, coarsely timed compiled-update runs showed a warmup-sensitive difference; higher-batch measurements did not establish a steady-state regression. An inline-dispatch alternative added another 226 raw/78 gzip bytes without a reliable timing benefit and was discarded.
- Reproduction commands, all timing ranges, artifact checksums, and limitations are recorded in the benchmark README.

## Validation

- [x] Production browser work and semantic gates, paired timing controls, and minified bundle comparison.
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/typetests/tsconfig.json`
- [x] Scoped formatting for all changed files; `git diff --check`; test-marker check.
- [x] `pnpm sync`
- [x] Related dev/prod, hydration, list, root-error, and compiler suites: **49 files / 856 tests passed** (includes the 216 tests in the two directly affected files). Three deliberate key-handling mutations each made the corresponding regression fail in both dev and prod; the runtime was restored exactly.
- [ ] Full `pnpm test`, `pnpm typecheck`, and repository-wide formatting were not run.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34653637226/attempts/2): **26/26 jobs passed** on signed head `bf66a67a4`. The merge incorporates main #1056, fixing the prior Three camera type failure and Solana module-reload timeout. Cursor Bugbot passed, all review threads are resolved, and the worktree is clean. GitHub still requires reviewer approval before merge.

Local tests used a temporary selection of the repository's existing `octane`/`octane-prod` projects, retaining their compiler plugins, exclusions, environments, and per-test setup. The unrelated React differential-fixture precompile was omitted because the selected suites do not use it. No additional dependency download was needed. Commands: `vitest run --config /private/tmp/1057-vitest.config.mjs` (216 tests), then `vitest run --config /private/tmp/1057-related-vitest.config.mjs --maxWorkers=4` (856 tests).

The rebuilt production work fixture matches the measured candidate byte-for-byte (`6b19ce09eb24956a00c0da2bdb26557b3bba227ed65aa1b4c2e3492e549522a8`). Standard production/server mapped fixtures and ordinary `@for` output are unchanged. Dev and `autoMemo:false` guarded component maps now pay for a full component slot to preserve transitions; measured emitted-code deltas were +5/+17 bytes, not a heap-cost measurement.

CI attempt 1 hit a Vitest browser-orchestration error while starting the adapted Base UI `MeterTrack.test.tsx`, with no assertion failure reported. That exact Chromium fixture passed 15/15 tests locally. The targeted shard retry and its dependent checks passed without further code changes; the underlying browser error cause was not available in the CI log.

## Risk / follow-ups

This touches key reads in the shared client reconciler and component-slot selection for guarded map item roots. The original failing hydration scenario is preserved. No server implementation or public/compiler ABI changes. Current-head CI is green; the full local differential suite was not run.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791755007&installation_model_id=432790&pr_number=1057&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1057&signature=f7f229bc3cbc4f633eb8f1333ee9fa3af950e06c5f4aa1f3c968aefa973c0985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes keyed reconciliation in the shared client runtime and compiler component-slot selection for map item roots—areas that affect hydration, list identity, and reorder correctness.
> 
> **Overview**
> **Removes per-list key callback wrappers** in the de-opt child-list path: reconciliation now reads prepared key arrays directly or invokes compiled map key functions at each read site via `readListKey`, eliminating 512 executed callback constructions per phase in the new work gate while keeping `@for` callback semantics, duplicate-key diagnostics, and hydration behavior.
> 
> **Fixes guarded `.map` item roots** in the compiler by passing `mappedItem` into `planJsx` so component map roots always use a full component slot (not a lite scope), preserving DOM/input identity when switching between native `Array.prototype.map` and a custom `map` implementation.
> 
> Adds an opt-in **`WORK_MODE=key-callback`** browser benchmark (descriptor lists, native mapped lists, compiled `@for` control), README evidence, a patch changeset, and expanded tests for nested descriptor reorders, mapped hydration, object keys, and manual `forBlock` key errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf66a67a407b06b73d40d70c9980c5cbd173441d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->