### PR TITLE
fix: tolerate npm publication propagation

### DIFF
--- a/scripts/reconcile-github-releases.mjs
+++ b/scripts/reconcile-github-releases.mjs
@@ -10,7 +10,7 @@ import {
 import { getPublishablePackages, REPO_ROOT } from './workspace-packages.mjs';
 
 const DEFAULT_GITHUB_API_URL = 'https://api.github.com';
-const NPM_PROPAGATION_RETRY_DELAYS_MS = [5_000, 10_000, 20_000, 30_000, 30_000];
+const NPM_PROPAGATION_RETRY_DELAYS_MS = [5_000, 10_000, 20_000, 30_000, 30_000, 30_000];
 const RELEASE_TAGGER_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com';
 const RELEASE_TAGGER_NAME = 'github-actions[bot]';
 

--- a/scripts/reconcile-github-releases.test.mjs
+++ b/scripts/reconcile-github-releases.test.mjs
@@ -99,6 +99,35 @@ describe('GitHub release reconciliation', () => {
 		assert.equal(inspections, 3);
 	});
 
+	test('waits through two minutes of npm registry propagation by default', async () => {
+		const pkg = { name: '@octanejs/example', version: '0.1.2' };
+		const pending = {
+			invalid: [],
+			pending: [pkg],
+			published: [],
+			unbootstrapped: [],
+			unreachable: [],
+		};
+		const published = {
+			...pending,
+			pending: [],
+			published: [pkg],
+		};
+		let elapsed = 0;
+
+		const state = await waitForNpmPublication([pkg], {
+			inspectReleaseState: async () => (elapsed < 120_000 ? pending : published),
+			log: () => {},
+			sleep: async (delay) => {
+				elapsed += delay;
+			},
+		});
+
+		assert.equal(state, published);
+		assert.ok(elapsed >= 120_000);
+		assert.ok(elapsed <= 130_000);
+	});
+
 	test('pushes annotated missing tags atomically without repository identity and creates every missing release sequentially', async () => {
 		const { expectedSha, remote, repository, root } = await createRepositoryFixture();
 		try {


### PR DESCRIPTION
## Summary

- extend npm publication convergence checks from 95 seconds to a bounded 125 seconds
- add a fake-clock regression proving the default policy tolerates two minutes of registry propagation

## Why

Publish run `34653731847` successfully published `octane@0.2.10` and `@octanejs/mcp-server@0.2.28`, then failed reconciliation because npm had exposed only the first package after 95 seconds. npm's publication timestamp shows MCP Server became visible about seven seconds after the workflow gave up. The next main publish run found all 122 packages published and passed.

This was not caused by the Three changeset: that pending changeset was isolated from the publish action, while MCP Server was an already-versioned package whose earlier publish had been blocked by red main CI.

## Changes

- add one final 30-second registry observation to the existing backoff sequence
- retain the existing fail-closed behavior after the bounded window
- exercise the real default retry policy with simulated registry state and no wall-clock delay

## Validation

- [x] `pnpm format:check` (full CI)
- [x] `pnpm typecheck` (full CI)
- [x] `pnpm test` (full CI)
- [x] `pnpm format:files:check`
- [x] `pnpm sync`
- [x] `pnpm release:preflight:test` (15 tests)

## Risk / follow-ups

- A genuinely missing publication now takes 30 seconds longer to report; invalid, unreachable, and stale release states remain fail-closed.
- No changeset is included because this only changes internal release automation.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal release automation only; genuinely missing npm publishes fail 30s later, with no change to auth, runtime, or package code.
> 
> **Overview**
> Extends the **default npm registry propagation window** in GitHub release reconciliation from ~95s to ~125s by adding one more **30s** backoff step to `NPM_PROPAGATION_RETRY_DELAYS_MS`. `waitForNpmPublication` behavior is unchanged: it still polls until all packages show as published or the bounded retries end, then reconciliation stays **fail-closed** on invalid/unreachable/pending states.
> 
> Adds a **fake-clock** test that uses the real default delay schedule and asserts a package still marked pending for two minutes is accepted once the registry “catches up” before the window expires (~120–130s total sleep).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2271ede39c8c489cd959ddc30ed6de5ec18c1222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791760577&installation_model_id=432790&pr_number=1059&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1059&signature=4eb67d091539a55eafb89263e606446bd72e3667ed4810584b516a68abf959fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
