### PR TITLE
perf: stabilize remaining runtime object shapes

### DIFF
--- a/.changeset/steady-object-caches.md
+++ b/.changeset/steady-object-caches.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Keep compiler memo caches off scope slot arrays, stabilize internal hook, host,
+list, and render-capture records, and initialize memo and template caches without
+sparse namespace entries. Preserve memo identity, staged hook values, keyed DOM
+reuse, and commit-time cleanup behavior.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -3103,6 +3103,22 @@
     "note": "Same-run clean tree-shaken application plus Octane runtime: closure-free lowering must stay within 2% gzip of the runtime-form control. No instrumentation contributes to these bytes."
   },
   {
+    "suite": "hook-memo",
+    "op": "named_reads",
+    "target": "compiler-cache-shapes",
+    "reference": "cache-shape-reference",
+    "maxRatio": 0,
+    "note": "Production compiler output for hook and automatic memo regions must not read named _m$N or _k$N properties from the dense DOM/control slot array. The fixture also exercises flat and shared-scope Provider controls."
+  },
+  {
+    "suite": "hook-memo",
+    "op": "named_writes",
+    "target": "compiler-cache-shapes",
+    "reference": "cache-shape-reference",
+    "maxRatio": 0,
+    "note": "Production compiler output must not publish hook or automatic memo regions through dynamically added named properties on the slot array."
+  },
+  {
     "suite": "transition-hooks",
     "op": "cycle_renders",
     "target": "octane",

--- a/benchmarks/hook-memo/README.md
+++ b/benchmarks/hook-memo/README.md
@@ -93,6 +93,118 @@ dependency tree. Keep those dependencies, hashes, and runner options identical
 for a before/after comparison. A nonstandard parser loader must be disclosed
 with the result.
 
+## Compiler cache shapes
+
+The `compiler-cache-shapes` target is a separate production fixture. It enables
+both `autoMemo` and `inlineHookMemo` and compiles without HMR or development
+metadata. The runner parses the compiled source to count reads and writes of
+named `_m$N`/`_k$N` properties on `__s.slots`, plus calls to the private
+`compilerMemoRegion` helper. The committed ratio guards require zero named
+reads and writes. The ordinary flat component must make zero region calls.
+These are deterministic source observations, not measured V8 object shapes.
+
+The clean production bundle also mounts combined hook/auto regions, each region
+alone, two alternate compiled bodies, and a flat control. An unrelated visible
+tick and a changed label must update while input DOM identity, typed text, and
+focus survive. A Context Provider switches its child compiled body with the
+same live input and label node; this checks the rare shared-scope overflow path.
+The semantic snapshot must match the frozen baseline. The target does not
+assume cache storage details in its behavioral assertions.
+
+To compare against an archived source tree with dependencies supplied by the
+current checkout:
+
+```bash
+OCTANE_MEMO_ROOT=/private/tmp/981-object-shapes-baseline \
+  OCTANE_MEMO_EXTERNAL_ROOT="$PWD" \
+  BENCH_JSON=/private/tmp/981-object-shapes-hook-frozen-baseline.json \
+  node benchmarks/hook-memo/run.mjs
+BENCH_JSON=/private/tmp/981-object-shapes-hook-candidate.json \
+  node benchmarks/hook-memo/run.mjs
+node benchmarks/bench.mjs --ratios hook-memo
+```
+
+On the frozen `fa11c1055` source and the candidate, Node 26.4.0,
+`@tsrx/core` 0.1.71, and esbuild 0.28.1 observed:
+
+| Production source metric | Frozen base | Candidate |
+| --- | ---: | ---: |
+| Named memo reads on `__s.slots` | 10 | 0 |
+| Named memo writes on `__s.slots` | 10 | 0 |
+| Memo-region helper call sites | 0 | 6 |
+| Helper calls in flat control | 0 | 0 |
+| Compiled fixture minified / gzip bytes | 4,070 / 1,252 | 4,044 / 1,238 |
+| Tree-shaken bundle minified / gzip bytes | 185,914 / 59,097 | 186,371 / 59,207 |
+
+Both runs used fixture SHA256
+`30a16a2b34e5c5217458e53cf286782ff5f3113077a8989b5b536886fd6c9478`
+and entry SHA256
+`1da6d1d36546e2cf9a86ad647f3369d3675929c3fbcb15a4dd6437d01e07d2c9`.
+Their DOM, input, focus, and identity controls produced the same semantic
+snapshot SHA256 `39c9e293b0f041760b59508bc827d2a8de9b1f499b57344e8edab63556a40ee7`.
+
+The two bundles also include simultaneous runtime object-shape edits, so their
+457-byte minified and 110-byte gzip differences cannot be attributed solely to
+the compiler cache change. The compiled fixture alone shrank 26 minified and
+14 gzip bytes. No wall-clock or garbage-collection improvement is inferred.
+An A→B→A Provider-child switch exposing stale cached content already occurs
+with the frozen base and is tracked separately; this fixture covers the one-way
+switch and repeat B render only.
+
+### Cache memory and common render operations
+
+The opt-in profile builds a second production entry with one extra runtime
+export (`hostComponent`) solely to obtain an actual lightweight `Scope` record.
+It is excluded from the regular source and bundle byte target. Build the two
+immutable bundles from the same fixture and runner, then inspect them:
+
+```bash
+OCTANE_MEMO_ROOT=/private/tmp/981-object-shapes-baseline \
+  OCTANE_MEMO_EXTERNAL_ROOT="$PWD" \
+  BENCH_SHAPE_ARTIFACT=/private/tmp/cache-shape-base.mjs \
+  node benchmarks/hook-memo/run.mjs
+BENCH_SHAPE_ARTIFACT=/private/tmp/cache-shape-candidate.mjs \
+  node benchmarks/hook-memo/run.mjs
+node benchmarks/hook-memo/cache-shapes-profile.mjs memory /private/tmp/cache-shape-base.mjs /private/tmp/cache-shape-base-memory.json
+node benchmarks/hook-memo/cache-shapes-profile.mjs memory /private/tmp/cache-shape-candidate.mjs /private/tmp/cache-shape-candidate-memory.json
+node benchmarks/hook-memo/cache-shapes-profile.mjs timing /private/tmp/cache-shape-base.mjs /private/tmp/cache-shape-candidate.mjs /private/tmp/cache-shape-timing.json
+```
+
+The profile imports each immutable bundle in a separate process. Memory mode
+uses V8's heap snapshot after a real production mount, reporting each sampled
+record's own bytes plus its direct property/array-elements backing. It does not
+include nested DOM or closure retention. The sample's Block and slot array,
+including both compiler-owned memo cell arrays, total **1,072 → 1,096 bytes**:
+the fixed record costs 56 bytes, replacing 40 bytes of named slot-property
+backing, while the Block itself gains 8 bytes. Flat Block plus slots are
+**776 → 784 bytes**; lightweight Scope plus its empty slots are **232 → 240
+bytes**. Both builds keep fast Block, Scope, and slot-array maps. The new field
+costs 8 bytes on every Block and Scope, and a memo-bearing Block costs 24 bytes
+more in this direct graph. A rare second body in the same scope also allocates
+an overflow Map, which these single-body byte totals exclude.
+
+As container alternatives using the same live memo cell arrays, a four-field
+fixed object was 56 bytes and fast, a packed four-entry JSArray was 80 bytes,
+and `Object.create(null)` plus two named properties was 184 bytes with slow
+properties on Node 26.4.0 / V8 14.6. The array/object choice was checked with
+separate-process ABBA happy-dom samples of actual `createRoot`, mount, update,
+and unmount. The flat control and combined memo body both update visible DOM;
+typed text, input identity, and focus survive. Six warmed tuple-to-object pairs
+gave median update time 1.90 → 2.05 µs for flat and 2.63 → 2.75 µs for combined;
+the combined/flat normalized ratio was 0.97. Mount medians were 32.98 → 35.54
+µs for flat and 39.58 → 38.20 µs for combined. A separate frozen-base to
+isolated fixed-object comparison measured median update 2.02 → 1.94 µs flat
+and 2.87 → 2.47 µs combined; mount 35.41 → 32.60 µs flat and 41.78 → 35.21
+µs combined. Per-sample ranges overlap and host conditions vary, so these
+timings do not establish a speedup. The fixed object was selected for its
+measured 24-byte container saving over the tuple.
+
+The unified `--ratios hook-memo` run checks the two new cache-shape guards, both
+of which pass. Eight older hook-allocation ratio guards currently breach with
+the frozen base and candidate identically (for example, eligible hit function
+expressions are 704 in both). Those inherited guard failures are independent
+of the memo cache storage layout.
+
 The observer's own copy-on-write and counting control can be run with:
 
 ```bash

--- a/benchmarks/hook-memo/cache-shapes-entry.mjs
+++ b/benchmarks/hook-memo/cache-shapes-entry.mjs
@@ -1,0 +1,2 @@
+export { createContext, createRoot, flushSync } from 'octane';
+export * from './cache-shapes.tsrx';

--- a/benchmarks/hook-memo/cache-shapes-profile-entry.mjs
+++ b/benchmarks/hook-memo/cache-shapes-profile-entry.mjs
@@ -1,0 +1,2 @@
+export * from './cache-shapes-entry.mjs';
+export { hostComponent } from 'octane';

--- a/benchmarks/hook-memo/cache-shapes-profile.mjs
+++ b/benchmarks/hook-memo/cache-shapes-profile.mjs
@@ -1,0 +1,295 @@
+// Optional production-bundle profile. The hook-memo ratio suite stays untimed;
+// this separate entry records actual Block/Scope/cache backing and noisy public
+// root timings against frozen and candidate bundles in fresh processes.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { getHeapSnapshot } from 'node:v8';
+import { Window } from 'happy-dom';
+
+const [mode, ...args] = process.argv.slice(2);
+if (mode === 'timing') {
+	const [base, candidate, output] = args;
+	assert.ok(base && candidate, 'Pass baseline and candidate production bundles.');
+	const samples = { base: [], candidate: [] };
+	for (let round = 0; round < 6; round++) {
+		for (const [name, bundle] of round % 2 === 0
+			? [
+					['base', base],
+					['candidate', candidate],
+				]
+			: [
+					['candidate', candidate],
+					['base', base],
+				]) {
+			const child = spawnSync(
+				process.execPath,
+				[fileURLToPath(import.meta.url), 'sample', bundle],
+				{
+					encoding: 'utf8',
+				},
+			);
+			if (child.status !== 0) throw new Error(child.stderr || child.stdout);
+			samples[name].push(JSON.parse(child.stdout.trim()));
+		}
+	}
+	const report = {
+		node: process.version,
+		v8: process.versions.v8,
+		metric:
+			'Microseconds per public createRoot+render+unmount or root.render update in happy-dom; host-bound and ungated.',
+		bundleSha256: Object.fromEntries(
+			Object.entries({ base, candidate }).map(([name, filename]) => [
+				name,
+				createHash('sha256').update(fs.readFileSync(filename)).digest('hex'),
+			]),
+		),
+		samples,
+	};
+	if (output) fs.writeFileSync(output, JSON.stringify(report, null, 2) + '\n');
+	console.log(JSON.stringify(report, null, 2));
+	process.exit(0);
+}
+
+const bundlePath = args[0];
+assert.ok(bundlePath, 'Pass an absolute production cache-shape bundle.');
+if (
+	mode === 'memory' &&
+	(!process.execArgv.includes('--allow-natives-syntax') ||
+		!process.execArgv.includes('--expose-gc'))
+) {
+	const child = spawnSync(
+		process.execPath,
+		[
+			'--allow-natives-syntax',
+			'--expose-gc',
+			fileURLToPath(import.meta.url),
+			...process.argv.slice(2),
+		],
+		{ stdio: 'inherit' },
+	);
+	process.exit(child.status ?? 1);
+}
+assert.ok(
+	mode === 'memory' || mode === 'sample',
+	'Use memory <bundle> or timing <base> <candidate>.',
+);
+const window = new Window({ url: 'http://localhost/' });
+for (const name of [
+	'window',
+	'document',
+	'navigator',
+	'Node',
+	'Element',
+	'HTMLElement',
+	'SVGElement',
+	'Comment',
+	'Text',
+	'Event',
+	'EventTarget',
+	'MutationObserver',
+	'HTMLInputElement',
+	'HTMLSelectElement',
+	'HTMLTextAreaElement',
+	'requestAnimationFrame',
+	'cancelAnimationFrame',
+]) {
+	const value = name === 'window' ? window : window[name];
+	if (value !== undefined)
+		Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+const bundle = await import(pathToFileURL(path.resolve(bundlePath)).href);
+
+function mount(body, props, observe) {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	const root = bundle.createRoot(container);
+	function Capture(properties, scope) {
+		if (observe) observe(scope);
+		body(properties, scope);
+	}
+	bundle.flushSync(() => root.render(Capture, props));
+	return {
+		container,
+		root,
+		Capture,
+		unmount() {
+			root.unmount();
+			container.remove();
+		},
+	};
+}
+
+if (mode === 'sample') {
+	const result = {};
+	for (const name of ['Flat', 'Combined']) {
+		const body = bundle[name];
+		const mounted = (count) => {
+			for (let index = 0; index < count; index++) {
+				const instance = mount(body, { label: 'alpha', tick: index });
+				assert.equal(instance.container.querySelector('#cache-label')?.textContent, 'alpha');
+				instance.unmount();
+			}
+		};
+		mounted(500);
+		let start = performance.now();
+		mounted(1500);
+		result[`${name}_mount_us`] = ((performance.now() - start) * 1000) / 1500;
+		const instance = mount(body, { label: 'alpha', tick: 0 });
+		const input = instance.container.querySelector('input');
+		input.value = 'retained';
+		input.focus();
+		const updated = (count, offset = 0) => {
+			for (let index = offset; index < count + offset; index++) {
+				const label = index % 4 === 0 ? 'beta' : 'alpha';
+				bundle.flushSync(() => instance.root.render(instance.Capture, { label, tick: index }));
+			}
+		};
+		updated(6000);
+		start = performance.now();
+		updated(20000, 6000);
+		result[`${name}_update_us`] = ((performance.now() - start) * 1000) / 20000;
+		assert.equal(instance.container.querySelector('input'), input);
+		assert.equal(input.value, 'retained');
+		assert.equal(document.activeElement, input);
+		assert.equal(instance.container.querySelector('#cache-label')?.textContent, 'alpha');
+		if (name === 'Flat')
+			assert.equal(instance.container.querySelector('output')?.textContent, '25999');
+		else
+			assert.equal(
+				instance.container.querySelector('#cache-host')?.getAttribute('data-tick'),
+				'25999',
+			);
+		instance.unmount();
+	}
+	console.log(JSON.stringify(result));
+} else {
+	let combinedScope;
+	const combined = mount(bundle.Combined, { label: 'alpha', tick: 0 }, (scope) => {
+		combinedScope = scope;
+	});
+	let flatScope;
+	const flat = mount(bundle.Flat, { label: 'alpha', tick: 0 }, (scope) => {
+		flatScope = scope;
+	});
+	assert.equal(combined.container.querySelector('#cache-label')?.textContent, 'alpha');
+	assert.equal(flat.container.querySelector('#cache-label')?.textContent, 'alpha');
+	let childScope;
+	const host = mount(
+		() => {},
+		{ label: 'alpha', tick: 0 },
+		(scope) => {
+			bundle.hostComponent(scope, 0, 'section', null);
+			childScope = scope.slots[0].childScope;
+		},
+	);
+	assert.ok(childScope, 'expected actual component lite Scope');
+	const records = {
+		combinedBlock: combinedScope,
+		flatBlock: flatScope,
+		liteScope: childScope,
+		combinedSlots: combinedScope.slots,
+		flatSlots: flatScope.slots,
+		liteSlots: childScope.slots,
+	};
+	if (combinedScope.compilerMemo) {
+		const region = combinedScope.compilerMemo;
+		records.memoRegion = region;
+		records.autoCells = Array.isArray(region) ? region[1] : region.auto;
+		records.hookCells = Array.isArray(region) ? region[2] : region.hooks;
+	} else {
+		for (const [key, value] of Object.entries(combinedScope.slots)) {
+			if (/^_m\$\d+$/.test(key)) records.autoCells = value;
+			if (/^_k\$\d+$/.test(key)) records.hookCells = value;
+		}
+	}
+	assert.ok(records.autoCells && records.hookCells, 'expected both compiler cache lanes');
+	// Alternate container layouts reference the *same* real memo cell arrays.
+	// Their direct bytes isolate the container's one-body storage cost.
+	records.objectAlternative = {
+		bodyId: 2,
+		autoCells: records.autoCells,
+		hookCells: records.hookCells,
+		overflow: null,
+	};
+	records.dictionaryAlternative = Object.create(null);
+	records.dictionaryAlternative['_m$2'] = records.autoCells;
+	records.dictionaryAlternative['_k$2'] = records.hookCells;
+	const mapEqual = new Function('a', 'b', 'return %HaveSameMap(a, b)');
+	const fast = new Function('object', 'return %HasFastProperties(object)');
+	const shapes = {
+		blockMapsEqual: mapEqual(combinedScope, flatScope),
+		fast: Object.fromEntries(Object.entries(records).map(([name, value]) => [name, fast(value)])),
+		fields: Object.fromEntries(
+			Object.entries(records).map(([name, value]) => [name, Object.keys(value)]),
+		),
+	};
+	globalThis.__octaneCacheShapeRecords = records;
+	globalThis.gc();
+	const chunks = [];
+	for await (const chunk of getHeapSnapshot()) chunks.push(chunk);
+	const snapshot = JSON.parse(Buffer.concat(chunks).toString());
+	const { nodes, edges, strings } = snapshot;
+	const meta = snapshot.snapshot.meta;
+	const width = meta.node_fields.length;
+	const edgeWidth = meta.edge_fields.length;
+	const countIndex = meta.node_fields.indexOf('edge_count');
+	const sizeIndex = meta.node_fields.indexOf('self_size');
+	const typeIndex = meta.edge_fields.indexOf('type');
+	const nameIndex = meta.edge_fields.indexOf('name_or_index');
+	const targetIndex = meta.edge_fields.indexOf('to_node');
+	const propertyType = meta.edge_types[typeIndex].indexOf('property');
+	const internalType = meta.edge_types[typeIndex].indexOf('internal');
+	const offsets = new Map();
+	let directory;
+	for (let node = 0, edge = 0; node < nodes.length; node += width) {
+		offsets.set(node, edge);
+		for (let count = nodes[node + countIndex]; count > 0; count--, edge += edgeWidth) {
+			if (
+				edges[edge + typeIndex] === propertyType &&
+				strings[edges[edge + nameIndex]] === '__octaneCacheShapeRecords'
+			)
+				directory = edges[edge + targetIndex];
+		}
+	}
+	assert.notEqual(directory, undefined, 'memory record directory absent');
+	const sizes = {};
+	for (
+		let edge = offsets.get(directory), count = nodes[directory + countIndex];
+		count > 0;
+		count--, edge += edgeWidth
+	) {
+		if (edges[edge + typeIndex] !== propertyType) continue;
+		const name = strings[edges[edge + nameIndex]];
+		if (!(name in records)) continue;
+		const node = edges[edge + targetIndex];
+		const own = nodes[node + sizeIndex];
+		let properties = 0;
+		let elements = 0;
+		for (
+			let child = offsets.get(node), remaining = nodes[node + countIndex];
+			remaining > 0;
+			remaining--, child += edgeWidth
+		) {
+			if (edges[child + typeIndex] !== internalType) continue;
+			const backing = strings[edges[child + nameIndex]];
+			if (backing === 'properties') properties = nodes[edges[child + targetIndex] + sizeIndex];
+			if (backing === 'elements') elements = nodes[edges[child + targetIndex] + sizeIndex];
+		}
+		sizes[name] = { own, properties, elements, directBytes: own + properties + elements };
+	}
+	assert.equal(Object.keys(sizes).length, Object.keys(records).length);
+	const report = { node: process.version, v8: process.versions.v8, shapes, sizes };
+	if (args[1]) fs.writeFileSync(args[1], JSON.stringify(report, null, 2) + '\n');
+	console.log(JSON.stringify(report, null, 2));
+	delete globalThis.__octaneCacheShapeRecords;
+	combined.unmount();
+	flat.unmount();
+	host.unmount();
+}
+await window.happyDOM.close();

--- a/benchmarks/hook-memo/cache-shapes.tsrx
+++ b/benchmarks/hook-memo/cache-shapes.tsrx
@@ -1,0 +1,67 @@
+import { useMemo } from 'octane';
+
+type Props = { label: string; tick: number };
+
+function Label(props: { text: string }) @{
+	<span id="cache-label">{props.text}</span>
+}
+
+function AlternateLabel(props: { text: string }) @{
+	<span id="cache-label">{'other:' + props.text}</span>
+}
+
+export function Combined(props: Props) @{
+	const memo = useMemo(() => ({ text: props.label }), [props.label]);
+	<div id="cache-host" data-tick={props.tick}>
+		<input defaultValue="draft" />
+		<Label text={memo.text} />
+	</div>
+}
+
+export function Alternate(props: Props) @{
+	const memo = useMemo(() => ({ text: props.label }), [props.label]);
+	<div id="cache-host" data-tick={props.tick}>
+		<input defaultValue="draft" />
+		<AlternateLabel text={memo.text} />
+	</div>
+}
+
+export function Flat(props: Props) @{
+	<div id="cache-host">
+		<input defaultValue="draft" />
+		<span id="cache-label">{props.label}</span>
+		<output>{String(props.tick)}</output>
+	</div>
+}
+
+export function HookOnly(props: Props) @{
+	const memo = useMemo(() => ({ text: props.label }), [props.label]);
+	<div id="cache-host">
+		<input defaultValue="draft" />
+		<span id="cache-label">{memo.text}</span>
+		<output>{String(props.tick)}</output>
+	</div>
+}
+
+export function AutoOnly(props: Props) @{
+	<div id="cache-host" data-tick={props.tick}>
+		<input defaultValue="draft" />
+		<Label text={props.label} />
+	</div>
+}
+
+export function ProviderFirst() @{
+	const memo = useMemo(() => ({ text: 'first' }), []);
+	<div id="cache-host">
+		<input defaultValue="draft" />
+		<Label text={memo.text} />
+	</div>
+}
+
+export function ProviderSecond() @{
+	const memo = useMemo(() => ({ text: 'second' }), []);
+	<div id="cache-host">
+		<input defaultValue="draft" />
+		<Label text={memo.text} />
+	</div>
+}

--- a/benchmarks/hook-memo/run.mjs
+++ b/benchmarks/hook-memo/run.mjs
@@ -65,6 +65,8 @@ const APP_FILES = [
 	path.join(ROOT, 'returned-jsx.tsx'),
 	path.join(ROOT, 'manual-hooks.ts'),
 ];
+const SHAPE_FILE = path.join(ROOT, 'cache-shapes.tsrx');
+const SHAPE_ENTRY = path.join(ROOT, 'cache-shapes-entry.mjs');
 const val = (score) => ({ score, median: score, min: score, samples: 1 });
 const bytes = (source) => Buffer.byteLength(source);
 const gzipBytes = (source) => gzipSync(source, { level: zlibConstants.Z_BEST_COMPRESSION }).length;
@@ -131,9 +133,9 @@ function octaneRequest(request) {
 	return path.resolve(OCTANE_ROOT, target);
 }
 
-async function bundleApplication(sources, outfile) {
+async function bundleApplication(sources, outfile, entry = path.join(ROOT, 'entry.mjs')) {
 	const result = await build({
-		entryPoints: [path.join(ROOT, 'entry.mjs')],
+		entryPoints: [entry],
 		absWorkingDir: REPO,
 		outfile,
 		bundle: true,
@@ -403,6 +405,152 @@ function codeSizes(sources, cleanBundle) {
 	};
 }
 
+function compileCacheShapes() {
+	const source = fs.readFileSync(SHAPE_FILE, 'utf8');
+	const output = compile(source, SHAPE_FILE, {
+		mode: 'client',
+		hmr: false,
+		dev: false,
+		autoMemo: true,
+		inlineHookMemo: true,
+	});
+	assert.equal(output.diagnostics.length, 0, 'cache-shape fixture emitted diagnostics');
+	return new Map([[SHAPE_FILE, output.code]]);
+}
+
+// A source-level ABI observation, deliberately separate from behavioral tests.
+// AST membership counts emitted named reads/writes on the DOM slot array and
+// cache-region calls; neither result depends on formatting or minified names.
+function compilerCacheShapeCounts(source) {
+	const ast = parseModule(source, SHAPE_FILE + '.js');
+	const result = { named_reads: 0, named_writes: 0, region_calls: 0, flat_region_calls: 0 };
+	const owner = [];
+	function walk(node, parent = null) {
+		if (!node || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child, parent);
+			return;
+		}
+		const isFunction = /^(?:FunctionDeclaration|FunctionExpression|ArrowFunctionExpression)$/.test(
+			node.type,
+		);
+		if (isFunction) owner.push(node.id?.name ?? null);
+		if (node.type === 'MemberExpression') {
+			const target = node.object;
+			const property = node.property?.name;
+			if (
+				target?.type === 'MemberExpression' &&
+				target.object?.name === '__s' &&
+				target.property?.name === 'slots' &&
+				/^_[mk]\$\d+$/.test(property ?? '')
+			) {
+				if (parent?.type === 'AssignmentExpression' && parent.left === node) result.named_writes++;
+				else result.named_reads++;
+			}
+		}
+		if (
+			node.type === 'CallExpression' &&
+			node.callee?.type === 'Identifier' &&
+			/\$compilerMemoRegion$/.test(node.callee.name)
+		) {
+			result.region_calls++;
+			if (owner.includes('Flat')) result.flat_region_calls++;
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'loc' || key === 'metadata' || key === 'comments' || key[0] === '_') continue;
+			if (value && typeof value === 'object') {
+				if (Array.isArray(value)) for (const child of value) walk(child, node);
+				else walk(value, node);
+			}
+		}
+		if (isFunction) owner.pop();
+	}
+	walk(ast);
+	return result;
+}
+
+function exerciseCacheShapes(bundle) {
+	const cases = [
+		['Combined', 'data-tick', ''],
+		['Alternate', 'data-tick', 'other:'],
+		['AutoOnly', 'data-tick', ''],
+		['HookOnly', 'output', ''],
+		['Flat', 'output', ''],
+	];
+	const snapshots = [];
+	for (const [name, tickPlace, prefix] of cases) {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = bundle.createRoot(container);
+		const render = (label, tick) =>
+			bundle.flushSync(() => root.render(bundle[name], { label, tick }));
+		const checkTick = (expected) => {
+			const visible =
+				tickPlace === 'output'
+					? container.querySelector('output')?.textContent
+					: container.querySelector('#cache-host')?.getAttribute('data-tick');
+			assert.equal(visible, String(expected), `${name}: unrelated tick is visible`);
+		};
+		render('alpha', 0);
+		const input = container.querySelector('input');
+		const labelNode = container.querySelector('#cache-label');
+		assert.equal(labelNode?.textContent, prefix + 'alpha');
+		checkTick(0);
+		input.value = 'typed';
+		input.focus();
+		render('alpha', 1);
+		checkTick(1);
+		assert.equal(container.querySelector('input'), input);
+		assert.equal(container.querySelector('#cache-label'), labelNode);
+		assert.equal(input.value, 'typed');
+		assert.equal(document.activeElement, input);
+		assert.equal(labelNode.textContent, prefix + 'alpha');
+		render('beta', 2);
+		checkTick(2);
+		assert.equal(container.querySelector('input'), input);
+		assert.equal(container.querySelector('#cache-label'), labelNode);
+		assert.equal(input.value, 'typed');
+		assert.equal(labelNode.textContent, prefix + 'beta');
+		snapshots.push([name, container.innerHTML, input.value]);
+		root.unmount();
+		assert.equal(container.innerHTML, '');
+		container.remove();
+	}
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	const root = bundle.createRoot(container);
+	const Context = bundle.createContext('default');
+	bundle.flushSync(() =>
+		root.render(Context.Provider, { value: 'initial', children: bundle.ProviderFirst }),
+	);
+	const input = container.querySelector('input');
+	const labelNode = container.querySelector('#cache-label');
+	assert.equal(labelNode?.textContent, 'first');
+	input.value = 'retained';
+	input.focus();
+	bundle.flushSync(() =>
+		root.render(Context.Provider, { value: 'changed', children: bundle.ProviderSecond }),
+	);
+	assert.equal(container.querySelector('input'), input);
+	assert.equal(container.querySelector('#cache-label'), labelNode);
+	assert.equal(input.value, 'retained');
+	assert.equal(document.activeElement, input);
+	assert.equal(labelNode.textContent, 'second');
+	bundle.flushSync(() =>
+		root.render(Context.Provider, { value: 'again', children: bundle.ProviderSecond }),
+	);
+	assert.equal(container.querySelector('input'), input);
+	assert.equal(container.querySelector('#cache-label'), labelNode);
+	assert.equal(input.value, 'retained');
+	assert.equal(document.activeElement, input);
+	assert.equal(labelNode.textContent, 'second');
+	snapshots.push(['ProviderFirst→ProviderSecond', container.innerHTML, input.value]);
+	root.unmount();
+	assert.equal(container.innerHTML, '');
+	container.remove();
+	return snapshots;
+}
+
 function withoutCallbackNames(snapshot) {
 	return Object.fromEntries(
 		Object.entries(snapshot).map(([name, value]) => [
@@ -534,11 +682,53 @@ try {
 			);
 		}
 	}
+	const shapeSources = compileCacheShapes();
+	const shapeCode = shapeSources.get(SHAPE_FILE);
+	const shapeFile = path.join(tempDir, 'cache-shapes-clean.mjs');
+	const { code: shapeBundle } = await bundleApplication(shapeSources, shapeFile, SHAPE_ENTRY);
+	fs.writeFileSync(shapeFile, shapeBundle);
+	if (process.env.BENCH_SHAPE_ARTIFACT) {
+		const artifact = path.resolve(process.env.BENCH_SHAPE_ARTIFACT);
+		const { code: profileBundle } = await bundleApplication(
+			shapeSources,
+			artifact,
+			path.join(ROOT, 'cache-shapes-profile-entry.mjs'),
+		);
+		fs.writeFileSync(artifact, profileBundle);
+	}
+	const shapeSnapshot = exerciseCacheShapes(await import(pathToFileURL(shapeFile).href));
+	const shapeCounts = compilerCacheShapeCounts(shapeCode);
+	assert.equal(shapeCounts.flat_region_calls, 0, 'flat control gained compiler memo work');
+	const shapeSizes = codeSizes(shapeSources, shapeBundle);
+	const shapeOps = {
+		...Object.fromEntries(Object.entries(shapeSizes).map(([key, value]) => [key, val(value)])),
+		...Object.fromEntries(Object.entries(shapeCounts).map(([key, value]) => [key, val(value)])),
+	};
+	const shapeHash = createHash('sha256').update(JSON.stringify(shapeSnapshot)).digest('hex');
+	targets.push({
+		name: 'compiler-cache-shapes',
+		ops: shapeOps,
+		meta: {
+			fixtureSha256: createHash('sha256').update(fs.readFileSync(SHAPE_FILE)).digest('hex'),
+			entrySha256: createHash('sha256').update(fs.readFileSync(SHAPE_ENTRY)).digest('hex'),
+			semanticsSha256: shapeHash,
+			snapshot: shapeSnapshot,
+			counts: shapeCounts,
+		},
+	});
+	console.log(
+		`cache-shapes: ${shapeCounts.named_reads} named reads, ${shapeCounts.named_writes} named writes, ${shapeCounts.region_calls} region calls; semantics ${shapeHash}`,
+	);
 	const payload = {
 		suite: 'hook-memo',
 		iterations: 1,
 		targets: [
 			...targets,
+			{
+				name: 'cache-shape-reference',
+				ops: { named_reads: val(1), named_writes: val(1) },
+				meta: { description: 'One named array property per source-level cache access.' },
+			},
 			{
 				name: 'one-per-render',
 				ops: onePerRender,

--- a/benchmarks/hook-memo/tsconfig.json
+++ b/benchmarks/hook-memo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["cache-shapes.tsrx"],
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2024"],
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "target": "ES2024",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "paths": {
+      "octane": ["../../packages/octane/src/index.ts"],
+      "octane/*": ["../../packages/octane/src/*"]
+    },
+    "plugins": [{ "name": "@tsrx/typescript-plugin" }]
+  }
+}

--- a/benchmarks/runtime-object-shapes/ARRAYS.md
+++ b/benchmarks/runtime-object-shapes/ARRAYS.md
@@ -1,0 +1,108 @@
+# Runtime array storage
+
+This diagnostic covers the three array findings in [#981](https://github.com/octanejs/octane/issues/981): inline hook memo cells, the general keyed reconciler's collected keys, and lazy templates' namespace cache. It runs the actual bundled production runtime. It does not infer heap savings from source allocation counts or claim an application-wide speedup.
+
+## Design and contract
+
+- `hookMemoCreate` fills with `null`. Regular memo sites test their validity cell against `true` before reading dependencies or results. Generated invariant callback sites use a nullish check. Both forms preserve first computation, cached `null`/`undefined` results, delayed conditional sites, and callback identity. On Chromium 149, the previous all-`undefined` array used double storage, then changed to holey object storage at publication. `null` starts in object storage.
+- The general keyed reconciler collects keys into `[]` using the same ascending indexed writes. Callback invocation order, raw key identity, errors, and subsequent key reads are unchanged. This removes holes caused by preallocation; an engine can still select a special representation for particular key values. Growing the temporary array can reserve more capacity than its length.
+- Lazy template records start with `[null, null, null]`, one entry per HTML/SVG/MathML destination. This prevents an initial SVG or MathML parse from skipping array indexes. Parsing still happens on first use, and each destination has a separate cached node. The token now starts with three entries, including tokens that are never parsed.
+
+These paths have no matching server-side array implementation. Existing namespace SSR/hydration coverage still exercises the shared compiler contract.
+
+## Run
+
+From the candidate checkout, build unminified, bundled ESM production runtimes from the baseline and candidate sources. The baseline used here was frozen from `fa11c1055` before implementation.
+
+```sh
+node_modules/.bin/esbuild /private/tmp/981-object-shapes-baseline/packages/octane/src/runtime.ts --bundle --format=esm --platform=browser --define:process.env.NODE_ENV='"production"' --outfile=/private/tmp/981-arrays-baseline-runtime.mjs
+node_modules/.bin/esbuild packages/octane/src/runtime.ts --bundle --format=esm --platform=browser --define:process.env.NODE_ENV='"production"' --outfile=/private/tmp/981-arrays-candidate-runtime.mjs
+
+node benchmarks/runtime-object-shapes/arrays.mjs /private/tmp/981-arrays-baseline-runtime.mjs /private/tmp/981-arrays-candidate-runtime.mjs --output /private/tmp/981-arrays-node-structural.json
+
+node benchmarks/runtime-object-shapes/arrays.mjs /private/tmp/981-arrays-baseline-runtime.mjs /private/tmp/981-arrays-candidate-runtime.mjs --chromium /Users/domgan/Library/Caches/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-mac-arm64/chrome-headless-shell --output /private/tmp/981-arrays-browser-structural.json
+
+node benchmarks/runtime-object-shapes/arrays.mjs /private/tmp/981-arrays-baseline-runtime.mjs /private/tmp/981-arrays-candidate-runtime.mjs --chromium /Users/domgan/Library/Caches/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-mac-arm64/chrome-headless-shell --timing --rounds 4 --output /private/tmp/981-arrays-browser-timing.json
+```
+
+Replace the browser path with an installed Chromium executable. The browser opens temporary local HTML files only. Node runs use the checkout's `jsdom`; browser runs use its actual DOM. To select another installed Node, invoke this script with that executable. No browser or dependency installation is performed.
+
+Without `--timing`, a separate post-build instrumented bundle exposes the actual reconciler key array, while the script reads actual memo cells and template records. `%HasHoleyElements`, `%HasFastPackedElements`, `%HasDoubleElements`, and `%HasObjectElements` report V8 representation. Runtime records receive no added fields. The probe also verifies key values, DOM survivor identity, edited input values, and destination namespaces.
+
+With `--timing`, the bundle is unchanged and V8 intrinsics are disabled. Each variant gets a fresh process/profile. Variant order alternates across rounds. Each workload has nine samples after warmup; reports retain every sample, engine version, and bundle SHA-256. Memo workloads create a cache and publish an object result, retaining a bounded ring of arrays. `--memo-only` skips template workloads for the alternative comparison below. These workloads measure constructor/publication or parser/clone cost, not isolated allocation cost or a whole render.
+
+## Structural results
+
+Observed on Node 24.19.0 / V8 13.6.233.17-node.51, Node 26.4.0 / V8 14.6.202.34-node.21, and Chromium 149.0.7827.55 on macOS arm64:
+
+| Actual runtime array | Baseline | Candidate |
+| --- | --- | --- |
+| Memo cells, Node 24/26, before/after publication | Packed object elements | Packed object elements |
+| Memo cells, Chromium 149, before publication | Holey double elements | Packed object elements |
+| Memo cells, Chromium 149, after object publication | Holey object elements | Packed object elements |
+| Template cache after MathML is parsed first, all measured engines | Length 3, one own entry, holey object elements | Length 3, three own entries, packed object elements |
+| Template cache after SVG and HTML subsequently parse | Still holey object elements | Still packed object elements |
+| Collected middle keys: string, number, object, mixed undefined, all measured engines | Holey elements | Packed elements |
+
+The candidate retains numeric specialization for numeric keys. The mixed-undefined list starts with a non-undefined key; this table is not a guarantee for every possible key sequence. In Chromium 149, both `fill(undefined)` and repeated `push(undefined)` produced holey double arrays. Merely replacing the constructor with `push(undefined)` would not address that behavior.
+
+V8's [elements-kind documentation](https://v8.dev/blog/elements-kinds) notes that `Array.prototype.fill` gained a repacking exception in February 2025. These conclusions are limited to the measured engines. The repository's minimum Node 22.22.2 uses [V8 12.4.254.21](https://raw.githubusercontent.com/nodejs/node/v22.22.2/deps/v8/include/v8-version.h); no Node 22 binary was installed for this run. An older V8 without fill repacking can retain holey classification for `new Array(size).fill(null)`. The candidate preserves the exact-size allocation and does not introduce engine detection.
+
+## Four alternating Chromium timing rounds
+
+Times below are milliseconds per 100,000 cache creations and first publications. Each cell is the median of four process medians; parentheses show their range. Lower is better.
+
+| Cache cells | Baseline `fill(undefined)` | Candidate `fill(null)` | Change |
+| --- | --- | --- | --- |
+| 2 | 4.85 (4.70–5.00) | 2.30 (2.20–2.60) | −52.6% |
+| 4 | 5.25 (5.10–5.50) | 2.90 (2.50–2.90) | −44.8% |
+| 8 | 5.95 (5.80–6.10) | 3.15 (3.00–3.30) | −47.1% |
+| 16 | 6.55 (6.50–6.90) | 3.40 (3.20–3.50) | −48.1% |
+| 32 | 8.90 (8.10–9.40) | 4.40 (4.10–4.60) | −50.6% |
+| 128 | 23.10 (22.80–23.20) | 11.50 (10.90–12.10) | −50.2% |
+
+Template token creation was 0.80 ms per 100,000 in both variants. First clone/parse medians per 1,000 tokens were HTML 3.55→3.45 ms, SVG 3.90→3.95 ms, and MathML 3.60→3.70 ms. Cached clone medians per 10,000 clones were HTML 0.90→0.90 ms, SVG 1.80→1.80 ms, and MathML 0.90→0.95 ms. These small differences do not establish a template throughput improvement. The namespace change is supported by representation evidence and unchanged behavior.
+
+Artifacts from this run:
+
+- `/private/tmp/981-arrays-chromium149-timing-four.json`
+- `/private/tmp/981-arrays-{node24,node26,chromium149}-structural.json`
+- Baseline bundle SHA-256: `3cd287da1781216daa625c5e24b3a9189db6ff711717536a695905bc32d1a2b2`
+- Candidate bundle SHA-256: `bee60812aa2da1e62b67258e48b3b0aebbb8005524d2e7366dbf3af4348c688f`
+
+These hashes identify the frozen bundles used for these isolated array measurements, rather than assuming a later combined runtime build is byte-identical.
+
+## Rejected alternative: repeated `push(null)`
+
+The alternative changed only `hookMemoCreate` in a temporary copy of the actual candidate bundle. Its implementation was:
+
+```js
+function hookMemoCreate(size) {
+  const cells = [];
+  for (let i = 0; i < size; i++) cells.push(null);
+  return cells;
+}
+```
+
+For reproduction, replace the exact `hookMemoCreate` function in a temporary copy of the unminified candidate bundle, then run `arrays.mjs CANDIDATE.mjs PUSH.mjs --timing --memo-only --rounds 4`, adding `--chromium` for the browser comparison. The report's baseline is then `fill(null)` and candidate is `push(null)`.
+
+Four alternating rounds showed faster small-cache construction, but extra capacity and slower large-cache construction:
+
+| Cells | Chromium 149 time change | Node 24 time change | Node 24 backing capacity: fill → push |
+| --- | --- | --- | --- |
+| 2 | −52.3% | −62.6% | 2 → 17 |
+| 4 | −51.0% | −60.7% | 4 → 17 |
+| 8 | −50.9% | −56.3% | 8 → 17 |
+| 16 | −40.9% | −49.0% | 16 → 17 |
+| 32 | −4.9% | +23.3% | 32 → 43 |
+| 128 | +35.3% | +35.6% | 128 → 140 |
+
+Backing capacities came from a separate, untimed Node 24 `%DebugPrint` diagnostic of both initialization expressions. They are element capacities, not claimed retained-heap bytes. Memo caches live with their component, so the extra capacity matters beyond the constructor timing. The minimal `fill(null)` candidate was retained; no size threshold, extra branch, or runtime engine detection was added.
+
+The exact alternative bundle SHA-256 was `ef101ad62dcba4872b7d219ea3f21ea12b0c988d51bf9cbe8775e622a283650a`. Results are in `/private/tmp/981-arrays-chromium149-fill-vs-push.json` and `/private/tmp/981-arrays-node24-fill-vs-push.json`.
+
+## Behavioral verification
+
+The focused development/production run passed 272 tests in six files, including new cases for nullish memo results and deferred conditional initialization, mixed raw-key reorders and full replacement preserving edited inputs, and a single ambiguous template mounted MathML→SVG→HTML twice. Existing namespace tests include SSR/hydration.
+
+Each new contract was deliberately broken locally and failed in both projects: falsely valid initial memo cells caused a non-callable callback; omitted key collection caused incorrect DOM order; a namespace cache forced to index zero produced an HTML node in MathML. Each scoped mutation was restored, and all eight new test cases passed again. No representation or allocation-count assertions were added to correctness tests.

--- a/benchmarks/runtime-object-shapes/HOOKS.md
+++ b/benchmarks/runtime-object-shapes/HOOKS.md
@@ -1,0 +1,139 @@
+# Hook records
+
+`hooks.mjs` captures actual `useState`, `useReducer`, and memo cells from the
+production runtime. It intercepts `Map.prototype.set` only while mounting the
+probe fixtures, restores the native method before updates and measurement, and
+never adds properties to the cells. It checks queued state/reducer output and
+current-state getters, then inspects V8 maps and heap snapshots. Sixteen disposable
+mounts settle constructor slack tracking before the retained samples are created.
+
+The default mode requires one map for each sampled family. Use `--observe` to
+inspect the baseline without requiring its maps to be uniform:
+
+```sh
+node benchmarks/runtime-object-shapes/hooks.mjs /tmp/baseline/runtime.mjs --observe --output /tmp/hooks-before.json
+node benchmarks/runtime-object-shapes/hooks.mjs /tmp/candidate/runtime.mjs --output /tmp/hooks-after.json
+```
+
+The launcher supplies `--allow-natives-syntax --expose-gc` to the child process.
+V8-specific inspection is confined to this benchmark; correctness tests observe
+DOM output, hook return values, stable getter identity, and memo identity.
+
+## Memory and maps
+
+Measured with Node 26.4.0 / V8 14.6.202.34-node.21. Bytes below are the actual
+cell's shallow heap size plus its property backing array, where present. They
+exclude retained closures, nested values, scopes, DOM, allocator fragmentation,
+and peak GC memory. These are per-cell measurements, not total application heap.
+
+| Sample | Baseline cell | Baseline property array | Baseline total | Eager total | Delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Idle state | 40 | 0 | 40 | 88 | +48 |
+| Idle reducer | 48 | 0 | 48 | 96 | +48 |
+| Getter state | 40 | 40 | 80 | 88 | +8 |
+| Getter reducer | 48 | 40 | 88 | 96 | +8 |
+| Queued state | 40 | 40 | 80 | 88 | +8 |
+| Queued reducer | 48 | 40 | 88 | 96 | +8 |
+| Settled-transition state | 40 | 64 | 104 | 88 | −16 |
+| Settled-transition reducer | 48 | 64 | 112 | 96 | −16 |
+| Ordinary memo | 40 | 0 | 40 | 64 | +24 |
+| Warm-recorded memo | 40 | 40 | 80 | 64 | −16 |
+| Native memo | 40 | 40 | 80 | 64 | −16 |
+
+All eager cells have zero property-array bytes. Across these samples, state maps
+fall from four to one, reducer maps from four to one, and memo maps from three to
+one. The memo samples exercise publication with ordinary, warm-recorded, and
+native evidence; they do not claim to cover every suspension/adoption lifecycle.
+The runtime also gives both adopted memo constructors the same field order.
+
+The idle memory increase is deliberate: the layout trades extra eagerly reserved
+fields for stable maps and faster transition handling. It does not reduce every
+record's memory footprint.
+
+## Production runtime timing
+
+`hooks-timing.mjs` runs complete public-root operations against supplied production
+bundles. It does not intercept maps, inspect shapes, snapshot heaps, or time
+synthetic record operations. The component calls actual state, reducer, and memo
+hooks and returns `null`, avoiding DOM-node creation while retaining root/scope
+bookkeeping. The getter case reads both current-state getters in every render.
+Assertions after each sample verify actual render counts and resulting values.
+
+```sh
+node benchmarks/runtime-object-shapes/hooks-timing.mjs /tmp/baseline/runtime.mjs /tmp/candidate/runtime.mjs --output /tmp/hooks-timing.json
+```
+
+There are nine fresh processes per variant, with variant order rotated each
+round. Within each process and getter mode:
+
+- Mount/unmount: 500 warmup operations, 1,500 measured operations.
+- Ordinary rerender: 4,000 warmup operations, 10,000 measured operations.
+- Settled transition: 500 warmup operations, 1,500 measured operations. Each sets
+  state and dispatches reducer work, then flushes its publication.
+
+The selection experiment built variants from the same frozen baseline
+`fa11c1055`, with only the five hook-constructor changes and their field types
+applied to the eager variant. This isolates the hook layout from concurrent
+compiler, scope, host, and array changes in this PR. Both builds used esbuild,
+`--bundle --platform=node --format=esm`,
+`--define:process.env.NODE_ENV='"production"'`, and
+`--define:__OCTANE_PROFILE_ENABLED__=false`.
+
+Results are microseconds per complete operation, **median [minimum, maximum]**
+across the nine processes on Node 26.4.0:
+
+| Operation | Baseline | Eager fields | Temporary cold record |
+| --- | ---: | ---: | ---: |
+| Ordinary mount/unmount | 6.328 [5.501, 7.122] | 5.831 [5.238, 11.612] | 6.284 [5.586, 7.317] |
+| Ordinary update | 0.762 [0.663, 0.929] | 0.692 [0.642, 0.800] | 0.698 [0.658, 0.814] |
+| Getter mount/unmount | 7.496 [5.164, 18.461] | 6.367 [3.479, 8.705] | 6.267 [3.466, 11.175] |
+| Getter update/read | 0.731 [0.588, 2.204] | 0.649 [0.589, 1.173] | 0.712 [0.588, 0.919] |
+| Ordinary transition | 31.945 [26.720, 35.672] | 25.401 [24.324, 26.805] | 33.319 [32.321, 38.119] |
+| Getter transition | 67.932 [66.352, 78.695] | 55.145 [52.694, 64.574] | 66.712 [64.966, 71.792] |
+
+Mount and ordinary/getter update ranges overlap substantially; these samples do
+not establish a throughput improvement for those common paths. The eager
+transition medians improve by 20.5% and 18.8%, respectively, with almost disjoint
+ordinary-transition ranges and disjoint getter-transition ranges. This is one V8
+version and one focused workload, not a cross-browser or application-wide claim.
+
+## Rejected cold-record alternative
+
+A temporary design moved `renderTransition`, `urgentTransition`,
+`pendingActionBatch`, and `pendingActionValue` into one lazily allocated record.
+State/reducer instances retained eagerly seeded queue/getter fields and used
+prototype accessors to preserve existing shared transition callers. It retained
+one map per family and passed the same behavioral controls.
+
+The hot state/reducer cells were 64/72 bytes, reducing getter and queued cases by
+16 bytes relative to baseline, while still adding 24 bytes to idle cells. Once a
+transition used the cold record, each record added another 56 bytes: totals of
+120/128 bytes, 16 bytes above baseline and 32 bytes above the eager layout. Its
+transition timing did not retain the eager improvement. The alternative was
+rejected and is not part of the runtime change. Rewriting every shared transition
+consumer for direct record access would also involve linked/deferred cells and
+requires separate design and measurement.
+
+## Behavioral regression
+
+`packages/octane/tests/plain-hook-memo.test.ts` exercises both compiler memo
+modes through the public root. The added case checks queued functional updates,
+reducer ordering, stable current-state getters, dependency-hit memo identity, and
+an asynchronous Action that stages `undefined` while committed DOM retains its
+previous values.
+
+Local validation passed all 56 cases in the development and production projects.
+A deliberate mutation made the state getter ignore its pending Action and read
+committed state instead. All four selected combinations failed on the observable
+getter result (`3` instead of `undefined`). Restoring that single line returned
+the full 56-case suite to green. No shape or serializer-count assertions were
+added to correctness tests.
+
+The local command used a temporary config that retained the root config's
+`octane` and `octane-prod` projects and setup files, narrowed their include list to
+this test, and omitted only the unrelated global React differential precompile
+because its dependency is unavailable in this checkout:
+
+```sh
+./node_modules/.bin/vitest run --config /private/tmp/981-object-hooks-vitest.config.mjs --silent=passed-only
+```

--- a/benchmarks/runtime-object-shapes/README.md
+++ b/benchmarks/runtime-object-shapes/README.md
@@ -1,0 +1,85 @@
+# Runtime object shapes
+
+Production-runtime probes for the remaining hidden-class and array findings in
+[issue #981](https://github.com/octanejs/octane/issues/981). These benchmarks
+observe private records; correctness tests assert public hook values, memo
+identity, DOM identity, hydration adoption, refs, and cleanup.
+
+- [Hook records and measured tradeoffs](HOOKS.md)
+- [Memo, keyed-list, and namespace arrays](ARRAYS.md)
+- [Compiler memo regions](../hook-memo/README.md)
+
+## Inputs
+
+Use a frozen baseline and candidate bundle built with identical settings and
+dependencies. The recorded baseline is `fa11c10556338420dc686a2e93bf1b5787099b30`.
+From each isolated checkout, bundle its authored runtime:
+
+```sh
+node --input-type=module - <<'JS'
+import { build } from 'esbuild';
+await build({
+  entryPoints: ['packages/octane/src/runtime.ts'],
+  outfile: '/tmp/runtime.mjs', // Use a distinct baseline/candidate destination.
+  bundle: true, format: 'esm', platform: 'neutral', target: 'esnext',
+  define: { 'process.env.NODE_ENV': '"production"' }, minify: false,
+});
+JS
+```
+
+The probes print runtime hashes. Timing uses untouched production bundles;
+structural interception, V8 intrinsics, and heap snapshots never run in a timing
+sample. Run timing processes without concurrent builds or tests.
+
+## Host, list, and render-capture records
+
+```sh
+node benchmarks/runtime-object-shapes/run.mjs /tmp/baseline/runtime.mjs /tmp/records-before.json --observe
+node benchmarks/runtime-object-shapes/run.mjs /tmp/candidate/runtime.mjs /tmp/records-after.json
+```
+
+The launcher supplies `--allow-natives-syntax --expose-gc`. The default gate
+requires one map per family; `--observe` records the baseline without that gate.
+Actual records are sampled after four warmup rounds and twelve rounds execute
+ordinary lists, keyed selection, and the guarded native-map entry. Both list
+constructor sites are exercised. Root commits are flushed before inspecting ref
+publication. The fixture checks keyed input identity and typed values after a
+reorder, host identity, fresh callable children, changed props, balanced ref
+cleanup, scheduled cleanup, and empty DOM after unmount.
+
+Recorded on Node 26.4.0 / V8 14.6.202.34-node.21:
+
+| Actual record | Baseline maps across modes | Candidate maps | Baseline bytes | Candidate bytes |
+| --- | ---: | ---: | ---: | ---: |
+| Host, no callable children | 2 | 1 | 88 | 80 |
+| Host, callable children | 2 | 1 | 112 | 80 |
+| Ordinary list | 3 | 1 | 120 | 136 |
+| Selection or native-map list | 3 | 1 | 160 | 136 |
+| Root capture, plain / detach / cleanup / both | 4 | 1 | 120 | 112 |
+
+Bytes are actual heap-snapshot shallow size plus the record's property backing
+array. They exclude DOM, closures, nested collections, allocator fragmentation,
+and peak GC memory. Optional capture arrays and Sets remain lazy. Seeding fields
+does not allocate those collections. Offscreen captures use the same constructor
+as root captures; the table samples root captures only.
+
+Both builds produce semantic SHA-256
+`2a6000b6335ec95631f70f64b72f85e69036f286150e6008bdfdb0392cd26298`.
+No application latency or total heap reduction is inferred from these structural
+measurements. Ordinary lists and unused hook cells reserve more memory; the hook
+report gives the full costs and measured transition benefit.
+
+## Correctness controls
+
+Focused development and production validation covers host children appearing,
+updating, disappearing, and remounting; keyed selection and fallback-to-native
+hydration; and a suspended foreign renderer with a delayed cleanup scheduler.
+Deliberately initializing the host's callable body to `null` fails when the input
+should appear. Treating an abandoned capture as committed fails the foreign
+renderer retry with a duplicate-owner error. Both mutations fail in both modes,
+and the restored four cases pass. The full four-file group passes 270 tests.
+
+Removing only the two list constructors' seeded optional fields from a separate
+bundle makes the structural guard fail with three list maps instead of one.
+That negative control changes no shared source. Behavioral tests continue to
+allow alternative internal layouts that preserve the same observable contract.

--- a/benchmarks/runtime-object-shapes/arrays.mjs
+++ b/benchmarks/runtime-object-shapes/arrays.mjs
@@ -1,0 +1,352 @@
+// Actual production-runtime array diagnostics and narrowly scoped cost probes.
+// Structural probes instrument a separate bundle and are never timed. Timings
+// use the untouched bundle, no V8 intrinsics, and do not measure heap bytes.
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { transformSync, version as esbuildVersion } from 'esbuild';
+
+const args = process.argv.slice(2);
+const value = (name) => {
+	const index = args.indexOf(name);
+	return index === -1 ? undefined : args[index + 1];
+};
+const child = args.includes('--child');
+const timing = args.includes('--timing');
+const marker = 'OCTANE_ARRAYS=';
+
+function exercise(runtime, timed, memoOnly = false) {
+	const check = (condition, message) => {
+		if (!condition) throw new Error(message);
+	};
+	const shape = timed
+		? null
+		: new Function(
+				'array',
+				`return {
+		length: array.length, ownEntries: Object.keys(array).length,
+		holey: %HasHoleyElements(array), packed: %HasFastPackedElements(array),
+		doubles: %HasDoubleElements(array), objects: %HasObjectElements(array)
+	}`,
+			);
+	const object = { value: 1 };
+	const namespaces = [
+		'http://www.w3.org/1999/xhtml',
+		'http://www.w3.org/2000/svg',
+		'http://www.w3.org/1998/Math/MathML',
+	];
+	function record(token) {
+		const result = Object.getOwnPropertySymbols(token)
+			.map((key) => token[key])
+			.find((entry) => entry && entry.html === '<a>value</a>');
+		check(result !== undefined, 'Expected actual lazy template record');
+		return result;
+	}
+	function mountTemplate(token, ns) {
+		const container = document.createElementNS(namespaces[ns], ['div', 'svg', 'math'][ns]);
+		document.body.appendChild(container);
+		const root = runtime.createRoot(container);
+		try {
+			root.render((props, scope) => {
+				runtime.bag0(scope, runtime.clone(token));
+			});
+			check(container.querySelector('a')?.namespaceURI === namespaces[ns], 'Wrong namespace');
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	}
+	if (!timed) {
+		const memo = [];
+		for (const size of [2, 4, 8, 16, 32, 128]) {
+			const cells = runtime.hookMemoCreate(size);
+			const initial = shape(cells);
+			runtime.hookMemoPublish0(cells, 0, object);
+			check(cells[0] === true && cells[1] === object, 'Memo publication failed');
+			memo.push({ size, initial, published: shape(cells) });
+		}
+		const token = runtime.template('<a>value</a>', 3);
+		const parsed = record(token).parsed;
+		const template = [{ stage: 'unparsed', ...shape(parsed) }];
+		for (const ns of [2, 1, 0, 2]) {
+			mountTemplate(token, ns);
+			template.push({ stage: ['html', 'svg', 'math'][ns], ...shape(parsed) });
+		}
+		const list = [];
+		for (const type of ['string', 'number', 'object', 'undefined']) {
+			const keys = Array.from({ length: 6 }, (_, i) =>
+				type === 'object'
+					? { i }
+					: type === 'number'
+						? i
+						: type === 'undefined' && i === 1
+							? undefined
+							: String(i),
+			);
+			const rows = keys.map((key, i) => ({ key, label: String(i) }));
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			const root = runtime.createRoot(container);
+			function App(props, scope) {
+				const parent = runtime.hostComponent(scope, 0, 'div', null);
+				runtime.forBlock(
+					scope,
+					1,
+					parent,
+					props.rows,
+					(row) => row.key,
+					(row, itemScope) => {
+						runtime.hostComponent(itemScope, 0, 'input', { defaultValue: row.label });
+					},
+				);
+			}
+			try {
+				root.render(App, { rows });
+				const before = [...container.querySelectorAll('input')];
+				before.forEach((input) => {
+					input.value = 'typed:' + input.value;
+				});
+				const order = [0, 3, 1, 4, 2, 5];
+				globalThis.__octaneArrayKeys = null;
+				runtime.flushSync(() => root.render(App, { rows: order.map((i) => rows[i]) }));
+				const after = [...container.querySelectorAll('input')];
+				order.forEach((old, i) =>
+					check(
+						after[i] === before[old] && after[i].value === 'typed:' + old,
+						'Lost list survivor',
+					),
+				);
+				const collected = globalThis.__octaneArrayKeys;
+				check(collected?.length === 4, 'General keyed middle was not captured');
+				check(
+					collected.every((key, i) => key === keys[order[i + 1]]),
+					'Collected keys differ',
+				);
+				list.push({ type, ...shape(collected) });
+			} finally {
+				root.unmount();
+				container.remove();
+			}
+		}
+		const alternatives = [
+			['fill undefined', () => new Array(8).fill(undefined)],
+			[
+				'push undefined',
+				() => {
+					const a = [];
+					for (let i = 0; i < 8; i++) a.push(undefined);
+					return a;
+				},
+			],
+			['fill null', () => new Array(8).fill(null)],
+			[
+				'push null',
+				() => {
+					const a = [];
+					for (let i = 0; i < 8; i++) a.push(null);
+					return a;
+				},
+			],
+		].map(([name, create]) => {
+			const a = create();
+			const initial = shape(a);
+			a[0] = true;
+			a[1] = object;
+			return { name, initial, published: shape(a) };
+		});
+		return { memo, template, list, alternatives };
+	}
+	// Keep created objects reachable across each timed batch; compare source
+	// operations rather than claiming these durations isolate allocator cost.
+	const ring = new Array(256);
+	let checksum = 0;
+	function measure(name, count, operation) {
+		for (let i = 0; i < Math.min(count, 5000); i++) operation(i);
+		const samplesMs = [];
+		for (let repeat = 0; repeat < 9; repeat++) {
+			const start = performance.now();
+			for (let i = 0; i < count; i++) operation(i);
+			samplesMs.push(performance.now() - start);
+		}
+		const ordered = [...samplesMs].sort((a, b) => a - b);
+		return { name, iterations: count, samplesMs, medianMs: ordered[4] };
+	}
+	const measurements = [];
+	for (const size of [2, 4, 8, 16, 32, 128]) {
+		measurements.push(
+			measure('memo-create-publish-' + size, 100000, (i) => {
+				const cells = runtime.hookMemoCreate(size);
+				runtime.hookMemoPublish0(cells, 0, object);
+				ring[i & 255] = cells;
+				checksum += cells[0] === true && cells[1] === object ? 1 : 0;
+			}),
+		);
+	}
+	if (memoOnly) {
+		globalThis.__octaneArrayBenchmarkSink = ring;
+		check(checksum > 0, 'Missing timed checksum');
+		return { measurements, checksum };
+	}
+	measurements.push(
+		measure('template-create', 100000, (i) => {
+			ring[i & 255] = runtime.template('<a>value</a>', 3);
+		}),
+	);
+	for (const ns of [0, 1, 2]) {
+		measurements.push(
+			measure('template-first-clone-' + ns, 1000, (i) => {
+				const token = runtime.template('<a>value</a>', ns);
+				ring[i & 255] = runtime.clone(token);
+			}),
+		);
+		const token = runtime.template('<a>value</a>', ns);
+		runtime.clone(token);
+		measurements.push(
+			measure('template-cached-clone-' + ns, 10000, (i) => {
+				ring[i & 255] = runtime.clone(token);
+			}),
+		);
+	}
+	globalThis.__octaneArrayBenchmarkSink = ring;
+	check(checksum > 0, 'Missing timed checksum');
+	return { measurements, checksum };
+}
+
+if (child) {
+	const { JSDOM } = await import('jsdom');
+	const { window } = new JSDOM('<!doctype html><body></body>', { url: 'http://localhost/' });
+	for (const name of [
+		'window',
+		'document',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'SVGElement',
+		'CharacterData',
+		'Comment',
+		'Text',
+		'Event',
+		'MouseEvent',
+		'CustomEvent',
+		'MutationObserver',
+	]) {
+		globalThis[name] = name === 'window' ? window : window[name];
+	}
+	const runtime = await import(pathToFileURL(value('--bundle')).href);
+	const report = {
+		node: process.version,
+		v8: process.versions.v8,
+		...exercise(runtime, timing, args.includes('--memo-only')),
+	};
+	process.stdout.write(marker + JSON.stringify(report) + '\n');
+	window.close();
+} else {
+	assert(
+		args.length >= 2,
+		'Usage: node arrays.mjs <baseline-runtime.mjs> <candidate-runtime.mjs> [--chromium <executable>] [--timing] [--memo-only] [--rounds <count>] [--output <json>]',
+	);
+	const rounds = Number(value('--rounds') ?? 1);
+	assert(Number.isInteger(rounds) && rounds > 0, '--rounds must be a positive integer');
+	const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-array-shapes-'));
+	try {
+		const runs = [];
+		// Each variant gets a fresh engine process/profile. Alternating the order
+		// across rounds makes drift visible in the retained per-run samples.
+		const ordered = Array.from({ length: rounds }, (_, round) =>
+			(round % 2 === 0 ? [0, 1] : [1, 0]).map((index) => ({ round, index, supplied: args[index] })),
+		).flat();
+		for (const { round, index, supplied } of ordered) {
+			const bundle = path.resolve(supplied);
+			const source = fs.readFileSync(bundle, 'utf8');
+			let executable = source;
+			if (!timing) {
+				const point = /\n  const newKeys = [^\n]+;\n  const newKeysToIdx = /g;
+				assert.equal(
+					[...source.matchAll(point)].length,
+					1,
+					'Expected one production keyed-array capture point',
+				);
+				executable = source.replace(point, (match) =>
+					match.replace(
+						'\n  const newKeysToIdx',
+						'\n  globalThis.__octaneArrayKeys = newKeys;\n  const newKeysToIdx',
+					),
+				);
+			}
+			let result;
+			if (args.includes('--chromium')) {
+				const script = transformSync(executable, {
+					format: 'iife',
+					globalName: 'OCTANE_RUNTIME',
+					target: 'esnext',
+				}).code;
+				const html = path.join(temporary, `run-${index}.html`);
+				fs.writeFileSync(
+					html,
+					'<!doctype html><body><script>' +
+						script.replaceAll('</script', '<\\/script') +
+						'</script><script>' +
+						`try { document.body.textContent = ${JSON.stringify(marker)} + JSON.stringify({ userAgent: navigator.userAgent, ...(${exercise.toString()})(OCTANE_RUNTIME, ${timing}, ${args.includes('--memo-only')}) }); } catch (error) { document.body.textContent = 'ARRAY_PROBE_ERROR=' + error.stack; }` +
+						'</script>',
+				);
+				const flags = [
+					'--no-sandbox',
+					'--no-first-run',
+					'--disable-gpu',
+					'--disable-background-networking',
+					`--user-data-dir=${path.join(temporary, 'profile-' + round + '-' + index)}`,
+				];
+				if (!timing) flags.push('--js-flags=--allow-natives-syntax');
+				result = spawnSync(
+					value('--chromium'),
+					[...flags, '--dump-dom', pathToFileURL(html).href],
+					{ encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 },
+				);
+			} else {
+				const file = path.join(temporary, `runtime-${index}.mjs`);
+				fs.writeFileSync(file, executable);
+				const flags = timing ? [] : ['--allow-natives-syntax'];
+				result = spawnSync(
+					process.execPath,
+					[
+						...flags,
+						fileURLToPath(import.meta.url),
+						'--child',
+						'--bundle',
+						file,
+						...(timing ? ['--timing'] : []),
+						...(args.includes('--memo-only') ? ['--memo-only'] : []),
+					],
+					{ encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 },
+				);
+			}
+			assert.equal(result.status, 0, result.stderr || result.error?.message);
+			const escaped = result.stdout.match(/OCTANE_ARRAYS=(\{[^\n]*\})/);
+			assert(escaped, result.stdout + result.stderr);
+			const report = JSON.parse(
+				escaped[1].replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>'),
+			);
+			runs.push({
+				round,
+				variant: index === 0 ? 'baseline' : 'candidate',
+				bundle,
+				sha256: createHash('sha256').update(source).digest('hex'),
+				...report,
+			});
+		}
+		const report = {
+			mode: timing ? 'untouched-bundle-timing' : 'instrumented-structural-diagnostic',
+			esbuildVersion,
+			runs,
+		};
+		const json = JSON.stringify(report, null, 2) + '\n';
+		if (args.includes('--output')) fs.writeFileSync(path.resolve(value('--output')), json);
+		process.stdout.write(json);
+	} finally {
+		fs.rmSync(temporary, { recursive: true, force: true });
+	}
+}

--- a/benchmarks/runtime-object-shapes/diagnostics.mjs
+++ b/benchmarks/runtime-object-shapes/diagnostics.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { getHeapSnapshot } from 'node:v8';
+
+/** Untimed V8 map groups and shallow record/property-array bytes.
+ * Run Node with --allow-natives-syntax --expose-gc. Records remain unmodified;
+ * closures, nested values, scopes and DOM retained by them are not attributed.
+ */
+export async function inspectRecords(records, families) {
+	const sameMap = new Function('left', 'right', 'return %HaveSameMap(left, right)');
+	const maps = {};
+	for (const [family, names] of Object.entries(families)) {
+		const groups = [];
+		for (const name of names) {
+			const group = groups.find((members) => sameMap(records[name], records[members[0]]));
+			if (group) group.push(name);
+			else groups.push([name]);
+		}
+		maps[family] = groups;
+	}
+	globalThis.__octaneObjectShapeRecords = records;
+	try {
+		globalThis.gc();
+		const chunks = [];
+		for await (const chunk of getHeapSnapshot()) chunks.push(chunk);
+		const snapshot = JSON.parse(Buffer.concat(chunks).toString());
+		const { nodes, edges, strings } = snapshot;
+		const meta = snapshot.snapshot.meta;
+		const width = meta.node_fields.length;
+		const edgeWidth = meta.edge_fields.length;
+		const edgeCount = meta.node_fields.indexOf('edge_count');
+		const size = meta.node_fields.indexOf('self_size');
+		const edgeType = meta.edge_fields.indexOf('type');
+		const edgeName = meta.edge_fields.indexOf('name_or_index');
+		const edgeTarget = meta.edge_fields.indexOf('to_node');
+		const property = meta.edge_types[edgeType].indexOf('property');
+		const internal = meta.edge_types[edgeType].indexOf('internal');
+		const offsets = new Map();
+		let recordNode;
+		for (let node = 0, edge = 0; node < nodes.length; node += width) {
+			offsets.set(node, edge);
+			for (let count = nodes[node + edgeCount]; count > 0; count--, edge += edgeWidth) {
+				if (
+					edges[edge + edgeType] === property &&
+					strings[edges[edge + edgeName]] === '__octaneObjectShapeRecords'
+				)
+					recordNode = edges[edge + edgeTarget];
+			}
+		}
+		assert.notEqual(
+			recordNode,
+			undefined,
+			'Retained hook record directory missing from heap snapshot',
+		);
+		const sizes = {};
+		for (
+			let edge = offsets.get(recordNode), count = nodes[recordNode + edgeCount];
+			count > 0;
+			count--, edge += edgeWidth
+		) {
+			if (edges[edge + edgeType] !== property) continue;
+			const name = strings[edges[edge + edgeName]];
+			if (!(name in records)) continue;
+			const node = edges[edge + edgeTarget];
+			let backingPropertiesBytes = 0;
+			for (
+				let childEdge = offsets.get(node), children = nodes[node + edgeCount];
+				children > 0;
+				children--, childEdge += edgeWidth
+			) {
+				if (
+					edges[childEdge + edgeType] === internal &&
+					strings[edges[childEdge + edgeName]] === 'properties'
+				)
+					backingPropertiesBytes = nodes[edges[childEdge + edgeTarget] + size];
+			}
+			sizes[name] = {
+				fields: Object.keys(records[name]),
+				shallowBytes: nodes[node + size],
+				backingPropertiesBytes,
+				recordAndPropertiesBytes: nodes[node + size] + backingPropertiesBytes,
+			};
+		}
+		assert.equal(Object.keys(sizes).length, Object.keys(records).length);
+		return { maps, records: sizes };
+	} finally {
+		delete globalThis.__octaneObjectShapeRecords;
+	}
+}

--- a/benchmarks/runtime-object-shapes/hooks-timing.mjs
+++ b/benchmarks/runtime-object-shapes/hooks-timing.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Production-runtime controls. Structural interception and heap snapshots live
+// in hooks.mjs and never run during these timing samples.
+const args = process.argv.slice(2);
+if (args[0] !== '--sample') {
+	const outputIndex = args.indexOf('--output');
+	const paths = args.slice(0, outputIndex === -1 ? undefined : outputIndex);
+	if (paths.length < 2)
+		throw new Error(
+			'Usage: node hooks-timing.mjs <baseline.mjs> <candidate.mjs> [alternative.mjs] [--output report.json]',
+		);
+	const reports = Object.fromEntries(paths.map((path) => [resolve(path), []]));
+	for (let round = 0; round < 9; round++) {
+		// Rotate process order so the same design is not always measured first.
+		for (let offset = 0; offset < paths.length; offset++) {
+			const path = resolve(paths[(round + offset) % paths.length]);
+			const sample = spawnSync(
+				process.execPath,
+				[fileURLToPath(import.meta.url), '--sample', path],
+				{ encoding: 'utf8', maxBuffer: 1024 * 1024 },
+			);
+			if (sample.status !== 0) throw new Error(sample.stderr || sample.stdout);
+			const marker = sample.stdout
+				.split('\n')
+				.find((line) => line.startsWith('OCTANE_HOOK_TIMING='));
+			if (!marker) throw new Error('Missing hook timing sample');
+			reports[path].push(JSON.parse(marker.slice('OCTANE_HOOK_TIMING='.length)));
+		}
+	}
+	const json =
+		JSON.stringify(
+			{
+				node: process.version,
+				v8: process.versions.v8,
+				metric:
+					'Microseconds per complete public-root operation, including root/scope/DOM bookkeeping; no isolated property-read throughput claim.',
+				samples: reports,
+			},
+			null,
+			2,
+		) + '\n';
+	if (outputIndex !== -1) await writeFile(resolve(args[outputIndex + 1]), json);
+	process.stdout.write(json);
+} else {
+	const { Window } = await import('happy-dom');
+	const window = new Window({ url: 'http://localhost/' });
+	for (const name of [
+		'window',
+		'document',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'SVGElement',
+		'Comment',
+		'Text',
+		'Event',
+		'MouseEvent',
+		'CustomEvent',
+		'MutationObserver',
+	])
+		globalThis[name] = name === 'window' ? window : window[name];
+	const runtime = await import(pathToFileURL(resolve(args[1])).href);
+	const stateSlot = Symbol('state'),
+		reducerSlot = Symbol('reducer'),
+		memoSlot = Symbol('memo');
+	const reducer = (value, action) => value + action;
+	let latest,
+		renders = 0,
+		sum = 0;
+	function Hooks(props) {
+		const state = props.getters
+			? runtime.__useStateWithGetter(0, stateSlot)
+			: runtime.useState(0, stateSlot);
+		const total = props.getters
+			? runtime.__useReducerWithGetter(reducer, 0, undefined, reducerSlot)
+			: runtime.useReducer(reducer, 0, undefined, reducerSlot);
+		const memo = runtime.useMemo(
+			() => ({ value: state[0] + total[0] }),
+			[state[0], total[0]],
+			memoSlot,
+		);
+		if (props.getters) sum += state[2]() + total[2]();
+		latest = { state, total, memo };
+		renders++;
+		return null;
+	}
+	const result = {};
+	try {
+		for (const getters of [false, true]) {
+			const prefix = getters ? 'getters' : 'ordinary';
+			const mount = (count) => {
+				for (let index = 0; index < count; index++) {
+					const root = runtime.createRoot(document.createElement('div'));
+					runtime.flushSync(() => root.render(Hooks, { getters, tick: index }));
+					root.unmount();
+				}
+			};
+			mount(500);
+			let before = renders,
+				begin = performance.now();
+			mount(1500);
+			result[prefix + 'Mount'] = ((performance.now() - begin) * 1000) / 1500;
+			assert.equal(renders - before, 1500);
+			assert.equal(latest.memo.value, 0);
+			const root = runtime.createRoot(document.createElement('div'));
+			runtime.flushSync(() => root.render(Hooks, { getters, tick: -1 }));
+			const update = (count) => {
+				for (let index = 0; index < count; index++)
+					runtime.flushSync(() => root.render(Hooks, { getters, tick: index }));
+			};
+			update(4000);
+			before = renders;
+			begin = performance.now();
+			update(10000);
+			result[prefix + 'Update'] = ((performance.now() - begin) * 1000) / 10000;
+			assert.equal(renders - before, 10000);
+			assert.equal(latest.memo.value, 0);
+			const transition = (count) => {
+				for (let index = 0; index < count; index++) {
+					runtime.startTransition(() => {
+						latest.state[1](index + 1);
+						latest.total[1](1);
+					});
+					runtime.flushSync(() => {});
+				}
+			};
+			transition(500);
+			const previousTotal = latest.total[0];
+			begin = performance.now();
+			transition(1500);
+			result[prefix + 'Transition'] = ((performance.now() - begin) * 1000) / 1500;
+			assert.equal(latest.state[0], 1500);
+			assert.equal(latest.total[0], previousTotal + 1500);
+			assert.equal(latest.memo.value, 1500 + previousTotal + 1500);
+			root.unmount();
+		}
+		assert.ok(sum > 0);
+		console.log('OCTANE_HOOK_TIMING=' + JSON.stringify(result));
+	} finally {
+		await window.happyDOM.close();
+	}
+}

--- a/benchmarks/runtime-object-shapes/hooks.mjs
+++ b/benchmarks/runtime-object-shapes/hooks.mjs
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { inspectRecords } from './diagnostics.mjs';
+
+// Untimed structural diagnostic. Capture actual runtime records without adding
+// fields to them, then compare V8 maps and heap-snapshot shallow sizes. The
+// property-array size is included separately; closures and retained scope/DOM
+// graphs are deliberately not attributed to an individual hook record.
+const args = process.argv.slice(2);
+const child = args[0] === '--probe';
+if (child) args.shift();
+const bundle = args[0];
+if (!bundle)
+	throw new Error('Usage: node hooks.mjs <runtime.mjs> [--observe] [--output <report.json>]');
+if (!child) {
+	const result = spawnSync(
+		process.execPath,
+		[
+			'--expose-gc',
+			'--allow-natives-syntax',
+			fileURLToPath(import.meta.url),
+			'--probe',
+			resolve(bundle),
+			...(args.includes('--observe') ? ['--observe'] : []),
+		],
+		{ encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+	);
+	if (result.status !== 0) {
+		process.stderr.write(result.stderr);
+		process.stderr.write(result.stdout);
+		throw new Error(`Hook structural probe exited with status ${result.status}`);
+	}
+	const marker = 'OCTANE_HOOK_SHAPES=';
+	const line = result.stdout.split('\n').find((value) => value.startsWith(marker));
+	if (!line) throw new Error('Hook structural probe did not return its report');
+	const report = JSON.parse(line.slice(marker.length));
+	const json = JSON.stringify(report, null, 2) + '\n';
+	const output = args.indexOf('--output');
+	if (output !== -1) await writeFile(resolve(args[output + 1]), json);
+	process.stdout.write(json);
+} else {
+	const { Window } = await import('happy-dom');
+	const window = new Window({ url: 'http://localhost/' });
+	for (const name of [
+		'window',
+		'document',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'SVGElement',
+		'Comment',
+		'Text',
+		'Event',
+		'MouseEvent',
+		'CustomEvent',
+		'MutationObserver',
+	]) {
+		globalThis[name] = name === 'window' ? window : window[name];
+	}
+	const runtime = await import(pathToFileURL(resolve(bundle)).href);
+	const stateSlot = Symbol('benchmark state');
+	const reducerSlot = Symbol('benchmark reducer');
+	const memoSlot = Symbol('benchmark memo');
+	const records = {};
+	const mounted = [];
+	const nativeSet = Map.prototype.set;
+	const reducer = (value, amount) => value + amount;
+	function capture(run, cells) {
+		Map.prototype.set = function (key, value) {
+			if (key === stateSlot && typeof value?.setter === 'function') cells.state = value;
+			if (key === reducerSlot && typeof value?.dispatch === 'function') cells.reducer = value;
+			if (key === memoSlot && value !== null && !Array.isArray(value) && 'deps' in value)
+				cells.memo = value;
+			return nativeSet.call(this, key, value);
+		};
+		try {
+			return run();
+		} finally {
+			Map.prototype.set = nativeSet;
+		}
+	}
+	function Hooks(props) {
+		const state = props.getters
+			? runtime.__useStateWithGetter(0, stateSlot)
+			: runtime.useState(0, stateSlot);
+		const total = props.getters
+			? runtime.__useReducerWithGetter(reducer, 0, undefined, reducerSlot)
+			: runtime.useReducer(reducer, 0, undefined, reducerSlot);
+		if (props.warm) runtime.registerWarmPlan(() => {}, props);
+		const create = () => ({ sum: state[0] + total[0] });
+		const memo = props.native
+			? runtime.nativePuMemo(create, [state[0], total[0]], memoSlot)
+			: runtime.useMemo(create, [state[0], total[0]], memoSlot);
+		props.bind({ state, total, memo });
+		return runtime.createElement('output', null, String(memo.sum));
+	}
+	function mount(options = {}) {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = runtime.createRoot(container);
+		const cells = {};
+		let controls;
+		const props = {
+			...options,
+			bind: (value) => {
+				controls = value;
+			},
+		};
+		capture(() => runtime.flushSync(() => root.render(Hooks, props)), cells);
+		assert.equal(container.textContent, '0');
+		const value = {
+			root,
+			container,
+			cells,
+			props,
+			get controls() {
+				return controls;
+			},
+		};
+		mounted.push(value);
+		return value;
+	}
+	try {
+		// Let constructor slack tracking settle before measuring any actual cells.
+		for (let index = 0; index < 16; index++) {
+			const warmup = mount();
+			warmup.root.unmount();
+			warmup.container.remove();
+			mounted.pop();
+		}
+		const idle = mount();
+		records.stateIdle = idle.cells.state;
+		records.reducerIdle = idle.cells.reducer;
+		records.memoOrdinary = idle.cells.memo;
+		const getters = mount({ getters: true });
+		records.stateGetter = getters.cells.state;
+		records.reducerGetter = getters.cells.reducer;
+		assert.equal(getters.controls.state[2](), 0);
+		assert.equal(getters.controls.total[2](), 0);
+		const queued = mount();
+		runtime.flushSync(() => {
+			queued.controls.state[1]((value) => value + 1);
+			queued.controls.state[1]((value) => value + 2);
+			queued.controls.total[1](4);
+		});
+		assert.equal(queued.container.textContent, '7');
+		records.stateAfterQueue = queued.cells.state;
+		records.reducerAfterQueue = queued.cells.reducer;
+		const transition = mount({ getters: true });
+		runtime.startTransition(() => {
+			transition.controls.state[1](2);
+			transition.controls.total[1](3);
+		});
+		runtime.flushSync(() => {});
+		assert.equal(transition.container.textContent, '5');
+		assert.equal(transition.controls.state[2](), 2);
+		assert.equal(transition.controls.total[2](), 3);
+		records.stateAfterTransition = transition.cells.state;
+		records.reducerAfterTransition = transition.cells.reducer;
+		if (transition.cells.state.transition !== undefined)
+			records.coldStateTransition = transition.cells.state.transition;
+		if (transition.cells.reducer.transition !== undefined)
+			records.coldReducerTransition = transition.cells.reducer.transition;
+		const warm = mount({ warm: true });
+		records.memoWarmRecorded = warm.cells.memo;
+		const native = mount({ native: true });
+		records.memoNative = native.cells.memo;
+		for (const [name, cell] of Object.entries(records))
+			assert.ok(cell, `Missing hook record ${name}`);
+		const families = {
+			state: Object.keys(records).filter((name) => name.startsWith('state')),
+			reducer: Object.keys(records).filter((name) => name.startsWith('reducer')),
+			memo: Object.keys(records).filter((name) => name.startsWith('memo')),
+		};
+		const coldNames = Object.keys(records).filter((name) => name.startsWith('cold'));
+		if (coldNames.length !== 0) families.cold = coldNames;
+		const inspection = await inspectRecords(records, families);
+		if (!args.includes('--observe')) {
+			for (const [family, maps] of Object.entries(inspection.maps))
+				assert.equal(maps.length, 1, `${family} hook records should share one map`);
+		}
+		console.log(
+			'OCTANE_HOOK_SHAPES=' +
+				JSON.stringify({
+					node: process.version,
+					v8: process.versions.v8,
+					runtime: resolve(bundle),
+					metric:
+						'Untimed V8 maps and heap-snapshot shallow record/property-array bytes; excludes retained closures, scopes, and DOM.',
+					controls: {
+						queuedText: queued.container.textContent,
+						transitionText: transition.container.textContent,
+						getters: [transition.controls.state[2](), transition.controls.total[2]()],
+					},
+					...inspection,
+				}),
+		);
+	} finally {
+		Map.prototype.set = nativeSet;
+		for (const { root, container } of mounted) {
+			root.unmount();
+			container.remove();
+		}
+		await window.happyDOM.close();
+	}
+}

--- a/benchmarks/runtime-object-shapes/run.mjs
+++ b/benchmarks/runtime-object-shapes/run.mjs
@@ -1,0 +1,208 @@
+// Untimed production-runtime shape diagnostics. Private records are observed
+// only here; public DOM, identity, ref and cleanup outcomes remain the controls.
+process.env.NODE_ENV = 'production';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { Window } from 'happy-dom';
+import { inspectRecords } from './diagnostics.mjs';
+
+const runtimePath = process.argv[2];
+const observe = process.argv.includes('--observe');
+if (!runtimePath) throw new Error('Pass an absolute bundled production runtime path.');
+if (
+	!process.execArgv.includes('--allow-natives-syntax') ||
+	!process.execArgv.includes('--expose-gc')
+) {
+	const child = spawnSync(
+		process.execPath,
+		['--allow-natives-syntax', '--expose-gc', import.meta.filename, ...process.argv.slice(2)],
+		{
+			stdio: 'inherit',
+			env: process.env,
+		},
+	);
+	process.exit(child.status ?? 1);
+}
+const window = new Window({ url: 'http://localhost/' });
+for (const name of [
+	'document',
+	'Node',
+	'Element',
+	'HTMLElement',
+	'HTMLInputElement',
+	'HTMLTextAreaElement',
+	'Event',
+	'MouseEvent',
+	'MutationObserver',
+	'SVGElement',
+]) {
+	Object.defineProperty(globalThis, name, { value: window[name], configurable: true });
+}
+Object.defineProperty(globalThis, 'window', { value: window, configurable: true });
+const runtime = await import(pathToFileURL(path.resolve(runtimePath)).href);
+const {
+	createRoot,
+	createElement,
+	flushSync,
+	forBlock,
+	keyedForBlock,
+	mapSlot,
+	hostComponent,
+	scheduleRenderCleanup,
+} = runtime;
+const sameMap = new Function('a', 'b', 'return %HaveSameMap(a, b);');
+const fast = new Function('a', 'return %HasFastProperties(a);');
+const records = { hosts: [], lists: [], captures: [] };
+const outcomes = [];
+const rows = Array.from({ length: 8 }, (_, id) => ({ id, label: `row:${id}` }));
+const key = (row) => row.id;
+function rowBody(row, scope) {
+	hostComponent(
+		scope,
+		0,
+		'li',
+		{ 'data-row': row.id },
+		createElement('input', { defaultValue: row.label }),
+	);
+}
+
+for (let iteration = 0; iteration < 12; iteration++) {
+	for (const mode of ['ordinary', 'selection', 'mapped']) {
+		const active = mode === 'selection';
+		const container = document.createElement('div');
+		document.body.append(container);
+		const refs = [];
+		let cleaned = 0;
+		let observed;
+		const refA = (node) => {
+			if (node !== null) {
+				refs.push('a');
+				return () => refs.push('-a');
+			}
+		};
+		const refB = (node) => {
+			if (node !== null) {
+				refs.push('b');
+				return () => refs.push('-b');
+			}
+		};
+		function Scene(props, scope) {
+			const host = hostComponent(
+				scope,
+				0,
+				'section',
+				{ ref: props.version === 0 ? refA : refB, 'data-version': props.version },
+				active ? () => createElement('span', null, `child:${props.version}`) : null,
+			);
+			const list = hostComponent(scope, 1, 'ul', null);
+			if (mode === 'mapped') {
+				mapSlot(
+					scope,
+					2,
+					list,
+					props.rows,
+					Array.prototype.map,
+					true,
+					(row) => createElement('li', { key: row.id }, row.label),
+					key,
+					rowBody,
+					0,
+					[props.version],
+				);
+			} else if (active) {
+				keyedForBlock(scope, 2, list, props.rows, key, rowBody, 0, [props.version]);
+				scheduleRenderCleanup(
+					(callback) => callback(),
+					null,
+					() => cleaned++,
+				);
+			} else forBlock(scope, 2, list, props.rows, key, rowBody);
+			observed = {
+				host: scope.slots[0],
+				list: mode === 'mapped' ? scope.slots[2].forSlot : scope.slots[2],
+				capture: scope.block.idState.renderOwner.transaction.capture,
+			};
+			assert.equal(host.parentNode, container);
+		}
+		const root = createRoot(container);
+		let verified = false;
+		try {
+			root.render(Scene, { rows, version: 0 });
+			flushSync(() => {});
+			const section = container.querySelector('section');
+			const inputs = [...container.querySelectorAll('input')];
+			assert.equal(inputs.length, rows.length);
+			for (const input of inputs) input.value = `typed:${input.value}`;
+			const first = observed;
+			flushSync(() => root.render(Scene, { rows: rows.toReversed(), version: 1 }));
+			assert.equal(container.querySelector('section'), section);
+			assert.equal(section.getAttribute('data-version'), '1');
+			if (active) assert.equal(section.textContent, 'child:1');
+			else assert.equal(section.textContent, '');
+			const reordered = [...container.querySelectorAll('input')];
+			for (let i = 0; i < inputs.length; i++) {
+				assert.equal(reordered[i], inputs[inputs.length - i - 1]);
+				assert.equal(reordered[i].value, `typed:row:${inputs.length - i - 1}`);
+			}
+			assert.deepEqual(refs, ['a', '-a', 'b']);
+			assert.equal(cleaned, active ? 2 : 0);
+			// Sample after warmup; each value is an actual record retained by its
+			// rendered root, not a replica literal or a patched runtime allocation.
+			if (iteration >= 4) {
+				records.hosts.push(observed.host);
+				records.lists.push(observed.list);
+				records.captures.push(first.capture, observed.capture);
+			}
+			outcomes.push([mode, section.textContent, reordered.map((input) => input.value), cleaned]);
+			verified = true;
+		} finally {
+			root.unmount();
+			assert.equal(container.childNodes.length, 0);
+			if (verified) assert.deepEqual(refs, ['a', '-a', 'b', '-b']);
+			container.remove();
+		}
+	}
+}
+const diagnostics = {};
+const heapRecords = {};
+const heapFamilies = {};
+for (const [name, values] of Object.entries(records)) {
+	const groups = [];
+	for (const value of values) {
+		let group = groups.find((item) => sameMap(item.example, value));
+		if (!group) {
+			group = { example: value, count: 0 };
+			groups.push(group);
+		}
+		group.count++;
+	}
+	diagnostics[name] = {
+		records: values.length,
+		fastProperties: values.filter(fast).length,
+		maps: groups.map(({ example, count }) => ({ count, fields: Object.keys(example) })),
+	};
+	if (!observe)
+		assert.equal(groups.length, 1, `${name} must retain one map across the exercised modes`);
+	heapFamilies[name] = groups.map(({ example }, index) => {
+		const key = `${name}:${index}`;
+		heapRecords[key] = example;
+		return key;
+	});
+}
+const payload = {
+	suite: 'runtime-object-shapes',
+	node: process.version,
+	v8: process.versions.v8,
+	runtimeSha: createHash('sha256').update(fs.readFileSync(runtimePath)).digest('hex'),
+	semanticSha: createHash('sha256').update(JSON.stringify(outcomes)).digest('hex'),
+	diagnostics,
+	heap: await inspectRecords(heapRecords, heapFamilies),
+};
+const output = process.argv[3]?.startsWith('--') ? undefined : process.argv[3];
+if (output) fs.writeFileSync(output, JSON.stringify(payload, null, 2) + '\n');
+console.log(JSON.stringify(payload, null, 2));
+await window.happyDOM.close();

--- a/docs/decallback-memo.md
+++ b/docs/decallback-memo.md
@@ -12,9 +12,9 @@ bisection. The public hook API and explicit dependency semantics do not change.
 ## Tier A — authored and auto-generated useMemo/useCallback
 
 Memo calls in proven render-scope bodies (the `localHookSlots` numeric-slot
-proof) become inline regions over a per-body flat cell array stored as a non-index property
-on `__s.slots` (`_k$N` — same trick as autoMemo's `_m$N`; named properties
-leave the slots array's packed elements kind alone). Layout per site:
+proof) become inline regions over a per-body flat cell array held in the scope's lazy
+compiler memo record. Its fixed `auto` and `hooks` fields hold this body's
+cells independently of the dense DOM/control slots. Layout per site:
 `[initFlag, dep0..depK-1, value]`; the array is pre-sized and `.fill`ed so
 conditional sites can't punch elements-kind holes. Expression bodies and
 single-return factories also lower in nested expressions, destructuring and

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1138,6 +1138,7 @@ function importSpecifierPair(entry) {
 // compiled components and authored runtime imports retain their stable shape.
 // New compiler-only helpers use the private, renderer-specific ABI instead.
 const HOOK_MEMO_RUNTIME_HELPERS = new Set([
+	'compilerMemoRegion',
 	'hookMemoCreate',
 	'hookMemoEqual',
 	'hookMemoPublish',
@@ -9192,15 +9193,14 @@ function compileInternal(
 		currentAutoMemoCacheName: null, // collision-free local bound to the body's cache array
 		currentAutoMemoCommittedName: null, // committed cache snapshot (copy-on-write source)
 		currentAutoCalculatedRenderableRefs: null, // proven non-escaping calculation holes, inherited by lexical child bodies
-		nextAutoMemoCacheId: 0, // unique non-index slots property per compiled render function
+		nextAutoMemoCacheId: 0, // per-compiled-body id in the scope's lazy memo regions
 		inlineHookMemo: inlineHookMemoEnabled, // de-callbacked useMemo/useCallback + pu creations
 		hasSlotMemoCandidates: false, // skip the final AST pass when no path-aware site survived
 		_puInlineLowering: false, // true only while a body pipeline ends in inlineHookMemoPass
 		currentHookMemoOffset: 0, // flat hook-memo cell offset for the body being emitted
-		currentHookMemoCacheProperty: null, // per-body `_k$N` slots property for the cell array
+		currentHookMemoBodyId: null, // non-null while compiling a body with inline hook cells
 		currentHookMemoNames: null, // lazily allocated flat-cache and expression-temp locals
 		currentHookMemoOwnerSafe: false, // own scope permits compiler-introduced bindings
-		nextHookMemoCacheId: 0, // unique non-index slots property per compiled render function
 		currentInvariantLocals: null, // Set<string> of component-lifetime-stable local values
 		currentEventInvariantLocals: null, // Set<string> safe to retain in native event slots
 		currentDirtyBindingStates: null, // proven primitive state identities inherited by JSX arms
@@ -13997,16 +13997,16 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 		ctx,
 		compactStateOwnerCache ? `_mp${ctx.nextAutoMemoCacheId}` : '__memoCommitted',
 	);
-	const autoMemoCacheProperty = `_m$${ctx.nextAutoMemoCacheId++}`;
+	const memoRegionId = ctx.nextAutoMemoCacheId++;
 	ctx.currentAutoMemoOffset = 0;
 	ctx.currentAutoMemoCacheName = autoMemoCacheName;
 	ctx.currentAutoMemoCommittedName = autoMemoCommittedName;
 	const prevHookMemoOffset = ctx.currentHookMemoOffset;
-	const prevHookMemoCacheProperty = ctx.currentHookMemoCacheProperty;
+	const prevHookMemoBodyId = ctx.currentHookMemoBodyId;
 	const prevHookMemoNames = ctx.currentHookMemoNames;
 	const prevHookMemoOwnerSafe = ctx.currentHookMemoOwnerSafe;
 	ctx.currentHookMemoOffset = 0;
-	ctx.currentHookMemoCacheProperty = `_k$${ctx.nextHookMemoCacheId++}`;
+	ctx.currentHookMemoBodyId = memoRegionId;
 	ctx.currentHookMemoNames = null;
 
 	// Body splitting. Two shapes to handle:
@@ -14351,10 +14351,28 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 
 	const bodyStatements = [];
 	const autoMemoSize = ctx.currentAutoMemoOffset;
-	const slotsMember = (prop) => b.member(b.member(b.id('__s'), 'slots'), prop);
+	const hookMemoSize = ctx.currentHookMemoOffset;
+	const memoRegionName =
+		autoMemoSize > 0 || hookMemoSize > 0 ? allocCompilerName(ctx, '__memoRegion') : null;
+	const memoCell = (name) => b.member(b.id(memoRegionName), name);
+	if (memoRegionName !== null) {
+		bodyStatements.push(
+			inheritOriginLoc(
+				b.const(
+					memoRegionName,
+					b.call(
+						requireRuntimeForContext(ctx, 'compilerMemoRegion'),
+						b.id('__s'),
+						b.literal(memoRegionId),
+					),
+				),
+				node,
+			),
+		);
+	}
 	if (autoMemoSize > 0) {
 		bodyStatements.push(
-			inheritOriginLoc(b.const(autoMemoCommittedName, slotsMember(autoMemoCacheProperty)), node),
+			inheritOriginLoc(b.const(autoMemoCommittedName, memoCell('auto')), node),
 			inheritOriginLoc(
 				b.let(
 					autoMemoCacheName,
@@ -14372,18 +14390,17 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	// suspension. Miss-side runtime publication also records the previous/next
 	// site during a held transition. Allocate through the runtime so authored
 	// bindings named Array or undefined cannot change the cache representation.
-	const hookMemoSize = ctx.currentHookMemoOffset;
 	if (hookMemoSize > 0) {
 		const hkName = hookMemoNames(ctx).cache;
 		bodyStatements.push(
-			inheritOriginLoc(b.let(hkName, slotsMember(ctx.currentHookMemoCacheProperty)), node),
+			inheritOriginLoc(b.let(hkName, memoCell('hooks')), node),
 			inheritOriginLoc(
 				b.if(
 					b.binary('===', b.id(hkName), b.void0),
 					b.stmt(
 						b.assignment(
 							'=',
-							slotsMember(ctx.currentHookMemoCacheProperty),
+							memoCell('hooks'),
 							b.assignment(
 								'=',
 								b.id(hkName),
@@ -14520,7 +14537,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			inheritOriginLoc(
 				b.if(
 					b.binary('!==', b.id(autoMemoCacheName), b.id(autoMemoCommittedName)),
-					b.stmt(b.assignment('=', slotsMember(autoMemoCacheProperty), b.id(autoMemoCacheName))),
+					b.stmt(b.assignment('=', memoCell('auto'), b.id(autoMemoCacheName))),
 					null,
 				),
 				node,
@@ -14549,7 +14566,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	ctx.currentAutoMemoCacheName = prevAutoMemoCacheName;
 	ctx.currentAutoMemoCommittedName = prevAutoMemoCommittedName;
 	ctx.currentHookMemoOffset = prevHookMemoOffset;
-	ctx.currentHookMemoCacheProperty = prevHookMemoCacheProperty;
+	ctx.currentHookMemoBodyId = prevHookMemoBodyId;
 	ctx.currentHookMemoNames = prevHookMemoNames;
 	ctx.currentHookMemoOwnerSafe = prevHookMemoOwnerSafe;
 	ctx.currentMapTemps = prevMapTemps;
@@ -16992,10 +17009,10 @@ function markHookSlotLocality(root, enabled) {
 //
 // De-callbacks useMemo/useCallback in proven render-scope bodies: instead of allocating an
 // arrow + a deps array every render and paying a hooks-map lookup, each site
-// becomes an inline region over a per-body flat cell array stored as a
-// non-index property on `__s.slots` (`_k$N`, the same trick as autoMemo's
-// `_m$N` — named properties don't disturb the slots array's packed elements
-// kind). Layout per site: [initFlag, dep0..depK-1, value].
+// becomes an inline region over a per-body flat cell array in the scope's
+// lazy compilerMemo record. The record is independent of the dense DOM slots
+// array; its fixed auto and hooks fields hold the two cell arrays respectively.
+// Layout per hook site: [initFlag, dep0..depK-1, value].
 //
 // Unlike the autoMemo region cache this one publishes IMMEDIATELY: the runtime
 // hooks map these regions replace
@@ -17469,7 +17486,7 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 			!canLowerClientMemo(call, name) ||
 			localSlotMarks.get(call) !== true ||
 			!ctx.currentHookMemoOwnerSafe ||
-			ctx.currentHookMemoCacheProperty === null
+			ctx.currentHookMemoBodyId === null
 		) {
 			return null;
 		}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -343,6 +343,8 @@ export interface Scope {
 	// (vs. the old `scope[`_for$N`]` dynamic string keys) keeps the Scope object shape
 	// MONOMORPHIC: bindings no longer mutate the scope's hidden class per component.
 	slots: any[];
+	/** Lazy compiler-owned memo regions, independent of the dense DOM/control slots. */
+	compilerMemo: CompilerMemoRegion | null;
 	/**
 	 * DEV ONLY (set by `dev`-compiled bodies; `undefined` in production): a structured
 	 * hydration source-location table — `{ slotIndex: [line, column] }` — plus `locFile`,
@@ -353,6 +355,17 @@ export interface Scope {
 	locs?: Record<number, [number, number]>;
 	locFile?: string;
 }
+
+// A compiled body normally owns the only region in its Scope. Context Providers
+// and loaded/lazy bodies can run a second body in that same Scope, so their
+// per-body caches live in a lazily allocated overflow Map instead of aliasing.
+// The fixed record keeps all four fields in-object with one stable V8 map.
+type CompilerMemoRegion = {
+	bodyId: number;
+	auto: any[] | undefined;
+	hooks: any[] | undefined;
+	overflow: Map<number, CompilerMemoRegion> | null;
+};
 
 interface ChildScope {
 	// withScope uses Symbol per call-site; componentSlotLite uses its numeric slot
@@ -4261,7 +4274,7 @@ function attachLiveFragmentRef(instance: FragmentInstance): void {
 // single-threaded, so every effect enqueued while the buffer is set belongs to the WIP.
 interface OffscreenCapture {
 	/** Root journals already record render validity without a second subtree set. */
-	rootTransaction?: boolean;
+	rootTransaction: boolean;
 	/** Executed bodies whose output/commit work is reusable only if this capture survives. */
 	renderRoot: Block | null;
 	renderedBlocks: Set<Block> | null;
@@ -4269,16 +4282,16 @@ interface OffscreenCapture {
 	events: PendingEffectEvent[];
 	eventActions: EffectEventCommitAction[];
 	refs: RefAttach[];
-	detaches?: any[];
+	detaches: any[] | undefined;
 	// uSES store-syncs enqueued during this off-screen render (see storeSyncQueue).
 	// Spliced into the live queue on commit, dropped on dispose — a WIP that never
 	// lands must not mutate a committed inst (its inst is fresh anyway, per the
 	// fresh-block render, so dropping is both correct and cheap).
 	stores: StoreInst<any>[];
 	/** Suspense visibility changes become recent only when this capture commits. */
-	suspenseCommits?: Set<TrySlot>;
+	suspenseCommits: Set<TrySlot> | undefined;
 	/** Speculative renderer transactions are released only after commit or discard. */
-	renderCleanups?: Array<(discarded: boolean) => void>;
+	renderCleanups: Array<(discarded: boolean) => void> | undefined;
 }
 let WIP_CAPTURE: OffscreenCapture | null = null;
 // Ordinary roots also capture commit work. Keep their generic publication path
@@ -4309,13 +4322,17 @@ export function scheduleRenderCleanup(
 
 function createOffscreenCapture(): OffscreenCapture {
 	return {
+		rootTransaction: false,
 		renderRoot: null,
 		renderedBlocks: null,
 		effects: [[], [], []],
 		events: [],
 		eventActions: [],
 		refs: [],
+		detaches: undefined,
 		stores: [],
+		suspenseCommits: undefined,
+		renderCleanups: undefined,
 	};
 }
 
@@ -6765,6 +6782,7 @@ class BlockImpl {
 	// Per-scope dense slot array (binding bag + control-flow/component/child slots),
 	// indexed by compile-time slot index. Keeps the scope shape monomorphic.
 	declare slots: any[];
+	declare compilerMemo: CompilerMemoRegion | null;
 	// For-block item bookkeeping.
 	declare forSlot: ForSlot | null;
 	declare prevSibling: Block | null;
@@ -6850,6 +6868,7 @@ class BlockImpl {
 		this.deoptNode = null;
 		this.deoptRefs = false;
 		this.slots = [];
+		this.compilerMemo = null;
 		this.forSlot = null;
 		this.prevSibling = null;
 		this.nextSibling = null;
@@ -6900,6 +6919,7 @@ class ScopeImpl {
 	// Per-scope dense slot array (binding bag + control-flow/component/child slots),
 	// indexed by compile-time slot index. Keeps the scope shape monomorphic.
 	declare slots: any[];
+	declare compilerMemo: CompilerMemoRegion | null;
 
 	constructor(parent: Scope, block: Block) {
 		this.block = block;
@@ -6916,6 +6936,7 @@ class ScopeImpl {
 		this.$$ctxCacheOwner = null;
 		this.mounted = false;
 		this.slots = [];
+		this.compilerMemo = null;
 	}
 }
 
@@ -8263,15 +8284,15 @@ interface StateSlot<T> {
 	value: T;
 	setter: (next: T | ((prev: T) => T)) => void;
 	/** Queued functional work is evaluated in the owner's next render. */
-	updates?: Array<T | ((previous: T) => T)>;
+	updates: Array<T | ((previous: T) => T)> | undefined;
 	/** Promoted transition work folds with the inputs of the rendering owner. */
-	renderTransition?: TransitionActionUpdate<T>;
+	renderTransition: TransitionActionUpdate<T> | undefined;
 	/** An urgent ancestor reads queued urgent operations without consuming the transition. */
-	urgentTransition?: boolean;
+	urgentTransition: boolean | undefined;
 	/** Allocated only for compiler-selected third-tuple consumers. */
-	getter?: () => T;
-	pendingActionBatch?: TransitionActionBatch;
-	pendingActionValue?: T;
+	getter: (() => T) | undefined;
+	pendingActionBatch: TransitionActionBatch | undefined;
+	pendingActionValue: T | undefined;
 }
 
 type StateSetter<T> = (next: T | ((prev: T) => T)) => void;
@@ -8387,6 +8408,12 @@ export function useState<T>(initial?: T | (() => T), slot?: HookSlot): StateTupl
 					__profileSchedule(block, 'state', slot);
 				scheduleRender(block);
 			},
+			updates: undefined,
+			renderTransition: undefined,
+			urgentTransition: undefined,
+			getter: undefined,
+			pendingActionBatch: undefined,
+			pendingActionValue: undefined,
 		};
 		ensureHooks(scope).set(slot, s);
 	}
@@ -8897,14 +8924,14 @@ interface ReducerSlot<S, A> {
 	dispatch: (action: A) => void;
 	reducer: (state: S, action: A) => S;
 	/** Render-phase actions are reduced by the reducer from the replaying render. */
-	renderPhaseActions?: A[];
+	renderPhaseActions: A[] | undefined;
 	/** A promoted Action is reduced with this render's reducer before publication. */
-	renderTransition?: TransitionActionUpdate<S>;
-	urgentTransition?: boolean;
+	renderTransition: TransitionActionUpdate<S> | undefined;
+	urgentTransition: boolean | undefined;
 	/** Allocated only for compiler-selected third-tuple consumers. */
-	getter?: () => S;
-	pendingActionBatch?: TransitionActionBatch;
-	pendingActionValue?: S;
+	getter: (() => S) | undefined;
+	pendingActionBatch: TransitionActionBatch | undefined;
+	pendingActionValue: S | undefined;
 }
 
 type ReducerTuple<S, A> = [S, (action: A) => void, () => S];
@@ -8995,6 +9022,12 @@ export function useReducer<S, A, I = S>(
 					__profileSchedule(block, 'reducer', slot);
 				scheduleRender(block);
 			},
+			renderPhaseActions: undefined,
+			renderTransition: undefined,
+			urgentTransition: undefined,
+			getter: undefined,
+			pendingActionBatch: undefined,
+			pendingActionValue: undefined,
 		};
 		ensureHooks(scope).set(slot, s);
 	} else {
@@ -9290,11 +9323,11 @@ export function useInsertionEffect(fn: EffectFn, deps?: any[] | null, slot?: Hoo
 interface MemoHookEntry<T = any> {
 	deps: any[] | undefined;
 	value: T;
-	warmEpisode?: number;
+	warmEpisode: number | undefined;
 	/** A consumed warm occurrence can return only when this scope is discarded. */
-	warmRecord?: WarmEntry;
-	/** Present only on compiler-owned native-read creation caches. */
-	nativeWitness?: NativeReadWitness | null;
+	warmRecord: WarmEntry | undefined;
+	/** Defined only on compiler-owned native-read creation caches. */
+	nativeWitness: NativeReadWitness | null | undefined;
 }
 
 function memoEntryHit<T>(slot: HookSlot, entry: MemoHookEntry<T>): MemoHookEntry<T> {
@@ -9314,6 +9347,8 @@ function adoptMemoEntry<T>(scope: Scope, slot: HookSlot, deps: any[]): MemoHookE
 		deps,
 		value: adopted.value as T,
 		warmEpisode: CURRENT_WARM_EPISODE,
+		warmRecord: undefined,
+		nativeWitness: undefined,
 	};
 	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalMemoEntry(scope, slot, entry);
 	ensureHooks(scope).set(slot, entry);
@@ -9346,8 +9381,13 @@ function publishMemoEntry<T>(
 	value: T,
 	nativeWitness?: NativeReadWitness | null,
 ): T {
-	const entry: MemoHookEntry<T> = { deps, value };
-	if (nativeWitness !== undefined) entry.nativeWitness = nativeWitness;
+	const entry: MemoHookEntry<T> = {
+		deps,
+		value,
+		warmEpisode: undefined,
+		warmRecord: undefined,
+		nativeWitness,
+	};
 	// The attempt records the replacement both ways: the cue re-render must
 	// dep-hit the old entry (never re-create old-version requests), and the
 	// promoted render must dep-hit this one (never create twice).
@@ -9415,8 +9455,35 @@ export function useCallback<F extends (...args: any[]) => any>(
 /** Compiler-owned intrinsics cannot be shadowed by bindings in an authored body. */
 export const hookMemoEqual = Object.is;
 
+/** @internal The usual compiled body takes the first-region fast path. */
+export function compilerMemoRegion(scope: Scope, bodyId: number): CompilerMemoRegion {
+	const region = scope.compilerMemo;
+	if (region !== null && region.bodyId === bodyId) return region;
+	return createCompilerMemoRegion(scope, bodyId, region);
+}
+
+function createCompilerMemoRegion(
+	scope: Scope,
+	bodyId: number,
+	first: CompilerMemoRegion | null,
+): CompilerMemoRegion {
+	if (first === null)
+		return (scope.compilerMemo = { bodyId, auto: undefined, hooks: undefined, overflow: null });
+	let overflow = first.overflow;
+	if (overflow === null) first.overflow = overflow = new Map();
+	let region = overflow.get(bodyId);
+	if (region === undefined) {
+		region = { bodyId, auto: undefined, hooks: undefined, overflow: null };
+		overflow.set(bodyId, region);
+	}
+	return region;
+}
+
 export function hookMemoCreate(size: number): any[] {
-	return new Array(size).fill(undefined);
+	// Validity cells test for true; invariant callbacks use a nullish check.
+	// A null fill also avoids undefined-double storage becoming holey when the
+	// first published value requires object elements in newer V8 versions.
+	return new Array(size).fill(null);
 }
 
 /** Compiler ABI: publish a successful inline memo computation immediately.
@@ -10255,6 +10322,7 @@ function resetHmrBlock(block: Block): void {
 			block._slots = null;
 			block.refFields = null;
 			block.slots = [];
+			block.compilerMemo = null;
 			block.deoptNode = null;
 		});
 
@@ -10312,6 +10380,7 @@ function resetScopeChildren(scope: Scope): void {
 		scope.effectSlots = null;
 		scope.hooks = null;
 		scope.slots = [];
+		scope.compilerMemo = null;
 		// The compiled ref manifest describes the OUTGOING body's binding bag. A compiled body
 		// re-stamps its own on mount, but the descriptor dialect never does — it would leave the
 		// old manifest pointed at a `childSlot` record, which `detachSubtreeRefs` would then read
@@ -13137,6 +13206,7 @@ function adoptNativeMemoEntry(scope: Scope, slot: HookSlot, deps: any[]): MemoHo
 		deps,
 		value: adopted.value,
 		warmEpisode: CURRENT_WARM_EPISODE,
+		warmRecord: undefined,
 		nativeWitness: adopted.nativeWitness,
 	};
 	if (ACTIVE_TRANSITION_ATTEMPT !== null) journalMemoEntry(scope, slot, entry);
@@ -13715,7 +13785,7 @@ interface LazyTemplateRecord {
 	html: string;
 	ns: 0 | 1 | 2 | 3;
 	frag: number;
-	parsed: Array<Element | undefined>;
+	parsed: Array<Element | null>;
 	/**
 	 * Lazily computed adoption-root descriptor for PROD hydration's parse-free
 	 * root check (see HydrationCapability.cloneLazy): 0 = not computed yet, a
@@ -13769,7 +13839,7 @@ export function template(html: string, ns: number = 0, frag: number = 0): Elemen
 			html,
 			ns: ns === 1 ? 1 : ns === 2 ? 2 : ns === 3 ? 3 : 0,
 			frag,
-			parsed: [],
+			parsed: [null, null, null],
 			root: 0,
 		} satisfies LazyTemplateRecord,
 	} as unknown as Element;
@@ -13844,7 +13914,7 @@ function resolveLazyTemplate(lazy: LazyTemplateRecord): Element {
 		ns = lazy.ns;
 	}
 	let parsed = lazy.parsed[ns];
-	if (parsed === undefined) {
+	if (parsed === null) {
 		parsed = parseTemplate(lazy.html, ns, lazy.frag);
 		lazy.parsed[ns] = parsed;
 	}
@@ -23457,13 +23527,13 @@ interface HostComponentSlot {
 	ref: any;
 	// The props applied last render — diffed against the next render so props/events that
 	// DISAPPEARED get removed (not left stale on the reused element).
-	props?: any;
+	props: any;
 	// Stable delegating children body + its current target (see hostComponent).
-	body?: ComponentBody;
-	latest?: ComponentBody | null;
+	body: ComponentBody | undefined;
+	latest: ComponentBody | null | undefined;
 	// Dedicated sub-scope holding the children's childSlot (slot 0), so the children
 	// reconcile/unmount via the Block tree without stamping a derived key on `scope`.
-	childScope?: Scope;
+	childScope: Scope | undefined;
 }
 
 // Render a host element (`<tag>`) that WRAPS a children render-body, from runtime
@@ -23491,7 +23561,15 @@ export function hostComponent(
 		const el = document.createElement(tag);
 		// The children childSlot exclusively OWNS `el`'s content (owns-parent
 		// mode) — no `<!---->` insertion anchor needed (marker-elision M2).
-		state = { el, anchor: null, ref: undefined };
+		state = {
+			el,
+			anchor: null,
+			ref: undefined,
+			props: undefined,
+			body: undefined,
+			latest: undefined,
+			childScope: undefined,
+		};
 		scope.slots[slot] = state;
 		// Children render into a dedicated sub-scope (registered on `scope.children` so
 		// unmountScope walks into it), keeping the children's slot off `scope` itself.
@@ -25313,6 +25391,8 @@ function renderPreparedChildList(
 			env: undefined,
 			adopt: null,
 			plainDeopt: false,
+			mappedNative: undefined,
+			selectionItems: undefined,
 		};
 		if (upgradeArmed) {
 			state.forSlot.adopt = buildDeoptAdoptQueue(upgradeChildren, state.start, state.end!);
@@ -32745,9 +32825,10 @@ interface ForSlot {
 	// focus, input state survive — React parity) instead of rebuilding.
 	// Consumed and nulled within the same render.
 	adopt: Array<{ key: any; node: Node }> | null;
-	// Present only on a childSlot owned by the compiler's guarded map ABI.
+	// Set only on a childSlot owned by the compiler's guarded map ABI.
 	// Keeps descriptor↔compiled adoption off every ordinary descriptor list.
-	mappedNative?: boolean;
+	// Undefined means the arm has not been selected; false is a selected fallback.
+	mappedNative: boolean | undefined;
 	// True when this de-opt list's items render through the plain `deoptItemBody`
 	// — no compiled map body, no mapped fallback wrapper. `mountItem` needs the
 	// fact but must NOT name `deoptItemBody` to get it: a live identity
@@ -32760,9 +32841,9 @@ interface ForSlot {
 	// one hidden class; only childSlot ever stamps or reads it, because only
 	// childSlot passes mountItem the de-opt sentinel.
 	plainDeopt: boolean;
-	// Present only when the compiler proved a keyed equality selection. Identity
+	// Set only when the compiler proved a keyed equality selection. Identity
 	// gates the two-row update without retaining extra state on ordinary lists.
-	selectionItems?: ArrayLike<any>;
+	selectionItems: ArrayLike<any> | undefined;
 }
 
 export function forBlock<T>(
@@ -32851,6 +32932,8 @@ export function forBlock<T>(
 			// sentinel — but both ForSlot literals declare it so every slot shares
 			// one hidden class and the stamp in childSlot transitions nothing.
 			plainDeopt: false,
+			mappedNative: undefined,
+			selectionItems: undefined,
 		};
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
@@ -33919,7 +34002,7 @@ function reconcileKeyed<T>(
 
 	// ── General case: both middles non-empty. Partition + LIS-move.
 	const newMidLen = newEnd - prefixLen + 1;
-	const newKeys: any[] = new Array(newMidLen);
+	const newKeys: any[] = [];
 	const newKeysToIdx = new Map<any, number>(); // key → MIDDLE-RELATIVE index (0..newMidLen-1)
 	for (let i = 0; i < newMidLen; i++) {
 		const key = readListKey(keySource, items[prefixLen + i], prefixLen + i, normalizeKey);

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -24,7 +24,6 @@ function trailingVersion(text: string | null): number {
 }
 
 function expectCompilerRegion(code: string): void {
-	expect(code).toMatch(/const __memoCommitted[\w$]* = __s\.slots\._m\$\d+;/);
 	expect(code).toMatch(/__s\.slots\[\d+\] === undefined \|\| __memoCache/);
 	// Dependencies are snapshotted into temporaries once per render; the guard
 	// compares and publishes those exact values.
@@ -32,9 +31,6 @@ function expectCompilerRegion(code: string): void {
 	expect(code).toMatch(/!_\$hookMemoEqual\(__memoCache[\w$]*\[\d+\], __memoDep[\w$]*\)/);
 	expect(code).toMatch(
 		/if \(__memoCache[\w$]* === __memoCommitted[\w$]*\) __memoCache[\w$]* = __memoCache[\w$]*\.slice\(\);/,
-	);
-	expect(code).toMatch(
-		/if \(__memoCache[\w$]* !== __memoCommitted[\w$]*\) __s\.slots\._m\$\d+ = __memoCache[\w$]*;/,
 	);
 }
 
@@ -792,6 +788,96 @@ describe('state-derived collections and independent host bindings', () => {
 });
 
 describe('compiler-owned component-region memoization', () => {
+	it('keeps alternate Provider children distinct while retaining live form state', () => {
+		const client = loadCompiledFixtureSource(
+			`import { useMemo } from 'octane';
+			function Child(props) @{ <span id="shared-label">{props.label}</span> }
+			function Alternate(props) @{ <span id="shared-label">{'alternate:' + props.label}</span> }
+			export function First() @{
+				const memo = useMemo(() => ({ label: 'first' }), []);
+				<div id="shared-host"><input defaultValue="draft"/><Child label={memo.label}/></div>
+			}
+			export function Second() @{
+				const memo = useMemo(() => ({ label: 'second' }), []);
+				<div id="shared-host"><input defaultValue="draft"/><Child label={memo.label}/></div>
+			}
+			export function AutoFirst() @{
+				const memo = useMemo(() => ({ label: 'same' }), []);
+				<div id="shared-host"><input defaultValue="draft"/><Child label={memo.label}/></div>
+			}
+			export function AutoSecond() @{
+				const memo = useMemo(() => ({ label: 'same' }), []);
+				<div id="shared-host"><input defaultValue="draft"/><Alternate label={memo.label}/></div>
+			}
+			export function Combined(props) @{
+				const memo = useMemo(() => ({ label: props.label }), [props.label]);
+				props.observe(memo);
+				<div id="shared-host" data-tick={props.tick}><input defaultValue="draft"/><Child label={memo.label}/></div>
+			}`,
+			{
+				id: 'provider-body-memo-lifetimes.tsrx',
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			},
+		);
+		const Context = createContext('default');
+		const root = mount(Context.Provider, { value: 'initial', children: client.First });
+		const input = root.find('input') as HTMLInputElement;
+		const label = root.find('#shared-label');
+		expect(label.textContent).toBe('first');
+		input.value = 'typed';
+		input.focus();
+
+		root.update(Context.Provider, { value: 'updated', children: client.Second });
+		expect(root.find('input')).toBe(input);
+		expect(input.value).toBe('typed');
+		expect(document.activeElement).toBe(input);
+		expect(root.find('#shared-label')).toBe(label);
+		expect(label.textContent).toBe('second');
+
+		root.update(Context.Provider, { value: 'again', children: client.Second });
+		expect(root.find('input')).toBe(input);
+		expect(input.value).toBe('typed');
+		expect(root.find('#shared-label')).toBe(label);
+		expect(label.textContent).toBe('second');
+		root.unmount();
+
+		const alternate = mount(Context.Provider, { value: 'initial', children: client.AutoFirst });
+		const alternateInput = alternate.find('input') as HTMLInputElement;
+		const firstLabel = alternate.find('#shared-label');
+		expect(firstLabel.textContent).toBe('same');
+		alternateInput.value = 'edited';
+		alternateInput.focus();
+		alternate.update(Context.Provider, { value: 'updated', children: client.AutoSecond });
+		expect(alternate.find('input')).toBe(alternateInput);
+		expect(alternateInput.value).toBe('edited');
+		expect(document.activeElement).toBe(alternateInput);
+		expect(alternate.find('#shared-label').textContent).toBe('alternate:same');
+		expect(alternate.find('#shared-label')).not.toBe(firstLabel);
+		alternate.unmount();
+
+		const observed: object[] = [];
+		const capture = (value: object) => observed.push(value);
+		const combined = mount(client.Combined, { label: 'same', tick: 0, observe: capture });
+		const combinedInput = combined.find('input') as HTMLInputElement;
+		combinedInput.value = 'kept';
+		combinedInput.focus();
+		const initialMemo = observed.at(-1);
+		const initialObservations = observed.length;
+		combined.update(client.Combined, { label: 'same', tick: 1, observe: capture });
+		expect(combined.find('#shared-host').getAttribute('data-tick')).toBe('1');
+		expect(observed.length).toBeGreaterThan(initialObservations);
+		expect(observed.at(-1)).toBe(initialMemo);
+		expect(combined.find('input')).toBe(combinedInput);
+		expect(combinedInput.value).toBe('kept');
+		expect(document.activeElement).toBe(combinedInput);
+		const stableMemo = observed.at(-1);
+		combined.update(client.Combined, { label: 'next', tick: 2, observe: capture });
+		expect(observed.at(-1)).not.toBe(stableMemo);
+		expect(combined.find('#shared-label').textContent).toBe('next');
+		combined.unmount();
+	});
+
 	it('preserves an independently updating pure hookful child under its hookful parent', () => {
 		const source = `
 			import { useState } from 'octane';

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -117,7 +117,11 @@ describe('manual keyed lists', () => {
 			for (const input of inputs) input.value = `typed:${input.value}`;
 			current = initial.toReversed();
 			view.update(ManualList, { items: current, getKey });
-			expect(view.findAll('input')).toEqual(inputs.toReversed());
+			const reversed = view.findAll('input') as HTMLInputElement[];
+			for (let i = 0; i < reversed.length; i++) {
+				expect(reversed[i]).toBe(inputs[inputs.length - 1 - i]);
+				expect(reversed[i].value).toBe(`typed:${current[i].label}`);
+			}
 
 			current = [initial[2], { id: 'new', label: 'new' }, initial[0]];
 			failKey = true;
@@ -141,6 +145,74 @@ describe('manual keyed lists', () => {
 			]);
 			expect(calls.length).toBeGreaterThan(0);
 			expect(calls.every((args) => args.length === 2)).toBe(true);
+		} finally {
+			view.unmount();
+		}
+	});
+
+	it('retains edited inputs across mixed-key middle reorders and later replacements', () => {
+		type Row = { id: string; key: unknown };
+		type Props = { items: Row[] };
+		const ManualList: ComponentBody<Props> = (props, scope) => {
+			const parent = hostComponent(scope, 0, 'div', null);
+			forBlock(
+				scope,
+				1,
+				parent,
+				props.items,
+				(item) => item.key,
+				(item, rowScope) => {
+					hostComponent(rowScope, 0, 'input', { 'data-id': item.id, defaultValue: item.id });
+				},
+			);
+		};
+		const initial: Row[] = ['a', {}, 2, undefined, Symbol('e'), 'f'].map((key, index) => ({
+			id: String.fromCharCode(97 + index),
+			key,
+		}));
+		const view = mount(ManualList, { items: initial });
+		try {
+			const original = view.findAll('input') as HTMLInputElement[];
+			const survivors = new Map(initial.map((item, index) => [item, original[index]]));
+			for (const input of original) input.value = `typed:${input.value}`;
+			const added: Row = { id: 'g', key: {} };
+			const reordered = [initial[0], initial[3], added, initial[1], initial[4], initial[5]];
+			view.update(ManualList, { items: reordered });
+			const middle = view.findAll('input') as HTMLInputElement[];
+			expect(middle.map((input) => input.getAttribute('data-id'))).toEqual([
+				'a',
+				'd',
+				'g',
+				'b',
+				'e',
+				'f',
+			]);
+			for (let i = 0; i < reordered.length; i++) {
+				const before = survivors.get(reordered[i]);
+				if (before !== undefined) {
+					expect(middle[i]).toBe(before);
+					expect(middle[i].value).toBe(`typed:${reordered[i].id}`);
+				} else {
+					expect(middle[i].value).toBe('g');
+				}
+			}
+			expect(original[2].isConnected).toBe(false);
+			const replacements: Row[] = [
+				{ id: 'x', key: {} },
+				{ id: 'y', key: 'y' },
+				{ id: 'z', key: 9 },
+			];
+			view.update(ManualList, { items: replacements });
+			const replaced = view.findAll('input') as HTMLInputElement[];
+			expect(replaced.map((input) => input.value)).toEqual(['x', 'y', 'z']);
+			for (const input of middle) expect(input.isConnected).toBe(false);
+			for (const input of replaced) input.value = `typed:${input.value}`;
+			view.update(ManualList, { items: replacements.toReversed() });
+			const reversed = view.findAll('input') as HTMLInputElement[];
+			for (let i = 0; i < reversed.length; i++) {
+				expect(reversed[i]).toBe(replaced[replaced.length - 1 - i]);
+				expect(reversed[i].value).toBe(`typed:${replacements[replacements.length - 1 - i].id}`);
+			}
 		} finally {
 			view.unmount();
 		}

--- a/packages/octane/tests/host-component-props.test.ts
+++ b/packages/octane/tests/host-component-props.test.ts
@@ -23,6 +23,58 @@ const HostBody = (props: any, scope: any): void => {
 };
 
 describe('hostComponent — reused host and children', () => {
+	it('accepts callable children after an empty mount and releases them when removed', () => {
+		const refs: string[] = [];
+		const hostRef = (element: Element | null) => {
+			if (element !== null) {
+				refs.push('attach');
+				return () => refs.push('detach');
+			}
+		};
+		const Host: ComponentBody<{ label: string | null; attached: boolean }> = (props, scope) => {
+			hostComponent(
+				scope,
+				0,
+				'section',
+				props.attached ? { ref: hostRef, 'data-label': props.label } : null,
+				props.label === null
+					? null
+					: () => createElement('input', { defaultValue: props.label, 'aria-label': props.label }),
+			);
+		};
+		const r = mount(Host, { label: null, attached: false });
+		try {
+			const section = r.find('section');
+			expect(section.childNodes).toHaveLength(0);
+			expect(refs).toEqual([]);
+			r.update(Host, { label: 'first', attached: true });
+			const input = r.find('input') as HTMLInputElement;
+			input.value = 'typed';
+			input.focus();
+			expect(refs).toEqual(['attach']);
+			r.update(Host, { label: 'second', attached: true });
+			expect(r.find('section')).toBe(section);
+			expect(r.find('input')).toBe(input);
+			expect(input.value).toBe('typed');
+			expect(input.getAttribute('aria-label')).toBe('second');
+			expect(document.activeElement).toBe(input);
+			r.update(Host, { label: null, attached: false });
+			expect(r.find('section')).toBe(section);
+			expect(section.childNodes).toHaveLength(0);
+			expect(section.hasAttribute('data-label')).toBe(false);
+			expect(input.isConnected).toBe(false);
+			expect(refs).toEqual(['attach', 'detach']);
+			r.update(Host, { label: 'third', attached: true });
+			const fresh = r.find('input') as HTMLInputElement;
+			expect(fresh).not.toBe(input);
+			expect(fresh.value).toBe('third');
+			r.unmount();
+			expect(refs).toEqual(['attach', 'detach', 'attach', 'detach']);
+		} finally {
+			r.unmount();
+		}
+	});
+
 	it('renders the value returned by callable children', () => {
 		const host: ComponentBody<{ label: string }> = (props, scope) => {
 			hostComponent(scope, 0, 'section', null, () =>

--- a/packages/octane/tests/hydration/mapped-fallback-hydrate.test.ts
+++ b/packages/octane/tests/hydration/mapped-fallback-hydrate.test.ts
@@ -86,7 +86,9 @@ describe('hydrateRoot — mapped-fallback keyed list', () => {
 		flushSync(() => {});
 
 		// Adopted, not rebuilt: the same element instances are still in place.
-		expect([...container.querySelectorAll('li.fallback-row')]).toEqual(rows);
+		const adopted = [...container.querySelectorAll('li.fallback-row')];
+		expect(adopted).toHaveLength(rows.length);
+		for (let index = 0; index < rows.length; index++) expect(adopted[index]).toBe(rows[index]);
 		expect(rows.map((row) => row.textContent)).toEqual(['a', 'b', 'c']);
 		root.unmount();
 	});
@@ -107,8 +109,15 @@ describe('hydrateRoot — mapped-fallback keyed list', () => {
 		const reordered = [...container.querySelectorAll('li.fallback-row')];
 		expect(reordered.map((row) => row.getAttribute('data-id'))).toEqual(['3', '1', '2']);
 		// Survivors keep their identity — the same three nodes, reordered.
-		expect(new Set(reordered)).toEqual(new Set(rows));
-		expect(reordered[0]).toBe(rows[2]);
+		for (const [index, previous] of [2, 0, 1].entries())
+			expect(reordered[index]).toBe(rows[previous]);
+		// A later plain array can re-enter the compiled arm without remounting
+		// the rows that were adopted through the custom-array fallback.
+		flushSync(() => root.render(MappedFallbackList, { items: ITEMS }));
+		const compiled = [...container.querySelectorAll('li.fallback-row')];
+		expect(compiled).toHaveLength(rows.length);
+		for (let index = 0; index < rows.length; index++) expect(compiled[index]).toBe(rows[index]);
+		expect(compiled.map((row) => row.textContent)).toEqual(['a', 'b', 'c']);
 		root.unmount();
 	});
 });

--- a/packages/octane/tests/inline-hook-memo.test.ts
+++ b/packages/octane/tests/inline-hook-memo.test.ts
@@ -22,6 +22,52 @@ describe('inline hook-memo behavior', () => {
 	for (const inlineHookMemo of [false, true]) {
 		const compileOptions = { hmr: false, dev: false, autoMemo: false, inlineHookMemo };
 
+		it(`initializes nullish results and callbacks, including a later conditional memo (inline=${inlineHookMemo})`, () => {
+			const { App } = loadCompiledFixtureSource(
+				`import { useCallback, useMemo } from 'octane';
+				export function App({ enabled, tick, observe, mark }) @{
+					const empty = useMemo(() => (mark('undefined'), undefined), []);
+					const nullable = useMemo(() => (mark('null'), null), []);
+					const callback = useCallback(() => 'ready', []);
+					const late = enabled && useMemo(() => (mark('late'), { label: 'later' }), []);
+					observe({ empty, nullable, callback, late });
+					<p>{tick + ':' + String(empty) + ':' + String(nullable) + ':' + callback() + ':' + (late ? late.label : 'off')}</p>
+				}`,
+				{ id: 'memo-empty-results.tsrx', mode: 'client', compileOptions },
+			);
+			const log = createLog();
+			const observed: Array<{
+				empty: undefined;
+				nullable: null;
+				callback: () => string;
+				late: false | { label: string };
+			}> = [];
+			const shared = {
+				mark: log.push,
+				observe: (value: (typeof observed)[number]) => observed.push(value),
+			};
+			const view = mount(App, { ...shared, enabled: false, tick: 0 });
+			try {
+				expect(view.html()).toBe('<p>0:undefined:null:ready:off</p>');
+				expect(log.drain()).toEqual(['undefined', 'null']);
+				const callback = observed[0].callback;
+				view.update(App, { ...shared, enabled: true, tick: 1 });
+				expect(view.html()).toBe('<p>1:undefined:null:ready:later</p>');
+				expect(log.drain()).toEqual(['late']);
+				const late = observed[1].late;
+				view.update(App, { ...shared, enabled: false, tick: 2 });
+				view.update(App, { ...shared, enabled: true, tick: 3 });
+				expect(view.html()).toBe('<p>3:undefined:null:ready:later</p>');
+				expect(log.drain()).toEqual([]);
+				expect(observed[3].empty).toBeUndefined();
+				expect(observed[3].nullable).toBeNull();
+				expect(observed[3].callback).toBe(callback);
+				expect(observed[3].late).toBe(late);
+			} finally {
+				view.unmount();
+			}
+		});
+
 		it(`preserves an ordinary factory's invocation scope (inline=${inlineHookMemo})`, () => {
 			const { App } = loadCompiledFixtureSource(
 				`import { useMemo } from 'octane';

--- a/packages/octane/tests/keyed-selection-alias.test.ts
+++ b/packages/octane/tests/keyed-selection-alias.test.ts
@@ -112,7 +112,10 @@ describe('keyed selection with an authored row-key local', () => {
 			rendered.update(KeyAliasTable, { ...props, selected: 2 });
 			const updated = [items[2]!, { ...items[1]!, label: 'Beta updated' }, items[0]!];
 			rendered.update(KeyAliasTable, { ...props, items: updated, selected: 1 });
-			expect(tableRows(rendered.container)).toEqual(original.toReversed());
+			const reordered = tableRows(rendered.container);
+			expect(reordered).toHaveLength(original.length);
+			for (let index = 0; index < original.length; index++)
+				expect(reordered[index]).toBe(original[original.length - index - 1]);
 			expect(rendered.findAll('.pick').map((node) => node.textContent)).toEqual([
 				'Gamma',
 				'Beta updated',
@@ -127,7 +130,10 @@ describe('keyed selection with an authored row-key local', () => {
 				items: [updated[0]!, updated[2]!],
 				selected: 2,
 			});
-			expect(tableRows(rendered.container)).toEqual([original[2], original[0]]);
+			const remaining = tableRows(rendered.container);
+			expect(remaining).toHaveLength(2);
+			expect(remaining[0]).toBe(original[2]);
+			expect(remaining[1]).toBe(original[0]);
 			expect(selectedLabels(rendered.container)).toEqual([]);
 			rendered.update(KeyAliasTable, { ...props, items: [], selected: null });
 			expect(tableRows(rendered.container)).toEqual([]);

--- a/packages/octane/tests/plain-hook-memo.test.ts
+++ b/packages/octane/tests/plain-hook-memo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { mount } from './_helpers';
+import { flushSync } from 'octane';
+import { act, mount } from './_helpers';
 import { loadPlainHookFixtureSource } from './_server-fixture';
 
 describe('memo hooks in plain modules', () => {
@@ -55,6 +56,91 @@ describe('memo hooks in plain modules', () => {
 			root.click('#right');
 			expect(root.find('#right').textContent).toBe('11.0');
 			root.unmount();
+		});
+
+		it(`keeps memo values and stable getters through queued updates and an awaiting Action (inline=${inlineHookMemo})`, async () => {
+			const { App } = load(`
+				import { createElement, useMemo, useReducer, useState, useTransition } from 'octane';
+				export function App(props) {
+					const [value, setValue, getValue] = useState(undefined);
+					const [total, dispatch, getTotal] = useReducer(
+						(previous, action) => action === 'clear' ? undefined : (previous ?? 0) + action,
+						undefined,
+					);
+					const memo = useMemo(() => ({ value, total }), [value, total]);
+					const [pending, start] = useTransition();
+					props.observe({ memo, setValue, getValue, dispatch, getTotal, start });
+					return createElement('p', null, [String(value), String(total), String(pending)].join('|'));
+				}
+			`);
+			let controls!: {
+				memo: { value: number | undefined; total: number | undefined };
+				setValue: (value: undefined | ((previous: number | undefined) => number)) => void;
+				getValue: () => number | undefined;
+				dispatch: (action: number | 'clear') => void;
+				getTotal: () => number | undefined;
+				start: (action: () => Promise<void>) => void;
+			};
+			let finish!: () => void;
+			const waiting = new Promise<void>((resolve) => {
+				finish = resolve;
+			});
+			const props = {
+				observe: (next: typeof controls) => {
+					controls = next;
+				},
+			};
+			const root = mount(App, props);
+			try {
+				const first = controls;
+				expect(root.find('p').textContent).toBe('undefined|undefined|false');
+				flushSync(() => {
+					controls.setValue((previous) => (previous ?? 0) + 1);
+					controls.setValue((previous) => (previous ?? 0) + 2);
+					controls.dispatch(4);
+					controls.dispatch(5);
+					expect(first.getValue()).toBe(3);
+					expect(first.getTotal()).toBe(9);
+				});
+				expect(root.find('p').textContent).toBe('3|9|false');
+				expect(controls.getValue).toBe(first.getValue);
+				expect(controls.getTotal).toBe(first.getTotal);
+				expect(controls.memo).toEqual({ value: 3, total: 9 });
+				expect(controls.memo).not.toBe(first.memo);
+				const committed = controls.memo;
+				root.update(App, props);
+				expect(controls.memo).toBe(committed);
+				await act(() =>
+					controls.start(async () => {
+						controls.setValue(undefined);
+						controls.dispatch('clear');
+						await waiting;
+					}),
+				);
+				expect(root.find('p').textContent).toBe('3|9|true');
+				expect(first.getValue()).toBeUndefined();
+				expect(first.getTotal()).toBeUndefined();
+				expect(controls.memo).toBe(committed);
+				await act(async () => {
+					finish();
+					await waiting;
+				});
+				expect(root.find('p').textContent).toBe('undefined|undefined|false');
+				expect(controls.getValue).toBe(first.getValue);
+				expect(controls.getTotal).toBe(first.getTotal);
+				expect(controls.memo).toEqual({ value: undefined, total: undefined });
+				flushSync(() => {
+					controls.setValue((previous) => (previous ?? 0) + 1);
+					controls.dispatch(2);
+				});
+				expect(root.find('p').textContent).toBe('1|2|false');
+				expect(first.getValue()).toBe(1);
+				expect(first.getTotal()).toBe(2);
+			} finally {
+				finish();
+				await act(() => {});
+				root.unmount();
+			}
 		});
 
 		it(`preserves short-circuit and nested argument evaluation order (inline=${inlineHookMemo})`, () => {

--- a/packages/octane/tests/svg-deopt.test.ts
+++ b/packages/octane/tests/svg-deopt.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import type { ClassValue } from 'octane/jsx-runtime';
-import { flushSync, hydrateRoot } from '../src/index.js';
+import { createRoot, flushSync, hydrateRoot } from '../src/index.js';
 import { mount } from './_helpers';
 import {
 	DeoptNamespaceSlots,
@@ -10,7 +10,7 @@ import {
 	TemplateClassNamespaces,
 	TemplateNamespaceDestinations,
 } from './_fixtures/svg-deopt.tsrx';
-import { loadServerFixture } from './_server-fixture.js';
+import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
 import {
 	activateStreamedMarkup,
 	createPipeableCollector,
@@ -149,6 +149,49 @@ function expectNamespaceClasses(
 }
 
 describe('de-opt SVG namespace', () => {
+	it('reuses an ambiguous template after first mounting in MathML, then SVG and HTML', () => {
+		const { App } = loadCompiledFixtureSource(
+			`export function App({ label }) @{ <a data-label={label}>{label as string}</a> }`,
+			{
+				id: 'template-namespace-cache-order.tsrx',
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false, autoMemo: false },
+			},
+		);
+		const mounted: Element[] = [];
+		for (const [namespace, tag] of [
+			[MATHML_NS, 'math'],
+			[SVG_NS, 'svg'],
+			[HTML_NS, 'div'],
+			[MATHML_NS, 'math'],
+			[SVG_NS, 'svg'],
+			[HTML_NS, 'div'],
+		]) {
+			const container = document.createElementNS(namespace, tag);
+			document.body.appendChild(container);
+			const root = createRoot(container);
+			try {
+				root.render(App, { label: 'first' });
+				const node = container.firstElementChild!;
+				expect(node.namespaceURI).toBe(namespace);
+				expect(node.localName).toBe('a');
+				expect(node.textContent).toBe('first');
+				expect(node.getAttribute('data-label')).toBe('first');
+				for (const previous of mounted) expect(node).not.toBe(previous);
+				mounted.push(node);
+				flushSync(() => root.render(App, { label: 'updated' }));
+				expect(container.firstElementChild).toBe(node);
+				expect(node.namespaceURI).toBe(namespace);
+				expect(node.textContent).toBe('updated');
+				expect(node.getAttribute('data-label')).toBe('updated');
+			} finally {
+				root.unmount();
+				expect(container.childNodes).toHaveLength(0);
+				container.remove();
+			}
+		}
+	});
+
 	it('creates SVG-namespaced elements (incl. case-preserved clipPath) via createElement', () => {
 		const r = mount(SvgViaCreateElement);
 		const svg = r.container.querySelector('svg') as SVGSVGElement;

--- a/packages/octane/tests/universal-renderer.test.ts
+++ b/packages/octane/tests/universal-renderer.test.ts
@@ -4574,13 +4574,16 @@ describe('mixed DOM and universal ownership', () => {
 			// owner. A later context update proves its bridge still points live.
 			for (const callback of scheduled.splice(0)) callback();
 			mounted.update(UniversalBoundaryFixture, { ...props, theme: 'light' });
-			expect(container.children).toEqual([host]);
+			expect(container.children).toHaveLength(1);
+			expect(container.children[0]).toBe(host);
 			expect(host.props).toMatchObject({ theme: 'light', value: 'ready' });
 		} finally {
 			mounted.unmount();
 			root.unmount();
 		}
+		for (const callback of scheduled.splice(0)) callback();
 		expect(container.children).toEqual([]);
+		expect(container.instanceCount).toBe(0);
 	});
 
 	it('does not transfer abandoned root suspension ownership to replacement props', async () => {


### PR DESCRIPTION
## Summary

Handles all three remaining items in the **Hidden-class stability** section of #981:

- Move compiled `_m$N` / `_k$N` caches off `scope.slots` into a lazily allocated fixed-shape memo region. Keep per-body isolation, immediate inline-hook publication, successful-body auto-memo publication, and HMR/reset behavior.
- Initialize the optional members of `StateSlot`, `ReducerSlot`, `MemoHookEntry`, both `ForSlot` constructors, `HostComponentSlot`, and `OffscreenCapture` with their existing absent-value semantics. Optional collections remain lazy.
- Initialize hook memo cells with `null`, build reconciliation keys contiguously, and seed all three lazy-template namespace entries.

## Evidence and tradeoffs

Actual production runtime probes reduce sampled State / Reducer / Memo maps **4/4/3 → 1/1/1**, Host / For / Capture maps **2/3/4 → 1/1/1**, and generated named slot-cache reads/writes **10/10 → 0/0**. Semantic controls preserve hook values and identities, typed inputs, keyed nodes, focus, refs, cleanup, hydration adoption, namespace selection, and deferred foreign-renderer ownership.

- Host records use 80 bytes versus 88/112; root captures use 112 versus 120; ordinary lists use 136 versus 120 while selection/mapped lists use 136 versus 160.
- Idle state/reducer cells reserve **48 extra bytes each**, ordinary memo entries 24; settled-transition cells and warm/native memo entries save 16. Nine isolated Node process rounds show lower transition medians; ordinary timing ranges overlap.
- The fixed memo-region record saves 24 bytes versus the rejected tuple. Relative to the old named caches, sampled memo-bearing Blocks cost 24 extra bytes and flat Block/Scope objects 8. No application latency improvement is claimed.
- Chromium 149 memo creation/publication is 45–53% faster in the narrow measured cases. Current Node 24/26 already repack `fill(undefined)`; Chromium's undefined-double storage differs. Older V8 may keep filled arrays holey, so packedness claims are limited to measured engines.

Reproducible commands, hashes, memory accounting, timing ranges, rejected alternatives, and limits are in `benchmarks/runtime-object-shapes/` and `benchmarks/hook-memo/README.md`.

## Validation

- [x] Targeted development/production tests and deliberate-red checks for cache-body isolation, hook/auto cache separation, staged undefined hook values, keyed middle reorder, mixed namespaces, host children, and discarded captures.
- [x] Core source `tsgo --noEmit -p packages/octane/tsconfig.json`; new fixture `tsrx-tsc --noEmit -p benchmarks/hook-memo/tsconfig.json`.
- [x] Final hook and Host/For/Capture structural guards; compiler-cache source guards; scoped Prettier and `git diff --check`.
- [x] Broad local core + signals run: 979 files / 17,334 tests passed, 14 expected failures. Two suites require the unavailable React precompile; three dependency-layout assertions fail identically with frozen-baseline and candidate compiler source.
- [x] `pnpm sync` (no additional generated diff).
- [x] [Current-head CI](https://github.com/octanejs/octane/actions/runs/34717614693): **26/26 jobs passed** at `e0ddf891e6162c59a0817a6956b8327c0a740efc`. Cursor Bugbot passed with no findings; no unresolved review threads.

Local differential precompile and broader test-file typechecking are unavailable because the installed `@tsrx/react` lacks `@tsrx/react-runtime`; the ordinary core and signals projects retain their production/development compiler configurations and skip that unrelated precompile. The scoped typecheck helper also selects the source-only tsgo configuration for test files importing TSRX/TSX; those diagnostics are not represented as passing test types. The cached `@tsrx/core` 0.1.71 resolves to an existing `/private/tmp/tsrx-core-0.1.71-unpkg` installation, and fixture-only installed hook-form/zustand paths are absent locally.

Eight older `hook-memo` allocation ratio guards fail with **identical frozen-baseline and candidate counts**; their budgets are unchanged. Both added named-cache guards pass. The README records this inherited state.

## Risk / follow-ups

A same-module Provider child switch A→B→A already displays stale A output on frozen `fa11c1055`; this PR preserves the existing cache lifetime and does not claim to fix that separate behavior. The reproducer is recorded in the issue follow-up. The new cache-shape fixture covers one-way A→B, repeated B, and ordinary memo hits/misses.

This PR covers the remaining Hidden-class stability items; the separately listed universal-renderer protocol/object findings remain in #981. It does not close the umbrella issue.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791837344&installation_model_id=432790&pr_number=1067&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1067&signature=ffc1e86f0a78eab24afd3dbdf3d59abb7ed88119a3bfe27d98517acc9808de0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler output ABI and hot-path runtime structures (scopes, hooks, keyed reconciliation, templates) across the whole renderer, though behavior is heavily regression-tested and benchmark-guarded.
> 
> **Overview**
> Moves **auto-memo and inline hook-memo** off named `_m$N` / `_k$N` properties on `__s.slots` into a scope-owned **`compilerMemoRegion`** with fixed `auto` and `hooks` cell arrays, plus an overflow map when a second compiled body shares the same scope (e.g. Provider child swaps). Generated bodies call `compilerMemoRegion(__s, bodyId)` instead of reading or writing those slot-array properties.
> 
> On the runtime side, several internal records now **seed optional fields up front** (state/reducer/memo hooks, host/list slots, offscreen capture) so V8 hidden classes stay stable, while lazy collections still allocate only when used. **Hook memo arrays** initialize with `null` instead of `undefined`; **keyed list reconciliation** builds middle keys with contiguous pushes instead of a pre-sized holey array; **lazy template** namespace caches start as three explicit entries so early MathML/SVG parses do not skip indexes.
> 
> Adds **hook-memo compiler-cache-shape** benchmarks and ratio guards (zero named slot-cache reads/writes), plus **runtime-object-shape** probes and docs. Tests and fixtures assert unchanged behavior for memo identity, staged transition values, keyed DOM reuse, host children, and namespace template reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ddf891e6162c59a0817a6956b8327c0a740efc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->