### PR TITLE
perf: reuse nested explicit child key prefixes

### DIFF
--- a/.changeset/nested-explicit-child-key-prefix.md
+++ b/.changeset/nested-explicit-child-key-prefix.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reuse wrapper-path serialization for nested explicitly keyed children while preserving key identity, hydration, and custom key conversion behavior.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -177,15 +177,18 @@ The opt-in `nested` mode uses three independent 1,000-row descriptor lists throu
 the same compiled `.tsrx` child hole. One list is wrapped in a same-kind array
 with a top-level sibling, giving its implicit leaves a real nested path; the
 second stays flat as a no-work control. A third uses the nested shape with every
-row explicitly keyed, checking that an implicit prefix is never prepared for
-fully keyed siblings. Each also contains a separate explicit key `"0"`; in the
+row explicitly keyed, measuring whether its siblings reuse one wrapper prefix.
+Each also contains a separate explicit key `"0"`; in the
 first two modes it sits beside implicit index zero. An unrelated update uses a
 different, prebuilt descriptor generation, so descriptor construction is outside timing.
 The gate checks order, complete inner HTML, survivor DOM identity, typed
-uncontrolled inputs, and focus. A `JSON.stringify` observer installed before
+uncontrolled inputs, and focus. It also reverses and restores the fully keyed
+siblings, checking exact survivor identity and order through both operations.
+A `JSON.stringify` observer installed before
 the production module loads reports calls for nested implicit identities,
-nested explicit keys, and any shared wrapper-path serialization. Observation
-finishes in a separate browser context before the clean timing run.
+full nested explicit tuples, individual explicit key JSON escaping, and shared
+wrapper-path serialization. Observation finishes in a separate browser context
+before the clean timing run.
 
 From the repository root, build the separate fixture while the runtime is at
 the baseline revision. This uses the normal minified production build:
@@ -199,19 +202,42 @@ cd benchmarks/js-framework/octane-tsrx
 From a second terminal at the repository root, record the baseline:
 
 ```bash
-WORK_MODE=nested WORK_EXPECT_NESTED_JSON=1000 WORK_EXPECT_PATH_JSON=0 TARGET_URL=http://127.0.0.1:5317/nested-work.html WORK_JSON=/tmp/nested-baseline.json node benchmarks/js-framework/style-work.mjs 30
+WORK_MODE=nested WORK_EXPECT_NESTED_JSON=0 WORK_EXPECT_PATH_JSON=1 WORK_EXPECT_MIXED_EXPLICIT_TUPLES=1 WORK_EXPECT_MIXED_EXPLICIT_VALUES=0 WORK_EXPECT_EXPLICIT_TUPLES=1001 WORK_EXPECT_EXPLICIT_VALUES=0 WORK_EXPECT_EXPLICIT_PATH=0 TARGET_URL=http://127.0.0.1:5317/nested-work.html WORK_JSON=/tmp/nested-baseline.json node benchmarks/js-framework/style-work.mjs 30
 ```
 
 After a runtime change, build with `--outDir dist/nested-work-candidate`, serve
 that directory on port 5318, and run the same command with
 `WORK_EXPECT_NESTED_JSON=0`, `WORK_EXPECT_PATH_JSON=1`, `TARGET_URL=http://127.0.0.1:5318/nested-work.html`,
-and `WORK_EXPECTED_HTML_SHA` set to the baseline output's `htmlSha`. Keep both
-built bundles and servers fixed; repeat the identical runner in A–B–B–A order
+`WORK_EXPECT_EXPLICIT_TUPLES=0`, `WORK_EXPECT_EXPLICIT_VALUES=1001`,
+`WORK_EXPECT_EXPLICIT_PATH=1`, `WORK_EXPECT_MIXED_EXPLICIT_TUPLES=0`,
+`WORK_EXPECT_MIXED_EXPLICIT_VALUES=1`, and `WORK_EXPECTED_HTML_SHA` set to the
+baseline output's `htmlSha`. Keep both built bundles and servers fixed; repeat
+the identical runner in A–B–B–A order
 for timing comparisons. Each of 30 samples measures eight toggled updates,
-dividing the elapsed time by eight. The flat and fully explicit lists measure
-how much general browser load changes between runs. Absolute timing differences inside this
-control's variation are inconclusive; the untimed JSON call counts and
-observable state are deterministic gates.
+dividing the elapsed time by eight. The flat and mostly implicit nested lists
+measure browser load and any cost shifted to the existing implicit path. Timing
+differences within the control variation are inconclusive; the JSON call counts
+and observable state are deterministic gates.
+
+On 2026-09-12 (Darwin arm64, Node 26.4.0), the frozen baseline and candidate
+production bundles passed the same HTML, DOM identity, input, focus, and reorder
+checks (`htmlSha` `64dd26ca…9427d92ed1650`). Per update, the fully keyed list
+changed from 1,001 full tuple JSON calls to one wrapper-path JSON call and 1,001
+scalar key JSON calls. The implicit list retained one path JSON call and no
+implicit tuple calls; the flat list made none. Bundle JS grew from 166,305 to
+166,409 bytes (+104); `gzip -n` grew from 53,557 to 53,586 bytes (+29).
+
+| Run | Fully keyed median / p95 (ms) | Nested implicit median / p95 (ms) | Flat median / p95 (ms) |
+| --- | ---: | ---: | ---: |
+| Baseline A1 | 0.550 / 0.575 | 0.550 / 0.575 | 0.500 / 0.550 |
+| Candidate B1 | 0.5625 / 0.6000 | 0.5500 / 0.6000 | 0.5125 / 0.5500 |
+| Candidate B2 | 0.5750 / 0.6125 | 0.5625 / 0.6000 | 0.5125 / 0.5500 |
+| Baseline A2 | 0.5500 / 0.6000 | 0.5375 / 0.5875 | 0.5000 / 0.5250 |
+
+The fully keyed median divided by the flat control was 1.10/1.10 for A1/A2
+and 1.10/1.12 for B1/B2. This fixture establishes less repeated wrapper-path
+serialization, but its timings do not establish a latency gain. These timings
+are environment-specific, and each row uses 30 samples of eight updates.
 
 ### List key callback work (opt-in)
 

--- a/benchmarks/js-framework/nested-work.mjs
+++ b/benchmarks/js-framework/nested-work.mjs
@@ -21,6 +21,7 @@ await context.addInitScript(() => {
 	const counts = {
 		nestedImplicitJson: 0,
 		nestedExplicitJson: 0,
+		explicitValueJson: 0,
 		flatImplicitJson: 0,
 		pathOnlyJson: 0,
 	};
@@ -34,6 +35,8 @@ await context.addInitScript(() => {
 			}
 		} else if (Array.isArray(value) && value.length === 2 && value[0] === 'wrapper') {
 			counts.pathOnlyJson++;
+		} else if (typeof value === 'string' && (value === '0' || /^row-\d+$/.test(value))) {
+			counts.explicitValueJson++;
 		}
 		return Reflect.apply(original, this, [value, ...rest]);
 	};
@@ -116,6 +119,18 @@ try {
 			versions[kind] = 1;
 			for (const other of kinds) check(other, versions[other], before[other]);
 		}
+		work.explicitReorder = observe('reorder-explicit');
+		const reordered = Array.from(lists().explicit.children);
+		const expectedReordered = [...before.explicit.slice(0, -1).reverse(), before.explicit.at(-1)];
+		if (
+			lists().explicit.getAttribute('data-version') !== '2' ||
+			reordered.length !== expectedReordered.length ||
+			reordered.some((row, index) => row !== expectedReordered[index])
+		) {
+			throw new Error('keyed reorder changed row identity or order');
+		}
+		work.explicitRestore = observe('restore-explicit');
+		for (const kind of kinds) check(kind, versions[kind], before[kind]);
 		const nextHtml = kinds.map((kind) => lists()[kind].innerHTML).join('|');
 		if (html !== nextHtml) throw new Error('visible HTML changed on unrelated updates');
 		for (const input of inputs) {
@@ -180,19 +195,26 @@ try {
 	assert.equal(semantic.rows.nested, ROWS + 2);
 	assert.equal(semantic.rows.flat, ROWS + 1);
 	assert.equal(semantic.rows.explicit, ROWS + 2);
-	assert.equal(semantic.work.explicit.nestedImplicitJson, 0);
-	assert.equal(semantic.work.explicit.nestedExplicitJson, ROWS + 1);
-	assert.equal(
-		semantic.work.explicit.pathOnlyJson,
-		0,
-		'fully keyed siblings need no implicit prefix',
-	);
+	const expectedExplicitTuples = Number(process.env.WORK_EXPECT_EXPLICIT_TUPLES ?? ROWS + 1);
+	const expectedExplicitValues = Number(process.env.WORK_EXPECT_EXPLICIT_VALUES ?? 0);
+	const expectedExplicitPath = Number(process.env.WORK_EXPECT_EXPLICIT_PATH ?? 0);
+	for (const kind of ['explicit', 'explicitReorder', 'explicitRestore']) {
+		assert.equal(semantic.work[kind].nestedImplicitJson, 0);
+		assert.equal(semantic.work[kind].nestedExplicitJson, expectedExplicitTuples);
+		assert.equal(semantic.work[kind].explicitValueJson, expectedExplicitValues);
+		assert.equal(semantic.work[kind].pathOnlyJson, expectedExplicitPath);
+	}
 	assert.equal(semantic.work.flat.pathOnlyJson, 0, 'flat siblings need no nested prefix');
+	assert.equal(semantic.work.flat.nestedExplicitJson, 0, 'flat keys need no nested encoding');
+	assert.equal(semantic.work.flat.explicitValueJson, 0, 'flat keys need no scalar encoding');
+	const expectedMixedExplicitTuples = Number(process.env.WORK_EXPECT_MIXED_EXPLICIT_TUPLES ?? 1);
+	const expectedMixedExplicitValues = Number(process.env.WORK_EXPECT_MIXED_EXPLICIT_VALUES ?? 0);
 	assert.equal(
 		semantic.work.nested.nestedExplicitJson,
-		1,
-		'nested explicit key retains exact encoding',
+		expectedMixedExplicitTuples,
+		'mixed nested explicit key retains exact encoding',
 	);
+	assert.equal(semantic.work.nested.explicitValueJson, expectedMixedExplicitValues);
 	assert.equal(semantic.work.nested.flatImplicitJson, 0);
 	assert.equal(
 		semantic.work.flat.nestedImplicitJson,

--- a/benchmarks/js-framework/octane-tsrx/src/nested-work.ts
+++ b/benchmarks/js-framework/octane-tsrx/src/nested-work.ts
@@ -22,15 +22,16 @@ function explicit(): OctaneNode {
 	);
 }
 
-function makeRows(kind: Kind): OctaneNode[] {
+function makeRows(kind: Kind, reverse = false): OctaneNode[] {
 	const siblings: OctaneNode[] = [];
 	for (let index = 0; index < ROWS; index++) {
 		siblings.push(row(index, kind === 'explicit'));
 		if (index === 0) siblings.push(explicit());
 	}
+	if (reverse) siblings.reverse();
 	if (kind === 'flat') return siblings;
 	// A same-kind nested array plus a sibling gives each enclosed leaf a real
-	// wrapper path. Its explicit key remains the serialization control.
+	// wrapper path. The explicit key beside the first row checks key namespaces.
 	return [siblings, createElement('li', { key: 'tail', 'data-work-index': 'tail' }, 'tail')];
 }
 
@@ -41,6 +42,7 @@ const prepared: Record<Kind, [OctaneNode[], OctaneNode[]]> = {
 	flat: [makeRows('flat'), makeRows('flat')],
 	explicit: [makeRows('explicit'), makeRows('explicit')],
 };
+const reorderedExplicit = makeRows('explicit', true);
 const roots: Partial<Record<Kind, WorkRoot>> = {};
 const containers: Partial<Record<Kind, HTMLElement>> = {};
 const versions: Record<Kind, number> = { nested: 0, flat: 0, explicit: 0 };
@@ -81,6 +83,19 @@ export function runNestedWork(operation: string): void {
 		const kind = operation.slice(7) as Kind;
 		if (!KINDS.includes(kind)) throw new Error(`unknown nested work kind: ${kind}`);
 		update(kind);
+		return;
+	}
+	if (operation === 'reorder-explicit' || operation === 'restore-explicit') {
+		const root = roots.explicit;
+		if (!root) throw new Error('explicit work root is not mounted');
+		const reordered = operation === 'reorder-explicit';
+		versions.explicit = reordered ? 2 : 1;
+		root.render(NestedWorkRows, {
+			id: 'explicit-work-rows',
+			rows: reordered ? reorderedExplicit : prepared.explicit[1],
+			version: versions.explicit,
+		});
+		flushSync(() => {});
 		return;
 	}
 	if (operation === 'unmount') {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -23748,8 +23748,9 @@ function deoptWrapperKind(value: any[]): DeoptWrapperKind {
 }
 
 const DEOPT_KEY_STRINGIFY = JSON.stringify;
+const DEOPT_KEY_STRING = String;
 
-function nestedImplicitKeyPrefix(path: readonly (string | number)[]): string | null {
+function nestedDeoptKeyPrefix(path: readonly (string | number)[]): string | null {
 	// Object-valued wrapper keys and custom array serialization may differ for
 	// each leaf. Keep their existing full-key serialization path.
 	if (JSON.stringify !== DEOPT_KEY_STRINGIFY || 'toJSON' in path) return null;
@@ -23757,7 +23758,7 @@ function nestedImplicitKeyPrefix(path: readonly (string | number)[]): string | n
 		const type = typeof path[i];
 		if (type !== 'string' && type !== 'number') return null;
 	}
-	return '[' + JSON.stringify(path) + ',"index",';
+	return '[' + JSON.stringify(path) + ',';
 }
 
 function appendScopedDeoptKey(
@@ -23766,7 +23767,7 @@ function appendScopedDeoptKey(
 	item: any,
 	index: number,
 	key: any,
-	implicitPrefix: string | null | undefined,
+	keyPrefix: string | null | undefined,
 ): string | null | undefined {
 	// Reconciliation keys are internal: top-level implicit positions are numbers,
 	// explicit keys carry a 'k' prefix, and nested paths are JSON strings. These
@@ -23781,20 +23782,30 @@ function appendScopedDeoptKey(
 	// explicit 'k' keys; numeric indices are distinct from both string forms.
 	if (path.length === 0) {
 		outKeys.push(explicit ? 'k' + String(key) : index);
-		return implicitPrefix;
+		return keyPrefix;
 	}
-	// Initialize only for the first implicit leaf: keyed-only wrappers must not
-	// pay for a prefix they cannot reuse. `null` disables caching for this scope;
-	// `undefined` means no implicit leaf has needed its prefix yet.
-	if (!explicit) {
-		if (implicitPrefix === undefined) implicitPrefix = nestedImplicitKeyPrefix(path);
-		if (implicitPrefix !== null && JSON.stringify === DEOPT_KEY_STRINGIFY && !('toJSON' in path)) {
-			outKeys.push(implicitPrefix + index + ']');
-			return implicitPrefix;
+	// Only inert keys can share a wrapper prefix. Keep custom coercion on the
+	// original expression below, including its serializer/callee lookup order.
+	if (
+		keyPrefix !== null &&
+		(!explicit || (typeof key === 'string' && String === DEOPT_KEY_STRING)) &&
+		JSON.stringify === DEOPT_KEY_STRINGIFY &&
+		!('toJSON' in path)
+	) {
+		if (keyPrefix === undefined) keyPrefix = nestedDeoptKeyPrefix(path);
+		if (keyPrefix !== null) {
+			outKeys.push(
+				explicit
+					? keyPrefix + '"key",' + JSON.stringify(String(key)) + ']'
+					: keyPrefix + '"index",' + index + ']',
+			);
+			return keyPrefix;
 		}
 	}
 	outKeys.push(JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]));
-	return implicitPrefix;
+	// A custom serializer may retain or mutate this path, even if it restores
+	// the built-ins before the next sibling. Never reuse its old prefix again.
+	return null;
 }
 
 // Flatten arrays and Fragment descriptors to renderable leaves while retaining
@@ -23812,20 +23823,13 @@ function flattenReactChildContainer(
 ): void {
 	const keyFn = kind === 'fragment' ? deoptKeyPositional : deoptKey;
 	const count = children.length;
-	let implicitPrefix: string | null | undefined = count > 1 ? undefined : null;
+	let keyPrefix: string | null | undefined = count > 1 ? undefined : null;
 	for (let i = 0; i < count; i++) {
 		const item = children[i];
 		if (isFragmentDescriptor(item)) {
 			if (item.ref != null || hasOwnProp.call(item.props, 'ref')) {
 				outItems.push(fragmentRefDescriptor(item));
-				implicitPrefix = appendScopedDeoptKey(
-					outKeys,
-					path,
-					item,
-					i,
-					keyFn(item, i),
-					implicitPrefix,
-				);
+				keyPrefix = appendScopedDeoptKey(outKeys, path, item, i, keyFn(item, i), keyPrefix);
 				continue;
 			}
 			const nested = fragmentDescriptorChildren(item);
@@ -23858,7 +23862,7 @@ function flattenReactChildContainer(
 			continue;
 		}
 		outItems.push(item);
-		implicitPrefix = appendScopedDeoptKey(outKeys, path, item, i, keyFn(item, i), implicitPrefix);
+		keyPrefix = appendScopedDeoptKey(outKeys, path, item, i, keyFn(item, i), keyPrefix);
 	}
 }
 

--- a/packages/octane/tests/deopt-child-key-aliasing.test.ts
+++ b/packages/octane/tests/deopt-child-key-aliasing.test.ts
@@ -407,6 +407,7 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 		'keeps nested sibling inputs through keyed wrapper reorders after %s',
 		(mode) => {
 			const escaped = 'quote"\\slash\n\u0000\ud800';
+			const leafKeys = [escaped, '\udc00', '\\ud800', '\\udc00', '0'];
 			const wrapperKeys = {
 				first: `first:${escaped}`,
 				second: `second:${escaped}`,
@@ -418,7 +419,7 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 					key === undefined ? { 'data-row': id } : { key, 'data-row': id },
 					createElement('input', { 'data-input': id, defaultValue: id }),
 				);
-			const group = (name: (typeof groupNames)[number]) =>
+			const group = (name: (typeof groupNames)[number], reverse: boolean) =>
 				createElement(
 					Fragment,
 					{ key: wrapperKeys[name] },
@@ -427,17 +428,19 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 					positionalChildren([
 						row(`${name}-inner-0`),
 						row(`${name}-inner-key-0`, '0'),
-						row(`${name}-inner-escaped`, escaped),
+						...(reverse ? [...leafKeys].reverse() : leafKeys).map((key) =>
+							row(`${name}-inner-escaped-${leafKeys.indexOf(key)}`, `leaf:${key}`),
+						),
 					]),
 				);
 			const pathLikeKey = JSON.stringify([
 				['keyed-fragment', wrapperKeys.first, 'wrapper', 2],
 				'key',
-				escaped,
+				`leaf:${escaped}`,
 			]);
 			const rows = (reverse: boolean) =>
 				positionalChildren([
-					...(reverse ? [...groupNames].reverse() : groupNames).map(group),
+					...(reverse ? [...groupNames].reverse() : groupNames).map((name) => group(name, reverse)),
 					row('outside', pathLikeKey),
 				]);
 			const order = (reverse: boolean) => [
@@ -446,7 +449,9 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 					`${name}-outer-escaped`,
 					`${name}-inner-0`,
 					`${name}-inner-key-0`,
-					`${name}-inner-escaped`,
+					...(reverse ? [...leafKeys].reverse() : leafKeys).map(
+						(key) => `${name}-inner-escaped-${leafKeys.indexOf(key)}`,
+					),
 				]),
 				'outside',
 			];
@@ -457,11 +462,19 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 			if (mode === 'server hydration') {
 				container.innerHTML = renderToString(server.RowsHole, { rows: initialRows }).html;
 			}
+			const serverInputs = Array.from(container.querySelectorAll<HTMLInputElement>('input'));
+			for (const input of serverInputs) input.value = `typed:${input.dataset.input}`;
+			const errors: unknown[] = [];
 			let root: ReturnType<typeof createRoot> | undefined;
 			try {
 				root =
 					mode === 'server hydration'
-						? hydrateRoot(container, RowsHole, { rows: initialRows })
+						? hydrateRoot(
+								container,
+								RowsHole,
+								{ rows: initialRows },
+								{ onRecoverableError: (error) => errors.push(error) },
+							)
 						: createRoot(container);
 				const activeRoot = root;
 				if (mode === 'client mount') activeRoot.render(RowsHole, { rows: initialRows });
@@ -473,6 +486,12 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 					]),
 				);
 				expect([...inputs.keys()]).toEqual(order(false));
+				if (mode === 'server hydration') {
+					for (const [index, input] of [...inputs.values()].entries()) {
+						expect(input).toBe(serverInputs[index]);
+					}
+					for (const [id, input] of inputs) expect(input.value).toBe(`typed:${id}`);
+				}
 				for (const [id, input] of inputs) input.value = `typed:${id}`;
 				const focused = inputs.get('second-inner-0')!;
 				focused.focus();
@@ -488,6 +507,7 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 					}
 					expect(document.activeElement).toBe(focused);
 				}
+				expect(errors).toEqual([]);
 			} finally {
 				root?.unmount();
 				container.remove();
@@ -495,48 +515,264 @@ describe('de-opt child keys — wrapper boundaries survive the top-level fast pa
 		},
 	);
 
-	it('preserves nested input state when array serialization is customized', () => {
-		const names = ['first', 'second'];
+	it.each(['implicit', 'explicit'] as const)(
+		'preserves nested %s input state when array serialization is customized',
+		(keyMode) => {
+			const names = ['first', 'second'];
+			const rows = (reverse: boolean) =>
+				(reverse ? [...names].reverse() : names).map((name) =>
+					createElement(
+						Fragment,
+						{ key: name },
+						...[0, 1].map((index) =>
+							createElement(
+								'li',
+								keyMode === 'explicit' ? { key: index } : null,
+								createElement('input', { 'data-input': `${name}-${index}` }),
+							),
+						),
+					),
+				);
+			const r = mount(RowsHole, { rows: rows(false) });
+			const previous = Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON');
+			try {
+				const inputs = r.findAll('input') as HTMLInputElement[];
+				for (const input of inputs) input.value = `typed:${input.dataset.input}`;
+				inputs[0].focus();
+				// An application serializer can customize standalone primitive arrays
+				// while leaving arrays embedded in another value unchanged.
+				Object.defineProperty(Array.prototype, 'toJSON', {
+					configurable: true,
+					value(this: unknown[], key: string) {
+						return key === '' && this.every((value) => ['string', 'number'].includes(typeof value))
+							? this.join(':')
+							: this;
+					},
+				});
+				for (const reverse of [true, false]) {
+					r.update(RowsHole, { rows: rows(reverse) });
+					expect(r.findAll('input')).toEqual(
+						reverse ? [inputs[2], inputs[3], inputs[0], inputs[1]] : inputs,
+					);
+					for (const input of inputs) {
+						expect(r.find(`[data-input="${input.dataset.input}"]`)).toBe(input);
+						expect(input.value).toBe(`typed:${input.dataset.input}`);
+					}
+					expect(document.activeElement).toBe(inputs[0]);
+				}
+			} finally {
+				if (previous) Object.defineProperty(Array.prototype, 'toJSON', previous);
+				else Reflect.deleteProperty(Array.prototype, 'toJSON');
+				r.unmount();
+			}
+		},
+	);
+
+	it('preserves keyed input state with an application JSON serializer', () => {
+		const stringify = JSON.stringify;
+		const names = ['first', 'second', 'third'];
 		const rows = (reverse: boolean) =>
-			(reverse ? [...names].reverse() : names).map((name) =>
-				createElement(
-					Fragment,
-					{ key: name },
-					...[0, 1].map((index) =>
-						createElement('li', null, createElement('input', { 'data-input': `${name}-${index}` })),
+			createElement(
+				Fragment,
+				{ key: 'wrapper' },
+				...(reverse ? [...names].reverse() : names).map((name) =>
+					createElement(
+						'li',
+						{ key: name },
+						createElement('input', { 'data-input': name, defaultValue: name }),
 					),
 				),
 			);
 		const r = mount(RowsHole, { rows: rows(false) });
-		const previous = Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON');
 		try {
 			const inputs = r.findAll('input') as HTMLInputElement[];
 			for (const input of inputs) input.value = `typed:${input.dataset.input}`;
-			inputs[0].focus();
-			// An application serializer can customize standalone primitive arrays
-			// while leaving arrays embedded in another value unchanged.
-			Object.defineProperty(Array.prototype, 'toJSON', {
-				configurable: true,
-				value(this: unknown[], key: string) {
-					return key === '' && this.every((value) => ['string', 'number'].includes(typeof value))
-						? this.join(':')
-						: this;
-				},
-			});
+			JSON.stringify = function (this: unknown, value: unknown) {
+				if (this !== JSON) throw new Error('JSON serializer lost its receiver');
+				return stringify(typeof value === 'string' ? `application:${value}` : value);
+			};
 			for (const reverse of [true, false]) {
 				r.update(RowsHole, { rows: rows(reverse) });
-				expect(r.findAll('input')).toEqual(
-					reverse ? [inputs[2], inputs[3], inputs[0], inputs[1]] : inputs,
-				);
+				expect(r.findAll('input')).toEqual(reverse ? [...inputs].reverse() : inputs);
 				for (const input of inputs) {
 					expect(r.find(`[data-input="${input.dataset.input}"]`)).toBe(input);
 					expect(input.value).toBe(`typed:${input.dataset.input}`);
 				}
-				expect(document.activeElement).toBe(inputs[0]);
 			}
 		} finally {
-			if (previous) Object.defineProperty(Array.prototype, 'toJSON', previous);
-			else Reflect.deleteProperty(Array.prototype, 'toJSON');
+			JSON.stringify = stringify;
+			r.unmount();
+		}
+	});
+
+	it('observes later mutations of arrays retained by an application serializer', () => {
+		const stringify = JSON.stringify;
+		const names = ['first', 'second', 'third'];
+		const children = names.map((name) =>
+			createElement(
+				'li',
+				{ key: name },
+				createElement('input', { 'data-input': name, defaultValue: name }),
+			),
+		);
+		const r = mount(RowsHole, {
+			rows: createElement(Fragment, { key: 'retained' }, children),
+		});
+		try {
+			const inputs = r.findAll('input') as HTMLInputElement[];
+			for (const input of inputs) input.value = `typed:${input.dataset.input}`;
+			const retained: unknown[][] = [];
+			const replaceRetainedValue = (before: string, after: string) => {
+				for (const array of retained) {
+					for (let i = 0; i < array.length; i++) {
+						if (array[i] === before) array[i] = after;
+					}
+				}
+			};
+			const nextChildren = [...children];
+			Object.defineProperty(nextChildren, 1, {
+				get() {
+					replaceRetainedValue('temporary', 'retained');
+					return children[1];
+				},
+			});
+			Object.defineProperty(nextChildren, 2, {
+				get() {
+					replaceRetainedValue('retained', 'changed');
+					return children[2];
+				},
+			});
+			const nextRows = createElement(Fragment, { key: 'temporary' }, nextChildren);
+			JSON.stringify = function (value: unknown) {
+				JSON.stringify = stringify;
+				return stringify(value, (_property, child: unknown) => {
+					if (Array.isArray(child)) retained.push(child);
+					return child;
+				});
+			};
+			try {
+				r.update(RowsHole, { rows: nextRows });
+			} finally {
+				JSON.stringify = stringify;
+			}
+			expect(r.findAll('input').map((input) => input.getAttribute('data-input'))).toEqual(names);
+			expect(r.find('[data-input="second"]')).toBe(inputs[1]);
+			expect(inputs[1].value).toBe('typed:second');
+			expect(r.find('[data-input="third"]')).not.toBe(inputs[2]);
+			expect((r.find('[data-input="third"]') as HTMLInputElement).value).toBe('third');
+		} finally {
+			JSON.stringify = stringify;
+			r.unmount();
+		}
+	});
+
+	it('preserves keyed input state when application string conversion customizes JSON', () => {
+		const string = String;
+		const names = ['first', 'second', 'third'];
+		const rows = (reverse: boolean) =>
+			createElement(
+				Fragment,
+				{ key: 'wrapper' },
+				...(reverse ? [...names].reverse() : names).map((name) =>
+					createElement(
+						'li',
+						{ key: `key:${name}` },
+						createElement('input', { 'data-input': name, defaultValue: name }),
+					),
+				),
+			);
+		const r = mount(RowsHole, { rows: rows(false) });
+		try {
+			const inputs = r.findAll('input') as HTMLInputElement[];
+			for (const input of inputs) input.value = `typed:${input.dataset.input}`;
+			for (const reverse of [true, false]) {
+				const nextRows = rows(reverse);
+				globalThis.String = new Proxy(string, {
+					apply(target, receiver, args) {
+						const key = args[0];
+						if (typeof key === 'string' && key.startsWith('key:')) {
+							return {
+								toJSON(property: string) {
+									return property === '' ? `standalone:${key}` : key;
+								},
+							};
+						}
+						return Reflect.apply(target, receiver, args);
+					},
+				});
+				try {
+					r.update(RowsHole, { rows: nextRows });
+				} finally {
+					globalThis.String = string;
+				}
+				expect(r.findAll('input')).toEqual(reverse ? [...inputs].reverse() : inputs);
+				for (const input of inputs) {
+					expect(r.find(`[data-input="${input.dataset.input}"]`)).toBe(input);
+					expect(input.value).toBe(`typed:${input.dataset.input}`);
+				}
+			}
+		} finally {
+			globalThis.String = string;
+			r.unmount();
+		}
+	});
+
+	it('observes serializer changes during key conversion and stops after the first error', () => {
+		const stringify = JSON.stringify;
+		const string = String;
+		const error = new Error('application serializer failed');
+		const converted: string[] = [];
+		const names = ['before', 'change', 'after', 'unreached'];
+		const rows = () =>
+			createElement(
+				Fragment,
+				{ key: 'wrapper' },
+				...names.map((name) =>
+					createElement(
+						'li',
+						{ key: `key:${name}` },
+						createElement('input', { 'data-input': name, defaultValue: name }),
+					),
+				),
+			);
+		const r = mount(RowsHole, { rows: rows() });
+		try {
+			const original = r.find('input') as HTMLInputElement;
+			original.value = 'typed';
+			const nextRows = rows();
+			globalThis.String = new Proxy(string, {
+				apply(target, receiver, args) {
+					const key = args[0];
+					if (typeof key === 'string' && key.startsWith('key:')) {
+						converted.push(key);
+						if (key === 'key:change') {
+							JSON.stringify = () => {
+								throw error;
+							};
+						}
+					}
+					return Reflect.apply(target, receiver, args);
+				},
+			});
+			let caught: unknown;
+			try {
+				r.update(RowsHole, { rows: nextRows });
+			} catch (failure) {
+				caught = failure;
+			} finally {
+				JSON.stringify = stringify;
+				globalThis.String = string;
+			}
+			expect(caught).toBe(error);
+			expect(converted).toEqual(['key:before', 'key:change', 'key:after']);
+			expect(r.container.childNodes.length).toBe(0);
+			r.update(RowsHole, { rows: rows() });
+			expect(r.findAll('input').map((input) => input.getAttribute('data-input'))).toEqual(names);
+			expect(r.find('input')).not.toBe(original);
+			expect((r.find('input') as HTMLInputElement).value).toBe('before');
+		} finally {
+			JSON.stringify = stringify;
+			globalThis.String = string;
 			r.unmount();
 		}
 	});


### PR DESCRIPTION
## Summary

Reuse wrapper-path serialization across nested explicitly keyed client children. Refs #981.

## Why / design

Nested explicit keys serialize the same wrapper path inside every leaf's identity tuple. Share the existing traversal-local prefix with explicit string keys, preserving native JSON escaping and the existing reconciliation encoding.

- Flat and singleton paths stay direct. Custom conversion, custom serialization, and unsupported values retain the original full-tuple expression and evaluation order.
- Any fallback permanently disables prefix reuse for that container: a serializer can retain and mutate the path after restoring the built-ins.
- A shared string avoids a second cache object or persistent list state. The tradeoff is an extra concatenation and eligibility checks on nested implicit leaves; the browser gate measures that control too.
- Add behavioral regressions, explicit reorder/restore benchmark gates, and an `octane` patch changeset.

## Performance evidence

Frozen production bundles, identical fixture, Darwin arm64 / Node 26.4.0 / Chromium 149.0.7827.55, A–B–B–A order; 30 samples × eight updates per list. Commands and complete median/p95 table are in `benchmarks/js-framework/README.md`.

| Per 1,001-key explicit update/reorder/restore | Baseline | Candidate |
| --- | ---: | ---: |
| Full nested tuple JSON calls | 1,001 | 0 |
| Scalar key JSON calls | 0 | 1,001 |
| Shared wrapper-path JSON calls | 0 | 1 |

HTML SHA, strict survivor identity, order, typed input values, and focus match. Nested implicit work remains zero full implicit tuples plus one shared path; flat JSON work remains zero. The mixed explicit leaf switches from one full tuple to one scalar serialization.

Explicit medians: baseline 0.550/0.550 ms; candidate 0.5625/0.5750 ms. Flat controls: 0.500/0.500 vs 0.5125/0.5125 ms. Explicit/flat ratios: 1.10/1.10 vs 1.10/1.12. **No latency gain is established.** The claim is less repeated wrapper-path serialization, not actual V8 heap-allocation savings.

Bundle: 166,305 → 166,409 minified bytes (+104); `gzip -n`: 53,557 → 53,586 (+29). A final rebuild after formatting and updating main is byte-identical to the measured candidate.

## Validation

- [x] Related Vitest development/production projects: **49 files / 866 tests pass**, including deopt lists, keyed reconciliation, hydration, root errors, SSR identity, and compiled map/lite cases. Focused behavioral coverage: **226 tests pass**.
- [x] Four deliberate broken variants fail on observable node identity: removing the String guard, removing the JSON guard, misidentifying escaped keys, and re-enabling the cache after serializer exposure. All mutations restored.
- [x] Core source and public API types: `tsgo --noEmit -p packages/octane/tsconfig.json` and `tsgo --noEmit -p packages/octane/typetests/tsconfig.json`.
- [x] Scoped Prettier checks, benchmark TSRX-aware typecheck, and `git diff --check`.
- [x] `pnpm_config_verify_deps_before_run=warn pnpm sync`: passed; no generated diff.
- Local tests used a temporary config preserving the Octane dev/prod projects while omitting unrelated React differential precompile. Full local `pnpm test` and the test-file TSRX typecheck remain blocked by missing `@tsrx/react-runtime`; they are not claimed as passing.
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34658958410): **26/26 jobs passed** on `94a9c7fa2ae4a95604fe391c9f802c9f3fcf77f8`. Cursor Bugbot passed with no findings; no unresolved review threads. The PR is ready for review and remains unmerged.

## Risk / follow-ups

The built-in identity guards retain the existing module-initialization assumptions; arbitrary accessor/proxy hardening is outside this optimization. SSR explicit-key prefix reuse and the other remaining key costs stay open under #981. Existing server encoding is unchanged, with strict client hydration-adoption coverage.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches de-opt list reconciliation key derivation in the hot render path; incorrect prefix reuse could corrupt keyed identity, though extensive gates and serializer edge-case tests mitigate this.
> 
> **Overview**
> **Reuses one wrapper-path `JSON.stringify` per nested sibling group** for explicitly keyed children (not only implicit index keys), so large keyed lists stop re-serializing the full `[path, "key", …]` tuple on every row.
> 
> In `appendScopedDeoptKey` / `nestedDeoptKeyPrefix`, the shared prefix is now `JSON.stringify(path) + ','` and each leaf appends either `"index",N]` or `"key",` + escaped scalar key. Eligibility is limited to built-in `JSON.stringify` / `String`; any fallback to the full tuple sets `keyPrefix` to `null` so later siblings cannot reuse a prefix after custom serializers or retained paths.
> 
> The nested de-opt **browser gate** (`nested-work.mjs`, README) now asserts the new call split (one path + N scalar key serializations vs N full tuples), adds explicit-list **reorder/restore** identity checks, and documents baseline vs candidate bundle/timing evidence without claiming a latency win.
> 
> **Vitest** expands `deopt-child-key-aliasing` with hydration, custom `JSON.stringify`/`String`, serializer retention/mutation, and reorder cases. An **octane patch** changeset records the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a9c7fa2ae4a95604fe391c9f802c9f3fcf77f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791761852&installation_model_id=432790&pr_number=1060&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1060&signature=bb1982883b3143fa7ebb191ffee40bfafa8584d874905c9f1b468e10fa35f7e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->