### PR TITLE
perf: reduce remaining DOM and event overhead

### DIFF
--- a/.changeset/tidy-dom-event-paths.md
+++ b/.changeset/tidy-dom-event-paths.md
@@ -1,5 +1,8 @@
 ---
 'octane': patch
+'@octanejs/mcp-server': patch
 ---
 
 Reduce DOM attribute, spread-prop, template mounting, metadata, and delegated-event work while preserving hydration, rollback, native event descriptors, and custom-element connection behavior.
+
+Expose the DOM attribute, template mount, and spread host benchmark suites through the MCP benchmark tool.

--- a/.changeset/tidy-dom-event-paths.md
+++ b/.changeset/tidy-dom-event-paths.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Reduce DOM attribute, spread-prop, template mounting, metadata, and delegated-event work while preserving hydration, rollback, native event descriptors, and custom-element connection behavior.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -877,7 +877,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 0.6,
-    "note": "rotate-backward is the LIS-vs-lastPlacedIndex differentiator: octane moves 1 node, React moves all survivors (known ~12x faster → 0.08x). Guard 0.6 leaves huge headroom while still catching a fast-path break."
+    "note": "rotate-backward is the LIS-vs-lastPlacedIndex differentiator: octane moves 1 node, React moves all survivors (known ~12x faster \u2192 0.08x). Guard 0.6 leaves huge headroom while still catching a fast-path break."
   },
   {
     "suite": "memo-wall",
@@ -1005,7 +1005,7 @@
     "target": "news-50/octane-tsrx",
     "reference": "news-50/react",
     "maxRatio": 1.2,
-    "note": "octane server render() vs react-dom renderToString at 50 cards (known ~0.6x → octane faster). Guard 1.2 tolerates noise but catches an octane SSR regression."
+    "note": "octane server render() vs react-dom renderToString at 50 cards (known ~0.6x \u2192 octane faster). Guard 1.2 tolerates noise but catches an octane SSR regression."
   },
   {
     "suite": "ssr-throughput",
@@ -1014,7 +1014,7 @@
     "reference": "deopt-page/octane-fast",
     "minRatio": 1.2,
     "maxRatio": 4.0,
-    "note": "intra-octane de-opt cliff: plain-.ts createElement vs compiled .tsrx SSR (known ~2.1x). Bounds the cliff so a broken fast path (ratio→1) or a runaway deopt (ratio>4) both surface."
+    "note": "intra-octane de-opt cliff: plain-.ts createElement vs compiled .tsrx SSR (known ~2.1x). Bounds the cliff so a broken fast path (ratio\u21921) or a runaway deopt (ratio>4) both surface."
   },
   {
     "suite": "bundle-size",
@@ -2317,7 +2317,7 @@
     "target": "octane-minimal",
     "reference": "react",
     "maxRatio": 3.5,
-    "note": "KNOWN GAP under active investigation: warmed /posts first-byte measured 2.57x react on 2026-07-20 (1.85ms vs 0.72ms) — the octane Start SSR stack, not the host (nitro-vs-minimal ~1x) and not the raw renderer (ssr-http shell is at parity). The 3.5 ceiling only catches further regression; renderer/Start fixes should TIGHTEN this guard."
+    "note": "KNOWN GAP under active investigation: warmed /posts first-byte measured 2.57x react on 2026-07-20 (1.85ms vs 0.72ms) \u2014 the octane Start SSR stack, not the host (nitro-vs-minimal ~1x) and not the raw renderer (ssr-http shell is at parity). The 3.5 ceiling only catches further regression; renderer/Start fixes should TIGHTEN this guard."
   },
   {
     "suite": "tanstack-start",
@@ -2333,7 +2333,7 @@
     "target": "octane-minimal",
     "reference": "react",
     "maxRatio": 3.5,
-    "note": "KNOWN GAP: warmed sequential ms/request on / measured 2.37x react on 2026-07-20 (695 vs 1650 req/s) — per-request overhead in the octane Start SSR path. The 3.5 ceiling only catches further regression; fixes should TIGHTEN it."
+    "note": "KNOWN GAP: warmed sequential ms/request on / measured 2.37x react on 2026-07-20 (695 vs 1650 req/s) \u2014 per-request overhead in the octane Start SSR path. The 3.5 ceiling only catches further regression; fixes should TIGHTEN it."
   },
   {
     "suite": "tanstack-start",
@@ -2733,7 +2733,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 1.3,
-    "note": "40 series `d` rebuilds (+8 areas, 32 sparklines, tick/legend text, 24 gradient stops) per frame through the generic prev-guarded setAttribute path, incl. the sanitize-url toLowerCase pair per write. Observed 0.95x, 2026-08-07 — octane must not fall behind react at bulk d-churn."
+    "note": "40 series `d` rebuilds (+8 areas, 32 sparklines, tick/legend text, 24 gradient stops) per frame through the generic prev-guarded setAttribute path, incl. the sanitize-url toLowerCase pair per write. Observed 0.95x, 2026-08-07 \u2014 octane must not fall behind react at bulk d-churn."
   },
   {
     "suite": "svg-dashboard",
@@ -2749,7 +2749,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 2.5,
-    "note": "Per-frame topology commits (10 node+icon transforms + ~26 incident edge d rebuilds, 30 frames). Observed 1.45x at introduction (2026-08-07) and 1.89x once the react fixture adopted the React Compiler rollout (#639, 2026-08-08) — a known octane gap: each topo commit re-walks the keyed row bindings including the 150 de-opt icon holes. Tripwire against the gap widening. The autoMemo host-spread admission adds always-missing region guards to these commits; a same-session A/B (2026-08-08, pre-#639 react column) attributed only ~0.1 ms (~1.4%) of octane's 7.0 ms to them."
+    "note": "Per-frame topology commits (10 node+icon transforms + ~26 incident edge d rebuilds, 30 frames). Observed 1.45x at introduction (2026-08-07) and 1.89x once the react fixture adopted the React Compiler rollout (#639, 2026-08-08) \u2014 a known octane gap: each topo commit re-walks the keyed row bindings including the 150 de-opt icon holes. Tripwire against the gap widening. The autoMemo host-spread admission adds always-missing region guards to these commits; a same-session A/B (2026-08-08, pre-#639 react column) attributed only ~0.1 ms (~1.4%) of octane's 7.0 ms to them."
   },
   {
     "suite": "svg-dashboard",
@@ -2773,7 +2773,7 @@
     "target": "octane-tsrx",
     "reference": "solid",
     "maxRatio": 0.9,
-    "note": "350 class-string rewrites per round through setClassAttr (SVG class is attribute-only). Observed 0.58x, 2026-08-07 — octane's many-small-writes profile beats solid's reconcile here; the guard rejects per-write fixed-cost regressions (alias lookup, sanitize, clsx normalize)."
+    "note": "350 class-string rewrites per round through setClassAttr (SVG class is attribute-only). Observed 0.58x, 2026-08-07 \u2014 octane's many-small-writes profile beats solid's reconcile here; the guard rejects per-write fixed-cost regressions (alias lookup, sanitize, clsx normalize)."
   },
   {
     "suite": "svg-dashboard",
@@ -2789,7 +2789,7 @@
     "target": "octane-tsrx",
     "reference": "solid",
     "maxRatio": 2.1,
-    "note": "480 foreignObject insert/removals per sample — the SVG→HTML namespace push/pop on runtime insertion. Observed 1.38x, 2026-08-07."
+    "note": "480 foreignObject insert/removals per sample \u2014 the SVG\u2192HTML namespace push/pop on runtime insertion. Observed 1.38x, 2026-08-07."
   },
   {
     "suite": "svg-dashboard",
@@ -2797,7 +2797,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 0.8,
-    "note": "360 portal commits per sample into the overlay <g> (mount, two moves, unmount per cycle). Observed 0.50x, 2026-08-07 — octane portals into SVG beat react's createPortal; the guard keeps that from silently inverting."
+    "note": "360 portal commits per sample into the overlay <g> (mount, two moves, unmount per cycle). Observed 0.50x, 2026-08-07 \u2014 octane portals into SVG beat react's createPortal; the guard keeps that from silently inverting."
   },
   {
     "suite": "svg-dashboard",
@@ -2805,7 +2805,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 1.2,
-    "note": "All 150 createElement-built icons re-diff per flip (tag swaps replace elements, same-tag patches attrs) plus 150 <use href> fast-path writes. Octane's DELIBERATE de-opt path vs react's one-and-only path — a cliff-width tripwire, not a win claim. Observed 0.79x, 2026-08-07."
+    "note": "All 150 createElement-built icons re-diff per flip (tag swaps replace elements, same-tag patches attrs) plus 150 <use href> fast-path writes. Octane's DELIBERATE de-opt path vs react's one-and-only path \u2014 a cliff-width tripwire, not a win claim. Observed 0.79x, 2026-08-07."
   },
   {
     "suite": "svg-dashboard",
@@ -2813,7 +2813,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 3,
-    "note": "200 edges x (style-object diff with unitless SVG props + data-* spread bag) per pulse. Observed 1.98x, 2026-08-07 — octane's setSpread + per-property style diff currently trails react's; tripwire against the gap widening while it is worked on."
+    "note": "200 edges x (style-object diff with unitless SVG props + data-* spread bag) per pulse. Observed 1.98x, 2026-08-07 \u2014 octane's setSpread + per-property style diff currently trails react's; tripwire against the gap widening while it is worked on."
   },
   {
     "suite": "svg-dashboard",
@@ -3124,7 +3124,7 @@
     "target": "octane",
     "reference": "work-model",
     "maxRatio": 1,
-    "note": "A useTransition start → pending render → settle cycle renders the owner exactly twice: the pending cue with the new value and the falling edge."
+    "note": "A useTransition start \u2192 pending render \u2192 settle cycle renders the owner exactly twice: the pending cue with the new value and the falling edge."
   },
   {
     "suite": "transition-hooks",
@@ -4215,5 +4215,261 @@
     "reference": "work-model",
     "maxRatio": 1,
     "note": "Whole-workload native Map.get calls during 64 completed urgent cycles, excluding mount/unmount and timing. Includes DOM/harness lookups; independent render-sequence, DOM, hold/release, and cleanup gates establish equal work. The measured per-cycle ceiling permits cheaper equivalent implementations."
+  },
+  {
+    "suite": "dom-template-mount",
+    "op": "insertBefore",
+    "target": "fragment-256",
+    "reference": "work-model",
+    "maxRatio": 1,
+    "note": "256 keyed three-root fragments mount with no more than 770 top-level insertBefore calls. Every root, text value, keyed survivor, focus, removal, and foreign-content control is checked; custom elements retain their sequential connection semantics in the real-browser gate."
+  },
+  {
+    "suite": "dom-template-mount",
+    "op": "labelTextCreates",
+    "target": "fragment-256",
+    "reference": "work-model",
+    "maxRatio": 0,
+    "note": "The 256 only-child labels reuse the cloned template's text placeholders. Their visible values and empty text-node identity survive updates, while sibling text holes remain in source order."
+  },
+  {
+    "suite": "dom-template-mount",
+    "op": "labelTextCreates",
+    "target": "flat-256",
+    "reference": "work-model",
+    "maxRatio": 0,
+    "note": "A flat single-root keyed list also avoids explicit label-text creation; it retains all 256 label values and nodes on update."
+  },
+  {
+    "suite": "dom-template-mount",
+    "op": "insertBefore",
+    "target": "flat-256",
+    "reference": "flat-work-model",
+    "maxRatio": 1,
+    "note": "The flat single-root control stays at or below 258 insertBefore calls for 256 keyed labels; fragment work is not moved to ordinary flat templates."
+  },
+  {
+    "suite": "dom-template-mount",
+    "op": "insertBefore",
+    "target": "unrelated-update",
+    "reference": "work-model",
+    "maxRatio": 0,
+    "note": "An unrelated visible output update retains all keyed rows and text without mounting or moving nodes."
+  },
+  {
+    "suite": "dom-template-mount",
+    "op": "insertBefore",
+    "target": "reorder",
+    "reference": "reorder-work-model",
+    "maxRatio": 1,
+    "note": "Reversing 256 keyed three-root rows stays within 1294 insertBefore calls while retaining every physical root, typed input, and focus."
+  },
+  {
+    "suite": "dom-attributes",
+    "op": "changed",
+    "target": "octane",
+    "reference": "reference",
+    "maxRatio": 0,
+    "note": "Production native attribute work: safe static names avoid generic routing; unchanged metadata avoids redundant writes while external DOM edits and object coercion remain observable."
+  },
+  {
+    "suite": "dom-attributes",
+    "op": "restored",
+    "target": "octane",
+    "reference": "reference",
+    "maxRatio": 0,
+    "note": "Production native attribute work: safe static names avoid generic routing; unchanged metadata avoids redundant writes while external DOM edits and object coercion remain observable."
+  },
+  {
+    "suite": "dom-attributes",
+    "op": "unchanged",
+    "target": "octane",
+    "reference": "reference",
+    "maxRatio": 0,
+    "note": "Production native attribute work: safe static names avoid generic routing; unchanged metadata avoids redundant writes while external DOM edits and object coercion remain observable."
+  },
+  {
+    "suite": "dom-attributes",
+    "op": "headStableWrites",
+    "target": "octane",
+    "reference": "reference",
+    "maxRatio": 0,
+    "note": "Production native attribute work: safe static names avoid generic routing; unchanged metadata avoids redundant writes while external DOM edits and object coercion remain observable."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-canonical_4",
+    "reference": "client-canonical_4-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-aliases_4",
+    "reference": "client-aliases_4-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-stable-events_4",
+    "reference": "client-stable-events_4-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-changed-events_4",
+    "reference": "client-changed-events_4-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-canonical_15",
+    "reference": "client-canonical_15-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-aliases_15",
+    "reference": "client-aliases_15-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-stable-events_15",
+    "reference": "client-stable-events_15-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-changed-events_15",
+    "reference": "client-changed-events_15-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-canonical_50",
+    "reference": "client-canonical_50-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-aliases_50",
+    "reference": "client-aliases_50-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-stable-events_50",
+    "reference": "client-stable-events_50-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "client-changed-events_50",
+    "reference": "client-changed-events_50-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "ssr-canonical_4",
+    "reference": "ssr-canonical_4-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "ssr-aliases_4",
+    "reference": "ssr-aliases_4-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "ssr-canonical_15",
+    "reference": "ssr-canonical_15-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "ssr-aliases_15",
+    "reference": "ssr-aliases_15-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "ssr-canonical_50",
+    "reference": "ssr-canonical_50-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "spread-hosts",
+    "op": "source_expressions",
+    "target": "ssr-aliases_50",
+    "reference": "ssr-aliases_50-budget",
+    "maxRatio": 1,
+    "note": "Executed production allocation expressions under spread/alias/event semantic controls; bounds retained writer, snapshot, own-key scan, and exceptional alias/event work. Not heap allocation or timing."
+  },
+  {
+    "suite": "event-delegation",
+    "op": "setProbes",
+    "target": "dispatch-work",
+    "reference": "dispatch-work-model",
+    "maxRatio": 0,
+    "note": "Production portal-free native dispatch retains framework/native order and exact public descriptors while avoiding repeated event-type sets, portal ancestry reads, and private symbols."
+  },
+  {
+    "suite": "event-delegation",
+    "op": "portalReads",
+    "target": "dispatch-work",
+    "reference": "dispatch-work-model",
+    "maxRatio": 0,
+    "note": "Production portal-free native dispatch retains framework/native order and exact public descriptors while avoiding repeated event-type sets, portal ancestry reads, and private symbols."
+  },
+  {
+    "suite": "event-delegation",
+    "op": "symbolPeak",
+    "target": "dispatch-work",
+    "reference": "dispatch-work-model",
+    "maxRatio": 0,
+    "note": "Production portal-free native dispatch retains framework/native order and exact public descriptors while avoiding repeated event-type sets, portal ancestry reads, and private symbols."
+  },
+  {
+    "suite": "event-delegation",
+    "op": "typeLookups",
+    "target": "dispatch-work",
+    "reference": "dispatch-work-model",
+    "maxRatio": 1,
+    "note": "Production portal-free native dispatch retains framework/native order and exact public descriptors while avoiding repeated event-type sets, portal ancestry reads, and private symbols."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -402,6 +402,9 @@ const SUITES = [
 			...(name === 'event-delegation' || name === 'external-store-fanout'
 				? [{ label: 'work', script: 'work.mjs', args: () => [] }]
 				: []),
+			...(name === 'event-delegation'
+				? [{ label: 'dispatch-work', script: 'dispatch-work.mjs', args: () => [] }]
+				: []),
 		],
 	})),
 	{
@@ -1000,6 +1003,15 @@ const SUITES = [
 		runs: [{ script: 'run.mjs', args: () => [] }],
 	},
 	{
+		// Production static attributes and live head reapplication, with exact
+		// generic routing/write counts; timing runs use an uninstrumented bundle.
+		name: 'dom-attributes',
+		cwd: 'dom-attributes',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'run.mjs', args: () => [] }],
+	},
+	{
 		// Transition/hook hot paths: useTransition cycles, functional updaters,
 		// suspended hold + release, urgent dispatch, delegated clicks, and an
 		// urgent update beside a queued transition. Deterministic creation-event
@@ -1015,6 +1027,15 @@ const SUITES = [
 		// compiled source and DOM/event controls for every dependency change.
 		name: 'template-call-memo',
 		cwd: 'template-call-memo',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'run.mjs', args: () => [] }],
+	},
+	{
+		// Production template clone/mount work for keyed multi-root and text
+		// bindings, with visible DOM and survivor identity controls.
+		name: 'dom-template-mount',
+		cwd: 'dom-template-mount',
 		servers: [],
 		iter: { normal: 1, quick: 1 },
 		runs: [{ script: 'run.mjs', args: () => [] }],
@@ -1172,6 +1193,15 @@ const SUITES = [
 		servers: [],
 		iter: { normal: 1, quick: 1 },
 		runs: [{ script: 'run-size.mjs', args: () => [] }],
+	},
+	{
+		// Production spread resolution: executed allocation expressions under
+		// client/SSR semantic controls; untouched timing is a separate manual run.
+		name: 'spread-hosts',
+		cwd: 'dom-events',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [{ script: 'spread.mjs', args: () => [] }],
 	},
 ];
 

--- a/benchmarks/dom-attributes/README.md
+++ b/benchmarks/dom-attributes/README.md
@@ -1,0 +1,55 @@
+# Static attributes and metadata updates
+
+The production Chromium fixture updates 256 keyed links with dynamic `title`,
+`href`, numeric `data-n`, SVG `cx`, and the `strokeWidth` alias. It verifies
+the actual values and retained link identity on changed, unchanged, and restored
+updates. A separate metadata case renders a title and description, repeats 128
+unchanged renders, repairs externally changed head values, then changes and
+unmounts them.
+
+```sh
+BENCH_SOURCE_ROOT=/absolute/frozen/source BENCH_JSON=/tmp/attrs-baseline.json \
+  node benchmarks/dom-attributes/run.mjs
+BENCH_JSON=/tmp/attrs-candidate.json BENCH_EXPECT_SPECIALIZED=1 \
+  node benchmarks/dom-attributes/run.mjs
+node benchmarks/bench.mjs --ratios dom-attributes
+```
+
+One instrumented bundle counts entry into the generic attribute writer. Native
+head writes are observed separately. Timing uses a second, untouched minified
+bundle, five warmup rounds, and 15 samples of 100 full updates. The browser is
+closed in `finally`. Counts describe routing work and native writes, not heap
+allocation, layout, or application performance. The same fixture and compiler
+options must be used for both source roots.
+
+Frozen `58da3448b` versus the candidate on Node 26.4.0 / Chromium 149:
+
+| Work | Baseline | Candidate |
+| --- | ---: | ---: |
+| Generic attribute writer calls per changed update | 1,280 | 0 |
+| Generic writer calls per unchanged update | 0 | 0 |
+| Generic writer calls per restored update | 1,280 | 0 |
+| Head attribute writes across 128 stable renders | 384 | 0 |
+
+The compiler selects simple writers only after excluding custom hosts,
+namespaces, property setters, boolean/enumerated/numeric attributes, and other
+special names. It resolves ordinary aliases once. Native URL sinks keep the
+shared sanitizer and exact empty-resource URL behavior; data attributes retain
+their boolean stringification. Development compilation keeps the diagnostic
+route. Every writer retains hydration admission, rollback snapshots, and
+post-success binding-cache publication.
+
+The head optimization deliberately compares **live** normalized values for common
+metadata attributes. It does not retain user objects or suppress their coercion.
+It exchanges redundant native writes for live attribute reads and retains the
+existing `textContent` comparison: removing live checks would stop repairing
+external edits. Uncommon metadata names retain the full writer. This is the
+contract-preserving disposition of the audit's proposed head cache, rather than
+a claim that all head reads are eliminated.
+
+The final pair has identical fixture and entry hashes. The complete minified
+fixture bundle grows from 165,755 to 167,873 bytes; gzip grows from 53,771 to
+54,375 bytes. This includes the PR's template, spread, and event changes, so the
+total delta cannot be attributed to the attribute helpers alone. These final
+runs overlapped core validation; their timing samples are not used for a latency
+claim. The regression guards use only the deterministic routing/write counts.

--- a/benchmarks/dom-attributes/cases.tsrx
+++ b/benchmarks/dom-attributes/cases.tsrx
@@ -1,0 +1,24 @@
+export function Attributes(props: { version: number; rows: number[] }) @{
+	<section>
+		@for (const id of props.rows; key id) {
+			<a
+				data-row={id}
+				title={'title-' + props.version}
+				href={'#v' + props.version}
+				data-n={props.version}
+			>
+				<svg>
+					<circle cx={props.version} strokeWidth={props.version} />
+				</svg>
+			</a>
+		}
+	</section>
+}
+
+export function Metadata(props: { version: number }) @{
+	<>
+		<title lang="en">{'title-' + props.version}</title>
+		<meta name="description" content={'description-' + props.version} />
+		<div>body</div>
+	</>
+}

--- a/benchmarks/dom-attributes/entry.mjs
+++ b/benchmarks/dom-attributes/entry.mjs
@@ -1,0 +1,4 @@
+import { createRoot, flushSync } from 'octane';
+import { Attributes, Metadata } from './cases.tsrx';
+
+globalThis.attributeBench = { createRoot, flushSync, Attributes, Metadata };

--- a/benchmarks/dom-attributes/run.mjs
+++ b/benchmarks/dom-attributes/run.mjs
@@ -1,0 +1,199 @@
+// Keep observed routing work separate from the untouched production timing bundle.
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+
+const repo = path.resolve(import.meta.dirname, '../..');
+const sourceRoot = path.resolve(process.env.BENCH_SOURCE_ROOT || repo);
+const pkg = path.join(sourceRoot, 'packages/octane');
+const { compile } = await import(pathToFileURL(path.join(pkg, 'src/compiler/index.js')).href);
+const exportsMap = JSON.parse(fs.readFileSync(path.join(pkg, 'package.json'), 'utf8')).exports;
+const fixturePath = path.join(import.meta.dirname, 'cases.tsrx');
+const fixture = fs.readFileSync(fixturePath, 'utf8');
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+const inputs = {
+	fixture: sha256(fixture),
+	entry: sha256(fs.readFileSync(path.join(import.meta.dirname, 'entry.mjs'))),
+};
+const compiled = compile(fixture, fixturePath, { dev: false, hmr: false, mode: 'client' });
+assert.deepEqual(compiled.diagnostics, []);
+
+async function bundle(instrument) {
+	const result = await build({
+		entryPoints: [path.join(import.meta.dirname, 'entry.mjs')],
+		bundle: true,
+		write: false,
+		minify: true,
+		format: 'iife',
+		platform: 'browser',
+		target: 'es2022',
+		define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+		nodePaths: [path.join(repo, 'node_modules'), path.join(repo, 'packages/octane/node_modules')],
+		plugins: [
+			{
+				name: 'attribute-work',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => {
+						const entry = exportsMap[request === 'octane' ? '.' : './' + request.slice(7)];
+						return { path: path.resolve(pkg, typeof entry === 'string' ? entry : entry.default) };
+					});
+					plugin.onLoad({ filter: /\.tsrx$/ }, () => ({
+						contents: compiled.code,
+						loader: 'js',
+						resolveDir: import.meta.dirname,
+					}));
+					if (instrument)
+						plugin.onLoad({ filter: /\/src\/runtime\.ts$/ }, ({ path: filename }) => {
+							let contents = fs.readFileSync(filename, 'utf8');
+							const entry =
+								'export function setAttribute(el: Element, name: string, value: any): void {';
+							assert.equal(
+								contents.split(entry).length,
+								2,
+								'generic writer instrumentation must match once',
+							);
+							contents = contents.replace(entry, entry + '\n globalThis.__attributeRouting++;');
+							return { contents, loader: 'ts', resolveDir: path.dirname(filename) };
+						});
+				},
+			},
+		],
+	});
+	return result.outputFiles[0].text;
+}
+
+const observedBundle = await bundle(true);
+const timedBundle = await bundle(false);
+const browser = await chromium.launch({ headless: true });
+try {
+	const page = await browser.newPage();
+	await page.addScriptTag({ content: observedBundle });
+	const observed = await page.evaluate(() => {
+		const { createRoot, flushSync, Attributes, Metadata } = globalThis.attributeBench;
+		const container = document.createElement('div');
+		document.body.append(container);
+		const root = createRoot(container);
+		const rows = Array.from({ length: 256 }, (_, id) => id);
+		root.render(Attributes, { version: 0, rows });
+		const first = container.querySelector('a');
+		const work = {};
+		for (const [name, version] of [
+			['changed', 1],
+			['unchanged', 1],
+			['restored', 0],
+		]) {
+			globalThis.__attributeRouting = 0;
+			flushSync(() => root.render(Attributes, { version, rows }));
+			work[name] = globalThis.__attributeRouting;
+			if (container.querySelector('a') !== first) throw new Error('survivor replaced');
+			for (const a of container.querySelectorAll('a')) {
+				if (
+					a.title !== 'title-' + version ||
+					a.getAttribute('href') !== '#v' + version ||
+					a.dataset.n !== String(version)
+				)
+					throw new Error('attribute mismatch');
+				const circle = a.querySelector('circle');
+				if (
+					circle.getAttribute('cx') !== String(version) ||
+					circle.getAttribute('stroke-width') !== String(version)
+				)
+					throw new Error('SVG alias mismatch');
+			}
+		}
+		root.unmount();
+		const headRoot = createRoot(container);
+		headRoot.render(Metadata, { version: 0 });
+		const meta = document.head.querySelector('meta[name="description"]');
+		const title = document.head.querySelector('title');
+		const set = Element.prototype.setAttribute;
+		let headWrites = 0;
+		Element.prototype.setAttribute = function (...args) {
+			if (this === title || this === meta) headWrites++;
+			return set.apply(this, args);
+		};
+		try {
+			for (let i = 0; i < 128; i++) flushSync(() => headRoot.render(Metadata, { version: 0 }));
+			work.headStableWrites = headWrites;
+			meta.setAttribute('content', 'foreign');
+			title.textContent = 'foreign';
+			flushSync(() => headRoot.render(Metadata, { version: 0 }));
+			if (meta.getAttribute('content') !== 'description-0' || title.textContent !== 'title-0')
+				throw new Error('head drift not repaired');
+			flushSync(() => headRoot.render(Metadata, { version: 1 }));
+			if (meta.getAttribute('content') !== 'description-1' || title.textContent !== 'title-1')
+				throw new Error('head update mismatch');
+		} finally {
+			Element.prototype.setAttribute = set;
+			headRoot.unmount();
+			container.remove();
+		}
+		return work;
+	});
+	await page.close();
+	const timingPage = await browser.newPage();
+	await timingPage.addScriptTag({ content: timedBundle });
+	const samples = await timingPage.evaluate(() => {
+		const { createRoot, flushSync, Attributes } = globalThis.attributeBench;
+		const container = document.createElement('div');
+		document.body.append(container);
+		const root = createRoot(container),
+			rows = Array.from({ length: 256 }, (_, id) => id);
+		root.render(Attributes, { version: 0, rows });
+		let version = 0;
+		const out = [];
+		for (let sample = -5; sample < 15; sample++) {
+			const start = performance.now();
+			for (let i = 0; i < 100; i++)
+				flushSync(() => root.render(Attributes, { version: ++version, rows }));
+			if (sample >= 0) out.push((performance.now() - start) / 100);
+		}
+		root.unmount();
+		container.remove();
+		return out;
+	});
+	const val = (score) => ({ score, median: score, min: score, samples: 1 });
+	const result = {
+		suite: 'dom-attributes',
+		iterations: 1,
+		sourceRoot,
+		node: process.version,
+		chromium: browser.version(),
+		inputs,
+		observed,
+		targets: [
+			{
+				name: 'octane',
+				ops: Object.fromEntries(Object.entries(observed).map(([key, score]) => [key, val(score)])),
+			},
+			{
+				name: 'reference',
+				ops: {
+					changed: val(1280),
+					unchanged: val(1),
+					restored: val(1280),
+					headStableWrites: val(384),
+				},
+			},
+		],
+		samplesMs: samples,
+		medianMs: [...samples].sort((a, b) => a - b)[7],
+		bundle: { minified: Buffer.byteLength(timedBundle), gzip: gzipSync(timedBundle).length },
+	};
+	if (process.env.BENCH_EXPECT_SPECIALIZED === '1') {
+		assert.equal(observed.changed, 0);
+		assert.equal(observed.restored, 0);
+		assert.equal(observed.unchanged, 0);
+		assert.equal(observed.headStableWrites, 0);
+	}
+	if (process.env.BENCH_JSON)
+		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(result, null, 2) + '\n');
+	console.log(JSON.stringify(result));
+} finally {
+	await browser.close();
+}

--- a/benchmarks/dom-events/SPREAD.md
+++ b/benchmarks/dom-events/SPREAD.md
@@ -1,0 +1,157 @@
+# Spread host resolution
+
+This benchmark exercises the production runtime boundary used by compiled spread
+hosts: `snapshotSpread`, authored source rows, `setHostPropSources`, and the
+retained prior complete snapshot. It also exercises `ssrAttrs` on Node. It does
+not include component scheduling, compiler source-row construction, layout, or
+paint in its timings.
+
+## Design and remaining costs
+
+The resolver retains one four-field record per distinct raw name and updates
+repeat writers in place. Once every source has been read, that same record can
+become the normalized alias winner. This removes the client's normalization
+pair and winner tuple per key, and the server's winner tuple. The ordinary
+client path and production SSR path iterate the winner Map directly; competing
+aliases retain the sorting array needed to preserve the winning raw prop's
+original insertion position. SSR development diagnostics retain their array.
+
+The unchanged-value check precedes event parsing after style, raw HTML, refs,
+and form-action handling. Controlled fields retain their live-DOM reassertion.
+Stable style objects still reach the style setter: getters can be observable or
+throw even when the object identity is unchanged. The existing style diff does
+not promise to detect mutations made to a previously supplied style object.
+
+Remaining costs are intentional:
+
+- Source rows preserve authored evaluation staging, raw-HTML presence, form
+  control aggregation, and synthesized class merging.
+- The spread snapshot keeps `Reflect.ownKeys`, enumerable checks, and reads of
+  enumerable symbol getters, discarding only the symbol key. Replacing it with
+  a string-only enumeration changes observable evaluation. A symbol getter may
+  delete a string property already snapshotted.
+- Null-prototype snapshots protect arbitrary prop names such as `__proto__`
+  from inherited setters. The raw-name and normalized-name Maps preserve both
+  raw insertion positions and last-writer alias precedence.
+- Changed handlers still create event metadata. A separate JSX-name cache would
+  retain another per-name table alongside native delegation metadata. Stable
+  handlers now bypass parsing; no extra persistent cache was introduced.
+
+No engine heap-size or allocation-elimination claim follows from these counts.
+They count executed source expressions in selected production functions, with
+explicit labels for array/record/Map creation, `Object.create`, `Object.keys`,
+and `Reflect.ownKeys`.
+
+## Run
+
+From the repository root, using already installed dependencies and Chromium:
+
+```sh
+node benchmarks/dom-events/spread.mjs
+node benchmarks/bench.mjs spread-hosts --quick --ratios
+node benchmarks/dom-events/spread.mjs --runtime-root /path/to/frozen/packages/octane --measure --output /tmp/spread-baseline-work.json
+node benchmarks/dom-events/spread.mjs --timing --runtime-root /path/to/frozen/packages/octane --output /tmp/spread-baseline-time.json
+node benchmarks/dom-events/spread.mjs --timing --output /tmp/spread-candidate-time.json
+```
+
+`--chromium /path/to/installed/executable` selects an existing browser.
+`--output` and `BENCH_JSON` preserve full metadata and observations. The ordinary
+run emits the common benchmark `targets` format and checks explicit source-work
+budgets. `--measure` observes a baseline that is expected to exceed those
+budgets. `--timing` builds untouched production bundles, without probes or
+`--jitless`; instrumented runs are never timed. Browser source-work observations
+use `--jitless` so the source expressions stay explicit.
+
+The client covers 4, 15, and 50 spread properties, canonical names, aliases,
+stable capture/bubble handlers, and changed handlers. Every case checks final
+attributes, native handler behavior and removal, host identity, and unmount.
+Server cases verify serialization and the final alias winner. Separate retained
+regressions cover repeated raw aliases, coercion order, getters/symbols,
+SSR/hydration identity, undefined removal, style failures/rollback, custom
+listeners, refs, and form controls.
+
+## Recorded source work
+
+Baseline: `58da3448b`, frozen before edits. Node and browser versions, original
+production bundle hashes, source sites, and all counters are included in JSON.
+For 12 updates with 15 spread props (plus one direct title):
+
+| Path | Baseline | Candidate |
+| --- | ---: | ---: |
+| Client canonical normalization/winner/order arrays | 396 | 0 |
+| Client canonical writer records | 192 | 192 |
+| Client canonical Maps | 24 | 24 |
+| Client stable two-handler metadata records | 24 | 0 |
+| SSR alias winner/order arrays | 240 | 12 |
+| SSR alias writer records | 228 | 228 |
+
+The 33 canonical arrays removed per update are separate from the authored rows
+and snapshot/enumeration arrays, which remain. The ratio guards bound the
+complete observed expression count in each case, not only the removed sites.
+
+## Timing observations
+
+Node 26.4.0 / V8 14.6.202.34-node.21 and Chromium 149.0.7827.55 on macOS arm64. Four rounds ran
+in two quiet windows, with baseline/candidate order ABBA in each window. Each
+fresh process/browser warmed its cases and retained seven measured batches:
+3,000 client updates or 10,000 server serializations per batch. The table lists
+candidate/baseline median ratios in round order. Ratios below one favor the
+candidate.
+
+These measurements are noisy and do not establish a blanket speedup. The
+canonical SSR control has unchanged source-expression counts, yet spans
+0.705–1.268×. The initial client 50-prop outlier did not recur in three further
+rounds. Source-work guards provide the durable regression signal.
+
+| Surface / case | Round 1 | Round 2 | Round 3 | Round 4 |
+| --- | ---: | ---: | ---: | ---: |
+
+| client canonical / 4 | 0.978× | 0.977× | 0.729× | 1.127× |
+| client aliases / 4 | 0.963× | 0.980× | 0.675× | 1.111× |
+| client stable-events / 4 | 0.946× | 0.911× | 0.827× | 1.039× |
+| client changed-events / 4 | 0.965× | 0.897× | 0.782× | 1.025× |
+| client canonical / 15 | 0.903× | 0.909× | 0.815× | 0.987× |
+| client aliases / 15 | 0.992× | 0.930× | 0.821× | 1.086× |
+| client stable-events / 15 | 1.025× | 0.909× | 0.758× | 1.058× |
+| client changed-events / 15 | 1.104× | 0.966× | 0.681× | 1.017× |
+| client canonical / 50 | 1.255× | 0.958× | 0.678× | 0.916× |
+| client aliases / 50 | 1.056× | 0.923× | 0.733× | 0.915× |
+| client stable-events / 50 | 1.025× | 0.935× | 0.717× | 0.892× |
+| client changed-events / 50 | 1.034× | 0.943× | 0.835× | 0.912× |
+| ssr canonical / 4 | 0.727× | 0.914× | 0.705× | 1.073× |
+| ssr aliases / 4 | 0.706× | 0.919× | 0.741× | 0.968× |
+| ssr canonical / 15 | 0.666× | 1.015× | 0.809× | 0.969× |
+| ssr aliases / 15 | 0.631× | 0.947× | 0.837× | 1.087× |
+| ssr canonical / 50 | 0.770× | 0.960× | 0.789× | 1.268× |
+| ssr aliases / 50 | 0.849× | 0.952× | 0.707× | 1.226× |
+
+All four rounds used identical production bundle bytes for each variant:
+
+| Bundle | Baseline SHA-256 | Candidate SHA-256 |
+| --- | --- | --- |
+| Client | `360fb9dcb714c0a299ab555e7e37af86da33f0f19427dc12ce2698b0fe3744d0` | `585abab40aee1f2b1b768d88f42b1acc82115450ff7f716dc3aa9c729148bcbc` |
+| Server | `8714f197262bebc8a4d6e30e3bc275bf864bb58e56f8004c4593cacb80ef61d6` | `4c5e674040384c6f796184f757b293074810bea047ca527cf6fcb74f56cc9671` |
+
+## Behavioral and guard verification
+
+- Four focused files passed in development and production: 120 tests covering
+  final host source aggregation, server input spread cascades, spread refs, and
+  the new spread-resolution cases.
+- Deliberately choosing alias winners by first insertion instead of last write
+  failed the new repeated-alias test for both client and server independently,
+  in development and production: the losing alias became visible.
+- Deliberately skipping a stable style object failed the new getter-error case
+  in both modes: the expected user getter exception was no longer observed.
+- Each mutation was restored by its exact snippet. All 12 new development and
+  production cases passed after restoration.
+- `node benchmarks/bench.mjs spread-hosts --quick --ratios` passed all 18 guards.
+
+The focused command is:
+
+```sh
+node node_modules/vitest/vitest.mjs run --config /path/to/core-vitest.config.mjs packages/octane/tests/conformance/spread-resolution.test.ts packages/octane/tests/conformance/client-host-source-aggregation.test.ts packages/octane/tests/conformance/server-input-spread-cascade.test.ts packages/octane/tests/spread-ref.test.ts --silent=passed-only
+```
+
+The local config retained the repository's core development/production projects
+and omitted unrelated React differential precompilation, whose dependency is
+unavailable in this worktree. This does not claim a full repository suite run.

--- a/benchmarks/dom-events/spread.mjs
+++ b/benchmarks/dom-events/spread.mjs
@@ -1,0 +1,296 @@
+// Source-work observations and untouched production timings are separate runs.
+// Counts describe executed allocation expressions, not engine allocations/heap.
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { build, transformSync } from 'esbuild';
+import { chromium } from 'playwright';
+import ts from 'typescript';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+
+const args = process.argv.slice(2);
+const option = (key, fallback) => {
+	const i = args.indexOf(key);
+	return i === -1 ? fallback : args[i + 1];
+};
+const runtimeRoot = path.resolve(
+	option('--runtime-root', path.resolve(import.meta.dirname, '../../packages/octane')),
+);
+const timing = args.includes('--timing');
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-spread-'));
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+const functions = new Set([
+	'snapshotSpread',
+	'normalizedHostProp',
+	'setHostPropSources',
+	'setSpread',
+	'eventSlot',
+	'ssrAttrs',
+]);
+
+function instrument(source) {
+	const ast = ts.createSourceFile('runtime.js', source, ts.ScriptTarget.Latest, true);
+	const changes = [];
+	const sites = {};
+	function visit(node, owner) {
+		if (ts.isFunctionDeclaration(node) && functions.has(node.name?.text)) owner = node.name.text;
+		if (owner) {
+			let kind;
+			if (ts.isArrayLiteralExpression(node)) kind = 'array';
+			else if (ts.isObjectLiteralExpression(node)) kind = 'record';
+			else if (ts.isNewExpression(node) && node.expression.getText(ast) === 'Map') kind = 'map';
+			else if (
+				ts.isCallExpression(node) &&
+				['Object.create', 'Object.keys', 'Reflect.ownKeys'].includes(node.expression.getText(ast))
+			)
+				kind = node.expression.getText(ast);
+			if (kind) {
+				const label = owner + ':' + kind;
+				sites[label] = (sites[label] ?? 0) + 1;
+				changes.push(
+					[node.getStart(ast), `(__spreadCount(${JSON.stringify(label)}), `],
+					[node.end, ')'],
+				);
+			}
+		}
+		ts.forEachChild(node, (child) => visit(child, owner));
+	}
+	visit(ast, null);
+	for (const [position, value] of changes.sort((a, b) => b[0] - a[0]))
+		source = source.slice(0, position) + value + source.slice(position);
+	return {
+		source:
+			'globalThis.__spreadWork = {}; function __spreadCount(k) { const w = globalThis.__spreadWork; w[k] = (w[k] || 0) + 1; }\n' +
+			source,
+		sites,
+	};
+}
+
+// This is the compiler runtime boundary: authored spreads are snapshotted,
+// source rows are resolved, and the prior complete snapshot is retained.
+function clientExercise(rt, timed) {
+	const check = (ok, message) => {
+		if (!ok) throw new Error(message);
+	};
+	const results = {};
+	for (const size of [4, 15, 50]) {
+		for (const mode of ['canonical', 'aliases', 'stable-events', 'changed-events']) {
+			const parent = document.createElement('div');
+			document.body.appendChild(parent);
+			const root = rt.createRoot(parent);
+			let el, scope, prev;
+			root.render((props, s) => {
+				scope = s;
+				el = rt.hostComponent(s, 0, 'button', null);
+			});
+			let clicks = 0;
+			const handler = () => {
+				clicks++;
+			};
+			const alternate = () => {
+				clicks += 2;
+			};
+			const raw = {};
+			for (let i = 0; i < size; i++) raw['data-p' + i] = String(i);
+			if (mode === 'aliases') {
+				raw.className = 'first';
+				raw.class = 'last';
+				raw.tabIndex = 0;
+			}
+			if (mode.endsWith('events')) {
+				raw.onClick = handler;
+				raw.onClickCapture = handler;
+			}
+			function update(i) {
+				raw['data-p0'] = String(i & 1);
+				if (mode === 'changed-events') raw.onClick = i & 1 ? alternate : handler;
+				const sources = [
+					[true, rt.snapshotSpread(raw)],
+					[false, 'title', 'fixed'],
+				];
+				prev = rt.setHostPropSources(el, sources, prev, scope);
+			}
+			update(0);
+			const live = parent.firstElementChild;
+			const iterations = timed ? 3000 : 12;
+			const samplesMs = [];
+			if (timed) for (let i = 0; i < 1000; i++) update(i);
+			globalThis.__spreadWork = {};
+			for (let sample = 0; sample < (timed ? 7 : 1); sample++) {
+				const start = performance.now();
+				for (let i = 0; i < iterations; i++) update(i);
+				samplesMs.push(performance.now() - start);
+			}
+			const work = { ...globalThis.__spreadWork };
+			check(parent.firstElementChild === live, 'Host identity changed');
+			check(el.title === 'fixed' && el.getAttribute('data-p0') === '1', 'Spread values missing');
+			check(
+				el.getAttribute('data-p' + (size - 1)) === String(size - 1),
+				'Last spread prop missing',
+			);
+			if (mode === 'aliases')
+				check(el.className === 'last' && el.tabIndex === 0, 'Alias winner changed');
+			if (mode.endsWith('events')) {
+				el.click();
+				check(
+					clicks === (mode === 'changed-events' ? 3 : 2),
+					'Handler phase/latest closure changed',
+				);
+				prev = rt.setHostPropSources(el, [[true, rt.snapshotSpread({})]], prev, scope);
+				el.click();
+				check(clicks === (mode === 'changed-events' ? 3 : 2), 'Removed handlers still fire');
+			}
+			root.unmount();
+			check(parent.childNodes.length === 0, 'Unmount left host');
+			parent.remove();
+			results[`${mode}_${size}`] = timed
+				? { iterations, samplesMs, medianMs: [...samplesMs].sort((a, b) => a - b)[3] }
+				: { iterations, work };
+		}
+	}
+	return results;
+}
+
+function serverExercise(rt, timed) {
+	const results = {};
+	for (const size of [4, 15, 50]) {
+		for (const mode of ['canonical', 'aliases']) {
+			const raw = {};
+			for (let i = 0; i < size; i++) raw['data-p' + i] = String(i);
+			if (mode === 'aliases') {
+				raw.className = 'first';
+				raw.class = 'last';
+				raw.tabIndex = 0;
+			}
+			const sources = [
+				[true, raw],
+				[false, 'title', 'fixed'],
+			];
+			let html;
+			const iterations = timed ? 10000 : 12;
+			const samplesMs = [];
+			if (timed) for (let i = 0; i < 2000; i++) rt.ssrAttrs(sources, 'button');
+			globalThis.__spreadWork = {};
+			for (let sample = 0; sample < (timed ? 7 : 1); sample++) {
+				const start = performance.now();
+				for (let i = 0; i < iterations; i++) html = rt.ssrAttrs(sources, 'button');
+				samplesMs.push(performance.now() - start);
+			}
+			assert(html.includes(' title="fixed"') && html.includes(` data-p${size - 1}="${size - 1}"`));
+			if (mode === 'aliases') assert(html.includes(' class="last"') && !html.includes('first'));
+			results[`${mode}_${size}`] = timed
+				? { iterations, samplesMs, medianMs: [...samplesMs].sort((a, b) => a - b)[3] }
+				: { iterations, work: globalThis.__spreadWork };
+		}
+	}
+	return results;
+}
+
+let browser;
+try {
+	const bundles = {};
+	for (const [name, platform] of [
+		['runtime', 'browser'],
+		['runtime.server', 'node'],
+	]) {
+		const result = await build({
+			entryPoints: [path.join(runtimeRoot, 'src', name + '.ts')],
+			bundle: true,
+			write: false,
+			format: 'esm',
+			platform,
+			target: 'esnext',
+			minify: false,
+			define: { 'process.env.NODE_ENV': '"production"' },
+		});
+		const original = result.outputFiles[0].text;
+		const observed = timing ? { source: original, sites: {} } : instrument(original);
+		bundles[name] = { ...observed, sha256: sha256(original), bytes: Buffer.byteLength(original) };
+	}
+	const serverFile = path.join(temporary, 'server.mjs');
+	fs.writeFileSync(serverFile, bundles['runtime.server'].source);
+	const server = await import(pathToFileURL(serverFile).href);
+	const ssr = serverExercise(server, timing);
+	const iife = transformSync(bundles.runtime.source, {
+		format: 'iife',
+		globalName: '__rt',
+		target: 'esnext',
+	}).code;
+	browser = await chromium.launch({
+		headless: true,
+		...(option('--chromium') ? { executablePath: option('--chromium') } : {}),
+		args: [
+			'--no-sandbox',
+			'--disable-background-networking',
+			...(timing ? [] : ['--js-flags=--jitless']),
+		],
+	});
+	const page = await browser.newPage();
+	const errors = [];
+	page.on('pageerror', (error) => errors.push(String(error)));
+	await page.setContent('<!doctype html><body></body>');
+	await page.addScriptTag({ content: iife });
+	const client = await page.evaluate(`(${clientExercise.toString()})(__rt, ${timing})`);
+	assert.deepEqual(errors, []);
+	const targets = [];
+	if (!timing) {
+		for (const [surface, cases] of Object.entries({ client, ssr })) {
+			for (const [name, entry] of Object.entries(cases)) {
+				const split = name.lastIndexOf('_');
+				const size = Number(name.slice(split + 1));
+				const mode = name.slice(0, split);
+				const actual = Object.values(entry.work).reduce((sum, n) => sum + n, 0);
+				// Explicit source-work ceilings, not theoretical engine allocation floors.
+				// Client keeps raw records, two Maps, snapshots and own-key scans;
+				// aliases need a sort array, changed event props still parse metadata.
+				const perUpdate =
+					surface === 'client'
+						? size + { canonical: 9, aliases: 13, 'stable-events': 11, 'changed-events': 12 }[mode]
+						: size + (mode === 'canonical' ? 3 : 8);
+				const budget = perUpdate * entry.iterations;
+				const stat = (n) => ({
+					source_expressions: deterministicStatForJson(deterministicCount(n)),
+				});
+				targets.push({ name: `${surface}-${name}`, ops: stat(actual) });
+				targets.push({ name: `${surface}-${name}-budget`, ops: stat(budget) });
+				const maps = entry.work[surface === 'client' ? 'setHostPropSources:map' : 'ssrAttrs:map'];
+				assert(maps >= entry.iterations, 'Every measured update resolved its prop sources');
+				if (!args.includes('--measure'))
+					assert(
+						actual <= budget,
+						`${surface}/${name}: source-work budget exceeded (${actual} > ${budget})`,
+					);
+			}
+		}
+	}
+	const report = {
+		suite: 'spread-hosts',
+		iterations: 1,
+		targets,
+		mode: timing ? 'untouched-production-timing' : 'instrumented-source-work',
+		node: process.version,
+		platform: process.platform,
+		architecture: process.arch,
+		v8: process.versions.v8,
+		browser: browser.version(),
+		runtimeRoot,
+		bundles: Object.fromEntries(
+			Object.entries(bundles).map(([k, v]) => [
+				k,
+				{ sha256: v.sha256, bytes: v.bytes, sites: v.sites },
+			]),
+		),
+		client,
+		ssr,
+	};
+	const json = JSON.stringify(report, null, 2) + '\n';
+	if (option('--output', process.env.BENCH_JSON))
+		fs.writeFileSync(option('--output', process.env.BENCH_JSON), json);
+	process.stdout.write(json);
+} finally {
+	await browser?.close();
+	fs.rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/dom-template-mount/README.md
+++ b/benchmarks/dom-template-mount/README.md
@@ -1,0 +1,74 @@
+# Compiled fragment and text mount work
+
+This production client gate compiles one `.tsrx` source and mounts 256 keyed
+three-root rows. Each row has a dynamic only-child label, a retained input, and
+two dynamic sibling text holes around a static element. It records top-level
+DOM API calls in happy-dom; internal happy-dom calls made *by* an instrumented
+method are excluded. The single-root 256-row list, unrelated visible update,
+keyed reverse, empty text, SVG/MathML content, native input value/focus, strict
+DOM survivor identity, and unmount are semantic controls.
+
+```bash
+node benchmarks/bench.mjs --ratios dom-template-mount
+BENCH_JSON=/private/tmp/dom-template-mount.json node benchmarks/dom-template-mount/run.mjs
+
+# Compare frozen source against current source using one fixture and runner:
+OCTANE_DOM_SOURCE_ROOT=/absolute/frozen/source \
+OCTANE_DOM_DEPS_ROOT=/absolute/checkout/with/dependencies \
+BENCH_BUNDLE_PATH=/private/tmp/dom-template-base.mjs \
+BENCH_JSON=/private/tmp/dom-template-base.json \
+node benchmarks/dom-template-mount/run.mjs
+
+OCTANE_DOM_DEPS_ROOT=/absolute/checkout/with/dependencies \
+BENCH_BUNDLE_PATH=/private/tmp/dom-template-candidate.mjs \
+BENCH_JSON=/private/tmp/dom-template-candidate.json \
+node benchmarks/dom-template-mount/run.mjs
+
+# An optional actual-Chromium correctness gate for each production bundle:
+node benchmarks/dom-template-mount/browser-work.mjs /private/tmp/dom-template-base.mjs
+node benchmarks/dom-template-mount/browser-work.mjs /private/tmp/dom-template-candidate.mjs
+```
+
+The browser gate registers a custom element, verifies that its constructor
+sees completed static/dynamic text, prepends its own Text node, retains both
+text nodes through a later update, and that each `connectedCallback` observes
+siblings arriving in authored order, mounts into an iframe document and checks
+adopted `ownerDocument`, then hydrates two existing server-shaped roots without
+replacing either root or its text node. An empty text update retains that
+adopted node. This is needed because native
+`insertBefore(fragment, anchor)` has a different custom-element connection
+order than successive per-node insertion: **both** callbacks see **both**
+siblings. The runtime retains the previous per-node path for parsed templates
+containing custom-element names or customized built-ins (`is`). The compiler
+also leaves custom-element and `<template>` only-child text templates empty:
+their clone/child semantics cannot assume an inert parser text placeholder.
+Only compiled native hosts with a seeded placeholder opt into Text reuse;
+unseeded callers retain the original append contract.
+
+At the frozen `58da3448b` baseline, the three-root mount made 1,794
+`insertBefore`, zero `replaceChild`, and 256 label `createTextNode` calls. The
+candidate makes 770 `insertBefore`, 512 `replaceChild` for the two sibling text
+holes per row, and zero label `createTextNode` calls. It inserts 256 native
+fragments. A new parsed template pays its three one-time child moves to build
+the cached fragment; subsequent clones reuse that shape. The flat control
+keeps 258 `insertBefore` while its 256 text labels also reuse cloned text.
+Keyed reverse remains at 1,294 `insertBefore`; an unrelated update performs
+zero. The ratio guards protect these bounded work counts along with the
+semantic checks. Neither call count nor happy-dom establishes a browser latency,
+paint, layout, GC, or application-wide speedup.
+
+The compiled fixture's minified/gzip bytes and complete production bundle
+bytes are recorded separately in the JSON result. With identical fixture and
+entry hashes, minified fixture output was 4,341/1,503 gzip bytes at the frozen
+baseline and 4,358/1,512 at the candidate. Complete bundle bytes were
+550,874/119,743 gzip and 553,271/120,411 respectively. The candidate bundle
+includes concurrent DOM attribute/event changes in the shared branch, so that
+bundle difference cannot be attributed to these two template changes.
+Real browser hydration
+checks the direct two-root case; the core dev/prod regression also covers
+keyed-row SSR adoption and preservation of the focused input. MathML namespace
+is asserted in that regression; happy-dom's foreign-content emulation is
+weaker, so this runner checks MathML text only. Native MutationObserver record
+grouping can differ for ordinary fragment insertion (one batch versus several
+per-node records), a DOM-operation detail outside this work gate's visible
+DOM/identity contract.

--- a/benchmarks/dom-template-mount/browser-work.mjs
+++ b/benchmarks/dom-template-mount/browser-work.mjs
@@ -1,0 +1,141 @@
+// Browser semantic gate for native custom-element connection and document
+// adoption. The bundle comes from run.mjs's BENCH_BUNDLE_PATH output.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const ROOT = path.resolve(
+	process.env.OCTANE_DOM_DEPS_ROOT || path.join(import.meta.dirname, '../..'),
+);
+const requireDeps = createRequire(path.join(ROOT, 'packages/octane/package.json'));
+const { chromium } = requireDeps('playwright');
+const bundleFile = process.argv[2];
+assert.ok(bundleFile, 'pass the production bundle written with BENCH_BUNDLE_PATH');
+const bundle = fs.readFileSync(bundleFile, 'utf8');
+const browser = await chromium.launch({ headless: true });
+try {
+	const page = await browser.newPage();
+	const facts = await page.evaluate(async (source) => {
+		const blob = new Blob([source], { type: 'text/javascript' });
+		const url = URL.createObjectURL(blob);
+		const runtime = await import(url);
+		URL.revokeObjectURL(url);
+		const callbacks = [];
+		customElements.define(
+			'octane-probe',
+			class extends HTMLElement {
+				constructor() {
+					super();
+					callbacks.push({
+						phase: 'construct',
+						visible: this.childNodes.length,
+						text: this.textContent,
+					});
+					if (this.getAttribute('data-name') === 'text') {
+						this.insertBefore(document.createTextNode('owned:'), this.firstChild);
+					}
+				}
+				connectedCallback() {
+					callbacks.push({
+						phase: 'connect',
+						name: this.getAttribute('data-name'),
+						text: this.textContent,
+						visible: [...this.parentElement.querySelectorAll('octane-probe')].map((node) =>
+							node.getAttribute('data-name'),
+						),
+					});
+				}
+			},
+		);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = runtime.createRoot(container);
+		root.render(runtime.CustomRoots);
+		const names = [...container.querySelectorAll('octane-probe')].map((node) =>
+			node.getAttribute('data-name'),
+		);
+		const connected = callbacks.splice(0);
+		root.unmount();
+		container.remove();
+		const textHost = document.createElement('div');
+		document.body.appendChild(textHost);
+		const textRoot = runtime.createRoot(textHost);
+		textRoot.render(runtime.CustomTextRoot, { label: 'dynamic' });
+		const customNode = textHost.querySelector('octane-probe');
+		const ownedText = customNode?.firstChild;
+		const authoredText = customNode?.lastChild;
+		runtime.flushSync(() => textRoot.render(runtime.CustomTextRoot, { label: 'updated' }));
+		const customText = {
+			text: customNode?.textContent,
+			children: customNode?.childNodes.length,
+			owned: customNode?.firstChild === ownedText && ownedText?.nodeValue === 'owned:',
+			authored: customNode?.lastChild === authoredText && authoredText?.nodeValue === 'updated',
+			callbacks: callbacks.splice(0),
+		};
+		textRoot.unmount();
+		textHost.remove();
+
+		const iframe = document.createElement('iframe');
+		document.body.appendChild(iframe);
+		const foreign = iframe.contentDocument;
+		const foreignHost = foreign.createElement('div');
+		foreign.body.appendChild(foreignHost);
+		const foreignRoot = runtime.createRoot(foreignHost);
+		foreignRoot.render(runtime.RootTextPair, { label: 'other' });
+		const adopted = [...foreignHost.querySelectorAll('#first, #last')].map((node) => ({
+			text: node.textContent,
+			owner: node.ownerDocument === foreign,
+		}));
+		foreignRoot.unmount();
+		iframe.remove();
+
+		const server = document.createElement('div');
+		server.innerHTML = '<strong id="first">Hydrated</strong><em id="last">tail</em>';
+		document.body.appendChild(server);
+		const first = server.querySelector('#first');
+		const last = server.querySelector('#last');
+		const text = first.firstChild;
+		const hydrated = runtime.hydrateRoot(server, runtime.RootTextPair, { label: 'Hydrated' });
+		runtime.flushSync(() => {});
+		const retained =
+			server.querySelector('#first') === first &&
+			server.querySelector('#last') === last &&
+			first.firstChild === text;
+		runtime.flushSync(() => hydrated.render(runtime.RootTextPair, { label: '' }));
+		const updated =
+			first.textContent === '' &&
+			first.firstChild === text &&
+			first.firstChild.nodeType === 3 &&
+			server.querySelector('#last') === last;
+		hydrated.unmount();
+		server.remove();
+		return { names, connected, customText, adopted, retained, updated };
+	}, bundle);
+	assert.deepEqual(facts.names, ['a', 'b']);
+	assert.deepEqual(facts.connected, [
+		{ phase: 'construct', visible: 1, text: 'A' },
+		{ phase: 'connect', name: 'a', text: 'A', visible: ['a'] },
+		{ phase: 'construct', visible: 1, text: 'B' },
+		{ phase: 'connect', name: 'b', text: 'B', visible: ['a', 'b'] },
+	]);
+	assert.deepEqual(facts.customText, {
+		text: 'owned:updated',
+		children: 2,
+		owned: true,
+		authored: true,
+		callbacks: [
+			{ phase: 'construct', visible: 1, text: 'dynamic' },
+			{ phase: 'connect', name: 'text', text: 'owned:dynamic', visible: ['text'] },
+		],
+	});
+	assert.deepEqual(facts.adopted, [
+		{ text: 'other', owner: true },
+		{ text: 'tail', owner: true },
+	]);
+	assert.equal(facts.retained, true, 'hydrate adopts both roots and text');
+	assert.equal(facts.updated, true, 'first update retains adopted text and trailing root');
+	console.log(`PASS dom-template-mount/browser: ${JSON.stringify(facts)}`);
+} finally {
+	await browser.close();
+}

--- a/benchmarks/dom-template-mount/cases.tsrx
+++ b/benchmarks/dom-template-mount/cases.tsrx
@@ -1,0 +1,87 @@
+type Row = {
+	readonly id: number;
+	readonly label: string;
+	readonly prefix: string;
+	readonly suffix: string;
+};
+type Props = { readonly rows: readonly Row[]; readonly tick: string };
+
+// The keyed body has three roots: the label exercises the only-child text
+// binding, and the final span has text holes on either side of a static node.
+export function FragmentRows({ rows, tick }: Props) @{
+	<section id="fragment-list">
+		<output>{tick}</output>
+		<div id="rows">
+			@for (const row of rows; key row.id) {
+				<>
+					<label data-label={row.id}>{row.label as string}</label>
+					<input data-input={row.id} />
+					<span data-span={row.id}>
+						{row.prefix as string}
+						<b>:</b>
+						{row.suffix as string}
+					</span>
+				</>
+			}
+		</div>
+	</section>
+}
+
+// A single-root control catches changes in ordinary template mounting.
+export function FlatRows({ rows, tick }: Props) @{
+	<section id="flat-list">
+		<output>{tick}</output>
+		<div id="rows">
+			@for (const row of rows; key row.id) {
+				<p data-row={row.id}>{row.label as string}</p>
+			}
+		</div>
+	</section>
+}
+
+function SvgPair({ label }: { readonly label: string }) @{
+	<>
+		<circle r="2" />
+		<text>{label as string}</text>
+	</>
+}
+
+export function ForeignSvg({ label }: { readonly label: string }) @{
+	<svg id="chart">
+		<SvgPair label={label} />
+	</svg>
+}
+
+function MathPair({ label }: { readonly label: string }) @{
+	<>
+		<mn>{label as string}</mn>
+		<mo>+</mo>
+	</>
+}
+
+export function ForeignMath({ label }: { readonly label: string }) @{
+	<math id="formula">
+		<MathPair label={label} />
+	</math>
+}
+
+// Native custom elements observe their live siblings synchronously when each
+// root connects. A fragment insert must retain that authored connection order.
+export function CustomRoots() @{
+	<>
+		<octane-probe data-name="a">A</octane-probe>
+		<octane-probe data-name="b">B</octane-probe>
+	</>
+}
+
+// A custom-element host's first connection observes the completed text child.
+export function CustomTextRoot({ label }: { readonly label: string }) @{
+	<octane-probe data-name="text">{label as string}</octane-probe>
+}
+
+export function RootTextPair({ label }: { readonly label: string }) @{
+	<>
+		<strong id="first">{label as string}</strong>
+		<em id="last">tail</em>
+	</>
+}

--- a/benchmarks/dom-template-mount/entry.mjs
+++ b/benchmarks/dom-template-mount/entry.mjs
@@ -1,0 +1,23 @@
+import { createRoot, flushSync, hydrateRoot } from 'octane';
+import {
+	CustomRoots,
+	CustomTextRoot,
+	FlatRows,
+	ForeignMath,
+	ForeignSvg,
+	FragmentRows,
+	RootTextPair,
+} from './cases.tsrx';
+
+export {
+	createRoot,
+	flushSync,
+	hydrateRoot,
+	CustomRoots,
+	CustomTextRoot,
+	FlatRows,
+	ForeignMath,
+	ForeignSvg,
+	FragmentRows,
+	RootTextPair,
+};

--- a/benchmarks/dom-template-mount/intrinsics.d.ts
+++ b/benchmarks/dom-template-mount/intrinsics.d.ts
@@ -1,0 +1,14 @@
+// These fixture-only tags exercise foreign-content and custom-element mounts.
+// Octane's public intrinsic table intentionally covers the React-shaped tags.
+import 'octane/jsx-runtime';
+
+declare module 'octane/jsx-runtime' {
+	export namespace JSX {
+		interface IntrinsicElements {
+			math: { id?: string; children?: unknown };
+			mn: { children?: unknown };
+			mo: { children?: unknown };
+			'octane-probe': { 'data-name'?: string; children?: unknown };
+		}
+	}
+}

--- a/benchmarks/dom-template-mount/run.mjs
+++ b/benchmarks/dom-template-mount/run.mjs
@@ -1,0 +1,336 @@
+// Production client mount work gate for compiled fragment and text bindings.
+process.env.NODE_ENV = 'production';
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+const HERE = import.meta.dirname;
+const SOURCE = path.resolve(process.env.OCTANE_DOM_SOURCE_ROOT || path.join(HERE, '../..'));
+const DEPS = path.resolve(process.env.OCTANE_DOM_DEPS_ROOT || path.join(HERE, '../..'));
+const PACKAGE = path.join(SOURCE, 'packages/octane');
+const requireDeps = createRequire(path.join(DEPS, 'packages/octane/package.json'));
+const { build, transformSync, version: esbuildVersion } = requireDeps('esbuild');
+const { Window } = await import(pathToFileURL(requireDeps.resolve('happy-dom')).href);
+const { compile } = await import(pathToFileURL(path.join(PACKAGE, 'src/compiler/index.js')).href);
+const exportsMap = JSON.parse(fs.readFileSync(path.join(PACKAGE, 'package.json'), 'utf8')).exports;
+const fixtureFile = path.join(HERE, 'cases.tsrx');
+const fixture = fs.readFileSync(fixtureFile, 'utf8');
+const rows = Array.from({ length: 256 }, (_, id) => ({
+	id,
+	label: `label-${id}`,
+	prefix: `left-${id}`,
+	suffix: `right-${id}`,
+}));
+const sha = (text) => createHash('sha256').update(text).digest('hex');
+const stat = (score) => ({ score, median: score, min: score, samples: 1 });
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-dom-template-mount-'));
+
+async function bundleFixture() {
+	const compiled = compile(fixture, fixtureFile, {
+		mode: 'client',
+		dev: false,
+		hmr: false,
+	});
+	assert.deepEqual(compiled.diagnostics, [], 'fixture compiler diagnostics');
+	const built = await build({
+		entryPoints: [path.join(HERE, 'entry.mjs')],
+		outfile: path.join(temp, 'entry.mjs'),
+		bundle: true,
+		write: false,
+		format: 'esm',
+		platform: 'browser',
+		target: 'es2022',
+		logLevel: 'silent',
+		define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+		nodePaths: [path.join(DEPS, 'packages/octane/node_modules'), path.join(DEPS, 'node_modules')],
+		plugins: [
+			{
+				name: 'dom-template-mount',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => {
+						const entry = exportsMap[request === 'octane' ? '.' : './' + request.slice(7)];
+						const target = typeof entry === 'string' ? entry : entry?.import || entry?.default;
+						assert.equal(typeof target, 'string', `public runtime export ${request}`);
+						return { path: path.resolve(PACKAGE, target) };
+					});
+					plugin.onLoad({ filter: /\.tsrx$/ }, ({ path: filename }) => {
+						assert.equal(filename, fixtureFile, 'unexpected fixture module');
+						return { contents: compiled.code, loader: 'js', resolveDir: HERE };
+					});
+				},
+			},
+		],
+	});
+	const output = built.outputFiles[0].text;
+	fs.writeFileSync(path.join(temp, 'entry.mjs'), output);
+	if (process.env.BENCH_BUNDLE_PATH) fs.writeFileSync(process.env.BENCH_BUNDLE_PATH, output);
+	const minified = transformSync(compiled.code, { minify: true }).code;
+	return {
+		module: await import(pathToFileURL(path.join(temp, 'entry.mjs')).href),
+		code: compiled.code,
+		meta: {
+			fixtureSha256: sha(fixture),
+			entrySha256: sha(fs.readFileSync(path.join(HERE, 'entry.mjs'))),
+			codeMinifiedBytes: Buffer.byteLength(minified),
+			codeGzipBytes: gzipSync(minified).length,
+			bundleBytes: Buffer.byteLength(output),
+			bundleGzipBytes: gzipSync(output).length,
+			esbuildVersion,
+		},
+	};
+}
+
+function setupDom() {
+	const window = new Window({ url: 'http://localhost/' });
+	for (const key of [
+		'window',
+		'document',
+		'navigator',
+		'Node',
+		'Element',
+		'HTMLElement',
+		'SVGElement',
+		'Text',
+		'Comment',
+		'DocumentFragment',
+		'Event',
+		'EventTarget',
+		'MutationObserver',
+		'HTMLInputElement',
+		'HTMLSelectElement',
+		'HTMLTextAreaElement',
+		'getComputedStyle',
+		'requestAnimationFrame',
+		'cancelAnimationFrame',
+	]) {
+		const value = key === 'window' ? window : window[key];
+		if (value !== undefined)
+			Object.defineProperty(globalThis, key, { value, writable: true, configurable: true });
+	}
+	return window;
+}
+
+function observeDom() {
+	const work = {
+		insertBefore: 0,
+		fragmentInsertBefore: 0,
+		replaceChild: 0,
+		appendChild: 0,
+		labelTextCreates: 0,
+	};
+	const originalInsert = Node.prototype.insertBefore;
+	const originalReplace = Node.prototype.replaceChild;
+	const originalAppend = Node.prototype.appendChild;
+	const originalText = document.createTextNode;
+	// happy-dom implements some native operations by calling these methods
+	// internally. Count only calls crossing in from the framework bundle.
+	let depth = 0;
+	Node.prototype.insertBefore = function (node, anchor) {
+		if (depth === 0) {
+			work.insertBefore++;
+			if (node.nodeType === 11) work.fragmentInsertBefore++;
+		}
+		depth++;
+		try {
+			return originalInsert.call(this, node, anchor);
+		} finally {
+			depth--;
+		}
+	};
+	Node.prototype.replaceChild = function (next, previous) {
+		if (depth === 0) work.replaceChild++;
+		depth++;
+		try {
+			return originalReplace.call(this, next, previous);
+		} finally {
+			depth--;
+		}
+	};
+	Node.prototype.appendChild = function (node) {
+		if (depth === 0) work.appendChild++;
+		depth++;
+		try {
+			return originalAppend.call(this, node);
+		} finally {
+			depth--;
+		}
+	};
+	document.createTextNode = function (text) {
+		if (/^label-\d+$/.test(text)) work.labelTextCreates++;
+		return originalText.call(this, text);
+	};
+	return {
+		work,
+		snapshot() {
+			return { ...work };
+		},
+		reset() {
+			for (const key of Object.keys(work)) work[key] = 0;
+		},
+		restore() {
+			Node.prototype.insertBefore = originalInsert;
+			Node.prototype.replaceChild = originalReplace;
+			Node.prototype.appendChild = originalAppend;
+			document.createTextNode = originalText;
+		},
+	};
+}
+
+function verify(container, currentRows, previous = new Map()) {
+	const children = [...container.querySelector('#rows').children];
+	assert.equal(children.length, currentRows.length * 3, 'all physical fragment roots');
+	const next = new Map();
+	for (let index = 0; index < currentRows.length; index++) {
+		const row = currentRows[index];
+		const nodes = children.slice(index * 3, index * 3 + 3);
+		assert.deepEqual(
+			nodes.map((node) => node.localName),
+			['label', 'input', 'span'],
+		);
+		assert.equal(nodes[0].textContent, row.label);
+		assert.equal(nodes[0].firstChild?.nodeType, 3);
+		assert.equal(nodes[0].childNodes.length, 1, 'single text node, even for empty text');
+		assert.equal(nodes[1].getAttribute('data-input'), String(row.id));
+		assert.equal(nodes[2].textContent, `${row.prefix}:${row.suffix}`);
+		assert.deepEqual(
+			[...nodes[2].childNodes].map((node) => node.nodeType),
+			[3, 1, 3],
+		);
+		if (previous.has(row.id)) {
+			const old = previous.get(row.id);
+			for (let i = 0; i < 3; i++) assert.strictEqual(nodes[i], old[i], 'keyed survivor');
+		}
+		next.set(row.id, nodes);
+	}
+	return next;
+}
+
+function runWork(bundle) {
+	const recorder = observeDom();
+	try {
+		const work = {};
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = bundle.createRoot(container);
+		recorder.reset();
+		root.render(bundle.FragmentRows, { rows, tick: 'start' });
+		work.mount = recorder.snapshot();
+		let survivor = verify(container, rows);
+		const focused = survivor.get(4)[1];
+		focused.value = 'typed';
+		focused.focus();
+		recorder.reset();
+		bundle.flushSync(() => root.render(bundle.FragmentRows, { rows, tick: 'changed' }));
+		work.unrelatedUpdate = recorder.snapshot();
+		assert.equal(container.querySelector('output')?.textContent, 'changed');
+		survivor = verify(container, rows, survivor);
+		const reversed = [...rows].reverse();
+		recorder.reset();
+		bundle.flushSync(() => root.render(bundle.FragmentRows, { rows: reversed, tick: 'reverse' }));
+		work.reorder = recorder.snapshot();
+		survivor = verify(container, reversed, survivor);
+		assert.strictEqual(survivor.get(4)[1], focused);
+		assert.equal(focused.value, 'typed');
+		assert.strictEqual(document.activeElement, focused);
+		const empty = { ...rows[7], label: '' };
+		const smaller = [empty, ...rows.slice(0, 7)];
+		bundle.flushSync(() => root.render(bundle.FragmentRows, { rows: smaller, tick: 'smaller' }));
+		verify(container, smaller, survivor);
+		assert.equal(container.querySelector('#rows > label')?.textContent, '');
+		root.unmount();
+		assert.equal(container.childNodes.length, 0);
+		container.remove();
+
+		// Flat control uses identical keyed row count, but no multi-root drain.
+		const flat = document.createElement('div');
+		document.body.appendChild(flat);
+		const control = bundle.createRoot(flat);
+		recorder.reset();
+		control.render(bundle.FlatRows, { rows, tick: 'flat' });
+		work.flatMount = recorder.snapshot();
+		assert.deepEqual(
+			[...flat.querySelectorAll('#rows > p')].map((p) => p.textContent),
+			rows.map((r) => r.label),
+		);
+		control.unmount();
+		flat.remove();
+
+		const foreign = document.createElement('div');
+		document.body.appendChild(foreign);
+		const other = bundle.createRoot(foreign);
+		other.render(bundle.ForeignSvg, { label: 'C' });
+		assert.equal(foreign.querySelector('svg text')?.textContent, 'C');
+		assert.equal(foreign.querySelector('svg circle')?.namespaceURI, 'http://www.w3.org/2000/svg');
+		other.unmount();
+		const math = bundle.createRoot(foreign);
+		math.render(bundle.ForeignMath, { label: 'C' });
+		assert.equal(foreign.querySelector('math')?.textContent, 'C+');
+		math.unmount();
+		foreign.remove();
+		return {
+			work,
+			semantics: sha(
+				JSON.stringify({
+					rows: rows.map((r) => [r.id, r.label, r.prefix, r.suffix]),
+					empty: empty.label,
+					focused: 'typed',
+					foreign: 'C',
+				}),
+			),
+		};
+	} finally {
+		recorder.restore();
+	}
+}
+
+let result;
+try {
+	setupDom();
+	const { module, code, meta } = await bundleFixture();
+	result = {
+		suite: 'dom-template-mount',
+		iterations: 1,
+		meta,
+		...runWork(module),
+		// A helper call exists only for multi-root bodies, including the flat-root
+		// parent's nested keyed row body. This is an output-shape diagnostic, not
+		// a behavior assertion.
+		compiled: {
+			drainFragCalls: [...code.matchAll(/_\$drainFrag\(/g)].length,
+			htextCalls: [...code.matchAll(/_\$htext\(/g)].length,
+			htextSwapCalls: [...code.matchAll(/_\$htextSwap\(/g)].length,
+		},
+	};
+	const target = (name, counts) => ({
+		name,
+		ops: Object.fromEntries(Object.entries(counts).map(([key, value]) => [key, stat(value)])),
+		meta: { fixtureSha256: meta.fixtureSha256, semantics: result.semantics },
+	});
+	result.targets = [
+		target('fragment-256', result.work.mount),
+		target('flat-256', result.work.flatMount),
+		target('unrelated-update', result.work.unrelatedUpdate),
+		target('reorder', result.work.reorder),
+		target('work-model', {
+			insertBefore: 770,
+			fragmentInsertBefore: 256,
+			replaceChild: 512,
+			appendChild: 4,
+			labelTextCreates: 1,
+		}),
+		target('flat-work-model', { insertBefore: 258 }),
+		target('reorder-work-model', { insertBefore: 1294 }),
+	];
+	console.log(`PASS dom-template-mount: ${JSON.stringify(result.work)}`);
+} finally {
+	fs.rmSync(temp, { recursive: true, force: true });
+}
+
+if (process.env.BENCH_JSON)
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(result, null, '\t')}\n`);

--- a/benchmarks/dom-template-mount/tsconfig.json
+++ b/benchmarks/dom-template-mount/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["cases.tsrx", "intrinsics.d.ts"],
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2024"],
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "target": "ES2024",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "paths": {
+      "octane": ["../../packages/octane/src/index.ts"],
+      "octane/*": ["../../packages/octane/src/*"]
+    },
+    "plugins": [{ "name": "@tsrx/typescript-plugin" }]
+  }
+}

--- a/benchmarks/event-delegation/README.md
+++ b/benchmarks/event-delegation/README.md
@@ -70,3 +70,140 @@ node benchmarks/bench.mjs --quick event-delegation
 
 Set `EVENT_URL` to an existing production `event-work.html` preview that also
 serves `event-work-no-capture.html` instead of building one.
+
+## Native dispatch metadata and portal-free paths
+
+`dispatch-work.mjs` builds the production client runtime and mounts a public
+root containing a button under eight ancestors, with one capture handler and
+nine bubble handlers. For 128 native clicks it checks all 1,280 callbacks,
+original event identity, target/currentTarget, and the 128 subsequent native
+root listeners. Those native listeners must see their own `currentTarget`,
+the original stop method, and no framework-owned public shadows.
+
+```bash
+node benchmarks/event-delegation/dispatch-work.mjs
+# Observe a separately built baseline without enforcing the new work limits:
+node benchmarks/event-delegation/dispatch-work.mjs /tmp/baseline-runtime.mjs --observe
+# Persist the detailed work and timing samples:
+node benchmarks/event-delegation/dispatch-work.mjs /tmp/candidate-runtime.mjs --output /tmp/event-work.json
+```
+
+The work sample temporarily observes Set/Map lookups, portal-parent reads, and
+private dispatch symbols. Every observer is restored before timing. The unified
+runner receives the counts through `BENCH_JSON`; ratio guards require zero
+category Set probes, zero portal-parent reads when no portal exists, no temporary
+private dispatch symbols on the Event, and at most two type-record reads per
+native click.
+
+| Work for 128 clicks | Baseline `58da3448b` | Candidate |
+| --- | ---: | ---: |
+| Category/registration Set probes | 1,408 | 0 |
+| Type metadata Map reads | 0 | 256 |
+| Portal-parent reads | 2,304 | 0 |
+| Peak temporary private dispatch symbols per Event | 3 | 0 |
+| Framework callbacks / later native listeners | 1,280 / 128 | 1,280 / 128 |
+
+Registration now retains one record per native type, shared by its capture and
+bubble registries. It precomputes both handler keys and static category bits;
+late registration updates the shared phase bits. Private propagation and
+currentTarget values live in reusable frames, one per peak simultaneous logical
+phase, with Event, DOM, and function references cleared after each phase. This
+moves a bounded amount of work/storage to registration and first use of a nested
+dispatch depth; it does not allocate a record per ordinary event.
+
+Portal-free paths skip portal metadata reads. Applications with active portals
+retain the existing ownership walk. Portal target creation/removal advances the
+existing event-route epoch, so removing the last portal after native capture
+cannot discard that delivery's original logical route.
+
+### Public property deletion remains necessary
+
+The original #981 suggestion to retain all Event properties cannot preserve the
+native-event contract. `currentTarget` must be absent as an own property after
+the logical phase, and the exact prior stop-method descriptors must be restored.
+The candidate removes private symbol add/delete churn while preserving those
+public restorations. It does **not** claim that native Events never enter V8
+dictionary mode, or that all heterogeneous DOM path reads disappear.
+
+### Correctness and negative controls
+
+The current-target, conformance event-listener, capture-events, portal-events,
+and event-dedup suites exercise both development and production. The independent
+`browser/event-metadata` suite bundles the public production client entry and
+runs in Chromium, without requiring the React differential compiler. Its metadata
+and portal teardown cases pass against both the frozen baseline and candidate.
+They cover retained
+outer stop methods during nested dispatch, native descriptor restoration,
+redispatch of the same Event, later registration of the bubble phase, and last
+portal removal during native target delivery. Additional native open/closed
+shadow cases check root rebasing, retargeting, and later native listeners.
+
+Three temporary runtime mutations each failed the corresponding browser case:
+using only the innermost frame canceled the wrong logical queue; ignoring the
+capture epoch dropped a removed portal's parent; replacing a previously
+registered type record dropped its capture phase. Each source snippet was
+restored before final validation. Existing controlled input, trusted click,
+portal remount, capture fallback, disabled-host, and nonbubbling-family controls
+remain in the adjacent suites and `work.mjs`.
+
+### Timing evidence
+
+On macOS arm64 with Node 26.4.0, esbuild 0.28.1, and Chromium 149.0.7827.55, the
+event-only patch was applied to a frozen `58da3448b` source snapshot and both sources were bundled with the same
+esbuild browser/ESM production defines. Builds finished before measurements.
+The fixture warms up with 500 events, observes 128 untimed events, restores all
+observers, then measures newly allocated native events plus dispatch and the
+same semantic checks.
+
+Four ABBA repetitions used eight fresh Chromium processes per revision, each
+with twelve rounds of 2,000 events. Median process medians were 7.2125µs baseline
+and 7.025µs candidate (0.974×); process medians ranged 6.050–12.925µs and
+5.575–13.625µs respectively. Two further ABBA repetitions used four fresh
+processes per revision and sixteen rounds of 10,000 events: 7.355µs versus
+7.1125µs (0.967×), with ranges 6.325–10.510µs and 5.715–9.390µs. These broad,
+overlapping ranges do not establish a throughput gain. The regression gates
+therefore enforce work counts, not an elapsed-time threshold.
+
+```bash
+./node_modules/.bin/esbuild /tmp/baseline/packages/octane/src/runtime.ts \
+  --bundle --platform=browser --format=esm \
+  --define:process.env.NODE_ENV='"production"' \
+  --define:__OCTANE_PROFILE_ENABLED__=false --outfile=/tmp/baseline-runtime.mjs
+# Repeat the same build for candidate-runtime.mjs, then run B,C,C,B twice:
+EVENT_TIMING_EVENTS=10000 EVENT_TIMING_ROUNDS=16 \
+  node benchmarks/event-delegation/dispatch-work.mjs /tmp/baseline-runtime.mjs --observe
+EVENT_TIMING_EVENTS=10000 EVENT_TIMING_ROUNDS=16 \
+  node benchmarks/event-delegation/dispatch-work.mjs /tmp/candidate-runtime.mjs
+```
+
+The isolated full runtime bundle grows from 341,561 to 342,274 minified bytes
+(+713, 0.21%) and from 107,521 to 107,811 gzip bytes (+290, 0.27%) with esbuild
+0.28.1. Registration records retain two computed keys per registered native type;
+reusable dispatch frames retain five fields per peak nesting depth and clear all
+object/function references between phases. These costs buy the work reductions
+above; there is no claim of eliminating public Event dictionary normalization.
+
+This narrow fixture isolates dispatch work after mount. It does not establish
+application responsiveness, trusted-input latency, or a gain for active-portal
+paths. The existing compiled controlled-form/trusted-click work gate provides
+separate integration coverage; native shadow/slot routing remains covered by the
+existing browser boundary suites.
+
+Final targeted validation used these suites (development and production runtime
+projects) plus the independent production browser and existing work gate:
+
+```bash
+./node_modules/.bin/vitest run packages/octane/tests/current-target.test.ts \
+  packages/octane/tests/conformance/event-listener.test.ts \
+  packages/octane/tests/capture-events.test.ts packages/octane/tests/portal-events.test.ts \
+  packages/octane/tests/event-dedup.test.ts
+./node_modules/.bin/vitest run --project octane-events-browser \
+  packages/octane/tests/browser/event-metadata/event-metadata.test.ts
+node benchmarks/event-delegation/work.mjs
+```
+
+The local runtime run used a scoped config retaining the repository's development
+and production setup while omitting the unrelated React differential precompile,
+whose `@tsrx/react-runtime` dependency was unavailable. It passed 132 tests; the
+independent production browser suite passed four cases. Both production work
+gates passed, including all 128 controlled edits and 16 trusted captured clicks.

--- a/benchmarks/event-delegation/dispatch-work.mjs
+++ b/benchmarks/event-delegation/dispatch-work.mjs
@@ -1,0 +1,232 @@
+// Isolated production-runtime dispatch work. Intrinsic observers are installed
+// only for the untimed sample; public native-event outcomes are checked in both.
+import assert from 'node:assert/strict';
+import { readFile, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+
+const args = process.argv.slice(2);
+const timingEvents = Number(process.env.EVENT_TIMING_EVENTS ?? 2000);
+const timingRounds = Number(process.env.EVENT_TIMING_ROUNDS ?? 12);
+assert(Number.isSafeInteger(timingEvents) && timingEvents > 0);
+assert(Number.isSafeInteger(timingRounds) && timingRounds > 0);
+const runtimePath = args[0] && !args[0].startsWith('--') ? resolve(args[0]) : null;
+const runtime = runtimePath
+	? await readFile(runtimePath, 'utf8')
+	: (
+			await build({
+				entryPoints: [
+					fileURLToPath(new URL('../../packages/octane/src/runtime.ts', import.meta.url)),
+				],
+				bundle: true,
+				write: false,
+				platform: 'browser',
+				format: 'esm',
+				define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+			})
+		).outputFiles[0].text;
+const server = createServer((request, response) => {
+	if (request.url === '/runtime.mjs') {
+		response.writeHead(200, { 'Content-Type': 'text/javascript' });
+		response.end(runtime);
+	} else {
+		response.writeHead(200, { 'Content-Type': 'text/html' });
+		response.end(
+			'<!doctype html><script type="module">import * as runtime from "/runtime.mjs";window.runtime=runtime;</script>',
+		);
+	}
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+let browser;
+try {
+	browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+	const page = await browser.newPage();
+	const failures = [];
+	page.on('pageerror', (error) => failures.push(error.message));
+	await page.goto(`http://127.0.0.1:${server.address().port}`);
+	await page.waitForFunction(() => window.runtime !== undefined);
+	const report = await page.evaluate(
+		({ timingEvents, timingRounds }) => {
+			const { createRoot, createElement, flushSync } = window.runtime;
+			const container = document.createElement('div');
+			document.body.append(container);
+			const root = createRoot(container);
+			const depth = 8;
+			let active,
+				callbacks = 0,
+				nativeAfter = 0,
+				invalid = 0,
+				symbolPeak = 0;
+			const handler = (event) => {
+				callbacks++;
+				if (
+					event !== active ||
+					!(event instanceof MouseEvent) ||
+					event.target.id !== 'event-target' ||
+					!event.currentTarget.id.startsWith('event-')
+				)
+					invalid++;
+				if (observing)
+					symbolPeak = Math.max(
+						symbolPeak,
+						Object.getOwnPropertySymbols(event).filter((key) =>
+							[
+								'octane.propagationFlags',
+								'octane.stopPropagation',
+								'octane.stopImmediatePropagation',
+								'octane.currentTarget',
+							].includes(key.description),
+						).length,
+					);
+			};
+			let body = createElement('button', { id: 'event-target', onClick: handler }, 'dispatch');
+			for (let index = 0; index < depth; index++)
+				body = createElement(
+					'div',
+					{
+						id: `event-${index}`,
+						onClick: handler,
+						...(index === depth - 1 ? { onClickCapture: handler } : null),
+					},
+					body,
+				);
+			flushSync(() => root.render(body));
+			const target = container.querySelector('#event-target');
+			const stop = Event.prototype.stopPropagation;
+			container.addEventListener('click', (event) => {
+				nativeAfter++;
+				if (
+					event !== active ||
+					event.currentTarget !== container ||
+					Object.hasOwn(event, 'currentTarget') ||
+					event.stopPropagation !== stop ||
+					Object.hasOwn(event, 'stopPropagation')
+				)
+					invalid++;
+			});
+			let observing = false,
+				setProbes = 0,
+				typeLookups = 0,
+				portalReads = 0;
+			const oldSetHas = Set.prototype.has,
+				oldMapGet = Map.prototype.get;
+			const portalDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, '$$portalParent');
+			function dispatch(count) {
+				for (let index = 0; index < count; index++) {
+					active = new MouseEvent('click', { bubbles: true, cancelable: true });
+					target.dispatchEvent(active);
+					if (
+						active.currentTarget !== null ||
+						Object.hasOwn(active, 'currentTarget') ||
+						Object.hasOwn(active, 'stopPropagation')
+					)
+						invalid++;
+				}
+			}
+			dispatch(500);
+			callbacks = 0;
+			nativeAfter = 0;
+			observing = true;
+			Set.prototype.has = function (value) {
+				if (value === 'click') setProbes++;
+				return oldSetHas.call(this, value);
+			};
+			Map.prototype.get = function (value) {
+				if (value === 'click') typeLookups++;
+				return oldMapGet.call(this, value);
+			};
+			Object.defineProperty(Element.prototype, '$$portalParent', {
+				configurable: true,
+				get() {
+					portalReads++;
+					return undefined;
+				},
+				set(value) {
+					Object.defineProperty(this, '$$portalParent', {
+						value,
+						writable: true,
+						configurable: true,
+					});
+				},
+			});
+			try {
+				dispatch(128);
+			} finally {
+				Set.prototype.has = oldSetHas;
+				Map.prototype.get = oldMapGet;
+				if (portalDescriptor === undefined) delete Element.prototype.$$portalParent;
+				else Object.defineProperty(Element.prototype, '$$portalParent', portalDescriptor);
+				observing = false;
+			}
+			const work = {
+				events: 128,
+				callbacks,
+				nativeAfter,
+				invalid,
+				setProbes,
+				typeLookups,
+				portalReads,
+				symbolPeak,
+			};
+			const timings = [];
+			for (let round = 0; round < timingRounds; round++) {
+				const start = performance.now();
+				dispatch(timingEvents);
+				timings.push(((performance.now() - start) * 1000) / timingEvents);
+			}
+			if (invalid !== 0) throw new Error(`Native event semantics failed ${invalid} times`);
+			root.unmount();
+			container.remove();
+			return { work, timingEvents, timingRounds, microsecondsPerDispatch: timings };
+		},
+		{ timingEvents, timingRounds },
+	);
+	assert.equal(report.work.invalid, 0);
+	assert.equal(report.work.callbacks, 128 * 10);
+	assert.equal(report.work.nativeAfter, 128);
+	assert.deepEqual(failures, []);
+	if (!args.includes('--observe')) {
+		assert.equal(report.work.setProbes, 0, 'Registered click metadata should avoid Set probes');
+		assert.equal(report.work.portalReads, 0, 'Portal-free clicks should avoid portal-parent reads');
+		assert.equal(report.work.symbolPeak, 0, 'Temporary dispatch state should stay off the Event');
+		assert(report.work.typeLookups <= 256, 'Each click needs at most two registered-type reads');
+	}
+	if (process.env.BENCH_JSON) {
+		const stat = (value) => ({ median: value, min: value, samples: 1 });
+		const keys = ['setProbes', 'portalReads', 'symbolPeak', 'typeLookups'];
+		await writeFile(
+			process.env.BENCH_JSON,
+			JSON.stringify(
+				{
+					suite: 'event-delegation-dispatch-work',
+					targets: [
+						{
+							name: 'dispatch-work',
+							ops: Object.fromEntries(keys.map((key) => [key, stat(report.work[key])])),
+							meta: { gate: 'passed' },
+						},
+						{
+							name: 'dispatch-work-model',
+							ops: Object.fromEntries(
+								keys.map((key) => [key, stat(key === 'typeLookups' ? 256 : 1)]),
+							),
+						},
+					],
+				},
+				null,
+				2,
+			) + '\n',
+		);
+	}
+	const json =
+		JSON.stringify({ runtime: runtimePath, browser: browser.version(), ...report }, null, 2) + '\n';
+	const output = args.indexOf('--output');
+	if (output !== -1) await writeFile(resolve(args[output + 1]), json);
+	process.stdout.write(json);
+} finally {
+	await browser?.close();
+	await new Promise((resolve) => server.close(resolve));
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -122,8 +122,10 @@ export const BENCHMARK_SUITES = [
 	'lynx-bundle-size',
 	'codegen-size',
 	'hook-memo',
+	'dom-attributes',
 	'transition-hooks',
 	'template-call-memo',
+	'dom-template-mount',
 	'compiler-throughput',
 	'tsrx-component-graph',
 	'tsrx-void-memo-aliases',
@@ -141,6 +143,7 @@ export const BENCHMARK_SUITES = [
 	'bundle-reachability',
 	'three-renderer',
 	'three-bundle-size',
+	'spread-hosts',
 ];
 
 const DEFAULT_TIMEOUT_MS = 120_000;

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -115,7 +115,7 @@ import {
 	hyphenateStyleName,
 } from '../dom-tables.js';
 import { isDelegatedEventProp } from '../event-names.js';
-import { sanitizeURLAttribute } from '../sanitize-url.js';
+import { sanitizeURLAttribute, shouldSanitizeURLAttribute } from '../sanitize-url.js';
 import {
 	invalidHtmlNestingWithAncestor,
 	invalidHtmlNestingWithParent,
@@ -424,7 +424,7 @@ function attrBindingHelper(bind) {
 	if (controlled !== undefined) return controlled;
 	switch (bind.kind) {
 		case 'attr':
-			return 'setAttribute';
+			return bind.attributeHelper ?? 'setAttribute';
 		case 'stringData':
 			return 'setStringData';
 		case 'booleanAttr':
@@ -446,6 +446,38 @@ function attrBindingHelper(bind) {
 		default:
 			return null;
 	}
+}
+
+// Production-only admission: development keeps the full authored-name diagnostic
+// route. Everything with property, boolean, numeric, namespace, or custom-host
+// semantics retains its existing writer. Aliases are resolved once at compile
+// time; opaque destination namespaces do not change these unnamespaced writes.
+function staticAttributeWriter(tag, name) {
+	if (tag.includes('-') || !/^[a-zA-Z_][a-zA-Z0-9_.-]*$/.test(name)) return null;
+	const lower = name.toLowerCase();
+	if (
+		lower.startsWith('on') ||
+		lower.startsWith('aria-') ||
+		MUST_USE_PROPERTY_PROPS.has(lower) ||
+		BOOLEAN_ATTR_PROPS.has(lower) ||
+		POSITIVE_NUMERIC_ATTR_PROPS.has(lower) ||
+		isEnumeratedBooleanAttr(name) ||
+		/^(?:xmlns|class|classname|style|value|checked|defaultvalue|defaultchecked|autofocus|innertext|textcontent|dangerouslysetinnerhtml|download|capture|rowspan|start|suppresscontenteditablewarning|suppressnativechangewarning|__octanenativechangediagnostic)$/.test(
+			lower,
+		)
+	)
+		return null;
+	const canonical = ATTRIBUTE_ALIASES.get(name) ?? name;
+	if (canonical.includes(':')) return null;
+	if (canonical.startsWith('data-')) {
+		return /^[a-z][a-z0-9_-]*$/.test(canonical.slice(5))
+			? { name: canonical, helper: 'setStringData' }
+			: null;
+	}
+	return {
+		name: canonical,
+		helper: shouldSanitizeURLAttribute(tag, canonical) ? 'setURLAttribute' : 'setPlainAttribute',
+	};
 }
 
 // Shared scalar comparisons retain the ordinary writer's semantics without
@@ -1179,6 +1211,10 @@ const NATIVE_READ_RUNTIME_HELPERS = new Set([
 const INTERNAL_CLIENT_RUNTIME_HELPERS = new Set([
 	'replaceRef',
 	'queueOwnRefDetach',
+	'setPlainAttribute',
+	'setPlainAttributeIfChanged',
+	'setURLAttribute',
+	'setURLAttributeIfChanged',
 	'setAttributeIfChanged',
 	'setStringDataIfChanged',
 	'setBooleanAttributeIfChanged',
@@ -24314,15 +24350,22 @@ function emitBindingMount(bind, elVar, bag) {
 	}
 	switch (bind.kind) {
 		case 'textOnlyChild': {
-			// `htext` creates + appends the text node on a fresh mount, ADOPTS the
-			// server text node when hydrating, and coerces the value itself — so the
-			// mount is a bare `htext(el, _v)`. Seeding `_prev` to the client value
+			// Only compiler-admitted native placeholders may be reused. An old
+			// two-argument caller or an excluded custom/template host must retain
+			// htext's append behavior when a separate Text child already exists.
+			// Hydration adopts the server text in either case. Seeding `_prev` to the client value
 			// makes the first update a no-op when it matches the server text (no
 			// hydration mismatch re-render).
 			return st(
 				b.block([
 					b.const('_v', bind.expr),
-					b.stmt(b.assignment('=', local(`_txt$${bind.id}`), b.call('_$htext', el(), V()))),
+					b.stmt(
+						b.assignment(
+							'=',
+							local(`_txt$${bind.id}`),
+							b.call('_$htext', el(), V(), ...(bind.seededText ? [b.literal(1)] : [])),
+						),
+					),
 					b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())),
 				]),
 			);
@@ -26353,8 +26396,8 @@ function emitElementHtml(
 			// needs none of setAttribute's alias, coercion, namespace, controlled-property,
 			// or invalid-name machinery. Element.setAttribute applies the same unnamespaced
 			// data attribute in HTML, SVG, and MathML, so destination-opaque component
-			// templates can retain this specialization. Unknown values, cased names, and
-			// every non-data attr retain the generic React-parity path.
+			// templates can retain this specialization. Production also admits unknown
+			// scalar data values through staticAttributeWriter below.
 			bindings.push({
 				id: bindings.length,
 				kind: 'stringData',
@@ -26365,13 +26408,15 @@ function emitElementHtml(
 				nameOrigin: attr.name,
 			});
 		} else {
+			const writer = ctx.dev ? null : staticAttributeWriter(tag, attrName);
 			bindings.push({
 				id: bindings.length,
 				kind: 'attr',
+				attributeHelper: writer?.helper,
 				name:
 					ctx.dev && (rawAttrName === 'tabIndex' || rawAttrName === 'htmlFor')
 						? rawAttrName
-						: attrName,
+						: (writer?.name ?? attrName),
 				expr,
 				path,
 				ns: hostNs,
@@ -26538,13 +26583,23 @@ function emitElementHtml(
 					: null;
 			appendTemplatePart(html, escaped, 'text', origins);
 		} else if (isKnownTextChildExpression(txtChild.expression, ctx.knownStringChildLocals)) {
+			const seededText = tag !== 'template' && !tag.includes('-') && !directPropNames.has('is');
 			bindings.push({
 				id: bindings.length,
 				kind: 'textOnlyChild',
 				expr: resolveStyleExpr(txtChild.expression, cssHash),
 				path,
+				seededText,
 			});
-			// The element stays empty in the template — runtime appends a Text node.
+			// A nonempty placeholder survives the HTML parser as one Text node. The
+			// mount writes its actual value before the cloned host is inserted, so
+			// even an empty value retains one stable text binding node. <template>
+			// puts parser children under .content rather than .firstChild. Custom
+			// element constructors can inspect children while the host is cloned;
+			// preserve the old empty template and create/append mount for them.
+			if (seededText) {
+				appendTemplatePart(html, ' ', 'text');
+			}
 		} else {
 			// Bare `{expr}` (no string cast) → RENDERABLE hole. As the host's SOLE
 			// child it lowers MARKERLESS: a primitive value is appended as a single

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -2863,7 +2863,7 @@ export function ssrAttrs(
 ): string {
 	namespace = resolveAttributeNamespace(namespace);
 	interface PropWriter {
-		rawName: string;
+		name: string;
 		value: unknown;
 		firstOrder: number;
 		lastOrder: number;
@@ -2875,12 +2875,12 @@ export function ssrAttrs(
 		if (typeof rawName !== 'string') return;
 		const order = sourceOrder++;
 		const previous = props.get(rawName);
-		props.set(rawName, {
-			rawName,
-			value,
-			firstOrder: previous?.firstOrder ?? order,
-			lastOrder: order,
-		});
+		if (previous !== undefined) {
+			previous.value = value;
+			previous.lastOrder = order;
+		} else {
+			props.set(rawName, { name: rawName, value, firstOrder: order, lastOrder: order });
+		}
 	}
 
 	for (const [isSpread, sourceOrName, directValue, merge] of sources) {
@@ -2924,7 +2924,7 @@ export function ssrAttrs(
 		// the original Map already holds their final values in insertion order.
 		if (canonical) {
 			let out = '';
-			for (const { rawName, value } of props.values()) {
+			for (const { name: rawName, value } of props.values()) {
 				if (
 					rawName === 'dangerouslySetInnerHTML' ||
 					(skipFormControls && isAggregatedFormAttribute(tag, rawName))
@@ -2936,13 +2936,12 @@ export function ssrAttrs(
 		}
 	}
 
-	const resolved = new Map<
-		string,
-		readonly [name: string, value: unknown, firstOrder: number, lastOrder: number]
-	>();
+	// Reuse the raw writer after all source reads; its normalized name is private
+	// to this resolution and the original Map is no longer consulted by name.
+	const resolved = new Map<string, PropWriter>();
 	let needsWinningOrderSort = false;
 	for (const writer of props.values()) {
-		const { rawName, value, firstOrder, lastOrder } = writer;
+		const { name: rawName, lastOrder } = writer;
 		if (
 			rawName === 'key' ||
 			rawName === 'ref' ||
@@ -2966,56 +2965,54 @@ export function ssrAttrs(
 		const identity = namespace === 'html' ? name.toLowerCase() : name;
 		const previous = resolved.get(identity);
 		if (previous !== undefined) {
-			if (previous[3] >= lastOrder) continue;
+			if (previous.lastOrder >= lastOrder) continue;
 			// Map order already matches firstOrder unless a later raw alias replaces
 			// an earlier normalized identity without moving its Map entry.
 			needsWinningOrderSort = true;
 		}
-		resolved.set(identity, [
+		writer.name =
 			process.env.NODE_ENV !== 'production' && (rawName === 'tabIndex' || rawName === 'htmlFor')
 				? rawName
-				: name,
-			value,
-			firstOrder,
-			lastOrder,
-		]);
+				: name;
+		resolved.set(identity, writer);
 	}
 	if (classMerges !== null) {
 		for (const extra of classMerges) {
-			const name = normalizeSsrAttributeName(extra.rawName, tag, namespace);
-			if (!VALID_ATTR_NAME.test(name)) continue;
-			const identity = namespace === 'html' ? name.toLowerCase() : name;
-			const previous = resolved.get(identity);
+			const previous = resolved.get('class');
 			if (previous !== undefined) {
-				resolved.set(identity, [
-					previous[0],
-					mergeClass(previous[1], extra.value),
-					previous[2],
-					extra.order,
-				]);
-				continue;
+				previous.value = mergeClass(previous.value, extra.value);
+				previous.lastOrder = extra.order;
+			} else {
+				resolved.set('class', {
+					name: 'class',
+					value: extra.value,
+					firstOrder: extra.order,
+					lastOrder: extra.order,
+				});
 			}
-			resolved.set(identity, [name, extra.value, extra.order, extra.order]);
 		}
 	}
 
 	let out = '';
-	const ordered = [...resolved.values()];
-	if (needsWinningOrderSort) ordered.sort((a, b) => a[2] - b[2]);
+	const ordered =
+		process.env.NODE_ENV !== 'production' || needsWinningOrderSort
+			? [...resolved.values()]
+			: resolved.values();
+	if (needsWinningOrderSort) (ordered as PropWriter[]).sort((a, b) => a.firstOrder - b.firstOrder);
 	if (process.env.NODE_ENV !== 'production') {
 		devValidateSsrAriaProps(
-			ordered.map(([name]) => name),
+			(ordered as PropWriter[]).map(({ name }) => name),
 			tag,
 			namespace,
 		);
 		devValidateSsrHostProps(
-			ordered.map(([name, value]) => [name, value] as const),
+			(ordered as PropWriter[]).map(({ name, value }) => [name, value] as const),
 			tag,
 			namespace,
 		);
 		if (tag === 'form' || tag === 'button' || tag === 'input') {
 			const formProps: Record<string, unknown> = Object.create(null);
-			for (const [name, value] of ordered) formProps[name] = value;
+			for (const { name, value } of ordered) formProps[name] = value;
 			const action =
 				tag === 'form' ? formProps.action : (formProps.formAction ?? formProps.formaction);
 			if (typeof action === 'function') devValidateSsrFormProps(tag, formProps);
@@ -3023,16 +3020,16 @@ export function ssrAttrs(
 	}
 	if (
 		process.env.NODE_ENV !== 'production' &&
-		ordered.some(([name, value]) => name === 'is' && typeof value === 'string')
+		(ordered as PropWriter[]).some(({ name, value }) => name === 'is' && typeof value === 'string')
 	) {
 		DEV_SSR_CUSTOM_HOST_DEPTH++;
 		try {
-			for (const [name, value] of ordered) out += ssrAttrEntry(name, value, tag, namespace);
+			for (const { name, value } of ordered) out += ssrAttrEntry(name, value, tag, namespace);
 		} finally {
 			DEV_SSR_CUSTOM_HOST_DEPTH--;
 		}
 	} else {
-		for (const [name, value] of ordered) {
+		for (const { name, value } of ordered) {
 			out += ssrAttrEntry(name, value, tag, namespace);
 		}
 	}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -13785,7 +13785,7 @@ interface LazyTemplateRecord {
 	html: string;
 	ns: 0 | 1 | 2 | 3;
 	frag: number;
-	parsed: Array<Element | null>;
+	parsed: Array<Node | null>;
 	/**
 	 * Lazily computed adoption-root descriptor for PROD hydration's parse-free
 	 * root check (see HydrationCapability.cloneLazy): 0 = not computed yet, a
@@ -13798,7 +13798,26 @@ interface LazyTemplateRecord {
 
 const LAZY_TEMPLATE = Symbol('octane.lazy-template');
 
-function parseTemplate(html: string, ns: 0 | 1 | 2, frag: number): Element {
+// The parser needs a wrapper to establish foreign-content namespaces and to
+// retain HTML fragment roots. Transfer ordinary children once while caching
+// the template; every later clone can insert the native fragment in one call.
+// Custom elements keep the wrapper: their connectedCallback can synchronously
+// inspect which earlier siblings have already joined the live parent.
+function fragmentTemplate(wrapper: Element): Node {
+	for (const descendant of wrapper.querySelectorAll('*')) {
+		if (descendant.localName.includes('-') || descendant.hasAttribute('is')) {
+			(wrapper as any).__oct_frag = true;
+			return wrapper;
+		}
+	}
+	const fragment = document.createDocumentFragment();
+	let child: Node | null;
+	while ((child = wrapper.firstChild) !== null) fragment.appendChild(child);
+	(fragment as any).__oct_frag = true;
+	return fragment;
+}
+
+function parseTemplate(html: string, ns: 0 | 1 | 2, frag: number): Node {
 	initDomOperations();
 	const t = document.createElement('template');
 	if (ns === 0) {
@@ -13812,7 +13831,7 @@ function parseTemplate(html: string, ns: 0 | 1 | 2, frag: number): Element {
 		// for clone() to SKIP the structural hydration check — there is no 1:1 server
 		// node to compare the wrapper against.
 		if (root.nodeType === 1 && root.localName === 'octane-frag') {
-			(root as any).__oct_frag = true;
+			return fragmentTemplate(root);
 		}
 		return root;
 	}
@@ -13826,8 +13845,7 @@ function parseTemplate(html: string, ns: 0 | 1 | 2, frag: number): Element {
 	t.innerHTML = `<${wrap}>${html}</${wrap}>`;
 	const wrapEl = t.content.firstChild as Element;
 	if (frag) {
-		(wrapEl as any).__oct_frag = true;
-		return wrapEl;
+		return fragmentTemplate(wrapEl);
 	}
 	return wrapEl.firstChild as Element;
 }
@@ -13904,7 +13922,7 @@ function lazyRootMatches(server: Node, lazy: LazyTemplateRecord): boolean {
  * Resolve a lazy compiler template token to its parsed (and per-namespace
  * cached) root for the namespace in effect at the current render site.
  */
-function resolveLazyTemplate(lazy: LazyTemplateRecord): Element {
+function resolveLazyTemplate(lazy: LazyTemplateRecord): Node {
 	let ns: 0 | 1 | 2;
 	if (lazy.ns === 3) {
 		const inherited =
@@ -14822,6 +14840,10 @@ export function clone<T extends Node>(node: T, loc?: string, partialStyles?: str
  */
 export function drainFrag(root: Node, parent: Node, anchor: Node | null): void {
 	if (activeHydration() !== null && (root as any).__oct_vfrag === true) return;
+	if (root.nodeType === 11) {
+		parent.insertBefore(root, anchor);
+		return;
+	}
 	let c: Node | null;
 	while ((c = getFirstChild(root)) !== null) parent.insertBefore(c, anchor);
 }
@@ -14906,19 +14928,27 @@ function isAttributeParserNormalizedMatch(server: string | null, client: string)
 }
 
 /**
- * Compiler-emitted for a single-text-child binding's mount. Normally creates the
- * text node and appends it; while hydrating, ADOPTS the element's existing
- * (server-rendered) text node so the DOM isn't rebuilt. The prev-value the
+ * Compiler-emitted for a single-text-child binding's mount. Reuses the cloned
+ * template's text placeholder only when the compiler explicitly seeded one,
+ * otherwise preserves baseline create/append semantics; while hydrating, ADOPTS the existing server
+ * text node so the DOM isn't rebuilt. The prev-value the
  * compiler seeds alongside this makes the first update a no-op when the client
  * value matches the server text (avoiding a mismatch re-render).
  */
-export function htext(el: Node, value: unknown): Text {
+export function htext(el: Node, value: unknown, seeded: 1 | undefined = undefined): Text {
 	// Coerce here (mirrors setText) rather than at every call site — keeps the
 	// per-text-hole mount codegen to a bare `htext(el, _v)`. Mount-once, so folding
 	// the coercion in costs nothing on the hot update path.
 	const text = coerceText(value);
 	const hydration = activeHydration();
 	if (hydration !== null) return hydration.htext(el, text);
+	if (seeded === 1) {
+		const first = getFirstChild(el);
+		if (first !== null && first.nodeType === 3) {
+			(first as Text).nodeValue = text;
+			return first as Text;
+		}
+	}
 	const t = document.createTextNode(text);
 	el.appendChild(t);
 	return t;
@@ -14945,8 +14975,7 @@ export function htextSwap(posNode: Node | null, value: unknown): Text {
 	// Fresh mount: posNode is the `<!>` placeholder — replace it in place.
 	const t = document.createTextNode(text);
 	const parent = posNode!.parentNode!;
-	parent.insertBefore(t, posNode);
-	parent.removeChild(posNode!);
+	parent.replaceChild(t, posNode!);
 	return t;
 }
 
@@ -15158,6 +15187,28 @@ export function setAttributeIfChanged(
 ): unknown {
 	if (previous === value) return previous;
 	setAttribute(el, name, value);
+	return value;
+}
+
+export function setPlainAttributeIfChanged(
+	value: unknown,
+	previous: unknown,
+	el: Element,
+	name: string,
+): unknown {
+	if (previous === value) return previous;
+	setPlainAttribute(el, name, value);
+	return value;
+}
+
+export function setURLAttributeIfChanged(
+	value: unknown,
+	previous: unknown,
+	el: Element,
+	name: string,
+): unknown {
+	if (previous === value) return previous;
+	setURLAttribute(el, name, value);
 	return value;
 }
 
@@ -16607,8 +16658,51 @@ function devValidateHostProps(el: Element, props: Record<string, unknown>): void
 }
 
 /**
- * Compiler-only fast path for a statically named `data-*` attribute whose
- * expression is proven to be a string at authoring time. Runtime values still
+ * Compiler-admitted native scalar attribute: the name is valid, already aliased,
+ * unnamespaced and has no property/boolean/numeric/URL semantics. Keep the
+ * generic development route even for production-compiled code loaded in dev.
+ */
+export function setPlainAttribute(el: Element, name: string, value: unknown): void {
+	if (process.env.NODE_ENV !== 'production') return setAttribute(el, name, value);
+	const type = typeof value;
+	const next =
+		value == null || type === 'boolean' || type === 'function' || type === 'symbol'
+			? null
+			: String(value);
+	const hydration = activeHydration();
+	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
+	if (next === null) el.removeAttribute(name);
+	else el.setAttribute(name, next);
+}
+
+/** Same scalar contract for a statically proven, unnamespaced native URL sink. */
+export function setURLAttribute(el: Element, name: string, value: unknown): void {
+	if (process.env.NODE_ENV !== 'production') return setAttribute(el, name, value);
+	const type = typeof value;
+	let next =
+		value == null || type === 'boolean' || type === 'function' || type === 'symbol'
+			? null
+			: String(value);
+	if (next !== null) {
+		if (
+			next === '' &&
+			(name === 'src' ||
+				(name === 'href' && el.nodeName !== 'A' && el.nodeName !== 'AREA') ||
+				(name === 'data' && el.nodeName === 'OBJECT'))
+		)
+			next = null;
+		else next = sanitizeURL(next);
+	}
+	const hydration = activeHydration();
+	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
+	if (next === null) el.removeAttribute(name);
+	else el.setAttribute(name, next);
+}
+
+/**
+ * Compiler-only fast path for a statically named `data-*` attribute. Runtime values still
  * follow the generic data-attribute contract: nullish/function/symbol remove,
  * while booleans, numbers and objects stringify. This matters when an `as
  * string` assertion or an external typed value is inaccurate at runtime. The
@@ -17267,18 +17361,11 @@ function isHostPropIdentityKey(name: string): boolean {
 	return isEventKey(name);
 }
 
-function normalizedHostProp(
-	el: Element,
-	rawName: string,
-): readonly [identity: string, name: string] {
-	if (rawName === 'class' || rawName === 'className') return ['class', 'class'];
+function normalizedHostProp(el: Element, rawName: string): string {
+	if (rawName === 'class' || rawName === 'className') return 'class';
 	const actionName = formActionAttributeName(el, rawName);
-	if (actionName !== null) return [actionName, actionName];
-	if (isHostPropIdentityKey(rawName)) return [rawName, rawName];
-	let name = rawName;
-	if (!isHtmlCustomElement(el)) name = ATTRIBUTE_ALIASES.get(name) ?? name;
-	const identity = el.namespaceURI === 'http://www.w3.org/1999/xhtml' ? name.toLowerCase() : name;
-	return [identity, name];
+	if (actionName !== null) return actionName;
+	return isHtmlCustomElement(el) ? rawName : (ATTRIBUTE_ALIASES.get(rawName) ?? rawName);
 }
 
 /**
@@ -17303,7 +17390,7 @@ export function setHostPropSources(
 	hasNestedChildren = false,
 ): Record<string, unknown> {
 	interface PropWriter {
-		rawName: string;
+		name: string;
 		value: unknown;
 		firstOrder: number;
 		lastOrder: number;
@@ -17315,12 +17402,12 @@ export function setHostPropSources(
 		if (typeof rawName !== 'string') return;
 		const order = sourceOrder++;
 		const previous = props.get(rawName);
-		props.set(rawName, {
-			rawName,
-			value,
-			firstOrder: previous?.firstOrder ?? order,
-			lastOrder: order,
-		});
+		if (previous !== undefined) {
+			previous.value = value;
+			previous.lastOrder = order;
+		} else {
+			props.set(rawName, { name: rawName, value, firstOrder: order, lastOrder: order });
+		}
 	}
 
 	for (const source of sources) {
@@ -17344,51 +17431,50 @@ export function setHostPropSources(
 		}
 	}
 
-	const values = new Map<
-		string,
-		readonly [name: string, value: unknown, firstOrder: number, lastOrder: number]
-	>();
+	// Source reads are complete. Reuse each raw writer as its normalized winner;
+	// neither Map escapes this call, and no second per-key tuple is needed.
+	const values = new Map<string, PropWriter>();
+	const html = el.namespaceURI === 'http://www.w3.org/1999/xhtml';
 	let needsWinningOrderSort = false;
 	for (const writer of props.values()) {
-		if (writer.rawName === 'key') continue;
-		const [identity, name] = normalizedHostProp(el, writer.rawName);
+		const rawName = writer.name;
+		if (rawName === 'key') continue;
+		const identityKey = isHostPropIdentityKey(rawName);
+		const name = identityKey ? rawName : normalizedHostProp(el, rawName);
+		const identity = html && !identityKey ? name.toLowerCase() : name;
 		const previous = values.get(identity);
 		if (previous !== undefined) {
-			if (previous[3] >= writer.lastOrder) continue;
-			// Map order already matches firstOrder unless a later raw alias replaces
-			// an earlier normalized identity without moving its Map entry.
+			if (previous.lastOrder >= writer.lastOrder) continue;
+			// A winning alias can have a later first insertion than this Map entry.
 			needsWinningOrderSort = true;
 		}
-		values.set(identity, [
-			process.env.NODE_ENV !== 'production' &&
-			(writer.rawName === 'tabIndex' || writer.rawName === 'htmlFor')
-				? writer.rawName
-				: name,
-			writer.value,
-			writer.firstOrder,
-			writer.lastOrder,
-		]);
+		writer.name =
+			process.env.NODE_ENV !== 'production' && (rawName === 'tabIndex' || rawName === 'htmlFor')
+				? rawName
+				: name;
+		values.set(identity, writer);
 	}
 	if (classMerges !== null) {
 		for (const extra of classMerges) {
-			const [identity, name] = normalizedHostProp(el, extra.rawName);
-			const previous = values.get(identity);
+			const previous = values.get('class');
 			if (previous !== undefined) {
-				values.set(identity, [
-					previous[0],
-					mergeClass(previous[1], extra.value),
-					previous[2],
-					extra.order,
-				]);
-				continue;
+				previous.value = mergeClass(previous.value, extra.value);
+				previous.lastOrder = extra.order;
+			} else {
+				values.set('class', {
+					name: 'class',
+					value: extra.value,
+					firstOrder: extra.order,
+					lastOrder: extra.order,
+				});
 			}
-			values.set(identity, [name, extra.value, extra.order, extra.order]);
 		}
 	}
 	const resolved: Record<string, unknown> = Object.create(null);
-	const ordered = [...values.values()];
-	if (needsWinningOrderSort) ordered.sort((a, b) => a[2] - b[2]);
-	for (const [name, value] of ordered) resolved[name] = value;
+	const ordered = needsWinningOrderSort
+		? [...values.values()].sort((a, b) => a.firstOrder - b.firstOrder)
+		: values.values();
+	for (const { name, value } of ordered) resolved[name] = value;
 	const formHost =
 		el.localName === 'input' || el.localName === 'textarea' || el.localName === 'select';
 	setSpread(el, resolved, prev, scope, true, formHost);
@@ -17555,9 +17641,12 @@ export function setSpread(
 			);
 			continue;
 		}
+		// Styles/raw HTML above still need their setters for stable object values.
+		// Controlled fields reassert live DOM drift; other unchanged props need no
+		// event-name parsing or custom-element routing.
+		if (v === pv && !isControlledHostProp(el, k)) continue;
 		const ev = eventSlot(k, el);
 		if (ev) {
-			if (v === pv) continue;
 			// Lazy-delegate any event we haven't seen — the compiler can't predict
 			// event names that arrive dynamically through spread. Capture-phase
 			// handlers (`onXxxCapture`) register their own capture-phase listener.
@@ -17573,10 +17662,6 @@ export function setSpread(
 			);
 			continue;
 		}
-		// Controlled `value`/`checked` bypass the identity skip — they must
-		// reassert every commit (the DOM may have drifted; the helper's own
-		// DOM-diff makes the call cheap).
-		if (v === pv && !isControlledHostProp(el, k)) continue;
 		// React only honors autoFocus from the final props of the element's mount.
 		// An absent initial spread must not turn a later update into a mount.
 		if (prev !== undefined && k === 'autoFocus' && !isHtmlCustomElement(el)) continue;
@@ -17711,6 +17796,33 @@ function rootIdentifierPrefix(block: Block): string {
 	return block.idState.prefix;
 }
 
+// Head attributes are reapplied even when an object-valued prop has the same
+// identity: its coercion may have changed, or outside code may have edited the
+// live head. Compare the final scalar value, retaining neither user objects nor
+// a stale authored-value cache. Common metadata names need no property, alias,
+// namespace, or URL routing, and equal values avoid native attribute mutation.
+function setHeadAttribute(el: Element, name: string, value: unknown): void {
+	switch (name) {
+		case 'name':
+		case 'content':
+		case 'lang':
+		case 'media':
+		case 'id':
+		case 'title':
+		case 'type':
+			break;
+		default:
+			return setAttribute(el, name, value);
+	}
+	const next = coerceAttrValue(el, name, value);
+	const hydration = activeHydration();
+	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
+	if (el.getAttribute(name) === next) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
+	if (next === null) el.removeAttribute(name);
+	else el.setAttribute(name, next);
+}
+
 export function headBlock(
 	scope: Scope,
 	slot: number,
@@ -17791,7 +17903,7 @@ export function headBlock(
 				continue;
 			}
 			names.push(k);
-			setAttribute(el, k, attrs[k]);
+			setHeadAttribute(el, k, attrs[k]);
 		}
 		state.attrNames = names;
 	} else {
@@ -18069,7 +18181,22 @@ export function evtNu(d: HandlerBundle, fn: any, args: any[]): void {
 // each root container when `createRoot` runs, and to each portal target when
 // the portal mounts. This matches ReactDOM 17+ behaviour: events scoped to
 // the React-owned subtrees, no document-level pollution.
-const _delegated = new Set<string>();
+interface DelegatedEventType {
+	name: string;
+	bubbleKey: string;
+	captureKey: string;
+	flags: number;
+}
+const EVENT_BUBBLE = 1;
+const EVENT_CAPTURE = 2;
+const EVENT_NATIVE_CAPTURE = 4;
+const EVENT_TARGET_ONLY = 8;
+const EVENT_DISCRETE = 16;
+const EVENT_RESTORE = 32;
+const EVENT_DISABLED_MOUSE = 64;
+const EVENT_DISABLED_ENTER = 128;
+const EVENT_CUSTOM_NATIVE_ONLY = 256;
+const _delegated = new Map<string, DelegatedEventType>();
 
 // Active delegation targets (createRoot containers + portal targets). A
 // portal target may host multiple portals; the refcount tracks how many
@@ -18164,7 +18291,7 @@ function prepareDelegatedEvent(event: Event, listener: Node): EventTarget[] | un
 // bubbling types always have a capture observer to snapshot root membership;
 // only these names also run a logical capture queue. Non-bubbling families share
 // one native capture callback for their capture and emulated bubble queues.
-const _delegatedCapture = new Set<string>();
+const _delegatedCapture = new Map<string, DelegatedEventType>();
 
 // Non-bubbling events must be delegated in the CAPTURE phase so the single root
 // listener still sees them (the capture phase reaches the root even when the event
@@ -18265,7 +18392,9 @@ export function delegateEvents(eventNames: string[]): void {
 	for (let i = 0; i < eventNames.length; i++) {
 		const name = eventNames[i];
 		if (_delegated.has(name)) continue;
-		_delegated.add(name);
+		const type = _delegatedCapture.get(name) ?? createDelegatedEventType(name);
+		type.flags |= EVENT_BUBBLE;
+		_delegated.set(name, type);
 		// Pre-seed the handler-slot key: the dispatch walk polls `$$<type>` on
 		// EVERY logical ancestor of every delegated event, and most of them carry
 		// no handler (see initDomOperations, trick 2).
@@ -18301,7 +18430,9 @@ export function delegateCaptureEvents(eventNames: string[]): void {
 	for (let i = 0; i < eventNames.length; i++) {
 		const name = eventNames[i];
 		if (_delegatedCapture.has(name)) continue;
-		_delegatedCapture.add(name);
+		const type = _delegated.get(name) ?? createDelegatedEventType(name);
+		type.flags |= EVENT_CAPTURE;
+		_delegatedCapture.set(name, type);
 		// Same seeding rationale as delegateEvents (the capture walk polls
 		// `$$capture:<type>` along the built path).
 		if (canSeed) seedExpando(Element.prototype, CAPTURE_PREFIX + name);
@@ -18335,7 +18466,7 @@ function registerDelegationTarget(target: Node, root = false): void {
 		if ((target as any).onclick == null && (target as any).nodeType === 1) {
 			(target as any).onclick = noop;
 		}
-		for (const name of _delegated) {
+		for (const name of _delegated.keys()) {
 			target.addEventListener(
 				name,
 				dispatchDelegated,
@@ -18349,7 +18480,7 @@ function registerDelegationTarget(target: Node, root = false): void {
 				);
 			}
 		}
-		for (const name of _delegatedCapture) {
+		for (const name of _delegatedCapture.keys()) {
 			if (_delegated.has(name)) continue;
 			target.addEventListener(
 				name,
@@ -18369,11 +18500,11 @@ function unregisterDelegationTarget(target: Node, root = false): void {
 	if (!prev) return;
 	if (prev === 1) {
 		_delegationTargets.delete(target);
-		for (const name of _delegated) {
+		for (const name of _delegated.keys()) {
 			target.removeEventListener(name, dispatchDelegated, delegatedCapture(name));
 			if (!delegatedCapture(name)) target.removeEventListener(name, dispatchDelegatedCapture, true);
 		}
-		for (const name of _delegatedCapture) {
+		for (const name of _delegatedCapture.keys()) {
 			target.removeEventListener(
 				name,
 				delegatedCapture(name) ? dispatchDelegated : dispatchDelegatedCapture,
@@ -18470,6 +18601,32 @@ const DISCRETE_EVENTS = new Set<string>([
  */
 let _dispatchDepth = 0;
 
+// Registration pays name parsing and category lookups once. Both native phases
+// share this record, including capture handlers registered after a root mounts.
+function createDelegatedEventType(name: string): DelegatedEventType {
+	return {
+		name,
+		bubbleKey: '$$' + name,
+		captureKey: CAPTURE_PREFIX + name,
+		flags:
+			(delegatedCapture(name) ? EVENT_NATIVE_CAPTURE : 0) |
+			(TARGET_ONLY_DELEGATED.has(name) ? EVENT_TARGET_ONLY : 0) |
+			(DISCRETE_EVENTS.has(name) ? EVENT_DISCRETE : 0) |
+			(RESTORE_EVENTS.has(name) ? EVENT_RESTORE : 0) |
+			(name === 'click' ||
+			name === 'dblclick' ||
+			name === 'mousedown' ||
+			name === 'mousemove' ||
+			name === 'mouseup'
+				? EVENT_DISABLED_MOUSE
+				: 0) |
+			(name === 'mouseenter' ? EVENT_DISABLED_ENTER : 0) |
+			(name === 'invalid' || EMULATED_BUBBLING_EVENTS.includes(name)
+				? EVENT_CUSTOM_NATIVE_ONLY
+				: 0),
+	};
+}
+
 // A bubble version closes capture-only flush fallbacks without retaining a DOM
 // path or a dispatch-completed flag on the Event. The same Event may be dispatched
 // again synchronously; every native delivery must start a fresh logical walk.
@@ -18480,19 +18637,38 @@ const DELEGATED_BUBBLE_VERSION = /* @__PURE__ */ Symbol('octane.bubbleVersion');
 // native stopImmediatePropagation must not abort an already-running logical queue.
 // These temporary methods still operate on the original browser Event, and the
 // exact prior own descriptors are restored before control returns to native code.
-const PROPAGATION_FLAGS = /* @__PURE__ */ Symbol('octane.propagationFlags');
-const NATIVE_STOP_PROPAGATION = /* @__PURE__ */ Symbol('octane.stopPropagation');
-const NATIVE_STOP_IMMEDIATE = /* @__PURE__ */ Symbol('octane.stopImmediatePropagation');
+interface DelegatedEventFrame {
+	event: Event | null;
+	flags: number;
+	stop: (() => void) | null;
+	immediate: (() => void) | null;
+	currentTarget: EventTarget | null;
+}
+// Private state belongs to the active logical phases, not to the native Event.
+// Nested dispatch reuses another frame; clearing it releases every Event/DOM
+// reference. Public method/accessor shadows still restore their exact lifetime.
+const DELEGATED_EVENT_FRAMES: DelegatedEventFrame[] = [];
+let delegatedEventFrameDepth = 0;
+
+function delegatedFrameFor(event: Event): DelegatedEventFrame | undefined {
+	for (let index = delegatedEventFrameDepth - 1; index >= 0; index--) {
+		const frame = DELEGATED_EVENT_FRAMES[index];
+		if (frame.event === event) return frame;
+	}
+}
+
 function stopDelegatedPropagation(this: Event): void {
-	if ((this as any)[PROPAGATION_FLAGS] !== undefined) (this as any)[PROPAGATION_FLAGS] |= 1;
-	const stop = (this as any)[NATIVE_STOP_PROPAGATION] || this.stopPropagation;
+	const frame = delegatedFrameFor(this);
+	if (frame !== undefined) frame.flags |= 1;
+	const stop = frame?.stop || this.stopPropagation;
 	// A consumer may retain the method and call it after native dispatch. The
 	// temporary dispatch state is gone then, but the restored native method lives on.
 	(stop === stopDelegatedPropagation ? Event.prototype.stopPropagation : stop).call(this);
 }
 function stopImmediateNativePropagation(this: Event): void {
-	if ((this as any)[PROPAGATION_FLAGS] !== undefined) (this as any)[PROPAGATION_FLAGS] |= 2;
-	const stop = (this as any)[NATIVE_STOP_IMMEDIATE] || this.stopImmediatePropagation;
+	const frame = delegatedFrameFor(this);
+	if (frame !== undefined) frame.flags |= 2;
+	const stop = frame?.immediate || this.stopImmediatePropagation;
 	(stop === stopImmediateNativePropagation ? Event.prototype.stopImmediatePropagation : stop).call(
 		this,
 	);
@@ -18527,14 +18703,21 @@ function beginDelegatedPropagation(
 	event: Event,
 	stop: PropertyDescriptor | undefined,
 	immediate: PropertyDescriptor | undefined | null,
-): void {
-	(event as any)[PROPAGATION_FLAGS] = 0;
-	(event as any)[NATIVE_STOP_PROPAGATION] = event.stopPropagation;
+): DelegatedEventFrame {
+	let frame = DELEGATED_EVENT_FRAMES[delegatedEventFrameDepth];
+	if (frame === undefined) {
+		frame = { event: null, flags: 0, stop: null, immediate: null, currentTarget: null };
+		DELEGATED_EVENT_FRAMES.push(frame);
+	}
+	delegatedEventFrameDepth++;
+	frame.event = event;
+	frame.flags = 0;
+	frame.stop = event.stopPropagation;
 	installPropagationMethod(event, 'stopPropagation', stop, STOP_PROPAGATION_DESCRIPTOR);
 	// Only emulated bubbling needs to distinguish a native immediate stop before
 	// starting another logical phase. Ordinary browser phases leave it untouched.
 	if (immediate !== null) {
-		(event as any)[NATIVE_STOP_IMMEDIATE] = event.stopImmediatePropagation;
+		frame.immediate = event.stopImmediatePropagation;
 		installPropagationMethod(
 			event,
 			'stopImmediatePropagation',
@@ -18542,6 +18725,7 @@ function beginDelegatedPropagation(
 			STOP_IMMEDIATE_DESCRIPTOR,
 		);
 	}
+	return frame;
 }
 
 function endDelegatedPropagation(
@@ -18549,23 +18733,24 @@ function endDelegatedPropagation(
 	stop: PropertyDescriptor | undefined,
 	immediate: PropertyDescriptor | undefined | null,
 ): void {
+	const frame = DELEGATED_EVENT_FRAMES[--delegatedEventFrameDepth];
+	frame.event = null;
+	frame.stop = null;
+	frame.immediate = null;
+	frame.currentTarget = null;
 	if (stop === undefined) delete (event as any).stopPropagation;
 	else Object.defineProperty(event, 'stopPropagation', stop);
 	if (immediate !== null) {
 		if (immediate === undefined) delete (event as any).stopImmediatePropagation;
 		else Object.defineProperty(event, 'stopImmediatePropagation', immediate);
-		delete (event as any)[NATIVE_STOP_IMMEDIATE];
 	}
-	delete (event as any)[PROPAGATION_FLAGS];
-	delete (event as any)[NATIVE_STOP_PROPAGATION];
 }
 
 // A receiver-specific target lets one accessor survive nested native dispatch.
-const CURRENT_TARGET_NODE = /* @__PURE__ */ Symbol('octane.currentTarget');
 const CURRENT_TARGET_DESCRIPTOR: PropertyDescriptor = {
 	configurable: true,
-	get(this: Event): EventTarget | null {
-		return (this as any)[CURRENT_TARGET_NODE] as EventTarget | null;
+	get(this: Event): EventTarget | null | undefined {
+		return delegatedFrameFor(this)?.currentTarget;
 	},
 };
 // Synchronous nested delegated walks borrow disjoint frames from this one stack.
@@ -18574,15 +18759,11 @@ const CAPTURE_PATH: any[] = [];
 // separate frame, and clearing the frame releases all node/handler references.
 const CAPTURE_SLOTS: EventSlot[] = [];
 
-function snapshotDelegatedSlots(base: number, key: string, event: Event): void {
-	const type = event.type;
+function snapshotDelegatedSlots(base: number, type: DelegatedEventType, capture: boolean): void {
+	const key = capture ? type.captureKey : type.bubbleKey;
 	const suppressDisabled =
-		type === 'click' ||
-		type === 'dblclick' ||
-		type === 'mousedown' ||
-		type === 'mousemove' ||
-		type === 'mouseup' ||
-		(type === 'mouseenter' && key[2] !== 'c');
+		(type.flags & EVENT_DISABLED_MOUSE) !== 0 ||
+		(!capture && (type.flags & EVENT_DISABLED_ENTER) !== 0);
 	for (let index = base; index < CAPTURE_PATH.length; index++) {
 		const node = CAPTURE_PATH[index];
 		const slot = node[key] as EventSlot;
@@ -18727,6 +18908,8 @@ function buildDelegatedPath(event: Event, listener: Node, path = event.composedP
 	const output = CAPTURE_PATH;
 	const base = output.length;
 	const epoch = (event as any)[EVENT_ROOT_EPOCH] ?? eventRootEpoch;
+	// Portal teardown after capture cannot erase the current event's logical route.
+	const mayHavePortal = portalEventTargetCount !== 0 || epoch !== eventRootEpoch;
 	const listenerIndex = path.indexOf(listener);
 	if (listenerIndex < 0) return 0;
 	// The usual application has one unchanged public root and no portals. It
@@ -18736,7 +18919,7 @@ function buildDelegatedPath(event: Event, listener: Node, path = event.composedP
 		let i = 0;
 		for (; i < listenerIndex; i++) {
 			const node = eventPathNode(path[i]);
-			if (node === null || node.$$portalParent != null) break;
+			if (node === null || (mayHavePortal && node.$$portalParent != null)) break;
 			output.push(node);
 		}
 		if (i === listenerIndex) return output.length - base;
@@ -18768,7 +18951,7 @@ function buildDelegatedPath(event: Event, listener: Node, path = event.composedP
 			}
 
 			output.push(node);
-			const logicalParent = node.$$portalParent;
+			const logicalParent = mayHavePortal ? node.$$portalParent : undefined;
 			if (logicalParent != null) {
 				// Use the actual portal container, NOT composedPath's next item:
 				// a direct portal child can be slotted, making that next item a
@@ -18931,8 +19114,8 @@ function reportListenerError(err: unknown): void {
 // publish after the dispatching script yields. Non-discrete events keep microtask
 // batching too; they must not be staged with an unrelated async Action merely
 // because they do not flush synchronously here.
-function maybeFlushDiscrete(type: string): void {
-	if (_dispatchDepth === 0 && DISCRETE_EVENTS.has(type) && pendingRestores.length > 0) {
+function maybeFlushDiscrete(type: DelegatedEventType): void {
+	if (_dispatchDepth === 0 && (type.flags & EVENT_DISCRETE) !== 0 && pendingRestores.length > 0) {
 		// Commit handler-scheduled work first, so the controlled restore below
 		// compares the DOM against the values the handlers just rendered.
 		if (!inFlush && hasPendingWork()) {
@@ -18954,23 +19137,22 @@ function maybeFlushDiscrete(type: string): void {
 	}
 	// Clear after the click's own handlers (and its outermost flush, when this is
 	// not a nested dispatch), including canceled/eventless activations.
-	if (type === 'click') activationCheckable = null;
+	if (type.name === 'click') activationCheckable = null;
 }
 
-function finishCaptureDispatch(event: Event): void {
-	const type = event.type;
-	if (!event.bubbles || event.cancelBubble || !_delegated.has(type)) {
-		if (event.bubbles && _delegated.has(type)) maybeEnqueueRestore(event);
+function finishCaptureDispatch(event: Event, type: DelegatedEventType): void {
+	if (!event.bubbles || event.cancelBubble || (type.flags & EVENT_BUBBLE) === 0) {
+		if (event.bubbles && (type.flags & EVENT_BUBBLE) !== 0) maybeEnqueueRestore(event, type);
 		maybeFlushDiscrete(type);
 		return;
 	}
-	if (!DISCRETE_EVENTS.has(type)) return;
+	if ((type.flags & EVENT_DISCRETE) === 0) return;
 	// A missed bubble can leave a restore queued by a nested event in capture.
 	// The target itself may also become controlled in a native listener below
 	// this root, so retain the fallback for form controls even when $$ctrl is
 	// not armed yet. Other events have no controlled work to finish here.
 	if (pendingRestores.length === 0) {
-		if (!RESTORE_EVENTS.has(type)) return;
+		if ((type.flags & EVENT_RESTORE) === 0) return;
 		const tag = (event.target as Element | null)?.localName;
 		if (tag !== 'input' && tag !== 'textarea' && tag !== 'select') return;
 	}
@@ -18980,7 +19162,7 @@ function finishCaptureDispatch(event: Event): void {
 		// (controlled restores and their sync flush). When a native listener stops
 		// the event below its root, close that window here instead.
 		if ((event as any)[DELEGATED_BUBBLE_VERSION] === bubbleVersion) {
-			maybeEnqueueRestore(event);
+			maybeEnqueueRestore(event, type);
 			maybeFlushDiscrete(type);
 		}
 	};
@@ -19002,12 +19184,13 @@ function finishCaptureDispatch(event: Event): void {
 }
 
 function dispatchDelegated(this: Node, event: Event): void {
-	const nativeCapture = delegatedCapture(event.type);
+	const type = _delegated.get(event.type) ?? _delegatedCapture.get(event.type);
+	if (type === undefined) return;
+	const nativeCapture = (type.flags & EVENT_NATIVE_CAPTURE) !== 0;
 	let path = nativeCapture ? prepareDelegatedEvent(event, this) : undefined;
 	(event as any)[DELEGATED_BUBBLE_VERSION] = ((event as any)[DELEGATED_BUBBLE_VERSION] || 0) + 1;
-	maybeEnqueueRestore(event);
-	const key = '$$' + event.type;
-	const targetOnly = TARGET_ONLY_DELEGATED.has(event.type);
+	maybeEnqueueRestore(event, type);
+	const targetOnly = (type.flags & EVENT_TARGET_ONLY) !== 0;
 	_dispatchDepth++;
 	const node = event.target as any;
 	// A submit dispatch targeting a form opens the manual-action useFormStatus
@@ -19023,38 +19206,39 @@ function dispatchDelegated(this: Node, event: Event): void {
 	const pathBase = CAPTURE_PATH.length;
 	let stop: PropertyDescriptor | undefined;
 	let propagationStarted = false;
+	let frame: DelegatedEventFrame;
 	try {
 		// Non-bubbling families share one native capture callback. Run the logical
 		// capture queue first, independent of module registration order, and honor
 		// a stop within that phase before starting the emulated bubble queue.
-		if (nativeCapture && _delegatedCapture.has(event.type)) {
+		if (nativeCapture && (type.flags & EVENT_CAPTURE) !== 0) {
 			path ??= event.composedPath();
-			if (dispatchDelegatedCapture.call(this, event, path)) return;
+			if (dispatchDelegatedCapture.call(this, event, path, type)) return;
 		}
-		if (!_delegated.has(event.type)) return;
+		if ((type.flags & EVENT_BUBBLE) === 0) return;
 		// Custom elements receive known nonbubbling events through authored
 		// capture handlers only. They do not install the native target listener
 		// that makes these built-in host events propagate in the bubble queue.
 		if (
 			node?.nodeType === 1 &&
 			isHtmlCustomElement(node) &&
-			(event.type === 'invalid' || EMULATED_BUBBLING_EVENTS.includes(event.type))
+			(type.flags & EVENT_CUSTOM_NATIVE_ONLY) !== 0
 		)
 			return;
 		buildDelegatedPath(event, this, path);
-		snapshotDelegatedSlots(pathBase, key, event);
+		snapshotDelegatedSlots(pathBase, type, false);
 		stop = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
 		propagationStarted = true;
-		beginDelegatedPropagation(event, stop, null);
+		frame = beginDelegatedPropagation(event, stop, null);
 		for (let i = pathBase; i < CAPTURE_PATH.length; i++) {
 			const current = CAPTURE_PATH[i];
 			// Target-only native families never transfer a handler to a root boundary.
 			if (targetOnly && current !== event.target) break;
 			const slot = CAPTURE_SLOTS[i];
 			if (slot != null) {
-				setCurrentTarget(event, current);
+				setCurrentTarget(event, current, frame);
 				fireEventSlot(slot, event);
-				if (((event as any)[PROPAGATION_FLAGS] & 1) !== 0) break;
+				if ((frame.flags & 1) !== 0) break;
 			}
 			if (targetOnly) break;
 		}
@@ -19085,42 +19269,48 @@ function dispatchDelegated(this: Node, event: Event): void {
 			reportListenerError(error);
 		}
 		_dispatchDepth--;
-		maybeFlushDiscrete(event.type);
+		maybeFlushDiscrete(type);
 	}
 }
 
 // Capture runs only this native listener's segment, in reverse path order.
 // Returning whether this queue stopped native propagation lets the shared
 // non-bubbling listener decide whether it may start its emulated bubble queue.
-function dispatchDelegatedCapture(this: Node, event: Event, path?: EventTarget[]): boolean {
+function dispatchDelegatedCapture(
+	this: Node,
+	event: Event,
+	path?: EventTarget[],
+	type = _delegated.get(event.type) ?? _delegatedCapture.get(event.type),
+): boolean {
 	path ??= prepareDelegatedEvent(event, this);
-	if (!_delegatedCapture.has(event.type)) return false;
+	if (type === undefined || (type.flags & EVENT_CAPTURE) === 0) return false;
 	path ??= event.composedPath();
-	if (!event.bubbles || !_delegated.has(event.type)) maybeEnqueueRestore(event);
-	const key = CAPTURE_PREFIX + event.type;
+	if (!event.bubbles || (type.flags & EVENT_BUBBLE) === 0) maybeEnqueueRestore(event, type);
 	const pathBase = CAPTURE_PATH.length;
 	buildDelegatedPath(event, this, path);
-	snapshotDelegatedSlots(pathBase, key, event);
+	snapshotDelegatedSlots(pathBase, type, true);
 	const stop = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
-	const immediate = delegatedCapture(event.type)
-		? Object.getOwnPropertyDescriptor(event, 'stopImmediatePropagation')
-		: null;
+	const immediate =
+		(type.flags & EVENT_NATIVE_CAPTURE) !== 0
+			? Object.getOwnPropertyDescriptor(event, 'stopImmediatePropagation')
+			: null;
 	const wasCancelled = event.cancelBubble;
 	let stopped = false;
 	_dispatchDepth++;
 	const nativeBatch = beginNativeEventBatch(event);
+	let frame: DelegatedEventFrame | undefined;
 	try {
-		beginDelegatedPropagation(event, stop, immediate);
+		frame = beginDelegatedPropagation(event, stop, immediate);
 		for (let i = CAPTURE_PATH.length - 1; i >= pathBase; i--) {
 			const slot = CAPTURE_SLOTS[i];
 			if (slot != null) {
-				setCurrentTarget(event, CAPTURE_PATH[i]);
+				setCurrentTarget(event, CAPTURE_PATH[i], frame);
 				fireEventSlot(slot, event);
-				if (((event as any)[PROPAGATION_FLAGS] & 1) !== 0) break;
+				if ((frame.flags & 1) !== 0) break;
 			}
 		}
 	} finally {
-		stopped = (event as any)[PROPAGATION_FLAGS] !== 0 || (!wasCancelled && event.cancelBubble);
+		stopped = frame?.flags !== 0 || (!wasCancelled && event.cancelBubble);
 		CAPTURE_PATH.length = pathBase;
 		CAPTURE_SLOTS.length = pathBase;
 		endDelegatedPropagation(event, stop, immediate);
@@ -19129,14 +19319,14 @@ function dispatchDelegatedCapture(this: Node, event: Event, path?: EventTarget[]
 			endNativeEventBatch(
 				event,
 				nativeBatch,
-				event.bubbles && !event.cancelBubble && _delegated.has(event.type),
+				event.bubbles && !event.cancelBubble && (type.flags & EVENT_BUBBLE) !== 0,
 				reportListenerError,
 			);
 		} catch (error) {
 			reportListenerError(error);
 		}
 		_dispatchDepth--;
-		finishCaptureDispatch(event);
+		finishCaptureDispatch(event, type);
 	}
 	return stopped;
 }
@@ -19149,14 +19339,17 @@ function noop(): void {}
 // measurement/indexOf). Native `currentTarget` is the listener's attach node (our
 // delegation ROOT), so shadow it with a configurable own property during each handler and
 // remove the shadow after the walk (restoring native semantics).
-function setCurrentTarget(event: Event, node: EventTarget | null): void {
-	(event as any)[CURRENT_TARGET_NODE] = node;
+function setCurrentTarget(
+	event: Event,
+	node: EventTarget | null,
+	frame: DelegatedEventFrame,
+): void {
+	frame.currentTarget = node;
 	Object.defineProperty(event, 'currentTarget', CURRENT_TARGET_DESCRIPTOR);
 }
 function clearCurrentTarget(event: Event): void {
 	// Deleting the own property re-exposes Event.prototype's native getter.
 	delete (event as any).currentTarget;
-	delete (event as any)[CURRENT_TARGET_NODE];
 }
 
 // ---------------------------------------------------------------------------
@@ -20742,9 +20935,9 @@ function isControlledHostProp(el: Element, name: string): boolean {
  * form control and the event can carry a user edit (see RESTORE_EVENTS).
  * Called by both delegated dispatchers, right after their dispatch stamp.
  */
-function maybeEnqueueRestore(event: Event): void {
+function maybeEnqueueRestore(event: Event, type: DelegatedEventType): void {
 	const t = event.target as any;
-	if (t === null || t.$$ctrl === undefined || !RESTORE_EVENTS.has(event.type)) return;
+	if (t === null || t.$$ctrl === undefined || (type.flags & EVENT_RESTORE) === 0) return;
 	const ctrl = t.$$ctrl as ControlledState;
 	if (event.type === 'input' && ctrl.compositionEndTask !== undefined) {
 		const inputEvent = event as InputEvent;
@@ -20868,6 +21061,7 @@ function registerPortalEventRange(target: Node, portal: PortalSlot): void {
 		ranges = new Set();
 		_portalEventRanges.set(target, ranges);
 		portalEventTargetCount++;
+		eventRootEpoch++;
 	}
 	ranges.add(portal);
 	(portal.start as PortalEventBoundary).$$portalEventRange = portal;
@@ -20885,6 +21079,7 @@ function unregisterPortalEventRange(target: Node, portal: PortalSlot): void {
 	if (ranges.size === 0) {
 		_portalEventRanges.delete(target);
 		portalEventTargetCount--;
+		eventRootEpoch++;
 	}
 }
 

--- a/packages/octane/tests/_fixtures/dom-template-text.tsrx
+++ b/packages/octane/tests/_fixtures/dom-template-text.tsrx
@@ -1,0 +1,59 @@
+type Row = {
+	readonly id: number;
+	readonly label: string;
+	readonly before: string;
+	readonly after: string;
+};
+type RowsProps = { readonly rows: readonly Row[]; readonly tick: string };
+
+export function FragmentTextRows({ rows, tick }: RowsProps) @{
+	<main>
+		<output>{tick}</output>
+		<div id="rows">
+			@for (const row of rows; key row.id) {
+				<>
+					<label data-label={row.id}>{row.label as string}</label>
+					<input data-input={row.id} />
+					<span data-span={row.id}>
+						{row.before as string}
+						<b>:</b>
+						{row.after as string}
+					</span>
+				</>
+			}
+		</div>
+	</main>
+}
+
+export function RootTextPair({ label }: { readonly label: string }) @{
+	<>
+		<strong id="first">{label as string}</strong>
+		<em id="last">{'tail'}</em>
+	</>
+}
+
+function SvgPair({ label }: { readonly label: string }) @{
+	<>
+		<circle r="2" />
+		<text>{label as string}</text>
+	</>
+}
+
+export function ForeignSvg({ label }: { readonly label: string }) @{
+	<svg id="chart">
+		<SvgPair label={label} />
+	</svg>
+}
+
+function MathPair({ label }: { readonly label: string }) @{
+	<>
+		<mn>{label as string}</mn>
+		<mo>+</mo>
+	</>
+}
+
+export function ForeignMath({ label }: { readonly label: string }) @{
+	<math id="formula">
+		<MathPair label={label} />
+	</math>
+}

--- a/packages/octane/tests/_fixtures/host-attribute-updates.tsrx
+++ b/packages/octane/tests/_fixtures/host-attribute-updates.tsrx
@@ -1,0 +1,50 @@
+export function Values(props) @{
+	<section>
+		<a
+			id="anchor"
+			title={props.value}
+			href={props.url}
+			data-n={props.value}
+			download={props.value}
+		/>
+		<img id="image" src={props.url} />
+		<svg id="svg" viewBox={props.value} xmlns={props.value}>
+			<circle id="circle" cx={props.value} strokeWidth={props.value} />
+			<use id="use" xlinkHref={props.url} />
+		</svg>
+		<input id="control" value={props.value} size={props.value} readOnly />
+		<div id="enumerated" spellCheck={props.value} />
+		<custom-values id="custom" title={props.value} href={props.url} />
+	</section>
+}
+
+export function Metadata(props) @{
+	<>
+		<title lang={props.lang}>{props.text as string}</title>
+		<meta name="description" {...props.attrs} content={props.content} />
+		<div>page</div>
+	</>
+}
+
+export function ScalarValue(props) @{
+	<a id="scalar" title={props.title} href={props.url} />
+}
+
+function Reader(props) @{
+	<p>{props.read() as string}</p>
+}
+
+function PendingMetadata(props) @{
+	<>
+		<title>{props.label as string}</title>
+		<meta name="pending-description" content={props.label} />
+	</>
+}
+
+export function PendingValues(props) @{
+	<>
+		<a id="pending-link" title={props.label} href={props.url} />
+		<PendingMetadata label={props.label} />
+		<Reader read={props.read} />
+	</>
+}

--- a/packages/octane/tests/attrs-events.test.ts
+++ b/packages/octane/tests/attrs-events.test.ts
@@ -175,31 +175,33 @@ describe('attributes', () => {
 		r.unmount();
 	});
 
-	it('specializes only safe data attributes whose values are proven strings', () => {
-		const specialized = compile(
-			`export function C(p) @{ <div data-key={'' + p.id} /> }`,
-			'data-string.tsrx',
-			{ dev: false },
-		).code;
-		expect(specialized).toContain('setStringData');
-		expect(specialized).not.toContain('setAttribute');
-
-		const generic = compile(
-			`export function C(p) @{ <div data-key={p.id} aria-label={'' + p.id} /> }`,
-			'data-generic.tsrx',
-			{ dev: false },
-		).code;
-		expect(generic).toContain('setAttribute');
-		expect(generic).not.toContain('setStringData');
-
-		const narrow = compile(
-			`export function C(p) @{ <button disabled={p.disabled} aria-label={p.label} /> }`,
-			'attributes-narrow.tsrx',
-			{ dev: false },
-		).code;
-		expect(narrow).toContain('setBooleanAttribute');
-		expect(narrow).toContain('setAriaAttribute');
-		expect(narrow).not.toContain('setAttribute');
+	it('preserves unknown data values beside native boolean and ARIA attributes in production output', () => {
+		const { C } = loadCompiledFixtureSource(
+			`export function C(p) @{ <button data-key={p.value} disabled={p.value} aria-label={p.value} /> }`,
+			{
+				id: '/production-data-values.tsrx',
+				mode: 'client',
+				compileOptions: { dev: false, hmr: false },
+			},
+		);
+		const r = mount(C, { value: false });
+		const button = r.find('button');
+		try {
+			for (const value of [false, true, 0, 2, 'text']) {
+				r.update(C, { value });
+				expect(button.getAttribute('data-key')).toBe(String(value));
+				expect(button.getAttribute('aria-label')).toBe(String(value));
+				expect(button.hasAttribute('disabled')).toBe(Boolean(value));
+			}
+			for (const value of [null, undefined, Symbol('removed'), () => 'removed']) {
+				r.update(C, { value });
+				expect(button.hasAttribute('data-key')).toBe(false);
+				expect(button.hasAttribute('aria-label')).toBe(false);
+				expect(button.hasAttribute('disabled')).toBe(false);
+			}
+		} finally {
+			r.unmount();
+		}
 	});
 
 	it('bakes static aria-* boolean literals as enumerated "true"/"false"', () => {

--- a/packages/octane/tests/browser/event-metadata/event-metadata.test.ts
+++ b/packages/octane/tests/browser/event-metadata/event-metadata.test.ts
@@ -1,0 +1,289 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+import { build } from 'esbuild';
+import { fileURLToPath } from 'node:url';
+import { launchBrowser } from '../../../../../test-utils/playwright-browser.js';
+import type * as Runtime from '../../../src/index.js';
+
+declare global {
+	interface Window {
+		OctaneEventRuntime: typeof Runtime;
+	}
+}
+
+let browser: Browser;
+let page: Page | undefined;
+let source: string;
+let failures: string[];
+
+beforeAll(async () => {
+	const result = await build({
+		entryPoints: [fileURLToPath(new URL('../../../src/index.ts', import.meta.url))],
+		bundle: true,
+		write: false,
+		format: 'iife',
+		platform: 'browser',
+		globalName: 'OctaneEventRuntime',
+		define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+	});
+	source = result.outputFiles[0].text;
+	browser = await launchBrowser({ headless: true });
+});
+
+afterEach(async () => {
+	await page?.close();
+	page = undefined;
+	expect(failures).toEqual([]);
+});
+afterAll(async () => {
+	await browser?.close();
+});
+
+async function openRuntime(): Promise<Page> {
+	failures = [];
+	page = await browser.newPage();
+	page.on('pageerror', (error) => failures.push(error.message));
+	await page.addScriptTag({ content: source });
+	return page;
+}
+
+describe('production native event metadata', () => {
+	it('restores native descriptors across nested cancellation, redispatch, and later bubble registration', async () => {
+		const page = await openRuntime();
+		const result = await page.evaluate(() => {
+			const { createRoot, createElement, flushSync } = window.OctaneEventRuntime;
+
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			const root = createRoot(container);
+			const log: string[] = [];
+			const checks: boolean[] = [];
+			const outer = new MouseEvent('click', { bubbles: true, detail: 1 });
+			const ownStop = function (this: Event) {
+				log.push('own-stop');
+				Event.prototype.stopPropagation.call(this);
+			};
+			Object.defineProperty(outer, 'stopPropagation', {
+				value: ownStop,
+				configurable: true,
+				enumerable: true,
+				writable: false,
+			});
+			let retained!: () => void;
+			let target!: Element;
+			let includeBubble = false;
+			const render = () =>
+				createElement(
+					'section',
+					{
+						id: 'metadata-parent',
+						onClick: (event: MouseEvent) => log.push(`parent:${event.detail}`),
+					},
+					createElement(
+						'button',
+						{
+							id: 'metadata-target',
+							onClick: (event: MouseEvent) => {
+								checks.push(event.currentTarget === target);
+								log.push(`target:${event.detail}`);
+								if (event === outer) {
+									retained = event.stopPropagation;
+									target.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 2 }));
+									checks.push(outer.currentTarget === target);
+								} else retained.call(outer);
+							},
+							onTransitionCancelCapture: (event: Event) => {
+								checks.push(event.currentTarget === target);
+								log.push('late:capture');
+							},
+							...(includeBubble
+								? {
+										onTransitionCancel: (event: Event) => {
+											checks.push(event.currentTarget === target);
+											log.push('late:bubble');
+										},
+									}
+								: null),
+						},
+						'target',
+					),
+				);
+			try {
+				flushSync(() => root.render(render()));
+				target = container.querySelector('button')!;
+				container.addEventListener('click', (event) => {
+					const descriptor = Object.getOwnPropertyDescriptor(event, 'stopPropagation');
+					checks.push(event.currentTarget === container && !Object.hasOwn(event, 'currentTarget'));
+					if (event === outer)
+						checks.push(
+							descriptor?.value === ownStop &&
+								descriptor.configurable === true &&
+								descriptor.enumerable === true &&
+								descriptor.writable === false,
+						);
+					else checks.push(descriptor === undefined);
+					log.push(`native:${(event as MouseEvent).detail}`);
+				});
+				target.dispatchEvent(outer);
+				target.dispatchEvent(outer);
+				checks.push(outer.currentTarget === null && outer.stopPropagation === ownStop);
+				target.dispatchEvent(new Event('transitioncancel', { bubbles: true }));
+				includeBubble = true;
+				flushSync(() => root.render(render()));
+				target.dispatchEvent(new Event('transitioncancel', { bubbles: true }));
+				retained.call(outer);
+				checks.push(outer.cancelBubble);
+				return { log, checks };
+			} finally {
+				root.unmount();
+				container.remove();
+			}
+		});
+		expect(result.checks.every(Boolean)).toBe(true);
+		expect(result.log).toEqual([
+			'target:1',
+			'target:2',
+			'own-stop',
+			'parent:2',
+			'native:2',
+			'native:1',
+			'target:1',
+			'target:2',
+			'own-stop',
+			'parent:2',
+			'native:2',
+			'native:1',
+			'late:capture',
+			'late:capture',
+			'late:bubble',
+			'own-stop',
+		]);
+	});
+
+	it('keeps a removed portal route through the end of its native dispatch', async () => {
+		const page = await openRuntime();
+		const result = await page.evaluate(() => {
+			const { createRoot, createElement, createPortal, flushSync } = window.OctaneEventRuntime;
+			const container = document.createElement('div');
+			const target = document.createElement('div');
+			document.body.append(container, target);
+			const root = createRoot(container);
+			const targetRoot = createRoot(target);
+			const log: string[] = [];
+			const render = (show: boolean) =>
+				createElement(
+					'section',
+					{
+						onClickCapture: () => log.push('capture'),
+						onClick: () => log.push('parent'),
+					},
+					show
+						? createPortal(
+								createElement(
+									'button',
+									{
+										onClick: () => log.push('target'),
+									},
+									'portal',
+								),
+								target,
+							)
+						: null,
+				);
+			try {
+				flushSync(() => root.render(render(true)));
+				const button = target.querySelector('button')!;
+				button.addEventListener(
+					'click',
+					() => {
+						log.push('native target');
+						flushSync(() => root.render(render(false)));
+					},
+					{ once: true },
+				);
+				button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+				return {
+					log,
+					detached: button.parentNode === null,
+					empty: target.querySelector('button') === null,
+				};
+			} finally {
+				root.unmount();
+				targetRoot.unmount();
+				container.remove();
+				target.remove();
+			}
+		});
+		expect(result).toEqual({
+			log: ['capture', 'native target', 'target', 'parent'],
+			detached: true,
+			empty: true,
+		});
+	});
+
+	it.each(['open', 'closed'] as const)(
+		'preserves %s shadow retargeting across public roots',
+		async (mode) => {
+			const page = await openRuntime();
+			const result = await page.evaluate((mode) => {
+				const { createRoot, createElement, flushSync } = window.OctaneEventRuntime;
+				const container = document.createElement('div');
+				container.id = 'native-root';
+				document.body.append(container);
+				const root = createRoot(container);
+				const log: string[] = [];
+				const record = (label: string) => (event: Event) => {
+					log.push(
+						`${label}:${(event.target as Element).id}:${(event.currentTarget as Element).id}`,
+					);
+				};
+				flushSync(() =>
+					root.render(
+						createElement(
+							'section',
+							{
+								id: 'outer',
+								onClickCapture: record('outer capture'),
+								onClick: record('outer bubble'),
+							},
+							createElement('div', { id: 'shadow-host' }),
+						),
+					),
+				);
+				const shadow = container.querySelector('#shadow-host')!.attachShadow({ mode });
+				const inner = createRoot(shadow);
+				try {
+					flushSync(() =>
+						inner.render(
+							createElement(
+								'button',
+								{
+									id: 'inner',
+									onClickCapture: record('inner capture'),
+									onClick: record('inner bubble'),
+								},
+								'inside',
+							),
+						),
+					);
+					container.addEventListener('click', record('native after'));
+					shadow
+						.querySelector('button')!
+						.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+					return log;
+				} finally {
+					inner.unmount();
+					root.unmount();
+					container.remove();
+				}
+			}, mode);
+			expect(result).toEqual([
+				'outer capture:shadow-host:outer',
+				'inner capture:inner:inner',
+				'inner bubble:inner:inner',
+				'outer bubble:shadow-host:outer',
+				'native after:shadow-host:native-root',
+			]);
+		},
+	);
+});

--- a/packages/octane/tests/browser/text-parser-hosts/hosts.tsrx
+++ b/packages/octane/tests/browser/text-parser-hosts/hosts.tsrx
@@ -1,0 +1,64 @@
+type Props = { readonly text: string };
+
+export function TextareaHole({ text }: Props) @{
+	<textarea id="target">{text as string}</textarea>
+}
+
+export function TableHole({ text }: Props) @{
+	<table id="target">{text as string}</table>
+}
+
+export function BodyHole({ text }: Props) @{
+	<table>
+		<tbody id="target">{text as string}</tbody>
+	</table>
+}
+
+export function RowHole({ text }: Props) @{
+	<table>
+		<tbody>
+			<tr id="target">{text as string}</tr>
+		</tbody>
+	</table>
+}
+
+export function ColgroupHole({ text }: Props) @{
+	<table>
+		<colgroup id="target">{text as string}</colgroup>
+	</table>
+}
+
+export function SelectHole({ text }: Props) @{
+	<select id="target">{text as string}</select>
+}
+
+export function OptionHole({ text }: Props) @{
+	<select>
+		<option id="target">{text as string}</option>
+	</select>
+}
+
+export function TablePair({ text }: Props) @{
+	<>
+		<table id="target">{text as string}</table>
+		<aside id="tail">tail</aside>
+	</>
+}
+
+export function BodyPair({ text }: Props) @{
+	<>
+		<table>
+			<tbody id="target">{text as string}</tbody>
+		</table>
+		<aside id="tail">tail</aside>
+	</>
+}
+
+export function ColgroupPair({ text }: Props) @{
+	<>
+		<table>
+			<colgroup id="target">{text as string}</colgroup>
+		</table>
+		<aside id="tail">tail</aside>
+	</>
+}

--- a/packages/octane/tests/browser/text-parser-hosts/text-parser-hosts.test.ts
+++ b/packages/octane/tests/browser/text-parser-hosts/text-parser-hosts.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import type { Browser, Page } from 'playwright';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { launchBrowser } from '../../../../../test-utils/playwright-browser.js';
+import { compile } from '../../../src/compiler/index.js';
+import type { createRoot, flushSync } from '../../../src/index.js';
+
+const fixtureURL = new URL('./hosts.tsrx', import.meta.url);
+const packageRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const packageExports = JSON.parse(
+	readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'),
+).exports as Record<string, string | { default?: string }>;
+const cases = {
+	TextareaHole: (text: string) => `<textarea id="target">${text}</textarea>`,
+	TableHole: (text: string) => `<table id="target">${text}</table>`,
+	BodyHole: (text: string) => `<table><tbody id="target">${text}</tbody></table>`,
+	RowHole: (text: string) => `<table><tbody><tr id="target">${text}</tr></tbody></table>`,
+	ColgroupHole: (text: string) => `<table><colgroup id="target">${text}</colgroup></table>`,
+	SelectHole: (text: string) => `<select id="target">${text}</select>`,
+	OptionHole: (text: string) => `<select><option id="target">${text}</option></select>`,
+	TablePair: (text: string) => `<table id="target">${text}</table><aside id="tail">tail</aside>`,
+	BodyPair: (text: string) =>
+		`<table><tbody id="target">${text}</tbody></table><aside id="tail">tail</aside>`,
+	ColgroupPair: (text: string) =>
+		`<table><colgroup id="target">${text}</colgroup></table><aside id="tail">tail</aside>`,
+} as const;
+type CaseName = keyof typeof cases;
+
+declare global {
+	interface Window {
+		OctaneTextParserHosts: {
+			createRoot: typeof createRoot;
+			flushSync: typeof flushSync;
+			fixtures: Record<CaseName, (props: { text: string }) => void>;
+		};
+	}
+}
+
+let browser: Browser;
+let page: Page | undefined;
+let source: string;
+let failures: string[];
+
+beforeAll(async () => {
+	const compiled = compile(readFileSync(fixtureURL, 'utf8'), fileURLToPath(fixtureURL), {
+		mode: 'client',
+		dev: false,
+		hmr: false,
+	});
+	expect(compiled.diagnostics).toEqual([]);
+	const result = await build({
+		stdin: {
+			contents: `import { createRoot, flushSync } from 'octane';
+import * as fixtures from 'text-parser-hosts-fixture';
+export { createRoot, flushSync, fixtures };`,
+			resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+			sourcefile: 'text-parser-hosts-entry.js',
+			loader: 'js',
+		},
+		bundle: true,
+		write: false,
+		format: 'iife',
+		platform: 'browser',
+		globalName: 'OctaneTextParserHosts',
+		define: { 'process.env.NODE_ENV': '"production"', __OCTANE_PROFILE_ENABLED__: 'false' },
+		plugins: [
+			{
+				name: 'text-parser-hosts-fixture',
+				setup(plugin) {
+					plugin.onResolve({ filter: /^octane(?:\/|$)/ }, ({ path: request }) => {
+						const entry = packageExports[request === 'octane' ? '.' : `./${request.slice(7)}`];
+						const target = typeof entry === 'string' ? entry : entry?.default;
+						if (!target) throw new Error(`Unknown Octane export: ${request}`);
+						return { path: resolve(packageRoot, target) };
+					});
+					plugin.onResolve({ filter: /^text-parser-hosts-fixture$/ }, () => ({
+						path: 'text-parser-hosts-fixture',
+						namespace: 'compiled-fixture',
+					}));
+					plugin.onLoad({ filter: /.*/, namespace: 'compiled-fixture' }, () => ({
+						contents: compiled.code,
+						loader: 'js',
+						resolveDir: packageRoot,
+					}));
+				},
+			},
+		],
+	});
+	source = result.outputFiles[0].text;
+	browser = await launchBrowser({ headless: true });
+});
+
+afterEach(async () => {
+	await page?.close();
+	page = undefined;
+	expect(failures).toEqual([]);
+});
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+describe('compiled text-only parser-sensitive hosts in Chromium', () => {
+	for (const name of Object.keys(cases) as CaseName[]) {
+		it(`${name} preserves mount, update, empty text, and DOM identity`, async () => {
+			failures = [];
+			page = await browser.newPage();
+			page.on('pageerror', (error) => failures.push(error.message));
+			await page.addScriptTag({ content: source });
+			const result = await page.evaluate((name) => {
+				const { createRoot, flushSync, fixtures } = window.OctaneTextParserHosts;
+				const container = document.createElement('form');
+				document.body.appendChild(container);
+				const root = createRoot(container);
+				try {
+					const Component = fixtures[name];
+					root.render(Component, { text: 'X' });
+					const target = container.querySelector('#target')!;
+					const text = target.firstChild;
+					const tail = container.querySelector('#tail');
+					const snapshot = () => ({
+						html: container.innerHTML,
+						childTypes: [...target.childNodes].map((child) => child.nodeType),
+						text: target.textContent,
+						sameTarget: container.querySelector('#target') === target,
+						sameText: target.firstChild === text,
+						sameTail: container.querySelector('#tail') === tail,
+						tailLast: tail === null || tail === container.lastElementChild,
+						topLevelCount: container.children.length,
+						value:
+							target instanceof HTMLTextAreaElement ||
+							target instanceof HTMLSelectElement ||
+							target instanceof HTMLOptionElement
+								? target.value
+								: null,
+						defaultValue: target instanceof HTMLTextAreaElement ? target.defaultValue : null,
+						parentValue:
+							target instanceof HTMLOptionElement
+								? (target.parentElement as HTMLSelectElement).value
+								: null,
+					});
+					const initial = snapshot();
+					if (target instanceof HTMLTextAreaElement) target.value = 'typed';
+					flushSync(() => root.render(Component, { text: 'Y' }));
+					const changed = snapshot();
+					if (target instanceof HTMLTextAreaElement) container.reset();
+					const reset = target instanceof HTMLTextAreaElement ? snapshot() : null;
+					flushSync(() => root.render(Component, { text: '' }));
+					const empty = snapshot();
+					return { initial, changed, reset, empty };
+				} finally {
+					root.unmount();
+					container.remove();
+				}
+			}, name);
+			const markup = cases[name];
+			const expectedTopLevelCount = name.endsWith('Pair') ? 2 : 1;
+			for (const [stage, value] of [
+				['initial', 'X'],
+				['changed', 'Y'],
+				['empty', ''],
+			] as const) {
+				expect(result[stage]).toMatchObject({
+					html: markup(value),
+					childTypes: [3],
+					text: value,
+					sameTarget: true,
+					sameText: true,
+					sameTail: true,
+					tailLast: true,
+					topLevelCount: expectedTopLevelCount,
+				});
+			}
+			if (name === 'TextareaHole') {
+				expect(result.initial).toMatchObject({ value: 'X', defaultValue: 'X' });
+				expect(result.changed).toMatchObject({ value: 'typed', defaultValue: 'Y' });
+				expect(result.reset).toMatchObject({
+					html: markup('Y'),
+					childTypes: [3],
+					text: 'Y',
+					sameTarget: true,
+					sameText: true,
+					value: 'Y',
+					defaultValue: 'Y',
+				});
+				expect(result.empty).toMatchObject({ value: '', defaultValue: '' });
+			} else if (name === 'OptionHole') {
+				expect(result.initial).toMatchObject({ value: 'X', parentValue: 'X' });
+				expect(result.changed).toMatchObject({ value: 'Y', parentValue: 'Y' });
+				expect(result.empty).toMatchObject({ value: '', parentValue: '' });
+			} else if (name === 'SelectHole') {
+				expect(result.initial.value).toBe('');
+				expect(result.changed.value).toBe('');
+				expect(result.empty.value).toBe('');
+			}
+		});
+	}
+});

--- a/packages/octane/tests/conformance/_fixtures/client-host-source-aggregation.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/client-host-source-aggregation.tsrx
@@ -107,3 +107,15 @@ export function DangerToSpreadChild(props) @{
 export function DynamicVoidChild(props) @{
 	<input id="dynamic-void-child">{props.child}</input>
 }
+
+export function RepeatedAliasSources(props) @{
+	<label {...props.first} {...props.second} htmlFor={props.finalFor}>label</label>
+}
+
+export function StableSpreadSources(props) @{
+	<button {...props.source}>button</button>
+}
+
+export function CustomSpreadSources(props) @{
+	<octane-spread-resolution {...props.source} />
+}

--- a/packages/octane/tests/conformance/event-listener.test.ts
+++ b/packages/octane/tests/conformance/event-listener.test.ts
@@ -581,6 +581,46 @@ describe('ReactDOMEventListener — native and framework cancellation', () => {
 		}
 	});
 
+	// A retained outer method must still address its own Event while a nested
+	// native dispatch is running another logical queue.
+	it('can stop an outer event through its retained method while another event is active', () => {
+		const log: string[] = [];
+		const outer = new MouseEvent('click', { bubbles: true, detail: 1 });
+		const nativeStop = function (this: Event) {
+			log.push('outer native stop');
+			Event.prototype.stopPropagation.call(this);
+		};
+		Object.defineProperty(outer, 'stopPropagation', {
+			value: nativeStop,
+			configurable: true,
+			writable: false,
+			enumerable: true,
+		});
+		const before = Object.getOwnPropertyDescriptor(outer, 'stopPropagation');
+		let retained!: () => void;
+		const r = mount(PropagationTree, {
+			onTarget: (event) => {
+				const detail = (event as MouseEvent).detail;
+				log.push(`target:${detail}`);
+				if (detail === 1) {
+					retained = event.stopPropagation;
+					r.find('.propagation-target').dispatchEvent(
+						new MouseEvent('click', { bubbles: true, detail: 2 }),
+					);
+				} else retained.call(outer);
+			},
+			onParent: (event) => log.push(`parent:${(event as MouseEvent).detail}`),
+		});
+		try {
+			r.find('.propagation-target').dispatchEvent(outer);
+			expect(log).toEqual(['target:1', 'target:2', 'outer native stop', 'parent:2']);
+			expect(Object.getOwnPropertyDescriptor(outer, 'stopPropagation')).toEqual(before);
+			expect(outer.currentTarget).toBe(null);
+		} finally {
+			r.unmount();
+		}
+	});
+
 	// Native EventTarget permits redispatch after a dispatch returns; logical
 	// propagation state must be scoped to that dispatch, not the Event's lifetime.
 	it('runs both phases again when the same native event is synchronously redispatched', () => {

--- a/packages/octane/tests/conformance/spread-resolution.test.ts
+++ b/packages/octane/tests/conformance/spread-resolution.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { flushSync, hydrateRoot } from 'octane';
+import { renderToString } from 'octane/server';
+import { mount } from '../_helpers.js';
+import { loadServerFixture } from '../_server-fixture.js';
+import * as client from './_fixtures/client-host-source-aggregation.tsrx';
+
+const server = loadServerFixture<typeof client>(
+	'packages/octane/tests/conformance/_fixtures/client-host-source-aggregation.tsrx',
+);
+
+afterEach(() => vi.restoreAllMocks());
+
+it('keeps the repeated raw alias winner in its original application position', () => {
+	for (const rendering of ['client', 'server'] as const) {
+		const log: string[] = [];
+		const value = (name: string) => ({
+			toString() {
+				log.push(name);
+				return name;
+			},
+		});
+		const props = {
+			first: { htmlFor: value('overwritten'), title: value('title') },
+			second: { for: value('losing alias') },
+			finalFor: value('final'),
+		};
+		if (rendering === 'server') {
+			const { html } = renderToString(server.RepeatedAliasSources, props);
+			expect(html).toContain('for="final"');
+			expect(html).not.toContain('overwritten');
+			expect(html).not.toContain('losing alias');
+		} else {
+			const result = mount(client.RepeatedAliasSources, props);
+			try {
+				expect(result.container.firstElementChild?.getAttribute('for')).toBe('final');
+			} finally {
+				result.unmount();
+			}
+		}
+		expect(log).toEqual(['final', 'title']);
+	}
+});
+
+it('adopts alias winners and removes a final undefined writer without reviving an earlier alias', () => {
+	const props = {
+		first: { htmlFor: 'first', title: 'title' },
+		second: { for: 'second' },
+		finalFor: 'final' as string | undefined,
+	};
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	container.innerHTML = renderToString(server.RepeatedAliasSources, props).html;
+	const element = container.firstElementChild;
+	const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+	const root = hydrateRoot(container, client.RepeatedAliasSources, props);
+	try {
+		flushSync(() => {});
+		expect(container.firstElementChild).toBe(element);
+		expect(element?.getAttribute('for')).toBe('final');
+		flushSync(() => root.render(client.RepeatedAliasSources, { ...props, finalFor: undefined }));
+		expect(container.firstElementChild).toBe(element);
+		expect(element?.hasAttribute('for')).toBe(false);
+		expect(element?.getAttribute('title')).toBe('title');
+		expect(errors.mock.calls).toEqual([]);
+	} finally {
+		root.unmount();
+		container.remove();
+	}
+});
+
+it('snapshots a string value before a later symbol getter deletes it', () => {
+	for (const rendering of ['client', 'server'] as const) {
+		const symbol = Symbol('delete earlier key');
+		const log: string[] = [];
+		const raw: Record<PropertyKey, unknown> = {};
+		Object.defineProperty(raw, 'title', {
+			enumerable: true,
+			configurable: true,
+			get() {
+				log.push('title');
+				return 'saved';
+			},
+		});
+		Object.defineProperty(raw, symbol, {
+			enumerable: true,
+			get() {
+				log.push('symbol');
+				delete raw.title;
+				return 'ignored';
+			},
+		});
+		if (rendering === 'server') {
+			expect(renderToString(server.StableSpreadSources, { source: raw }).html).toContain(
+				'title="saved"',
+			);
+		} else {
+			const result = mount(client.StableSpreadSources, { source: raw });
+			try {
+				expect(result.container.firstElementChild?.getAttribute('title')).toBe('saved');
+			} finally {
+				result.unmount();
+			}
+		}
+		expect(log).toEqual(['title', 'symbol']);
+	}
+});
+
+it('diffs a replaced style object while stable handlers retain capture and bubble behavior', () => {
+	const log: string[] = [];
+	const style = { color: 'red', backgroundColor: 'black' } as Record<string, string>;
+	const source: Record<string, unknown> = {
+		style,
+		onClickCapture: () => log.push('capture'),
+		onClick: () => log.push('bubble'),
+	};
+	const result = mount(client.StableSpreadSources, { source });
+	try {
+		const button = result.container.firstElementChild as HTMLButtonElement;
+		source.style = { color: 'blue' };
+		result.update(client.StableSpreadSources, { source });
+		expect(result.container.firstElementChild).toBe(button);
+		expect(button.style.color).toBe('blue');
+		expect(button.style.backgroundColor).toBe('');
+		button.click();
+		expect(log).toEqual(['capture', 'bubble']);
+		delete source.onClickCapture;
+		source.onClick = () => log.push('replacement');
+		result.update(client.StableSpreadSources, { source });
+		button.click();
+		expect(log).toEqual(['capture', 'bubble', 'replacement']);
+		delete source.onClick;
+		result.update(client.StableSpreadSources, { source });
+		button.click();
+		expect(log).toEqual(['capture', 'bubble', 'replacement']);
+	} finally {
+		result.unmount();
+	}
+});
+
+it('keeps case-sensitive custom listeners separate from delegated JSX handlers', () => {
+	const custom = vi.fn();
+	const click = vi.fn();
+	const source: Record<string, unknown> = { onWidgetReady: custom, onClick: click };
+	const result = mount(client.CustomSpreadSources, { source });
+	try {
+		const element = result.container.firstElementChild as HTMLElement;
+		result.update(client.CustomSpreadSources, { source });
+		element.dispatchEvent(new Event('WidgetReady'));
+		element.dispatchEvent(new Event('widgetready'));
+		element.click();
+		expect(custom).toHaveBeenCalledTimes(1);
+		expect(click).toHaveBeenCalledTimes(1);
+		delete source.onWidgetReady;
+		delete source.onClick;
+		result.update(client.CustomSpreadSources, { source });
+		element.dispatchEvent(new Event('WidgetReady'));
+		element.click();
+		expect(custom).toHaveBeenCalledTimes(1);
+		expect(click).toHaveBeenCalledTimes(1);
+	} finally {
+		result.unmount();
+	}
+});
+
+it('observes a stable style getter failure and permits a fresh root after rollback', () => {
+	let fail = false;
+	const source = {
+		style: {
+			get color() {
+				if (fail) throw new Error('style getter failed');
+				return 'blue';
+			},
+		},
+	};
+	const result = mount(client.StableSpreadSources, { source });
+	try {
+		fail = true;
+		expect(() => result.update(client.StableSpreadSources, { source })).toThrow(
+			'style getter failed',
+		);
+		expect(result.container.childNodes).toHaveLength(0);
+		fail = false;
+		result.update(client.StableSpreadSources, { source });
+		expect((result.container.firstElementChild as HTMLButtonElement).style.color).toBe('blue');
+	} finally {
+		result.unmount();
+	}
+});

--- a/packages/octane/tests/dom-template-text.test.ts
+++ b/packages/octane/tests/dom-template-text.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import * as ServerRT from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { htext } from '../src/runtime.js';
+import { mount } from './_helpers.js';
+import { loadServerFixture } from './_server-fixture.js';
+import {
+	ForeignMath,
+	ForeignSvg,
+	FragmentTextRows,
+	RootTextPair,
+} from './_fixtures/dom-template-text.tsrx';
+
+const rows = [
+	{ id: 1, label: 'one', before: 'left-1', after: 'right-1' },
+	{ id: 2, label: 'two', before: 'left-2', after: 'right-2' },
+	{ id: 3, label: 'three', before: 'left-3', after: 'right-3' },
+];
+
+const nodeTriples = (container: HTMLElement) => {
+	const nodes = [...container.querySelector('#rows')!.children];
+	expect(nodes.length % 3).toBe(0);
+	expect(nodes.map((node) => node.localName)).toEqual(
+		['label', 'input', 'span', 'label', 'input', 'span', 'label', 'input', 'span'].slice(
+			0,
+			nodes.length,
+		),
+	);
+	return Array.from({ length: nodes.length / 3 }, (_, index) =>
+		nodes.slice(index * 3, index * 3 + 3),
+	);
+};
+
+describe('compiled fragment and text children', () => {
+	it('does not overwrite existing text when no compiler placeholder was seeded', () => {
+		const host = document.createElement('octane-probe');
+		const owned = document.createTextNode('owned:');
+		host.appendChild(owned);
+		const authored = htext(host, 'dynamic');
+		expect(host.textContent).toBe('owned:dynamic');
+		expect(host.firstChild).toBe(owned);
+		expect(host.lastChild).toBe(authored);
+	});
+
+	it('keeps keyed multi-root nodes, text holes, and typed focus through updates and removal', () => {
+		const r = mount(FragmentTextRows, { rows, tick: 'start' });
+		let triples = nodeTriples(r.container);
+		expect(triples.map(([label]) => label.textContent)).toEqual(['one', 'two', 'three']);
+		for (const [label, , span] of triples) {
+			expect([...label.childNodes].map((node) => node.nodeType)).toEqual([3]);
+			expect([...span.childNodes].map((node) => node.nodeType)).toEqual([3, 1, 3]);
+		}
+		const initial = triples;
+		const focused = initial[1][1] as HTMLInputElement;
+		focused.value = 'typed';
+		focused.focus();
+		r.update(FragmentTextRows, { rows, tick: 'changed' });
+		expect(r.find('output').textContent).toBe('changed');
+		triples = nodeTriples(r.container);
+		for (let index = 0; index < rows.length; index++) {
+			for (let part = 0; part < 3; part++) expect(triples[index][part]).toBe(initial[index][part]);
+		}
+
+		const reversed = [...rows].reverse();
+		r.update(FragmentTextRows, { rows: reversed, tick: 'reversed' });
+		triples = nodeTriples(r.container);
+		for (let index = 0; index < reversed.length; index++) {
+			expect(triples[index][0]).toBe(initial[reversed[index].id - 1][0]);
+			expect(triples[index][1]).toBe(initial[reversed[index].id - 1][1]);
+			expect(triples[index][2]).toBe(initial[reversed[index].id - 1][2]);
+			expect(triples[index][2].textContent).toBe(
+				`${reversed[index].before}:${reversed[index].after}`,
+			);
+		}
+		expect(focused.value).toBe('typed');
+		expect(document.activeElement).toBe(focused);
+
+		const empty = { ...rows[1], label: '', before: '', after: '' };
+		r.update(FragmentTextRows, { rows: [empty], tick: 'small' });
+		const [label, input, span] = nodeTriples(r.container)[0];
+		expect(label).toBe(initial[1][0]);
+		expect(input).toBe(focused);
+		expect(label.textContent).toBe('');
+		expect([...label.childNodes].map((node) => node.nodeType)).toEqual([3]);
+		expect(span.textContent).toBe(':');
+		expect([...span.childNodes].map((node) => node.nodeType)).toEqual([3, 1, 3]);
+		expect(initial[0][0].isConnected).toBe(false);
+		r.unmount();
+		expect(focused.isConnected).toBe(false);
+	});
+
+	it('adopts multi-root and text nodes during hydration and updates the same nodes', () => {
+		const server = loadServerFixture('packages/octane/tests/_fixtures/dom-template-text.tsrx');
+		const props = { rows, tick: 'server' };
+		const { html } = ServerRT.renderToString(server.FragmentTextRows, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const before = nodeTriples(container);
+		const text = before[0][0].firstChild;
+		const siblingText = before[0][2].firstChild;
+		const focused = before[1][1] as HTMLInputElement;
+		focused.value = 'typed';
+		focused.focus();
+		const root = hydrateRoot(container, FragmentTextRows, props);
+		flushSync(() => {});
+		const after = nodeTriples(container);
+		for (let index = 0; index < rows.length; index++) {
+			for (let part = 0; part < 3; part++) expect(after[index][part]).toBe(before[index][part]);
+		}
+		expect(after[0][0].firstChild).toBe(text);
+		expect(after[0][2].firstChild).toBe(siblingText);
+		flushSync(() => root.render(FragmentTextRows, { rows: [...rows].reverse(), tick: 'client' }));
+		expect(nodeTriples(container)[1][1]).toBe(focused);
+		expect(focused.value).toBe('typed');
+		expect(document.activeElement).toBe(focused);
+		root.unmount();
+		container.remove();
+	});
+
+	it('preserves direct fragment roots and foreign-content siblings', () => {
+		const pair = mount(RootTextPair, { label: 'ready' });
+		const first = pair.find('#first');
+		const last = pair.find('#last');
+		pair.update(RootTextPair, { label: '' });
+		expect(pair.find('#first')).toBe(first);
+		expect(first.textContent).toBe('');
+		expect(first.firstChild?.nodeType).toBe(3);
+		expect(pair.find('#last')).toBe(last);
+		pair.unmount();
+
+		const svg = mount(ForeignSvg, { label: 'S' });
+		expect(svg.find('circle').namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(svg.find('text').namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(svg.find('text').textContent).toBe('S');
+		svg.unmount();
+		const math = mount(ForeignMath, { label: 'M' });
+		expect(math.find('mn').namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+		expect(math.find('mn').textContent).toBe('M');
+		math.unmount();
+	});
+});

--- a/packages/octane/tests/host-attribute-updates.test.ts
+++ b/packages/octane/tests/host-attribute-updates.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, hydrateRoot } from 'octane';
+import { renderToString } from 'octane/server';
+import { act, mount } from './_helpers.js';
+import { loadServerFixture } from './_server-fixture.js';
+import * as client from './_fixtures/host-attribute-updates.tsrx';
+
+const server = loadServerFixture<typeof client>(
+	'packages/octane/tests/_fixtures/host-attribute-updates.tsrx',
+);
+afterEach(() => vi.unstubAllEnvs());
+
+describe.each(['test', 'production'])('host values with %s runtime semantics', (environment) => {
+	it('uses one URL coercion for validation and writing', () => {
+		vi.stubEnv('NODE_ENV', environment);
+		let available = true;
+		const url = {
+			toString() {
+				if (!available) throw new Error('URL coerced twice');
+				available = false;
+				return '#coerced';
+			},
+		};
+		const r = mount(client.ScalarValue, { title: 'title', url });
+		try {
+			expect(r.find('#scalar').getAttribute('href')).toBe('#coerced');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('restores exact live attributes and metadata when a later sibling suspends', async () => {
+		vi.stubEnv('NODE_ENV', environment);
+		let resolve!: () => void;
+		const pending = new Promise<void>((done) => {
+			resolve = done;
+		});
+		let waiting = false;
+		const read = () => {
+			if (waiting) throw pending;
+			return 'ready';
+		};
+		const r = mount(client.PendingValues, { label: 'initial', url: '#initial', read });
+		const link = r.find('#pending-link');
+		const title = document.head.querySelector('title')!;
+		const meta = document.head.querySelector('meta[name="pending-description"]')!;
+		try {
+			link.setAttribute('title', 'foreign');
+			link.removeAttribute('href');
+			title.textContent = 'foreign head';
+			meta.setAttribute('content', 'foreign metadata');
+			const textNode = title.firstChild;
+			waiting = true;
+			r.update(client.PendingValues, { label: 'next', url: '#next', read });
+			expect(link.getAttribute('title')).toBe('foreign');
+			expect(link.hasAttribute('href')).toBe(false);
+			expect(meta.getAttribute('content')).toBe('foreign metadata');
+			expect(title.textContent).toBe('foreign head');
+			expect(title.firstChild).toBe(textNode);
+			waiting = false;
+			await act(() => resolve());
+			expect(r.find('#pending-link')).toBe(link);
+			expect(link.getAttribute('href')).toBe('#next');
+			expect(meta.getAttribute('content')).toBe('next');
+			expect(title.textContent).toBe('next');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('preserves coercion, aliases, URL filtering, and special host properties across updates', () => {
+		vi.stubEnv('NODE_ENV', environment);
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const r = mount(client.Values, { value: 2, url: '#initial' });
+		try {
+			const anchor = r.find('#anchor');
+			const circle = r.find('#circle');
+			expect(anchor.getAttribute('title')).toBe('2');
+			expect(circle.getAttribute('stroke-width')).toBe('2');
+			expect(r.find('#svg').getAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns')).toBe('2');
+			r.update(client.Values, { value: false, url: '' });
+			expect(anchor.hasAttribute('title')).toBe(false);
+			expect(anchor.getAttribute('data-n')).toBe('false');
+			expect(anchor.getAttribute('href')).toBe('');
+			expect(r.find('#image').hasAttribute('src')).toBe(false);
+			expect(r.find('#enumerated').getAttribute('spellcheck')).toBe('false');
+			expect(anchor.hasAttribute('download')).toBe(false);
+			r.update(client.Values, { value: true, url: 'j\navascript:alert(1)' });
+			expect(anchor.hasAttribute('title')).toBe(false);
+			expect(anchor.getAttribute('data-n')).toBe('true');
+			expect(anchor.getAttribute('download')).toBe('');
+			expect(anchor.getAttribute('href')).toContain('React has blocked a javascript: URL');
+			expect(r.find('#use').getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toContain(
+				'React has blocked',
+			);
+			expect(r.find('#custom').getAttribute('title')).toBe('');
+			expect(r.find('#custom').getAttribute('href')).toBe('j\navascript:alert(1)');
+			for (const value of [null, undefined, Symbol('remove'), () => 'remove']) {
+				r.update(client.Values, { value, url: '#next' });
+				expect(anchor.hasAttribute('title')).toBe(false);
+				expect(anchor.hasAttribute('data-n')).toBe(false);
+				expect(circle.hasAttribute('cx')).toBe(false);
+			}
+			r.update(client.Values, { value: 7, url: '#restored' });
+			expect(r.find('#anchor')).toBe(anchor);
+			expect(r.find('#circle')).toBe(circle);
+			expect(circle.getAttribute('cx')).toBe('7');
+			expect((r.find('#control') as HTMLInputElement).value).toBe('7');
+		} finally {
+			r.unmount();
+			warning.mockRestore();
+		}
+	});
+
+	it('adopts server attributes and preserves their nodes on the next update', () => {
+		vi.stubEnv('NODE_ENV', environment);
+		const props = { value: 2, url: '#same' };
+		const container = document.createElement('div');
+		document.body.append(container);
+		container.innerHTML = renderToString(server.Values, props).html;
+		const anchor = container.querySelector('#anchor');
+		const circle = container.querySelector('#circle');
+		const diagnostic = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.Values, props);
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('#anchor')).toBe(anchor);
+			expect(container.querySelector('#circle')).toBe(circle);
+			expect(diagnostic).not.toHaveBeenCalled();
+			flushSync(() => root.render(client.Values, { value: 3, url: '#next' }));
+			expect(anchor!.getAttribute('title')).toBe('3');
+			expect(circle!.getAttribute('stroke-width')).toBe('3');
+		} finally {
+			root.unmount();
+			container.remove();
+			diagnostic.mockRestore();
+		}
+	});
+});
+
+it('recoerces metadata objects, removes omitted attrs, and repairs external head edits', () => {
+	let content = 'first';
+	const value = { toString: () => content };
+	const props = { lang: 'en', text: 'first title', attrs: { media: 'screen' }, content: value };
+	const r = mount(client.Metadata, props);
+	const meta = document.head.querySelector('meta[name="description"]')!;
+	const title = document.head.querySelector('title')!;
+	try {
+		expect(meta.getAttribute('content')).toBe('first');
+		content = 'second';
+		r.update(client.Metadata, { ...props, attrs: {} });
+		expect(meta.getAttribute('content')).toBe('second');
+		expect(meta.hasAttribute('media')).toBe(false);
+		meta.setAttribute('content', 'foreign');
+		title.textContent = 'foreign title';
+		r.update(client.Metadata, { ...props, attrs: {} });
+		expect(meta.getAttribute('content')).toBe('second');
+		expect(title.textContent).toBe('first title');
+		r.update(client.Metadata, { ...props, text: '', lang: null, content: null });
+		expect(title.textContent).toBe('');
+		expect(title.hasAttribute('lang')).toBe(false);
+		expect(meta.hasAttribute('content')).toBe(false);
+	} finally {
+		r.unmount();
+	}
+	expect(meta.isConnected).toBe(false);
+	expect(title.isConnected).toBe(false);
+});

--- a/packages/octane/tests/portal-events.test.ts
+++ b/packages/octane/tests/portal-events.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mount } from './_helpers';
-import { flushSync } from '../src/index.js';
+import { createRoot, createElement, createPortal, flushSync } from '../src/index.js';
 import {
 	BasicPortalClick,
 	CrossPortalBubble,
@@ -32,6 +32,55 @@ function clickIn(target: ParentNode, selector: string): void {
 }
 
 describe('portal — event delegation', () => {
+	it('retains the logical route when the last portal is removed after native capture', () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = createRoot(container);
+		// This independent root keeps the native listener on the shared target
+		// alive after the last portal unmounts during the event's target phase.
+		const targetRoot = createRoot(portalTarget);
+		const log: string[] = [];
+		const render = (show: boolean) =>
+			createElement(
+				'section',
+				{
+					onClickCapture: () => log.push('capture'),
+					onClick: () => log.push('parent'),
+				},
+				show
+					? createPortal(
+							createElement(
+								'button',
+								{
+									onClick: () => log.push('target'),
+								},
+								'portal',
+							),
+							portalTarget,
+						)
+					: null,
+			);
+		try {
+			flushSync(() => root.render(render(true)));
+			const button = portalTarget.querySelector('button')!;
+			button.addEventListener(
+				'click',
+				() => {
+					log.push('native target');
+					flushSync(() => root.render(render(false)));
+				},
+				{ once: true },
+			);
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(log).toEqual(['capture', 'native target', 'target', 'parent']);
+			expect(portalTarget.querySelector('button')).toBe(null);
+		} finally {
+			root.unmount();
+			targetRoot.unmount();
+			container.remove();
+		}
+	});
+
 	it('fires click handlers attached INSIDE the portal contents', () => {
 		const r = mount(BasicPortalClick, { target: portalTarget });
 		expect(r.find('.count').textContent).toBe('0');


### PR DESCRIPTION
## Summary

Addresses all eight remaining findings in **DOM writes, templates, events** from #981. This includes an explicit disposition for costs required by existing observable behavior; the separate descriptor-renderer findings remain outside this PR.

| Finding | Change |
| --- | --- |
| Static attributes use generic routing | Compiler selects native scalar/data/URL writers after conservative admission; aliases are resolved once. Development diagnostics, URL filtering, coercion, hydration, and rollback remain intact. |
| Spread resolution allocations | Reuse fixed writer records; remove normalization/winner tuples and the ordinary ordering array; skip parsing unchanged handlers. Client and SSR preserve source evaluation and alias precedence. |
| Multi-root template insertion | Cache native DocumentFragments and insert each clone once. Templates containing custom elements retain sequential insertion because connection callbacks observe sibling visibility. |
| Text-only mounting | Reuse compiler-seeded text placeholders; replace sibling placeholders with `replaceChild`. Unseeded calls preserve append behavior and constructor-owned text. |
| Temporary Event properties | Move private propagation/current-target state into reusable dispatch frames. Restore public own-property descriptors exactly, including required deletions. |
| Per-event concatenation and type probes | Share cached keys/category flags across capture and bubble registration for each event type. |
| Portal reads on ordinary paths | Gate portal-parent reads on portal presence and the captured topology epoch, preserving an in-flight route after portal teardown. |
| Repeated head writes | Compare live normalized values for common metadata attributes before writing. Retain coercion and live text comparison to repair external edits. |

Includes patch changes for `octane` and `@octanejs/mcp-server`, regressions, production browser controls, reproducible benchmark runners, and deterministic ratio guards.

## Why

These paths run per changed host value, mount, or native event. The changes remove measured repeated work while preserving native events, custom-element callbacks, SSR/hydration identity, getter ordering, and suspended-render rollback.

## Performance evidence

Frozen baseline: `58da3448b27130f82bdc447fce05a5c661bd161e`. Same fixtures and build settings for each comparison.

- 256 hosts × five changed static attributes: **1,280 → 0** generic writer calls; unchanged renders remain zero.
- 128 unchanged metadata renders: **384 → 0** native attribute writes, with external-edit repair verified.
- 15 spread props plus one direct prop, 12 updates: **396 → 0** normalization/winner/order array expressions; writer records and Maps remain unchanged. Stable two-handler metadata records: **24 → 0**. SSR alias winner/order arrays: **240 → 12**.
- 256 three-root rows: **1,794 → 770** `insertBefore` calls; **256 → 0** label Text creations. Flat-mount and keyed-reverse controls retain their original operation counts.
- 128 native clicks: event type Set probes **1,408 → 0**, portal-parent reads **2,304 → 0**, temporary private symbols at handlers **3 → 0**. All 1,280 framework and 128 native-after callbacks remain correct.
- Full production attribute fixture bundle: **165,755 → 167,873** minified bytes; **53,771 → 54,375** gzip bytes. Identical fixture/entry hashes. This includes all changes in the PR; final sample timings overlapped core validation and are not used for a latency claim.
- Event-only minified runtime cost: **+713 bytes**, **+290 gzip bytes**. Per-type records live with existing registration tables; dispatch frames scale with maximum nested depth and clear Event/DOM references after use.

Spread and event paired timings were noisy, including unchanged controls. These results support source-work/native-operation claims, not a throughput or heap-allocation claim. Commands, counters, retained costs, and timing distributions are documented in `benchmarks/dom-attributes`, `benchmarks/dom-events/SPREAD.md`, `benchmarks/dom-template-mount`, and `benchmarks/event-delegation/README.md`.

## Validation

- [ ] `pnpm format:check` (scoped formatting recorded below)
- [ ] `pnpm typecheck` (scoped checks recorded below)
- [ ] `pnpm test` (local core and CI results recorded below)
- [x] Core and public typetests: `tsgo --noEmit` against `packages/octane/tsconfig.json` and `packages/octane/typetests/tsconfig.json`.
- [x] Focused dev/production regressions: events 132 tests; spreads 120 tests; templates/text 8 tests; static attributes/head targeted coverage.
- [x] Production Chromium: nested/redispatched native events, exact descriptors, late registration, last-portal teardown, open/closed shadow roots, custom-element sibling observations and owned text, iframe adoption, SSR-shaped hydration, empty text identity.
- [x] Deliberate-red checks fail for broken alias precedence (client/server), stable-style getter skipping, attribute boolean removal, URL filtering, head rollback, template/text mounting, nested event state, late type registration, and portal teardown; candidate restored afterward.
- [x] Scoped `pnpm format:files:check`: all changed source/test/benchmark files pass. `git diff --check` passes.
- [x] All **32 new deterministic guards** pass: attributes 4, spreads 18, templates 6, event dispatch 4. Existing event production controls also pass.
- [x] Broad core dev/production run: **16,972 passed**, 14 expected failures; three assertions and two suite imports fail for baseline dependency-layout reasons reproduced with frozen owning source. React differential suites excluded from this local run.
- [x] TSRX checks: attribute and template benchmark fixtures pass; byte-identical new test fixture copies pass in an isolated TSRX config. Existing host-source fixture retains its same four baseline duplicate-attribute diagnostics; new exports introduce none.
- [x] `pnpm sync` and changeset/release-plan validation completed; no unrelated generated changes.

Local dependency limitations: `imperative-dom` cannot load its React oracle because `@tsrx/react-runtime` is absent (both modes); `external-hook-slot` expects a missing installed workspace package link (both modes); `browser-compiler-bundle` expects a package path segment absent from the local unpacked parser path (dev only). Baseline/candidate probes reproduce each failure. Normal repository CI configuration is unchanged. Current-head CI passed; see the linked run below.

## Review and CI follow-up

The first full CI run passed every behavior/parity/browser/type/lint/package/example job except the MCP suite-catalog assertion (plus its dependent aggregate checks). Commit `ca1c7d0eb` adds the three benchmark suites to the MCP schema; its 15 focused tests pass.

Bugbot’s parser-sensitive text concern was checked against frozen baseline and candidate in Chromium. All ten cases, including dirty textarea value/defaultValue/reset behavior and multi-root table templates, produce identical observations. Ten retained CI browser tests pass. The review thread is answered and resolved; runtime/compiler code remains unchanged in the follow-up. The new browser test passes scoped TypeScript checking; fixture TSRX checking remains blocked by the documented local React-runtime dependency.

Current-head [CI](https://github.com/octanejs/octane/actions/runs/34721738387) passed **26/26 jobs** for `ca1c7d0eb`. Bugbot's follow-up review passed with **no issues found**. The PR is ready for review, contains the live `main` base, and has no unresolved review threads.

## Risk / follow-ups

- Spread snapshots, source rows, arbitrary-name dictionaries, getter/symbol reads, and alias sorting remain where required; this is not zero-allocation spread rendering.
- The audit's proposed permanent Event shadows would change own-property observability. Required public descriptor restoration/deletion remains; this PR does not claim to prevent V8 dictionary mode entirely.
- Live head reads remain necessary for external-edit repair. The head change trades redundant writes for attribute reads and retains `textContent` comparison.
- Custom-element templates retain sequential insertion. Other polymorphic DOM reads and dynamic descriptor-renderer work remain covered by their separate #981 findings.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791841716&installation_model_id=432790&pr_number=1068&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1068&signature=a7f4d9fb89cb5e2ffbabd1bb718115f75323d8dba1f08fb57de8bcb4a6215f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core production DOM writes, spread resolution, template mount/hydration, and native delegated dispatch; regressions would surface as subtle DOM or event-order bugs despite new guards and tests.
> 
> **Overview**
> This PR trims hot-path work in the **client compiler and runtime** while keeping hydration, rollback, native event semantics, and custom-element behavior unchanged.
> 
> **Static attributes and head metadata:** Production compilation can route safe scalar bindings to **`setPlainAttribute` / `setURLAttribute`** (and matching `*IfChanged` helpers) instead of the generic **`setAttribute`** router. Common **`<title>` / `<meta>`** updates compare **live** normalized values before writing so repeated renders skip redundant native head mutations without dropping external-edit repair.
> 
> **Spread hosts:** **`setHostPropSources`** and **`ssrAttrs`** reuse in-place writer records, drop per-update normalization/winner/order tuple churn, skip unchanged non-controlled props (including stable event handlers where safe), and keep alias/class merge semantics.
> 
> **Template mounting:** Multi-root clones can cache **native `DocumentFragment`s** and mount with a single **`insertBefore`**, with a **per-node fallback** when custom elements or customized built-ins require sequential connection order. **Only-child text** bindings can **reuse parser-seeded text nodes** via **`htext(..., seeded)`**; sibling text holes use **`replaceChild`** in **`htextSwap`**.
> 
> **Delegated events:** Event types get shared **registration metadata** (keys + category flags). Dispatch stores propagation/current-target state in **reusable frames** instead of temporary Event symbols, avoids **Set/portal-parent probes** on portal-free paths, and bumps an **event-route epoch** when portal topology changes so in-flight dispatch keeps the captured route.
> 
> **Tooling:** Adds deterministic benchmark suites (**`dom-attributes`**, **`dom-template-mount`**, **`spread-hosts`**, **`event-delegation` dispatch-work**), **32 ratio guards** in **`benchmarks/baselines/ratios.json`**, focused tests/fixtures, and registers those suites on **`@octanejs/mcp-server`**. Patch changeset for **`octane`** and MCP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1c7d0ebe52fd49ebdbcd8d76504ea5f517c430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->