### PR TITLE
perf: reduce effect and scheduler bookkeeping

### DIFF
--- a/.changeset/quiet-waves-attach.md
+++ b/.changeset/quiet-waves-attach.md
@@ -1,0 +1,6 @@
+---
+"octane": patch
+"@octanejs/mcp-server": patch
+---
+
+Reduce scheduler batch bookkeeping and skip ref sorting for sibling-only attachment queues, preserving update ordering, effect lifecycle checks, and render-loop limits. Expose deterministic scheduling benchmarks through the MCP benchmark catalog.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -4471,5 +4471,141 @@
     "reference": "dispatch-work-model",
     "maxRatio": 1,
     "note": "Production portal-free native dispatch retains framework/native order and exact public descriptors while avoiding repeated event-type sets, portal ancestry reads, and private symbols."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "collections",
+    "target": "chain",
+    "reference": "chain-budget",
+    "maxRatio": 0,
+    "note": "Scheduler depth ordering allocates no Map or Set per wave."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "parent_reads",
+    "target": "chain",
+    "reference": "chain-budget",
+    "maxRatio": 1,
+    "note": "Scheduler ancestry work stays bounded under depth, stable-order, reparenting and lite-shape controls."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "collections",
+    "target": "siblings",
+    "reference": "siblings-budget",
+    "maxRatio": 0,
+    "note": "Scheduler depth ordering allocates no Map or Set per wave."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "parent_reads",
+    "target": "siblings",
+    "reference": "siblings-budget",
+    "maxRatio": 1,
+    "note": "Scheduler ancestry work stays bounded under depth, stable-order, reparenting and lite-shape controls."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "collections",
+    "target": "sparse",
+    "reference": "sparse-budget",
+    "maxRatio": 0,
+    "note": "Scheduler depth ordering allocates no Map or Set per wave."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "parent_reads",
+    "target": "sparse",
+    "reference": "sparse-budget",
+    "maxRatio": 1,
+    "note": "Scheduler ancestry work stays bounded under depth, stable-order, reparenting and lite-shape controls."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "collections",
+    "target": "mixed",
+    "reference": "mixed-budget",
+    "maxRatio": 0,
+    "note": "Scheduler depth ordering allocates no Map or Set per wave."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "parent_reads",
+    "target": "mixed",
+    "reference": "mixed-budget",
+    "maxRatio": 1,
+    "note": "Scheduler ancestry work stays bounded under depth, stable-order, reparenting and lite-shape controls."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "collections",
+    "target": "lite",
+    "reference": "lite-budget",
+    "maxRatio": 0,
+    "note": "Scheduler depth ordering allocates no Map or Set per wave."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "parent_reads",
+    "target": "lite",
+    "reference": "lite-budget",
+    "maxRatio": 1,
+    "note": "Scheduler ancestry work stays bounded under depth, stable-order, reparenting and lite-shape controls."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-single",
+    "reference": "ref-single-budget",
+    "maxRatio": 0,
+    "note": "Ref attachment preserves child-before-parent and disjoint ordering; single/sibling queues need no sort."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-siblings",
+    "reference": "ref-siblings-budget",
+    "maxRatio": 0,
+    "note": "Ref attachment preserves child-before-parent and disjoint ordering; single/sibling queues need no sort."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-mixed",
+    "reference": "ref-mixed-budget",
+    "maxRatio": 1,
+    "note": "Ref attachment preserves child-before-parent and disjoint ordering; single/sibling queues need no sort."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-deep-disjoint",
+    "reference": "ref-deep-disjoint-budget",
+    "maxRatio": 1,
+    "note": "Ref attachment preserves child-before-parent and disjoint ordering; single/sibling queues need no sort."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-unowned-first",
+    "reference": "ref-unowned-first-budget",
+    "maxRatio": 1,
+    "note": "Ref queues without an owning block preserve attachment order and cannot crash the commit."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-unowned-last",
+    "reference": "ref-unowned-last-budget",
+    "maxRatio": 1,
+    "note": "Ref queues without an owning block preserve attachment order and cannot crash the commit."
+  },
+  {
+    "suite": "effect-scheduling",
+    "op": "sort_calls",
+    "target": "ref-unowned-only",
+    "reference": "ref-unowned-only-budget",
+    "maxRatio": 0,
+    "note": "Ref queues without an owning block preserve attachment order and cannot crash the commit."
   }
 ]

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -1195,6 +1195,16 @@ const SUITES = [
 		runs: [{ script: 'run-size.mjs', args: () => [] }],
 	},
 	{
+		name: 'effect-scheduling',
+		cwd: 'effect-scheduling',
+		servers: [],
+		iter: { normal: 1, quick: 1 },
+		runs: [
+			{ script: 'wave.mjs', args: () => [] },
+			{ script: '../effect-postorder/refs.mjs', args: () => [] },
+		],
+	},
+	{
 		// Production spread resolution: executed allocation expressions under
 		// client/SSR semantic controls; untouched timing is a separate manual run.
 		name: 'spread-hosts',

--- a/benchmarks/effect-postorder/README.md
+++ b/benchmarks/effect-postorder/README.md
@@ -9,11 +9,34 @@ node benchmarks/effect-postorder/run.mjs upstream/main
 The script extracts the **actual** `comparePostOrder` implementation from the
 specified Git revision and the working `packages/octane/src/runtime.ts`, strips
 its TypeScript annotations, and runs identical sorts. It checks both versions
-against tree postorder and compares sampled pairs before timing. The three
-shapes are a 400-component chain, 1,000 sibling owners, and uneven sibling
-branches. A counted pass records parent-chain reads independently of the timed
+against tree postorder and compares sampled pairs before timing. The four
+shapes are a 400-component chain, 1,000 sibling owners, uneven sibling
+branches, and 128 deep disjoint leaves whose parents sit 25 levels below a
+shared root. A counted pass records parent-chain reads independently of the timed
 pass. Eight interleaved, warmed batches report median microseconds per sort.
 
 This isolates sorting cost; it does not measure render, DOM, or effect callback
 time. Use `benchmarks/effectful-list` for the full 1,000-row lifecycle path,
 and the conformance effect-order tests for observable effect/ref ordering.
+
+The separate untimed ref-drain guard exercises the production `drainRefAttaches`
+and comparator with 1,000 sibling refs, deep disjoint branches, a mixed-depth
+parent/child commit, a single ref, and ownerless refs before, after, and without
+owned refs. It checks callback order and counts native sort calls, with no DOM
+or callback timing claim:
+
+```bash
+node benchmarks/effect-postorder/refs.mjs <baseline-git-ref> --measure
+node benchmarks/effect-postorder/refs.mjs <baseline-git-ref>
+```
+
+The `effect-scheduling` ratio suite runs this guard alongside the scheduler
+wave guard. Single-ref, 1,000-sibling, and ownerless-only batches must call
+native sort zero times; mixed-ancestry, deep-disjoint, and mixed-owner batches
+retain one sort and the same postorder callbacks. At base `8a45222ab`, all
+seven cases each sorted once. The candidate skips three sorts and retains the
+other four. Null owners compare equal to unrelated entries, so an ownerless
+entry can join a same-parent queue without changing callback order. The
+deep-disjoint comparator shape reads 11,340 parent links for 129 queued
+effects on both versions: sorting those branches still needs the ancestry
+check, and this change adds no persistent block depth field.

--- a/benchmarks/effect-postorder/refs.mjs
+++ b/benchmarks/effect-postorder/refs.mjs
@@ -1,0 +1,145 @@
+// Exercise the actual ref-attach drain and postorder comparator without DOM.
+// The counted Array subclass observes native sort calls; callback order is
+// checked independently of the measurement.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import path from 'node:path';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+
+process.chdir(path.resolve(import.meta.dirname, '../..'));
+const file = 'packages/octane/src/runtime.ts';
+const baselineRef = process.argv.slice(2).find((arg) => !arg.startsWith('--'));
+const measure = process.argv.includes('--measure');
+
+function instantiate(source) {
+	const refStart = source.indexOf('function drainRefAttaches():');
+	const refEnd = source.indexOf('// Callback replacement', refStart);
+	const comparisonStart = source.indexOf('function blockIsAncestorOf(');
+	const comparisonEnd = source.indexOf('function finishEffectCommit()', comparisonStart);
+	assert.ok(
+		refStart >= 0 && refEnd > refStart && comparisonStart >= 0 && comparisonEnd > comparisonStart,
+	);
+	const code = stripTypeScriptTypes(
+		source.slice(comparisonStart, comparisonEnd) + '\n' + source.slice(refStart, refEnd),
+	);
+	return Function(`"use strict";
+		const counts = { sorts: 0 };
+		class CountedQueue extends Array {
+			sort(compare) { counts.sorts++; return super.sort(compare); }
+		}
+		class MaximumUpdateDepthError extends Error {}
+		let refAttachQueue = new CountedQueue();
+		let REF_CALLBACK_DEPTH = 0;
+		let NATIVE_READ_DRIVER = null;
+		let activityRefState = null;
+		const log = [];
+		function blockSubtreeDisposed(block) { return block?.disposed === true; }
+		function findHiddenActivity() { return null; }
+		function attachRef(ref, el) { log.push(ref); }
+		function findTryHandler() { return null; }
+		function reportCaughtError() { throw new Error('unexpected caught ref error'); }
+		function reportUncaughtError() { throw new Error('unexpected uncaught ref error'); }
+		${code}
+		return { counts, log, enqueue(entries) { refAttachQueue.push(...entries); }, drain: drainRefAttaches };
+	`)();
+}
+
+function workload(shape) {
+	const queued = [];
+	let id = 0;
+	function add(parent, attach = true) {
+		const block = { parentBlock: parent };
+		if (attach) queued.push({ block, ref: id++, el: {} });
+		return block;
+	}
+	function addUnowned() {
+		return { block: null, ref: id++, el: {} };
+	}
+	const root = add(
+		null,
+		shape === 'mixed' || shape === 'unowned-first' || shape === 'unowned-last',
+	);
+	if (shape === 'siblings') {
+		for (let i = 0; i < 1000; i++) add(root);
+	} else if (shape === 'single') {
+		add(root);
+	} else if (shape === 'mixed') {
+		add(root);
+		const branch = add(root);
+		add(branch);
+	} else if (shape === 'deep-disjoint') {
+		for (let i = 0; i < 128; i++) {
+			let parent = add(root, false);
+			for (let depth = 0; depth < 24; depth++) parent = add(parent, false);
+			add(parent);
+		}
+	} else if (shape === 'unowned-first') {
+		queued.unshift(addUnowned());
+		add(root);
+	} else if (shape === 'unowned-last') {
+		add(root);
+		queued.push(addUnowned());
+	} else if (shape === 'unowned-only') {
+		for (let i = 0; i < 3; i++) queued.push(addUnowned());
+	}
+	const expected =
+		shape === 'mixed'
+			? [1, 3, 2, 0]
+			: shape === 'unowned-first'
+				? [1, 2, 0]
+				: shape === 'unowned-last'
+					? [1, 0, 2]
+					: queued.map((entry) => entry.ref);
+	return { queued, expected };
+}
+
+function observe(source, shape) {
+	const runtime = instantiate(source);
+	const { queued, expected } = workload(shape);
+	runtime.enqueue(queued);
+	runtime.drain();
+	assert.deepEqual(runtime.log, expected);
+	runtime.drain(); // An empty second commit cannot attach or sort again.
+	assert.deepEqual(runtime.log, expected);
+	return { entries: queued.length, sorts: runtime.counts.sorts };
+}
+
+const sources = [['candidate', readFileSync(file, 'utf8')]];
+if (baselineRef)
+	sources.unshift([
+		'baseline',
+		execFileSync('git', ['show', `${baselineRef}:${file}`], {
+			encoding: 'utf8',
+			maxBuffer: 8 * 1024 * 1024,
+		}),
+	]);
+const targets = [];
+for (const [label, source] of sources) {
+	for (const shape of [
+		'single',
+		'siblings',
+		'mixed',
+		'deep-disjoint',
+		'unowned-first',
+		'unowned-last',
+		'unowned-only',
+	]) {
+		const result = observe(source, shape);
+		if (!measure && label === 'candidate' && shape === 'siblings') {
+			assert.equal(result.sorts, 0, 'sibling-only refs must drain without sorting');
+		}
+		console.log(`${label} ${shape}: ${result.entries} refs, ${result.sorts} sorts`);
+		if (label === 'candidate') {
+			const stat = (value) => deterministicStatForJson(deterministicCount(value));
+			targets.push({ name: `ref-${shape}`, ops: { sort_calls: stat(result.sorts) } });
+			targets.push({ name: `ref-${shape}-budget`, ops: { sort_calls: stat(1) } });
+		}
+	}
+}
+if (process.env.BENCH_JSON)
+	writeFileSync(
+		process.env.BENCH_JSON,
+		JSON.stringify({ suite: 'effect-scheduling', targets }, null, 2) + '\n',
+	);

--- a/benchmarks/effect-postorder/run.mjs
+++ b/benchmarks/effect-postorder/run.mjs
@@ -56,6 +56,14 @@ function workload(shape, counted = false) {
 			let parent = add(root);
 			for (let depth = 0; depth < i % 6; depth++) parent = add(parent);
 		}
+	} else if (shape === 'deep-disjoint') {
+		// Leaves share only the root. Comparing adjacent entries must reject
+		// ancestry even though their immediate parents are many levels apart.
+		for (let i = 0; i < 128; i++) {
+			let parent = add(root, false);
+			for (let depth = 0; depth < 24; depth++) parent = add(parent, false);
+			add(parent);
+		}
 	}
 	const expected = [];
 	function visit(node) {
@@ -86,7 +94,7 @@ function time(comparison, nodes, repeats) {
 	return ((performance.now() - start) * 1000) / repeats;
 }
 
-for (const shape of ['chain', 'siblings', 'mixed']) {
+for (const shape of ['chain', 'siblings', 'mixed', 'deep-disjoint']) {
 	const { nodes, expected } = workload(shape);
 	assert.deepEqual(
 		sorted(baseline, nodes).map((entry) => entry.id),

--- a/benchmarks/effect-scheduling/README.md
+++ b/benchmarks/effect-scheduling/README.md
@@ -1,0 +1,120 @@
+# Effects and scheduling work guards
+
+Issue [#981](https://github.com/octanejs/octane/issues/981) identifies scheduler
+wave bookkeeping, effect/ref ancestry sorting, and effect dispatch overhead.
+This suite covers the first two; the existing
+[`effectful-list/dispatch.mjs`](../effectful-list/dispatch.mjs) checks dispatch
+arguments and stale-entry membership.
+
+```sh
+node benchmarks/bench.mjs effect-scheduling --ratios
+node benchmarks/effect-scheduling/wave.mjs 8a45222ab
+node benchmarks/effect-postorder/refs.mjs 8a45222ab
+node benchmarks/effect-postorder/run.mjs 8a45222ab
+node benchmarks/effectful-list/dispatch.mjs 8a45222ab
+```
+
+## Scheduler waves
+
+`wave.mjs` extracts the actual runtime sort, strips TypeScript, and compares it
+with a frozen Git revision. It measures Map/Set construction and parent reads
+separately from uninstrumented helper timings. Stable shallow-first ordering,
+repeated epochs, changed ancestry, and lightweight proxy shapes are semantic
+controls. The fixtures include a reversed 400-node chain, 1,000 siblings,
+1,000 updates beneath 40 unqueued ancestors, mixed roots, and a chain containing
+lightweight ancestry proxies.
+
+At baseline `8a45222ab`, every multi-block sort constructs one Set and one Map.
+The candidate constructs neither. It also removes the temporary path array and
+per-sort comparator closure. Parent reads in the counted pass:
+
+| Shape | Baseline | Candidate |
+| --- | ---: | ---: |
+| Reversed chain | 400 | 800 |
+| Siblings | 2,000 | 2,002 |
+| Shared unqueued ancestors | 42,000 | 2,082 |
+| Mixed roots/depths | 734 | 1,370 |
+| Shared chain with lite proxies | 42,000 | 2,082 |
+
+The tradeoff is a second walk over each uncached path. Cache state uses the
+existing numeric scheduler fields only during sorting; positive drain IDs
+restore their loop-guard meaning before a block executes. Each new drain
+invalidates old depths. No tree pointers, extra Block fields, or collections
+are retained. Lite proxies receive no fields and still contribute to depth;
+shared consecutive lite proxies can be traversed repeatedly.
+
+The single-update path remains outside the sort. These are executed source-work
+counts, not V8 heap-allocation measurements or application-latency claims.
+The helper timings isolate sorting and are not a substitute for a full render.
+
+## Ref attachment and effect ordering
+
+The paired ref probe observes native sort calls and independently verifies
+callback order. A single ref and 1,000 sibling refs each go from one sort to
+zero. Mixed ancestry and deep disjoint branches retain one sort. A named
+comparator removes the per-drain closure on that fallback.
+
+Effect ordering retains its ancestry fallback: descendants precede their
+queued ancestors, while disjoint branches retain enqueue order even at unequal
+depths. The existing direct-parent/sibling shortcuts already cover the ordinary
+effectful-list fixture. Global depth fields would impose a cost on unrelated
+blocks; no such fields are introduced.
+
+The new 128-leaf deep-disjoint comparator fixture and existing chain, sibling,
+and mixed fixtures validate the retained fallback. Their parent-read counts
+are unchanged. See the production lifecycle measurements below for the full
+1,000-row workload.
+
+## Coverage and limits
+
+Seventeen deterministic ratio guards cover wave collections/ancestry work and
+ref sort calls, including entries without an owning block. Behavioral tests protect ancestor removal, deep render-phase
+convergence, sibling notification order, failed-root isolation, node identity
+through hydration, and nested ref attachment. Deliberate positive depth stamps,
+reversed stable ties, and omitted mixed-ref sorting each fail the corresponding
+consumer tests in development and production.
+
+Effect dispatch keeps hook-Map membership validation and `apply(null, args)`.
+A retained effect-list record can outlive its hook-key ownership; revisions
+alone do not establish membership. Callback invocation must preserve the null
+receiver, positional dependency arguments, and observable callback/argument
+access. The dispatch controls reject missing/replaced slots and stale revisions.
+Neither an unchecked indexed lookup nor an unguarded arity switch is adopted.
+
+## Production lifecycle and bundle comparison
+
+A frozen baseline and the final candidate were production-built through both
+existing effectful-list dialects and served to Chromium. An A–B–B–A run used
+eight warmup and eight measured samples per operation. All 48 lifecycle gates
+passed: four runs × two dialects × six operations, checking expected 1,000-row
+effect/ref callbacks, cleanups, and DOM shape.
+
+Median milliseconds, in A1 / B1 / B2 / A2 order:
+
+| Dialect | Mount | Dependency update | Remount |
+| --- | --- | --- | --- |
+| TSRX | 12.0 / 15.2 / 10.1 / 17.3 | 4.21 / 4.03 / 2.70 / 6.77 | 13.2 / 10.3 / 10.4 / 19.7 |
+| JSX | 14.2 / 16.5 / 10.4 / 19.2 | 4.98 / 4.50 / 3.04 / 5.20 | 12.5 / 12.5 / 12.5 / 18.3 |
+
+Both the baseline and candidate vary substantially. These results do not
+establish an end-to-end latency gain. The deterministic collection/read/sort
+reductions above are the supported performance claim.
+
+| Production bundle | Baseline | Candidate | Delta |
+| --- | ---: | ---: | ---: |
+| TSRX minified JavaScript | 176,968 B | 177,227 B | +259 B |
+| TSRX gzip level 9 | 57,005 B | 57,058 B | +53 B |
+| JSX minified JavaScript | 178,607 B | 178,866 B | +259 B |
+| JSX gzip level 9 | 57,655 B | 57,713 B | +58 B |
+
+TSRX baseline bundle SHA-256:
+`8b7676e32df89ab95f8047641396c607d360dfa727ed573dda7025543cda35e1`.
+TSRX candidate bundle SHA-256:
+`8a8e7c23745caffcb8a8c7b747b1e6181ed845bf27b8b6e01d19c3231e476d4b`.
+JSX baseline bundle SHA-256:
+`36d911fa761e00aa6f9a3ff2e9208bc1bbc3665f99f97e5a2351cc7c1eff90f2`.
+JSX candidate bundle SHA-256:
+`14f46cfbcd1ab43b55deb11e226746ac0ccd7926066650c769f4dbdb300328b6`.
+Node 26.4.0 on macOS ARM64 was used for the helper probes. Browser timings use
+Chromium and do not establish Firefox or WebKit timing behavior. Server effect
+bodies do not execute; client hydration behavior is covered separately.

--- a/benchmarks/effect-scheduling/wave.mjs
+++ b/benchmarks/effect-scheduling/wave.mjs
@@ -1,0 +1,192 @@
+// Isolate the actual scheduler sort with deterministic work and semantic controls.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { performance } from 'node:perf_hooks';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+import path from 'node:path';
+
+process.chdir(path.resolve(import.meta.dirname, '../..'));
+const shapes = ['chain', 'siblings', 'sparse', 'mixed', 'lite'];
+
+const file = 'packages/octane/src/runtime.ts';
+const baselineRef = process.argv.slice(2).find((arg) => !arg.startsWith('--'));
+const measure = process.argv.includes('--measure');
+function instantiate(source, counted = true) {
+	const start = source.indexOf('function sortWaveByDepth(');
+	const end = source.indexOf('// Visibility-owner scheduling', start);
+	assert.ok(start >= 0 && end > start);
+	const code = stripTypeScriptTypes(source.slice(start, end));
+	const counts = { maps: 0, sets: 0 };
+	const run = Function(
+		'Map',
+		'Set',
+		`${code}\nreturn sortWaveByDepth;`,
+	)(
+		counted
+			? class extends Map {
+					constructor(...args) {
+						super(...args);
+						counts.maps++;
+					}
+				}
+			: Map,
+		counted
+			? class extends Set {
+					constructor(...args) {
+						super(...args);
+						counts.sets++;
+					}
+				}
+			: Set,
+	);
+	return { run, counts };
+}
+function workload(shape, counted) {
+	let reads = 0;
+	const nodes = [];
+	const wave = [];
+	function add(parent, queued = true) {
+		const block = { id: nodes.length, drainStamp: 7, drainRenders: 19 };
+		if (counted)
+			Object.defineProperty(block, 'parentBlock', {
+				get() {
+					reads++;
+					return parent;
+				},
+			});
+		else block.parentBlock = parent;
+		nodes.push({ block, depth: parent === null ? 0 : nodes[parent.id].depth + 1 });
+		if (queued) wave.push(block);
+		return block;
+	}
+	const root = add(null, shape === 'chain');
+	if (shape === 'chain') {
+		let parent = root;
+		for (let i = 1; i < 400; i++) parent = add(parent);
+		wave.reverse();
+	} else if (shape === 'siblings') {
+		for (let i = 0; i < 1000; i++) add(root);
+	} else if (shape === 'sparse' || shape === 'lite') {
+		let parent = root;
+		for (let i = 0; i < 40; i++) {
+			parent = add(parent, false);
+			if (shape === 'lite' && i % 2 === 0) {
+				delete parent.drainStamp;
+				delete parent.drainRenders;
+			}
+		}
+		for (let i = 0; i < 1000; i++) add(parent);
+	} else {
+		for (let i = 0; i < 100; i++) {
+			let parent = i % 2 ? root : add(null, false);
+			for (let j = 0; j < i % 12; j++) parent = add(parent, j % 3 === 0);
+			add(parent);
+		}
+		wave.reverse();
+	}
+	const expected = wave
+		.slice()
+		.sort((a, b) => nodes[a.id].depth - nodes[b.id].depth)
+		.map((b) => b.id);
+	return {
+		wave,
+		expected,
+		lite: nodes.filter(({ block }) => block.drainStamp === undefined).map(({ block }) => block),
+		get reads() {
+			return reads;
+		},
+	};
+}
+const sources = [['candidate', readFileSync(file, 'utf8')]];
+if (baselineRef)
+	sources.unshift([
+		'baseline',
+		execFileSync('git', ['show', `${baselineRef}:${file}`], {
+			encoding: 'utf8',
+			maxBuffer: 8 * 1024 * 1024,
+		}),
+	]);
+const targets = [];
+for (const [target, source] of sources) {
+	const metrics = {};
+	for (const shape of shapes) {
+		const runtime = instantiate(source);
+		const sample = workload(shape, true);
+		assert.equal(runtime.run(sample.wave, 8), sample.wave);
+		assert.deepEqual(
+			sample.wave.map((b) => b.id),
+			sample.expected,
+		);
+		for (const lite of sample.lite) {
+			assert.equal('drainStamp' in lite, false);
+			assert.equal('drainRenders' in lite, false);
+		}
+		metrics[`${shape}_collections`] = runtime.counts.maps + runtime.counts.sets;
+		metrics[`${shape}_parent_reads`] = sample.reads;
+		// Repeat with a fresh epoch after changing ancestry: cached depths must expire.
+		const moved = workload(shape, false);
+		runtime.run(moved.wave, 9);
+		moved.wave.reverse();
+		for (const block of moved.wave) block.parentBlock = null;
+		const stable = moved.wave.slice();
+		runtime.run(moved.wave, 10);
+		assert.deepEqual(moved.wave, stable);
+		if (!measure && target === 'candidate') {
+			assert.equal(metrics[`${shape}_collections`], 0);
+			assert.ok(
+				sample.reads <= (shape === 'mixed' ? 2400 : 2200),
+				`${shape}: ancestry work bounded`,
+			);
+		}
+		const timed = workload(shape, false);
+		const timedRuntime = instantiate(source, false);
+		for (let i = 1; i <= 100; i++) {
+			timed.wave.reverse();
+			timedRuntime.run(timed.wave, i + 100);
+		}
+		const batches = [];
+		for (let batch = 0; batch < 8; batch++) {
+			const start = performance.now();
+			for (let i = 0; i < 100; i++) {
+				timed.wave.reverse();
+				timedRuntime.run(timed.wave, 300 + batch * 100 + i);
+			}
+			batches.push((performance.now() - start) * 10);
+		}
+		batches.sort((a, b) => a - b);
+		console.log(
+			JSON.stringify({
+				target,
+				shape,
+				collections: metrics[`${shape}_collections`],
+				parentReads: sample.reads,
+				medianUs: batches[4],
+				minUs: batches[0],
+				maxUs: batches[7],
+			}),
+		);
+	}
+	if (target === 'candidate') {
+		const stat = (value) => deterministicStatForJson(deterministicCount(value));
+		for (const shape of shapes) {
+			targets.push({
+				name: shape,
+				ops: {
+					collections: stat(metrics[`${shape}_collections`]),
+					parent_reads: stat(metrics[`${shape}_parent_reads`]),
+				},
+			});
+			targets.push({
+				name: `${shape}-budget`,
+				ops: { collections: stat(1), parent_reads: stat(shape === 'mixed' ? 2400 : 2200) },
+			});
+		}
+	}
+}
+if (process.env.BENCH_JSON)
+	writeFileSync(
+		process.env.BENCH_JSON,
+		JSON.stringify({ suite: 'effect-scheduling', targets }, null, 2) + '\n',
+	);

--- a/benchmarks/effectful-list/README.md
+++ b/benchmarks/effectful-list/README.md
@@ -86,25 +86,11 @@ produces numbers — so one broken transition can't blank out the whole run. If
 ANY gate failed the harness still exits 1 and writes `BENCH_JSON` with a
 top-level `failed` reason (the contract). Counters are reset between ops.
 
-> **Known octane bug (as of this writing): `clear` and `remount` gates FAIL on
-> both octane targets.** When a keyed `@for` list of cross-module `<Row/>`
-> components is cleared to empty (`clear`) or fully replaced with all-new keys
-> (`remount`), octane fires **zero** effect/ref cleanups (`cleanups` and
-> `refCleanups` stay 0 instead of 1000) — a genuine effect/ref-cleanup **leak**
-> on the bulk-teardown fast path. It reproduces only on the batch-clear path:
-> the per-item reconcile teardown is correct, which is why `remove_100_scattered`
-> (100 scattered unmounts with 900 survivors) passes with `cleanups`/`refCleanups`
-> = 100. Root cause is `fireCleanupsOnly` in `packages/octane/src/runtime.ts`
-> (the `batchClearItems` disposal path): it recurses only into `scope.children`
-> and never walks `scope._slots`, so a row's slot-stashed child block (a
-> cross-module component rendered via `componentSlot`, and by extension nested
-> portals/control-flow) has its cleanups skipped. `unmountScope` (the per-item
-> path) walks `_slots` correctly. The fixtures are authored faithfully and are
-> NOT worked around — the failing gates are the intended regression signal and
-> will auto-pass once the runtime walks `_slots` in `fireCleanupsOnly` (and its
-> `b.cleanups.length || b.children.length` call-guard in `batchClearItems`
-> accounts for `_slots`). React, Preact, Solid, Ripple, and Svelte pass all six
-> gates.
+The earlier batch-clear cleanup defect no longer reproduces on the frozen
+`8a45222ab` baseline or the current effects/scheduling candidate. The production
+Octane fixture passes all six lifecycle gates, including 1,000 effect cleanups
+and 1,000 ref cleanups for `clear` and `remount`. The fixtures retain those gates
+as regression protection; see [the current measurements](../effect-scheduling/README.md).
 
 `clear` is specifically the path js-framework's `clear` skips: there, teardown
 of effect-free rows is pure DOM removal; here every removed row runs a passive
@@ -200,7 +186,7 @@ output (median/min/p95/sd per op per target).
   ops (it's the idiomatic solid pattern for externally-produced immutable
   data, same as the dbmon bench).
 
-## Dispatch argument allocation guard
+## Effect dispatch work and callback contract
 
 ```bash
 node benchmarks/effectful-list/dispatch.mjs
@@ -208,20 +194,68 @@ node benchmarks/effectful-list/dispatch.mjs <baseline-git-ref>
 BENCH_JSON=/tmp/effect-dispatch.json node benchmarks/effectful-list/dispatch.mjs <baseline-git-ref>
 ```
 
-This untimed companion extracts the actual `runEffectBody` declaration by
-TypeScript AST and compiles its production branch. It dispatches 1,000 effects
+This untimed companion extracts the actual `runEffectBody` and
+`fireEffectCleanup` declarations by TypeScript AST and compiles their production
+branches. It dispatches 1,000 effects
 in each of the three effect phases, with omitted arguments, an explicit empty
 array, and three explicit values. Separate clean and observed executions must
 agree on callback arguments and receiver, cleanup delivery, and exception
 handling. Stale revisions, disconnected bodies, and superseded publications
-are skipped. The default guard requires zero argument-array creation events;
+are skipped. Additional controls remove or replace the current hook entry while
+retaining the declaration list, and revoke membership inside a cleanup before
+its body runs. The default guard requires zero argument-array creation events
+and at most one hook Map read per cleanup/body attempt;
 `--measure` records historical implementations without enforcing that ceiling.
 
 The observer runs after production transformation and counts source array-literal
-creation events inside this helper. Its collaborators are boundary stubs; the
+creation events inside these helpers. A fixture-owned Map observer counts their
+hook lookups. Their collaborators are boundary stubs; the
 fixture and observer allocations are excluded. The existing browser workload
 and runtime tests cover lifecycle integration. These numbers do not measure
 heap allocation, garbage collection, or end-user latency: an optimizing engine
 may already remove a short-lived empty array. The JSON records Node/V8 versions
 and runtime/helper hashes; a paired run uses the same fixture and toolchain.
 The explicit-array cases are negative controls and must remain at zero.
+
+### Remaining dispatch proposals from #981
+
+The `8a45222ab` baseline and this change both perform **21,000 hook Map reads and
+zero argument-array creations** in each 3,000-effect case. Each iteration has
+three current cleanup/body attempts, two stale-revision attempts, two superseded
+publication attempts, and a disconnected body that returns before lookup.
+These are deterministic work counts, not timing or heap-allocation measurements.
+The earlier removal of the no-deps `[]` fallback remains protected; this audit
+makes no additional dispatch throughput claim.
+
+Two alternatives were rejected:
+
+- **Indexing the effect declaration list or retaining an unchecked slot pointer:**
+  the hooks Map remains the authority for membership. The body pass must resolve
+  it again after user cleanup can reenter rendering. An old slot's matching
+  revision does not prove current membership after a removal or replacement.
+  The membership controls reject the indexed-list variant; no per-record pointer,
+  generation, or extra invalidation scheme was added to force this optimization.
+- **Calling zero-to-four-argument callbacks directly:** a callback can expose its
+  own `apply` property, including a getter that throws. Reading dependency values
+  before that property also changes observable ordering. The new public-root
+  callback tests preserve the null receiver, positional values, sparse arrays,
+  getter ordering, returned cleanup, and error reporting in every effect phase.
+  A specialization would need additional guards and a benefit sufficient to pay
+  for them. The existing `apply(null, args)` path is retained.
+
+Reproduce the dispatch comparison with:
+
+```bash
+BENCH_JSON=/tmp/effect-dispatch-981.json node benchmarks/effectful-list/dispatch.mjs 8a45222ab
+./node_modules/.bin/vitest run packages/octane/tests/effect-callback-contract.test.ts
+```
+
+The full effectful-list browser gates remain the integration check for actual
+mount, unchanged-dependency update, changed-dependency update, and teardown.
+
+Validation on Node 26.4.0 / V8 14.6: all 54 callback-contract cases passed in
+development and production. Replacing the call with `Reflect.apply` made all
+12 own-`apply` cases fail; the original call was restored and all 54 passed
+again. A scratch extraction using `effectSlots[entry.order]` with both key and
+revision guards failed the membership control. The final guard passed for both
+the baseline and candidate; their extracted dispatch-helper hashes are equal.

--- a/benchmarks/effectful-list/dispatch.mjs
+++ b/benchmarks/effectful-list/dispatch.mjs
@@ -26,11 +26,13 @@ const sha256 = (source) => createHash('sha256').update(source).digest('hex');
 
 function productionHelper(source) {
 	const ast = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-	const helper = ast.statements.find(
-		(node) => ts.isFunctionDeclaration(node) && node.name?.text === 'runEffectBody',
+	const helpers = ast.statements.filter(
+		(node) =>
+			ts.isFunctionDeclaration(node) &&
+			['fireEffectCleanup', 'runEffectBody'].includes(node.name?.text),
 	);
-	assert.ok(helper, 'effect-dispatch helper is present');
-	return transformSync(helper.getText(ast), {
+	assert.equal(helpers.length, 2, 'effect cleanup/body dispatch helpers are present');
+	return transformSync(helpers.map((helper) => helper.getText(ast)).join('\n'), {
 		loader: 'ts',
 		define: { 'process.env.NODE_ENV': '"production"' },
 		minifySyntax: true,
@@ -48,23 +50,30 @@ function instantiate(code) {
 		class MaximumUpdateDepthError extends Error {}
 		function nativeEffectPublicationCurrent(entry) { return entry.current !== false; }
 		function reportEffectError(block, error) { errors.push({ block, error }); }
+		function runEffectCleanupCallback(cleanup) { cleanup(); }
 		${code}
-		return { run: runEffectBody, errors, MaximumUpdateDepthError,
+		return { run: runEffectBody, clean: fireEffectCleanup, errors, MaximumUpdateDepthError,
 			phase: () => CURRENT_EFFECT_PHASE, depth: () => EFFECT_BODY_DEPTH };
 	`)();
 }
 
 function workload(code, argsKind) {
 	const runtime = instantiate(code);
-	const snapshot = { calls: 0, cleanups: 0, argumentValues: 0 };
+	const snapshot = { calls: 0, cleanups: 0, argumentValues: 0, hookMapReads: 0 };
 	const token = {};
 	for (let phase = 0; phase < 3; phase++) {
 		for (let index = 0; index < count; index++) {
 			const args =
 				argsKind === 'omitted' ? undefined : argsKind === 'empty' ? [] : [index, token, undefined];
 			const slotKey = Symbol();
-			const slot = { revision: 1, cleanup: undefined };
-			const scope = { block: {}, hooks: new Map([[slotKey, slot]]) };
+			const slot = { slot: slotKey, order: 0, revision: 1, cleanup: undefined };
+			const hooks = new Map([[slotKey, slot]]);
+			const read = hooks.get;
+			hooks.get = function (key) {
+				snapshot.hookMapReads++;
+				return read.call(this, key);
+			};
+			const scope = { block: {}, hooks, effectSlots: [slot] };
 			const cleanup = () => snapshot.cleanups++;
 			function body() {
 				assert.equal(this, null);
@@ -80,17 +89,21 @@ function workload(code, argsKind) {
 				snapshot.calls++;
 				return cleanup;
 			}
-			const entry = { fn: body, args, slot: slotKey, revision: 1, scope, phase };
+			const entry = { fn: body, args, slot: slotKey, order: 0, revision: 1, scope, phase };
+			runtime.clean(entry);
 			runtime.run(entry);
 			assert.equal(runtime.phase(), -1);
 			assert.equal(runtime.depth(), 0);
 			assert.equal(slot.cleanup, cleanup);
-			slot.cleanup();
+			runtime.clean(entry);
+			assert.equal(slot.cleanup, undefined);
 			// Stale revisions, disconnected bodies, and superseded publications
 			// must neither invoke a callback nor create its argument fallback.
 			runtime.run({ ...entry, revision: 0 });
+			runtime.clean({ ...entry, revision: 0 });
 			runtime.run({ ...entry, fn: null });
 			runtime.run({ ...entry, current: false });
+			runtime.clean({ ...entry, current: false });
 		}
 	}
 	assert.equal(snapshot.calls, count * 3);
@@ -100,17 +113,65 @@ function workload(code, argsKind) {
 	return snapshot;
 }
 
+function membershipControls(code) {
+	const runtime = instantiate(code);
+	const key = Symbol();
+	let calls = 0;
+	let cleanups = 0;
+	const slot = {
+		slot: key,
+		order: 0,
+		revision: 1,
+		cleanup() {
+			cleanups++;
+		},
+	};
+	const scope = { block: {}, hooks: new Map([[key, slot]]), effectSlots: [slot] };
+	const entry = {
+		scope,
+		slot: key,
+		order: 0,
+		revision: 1,
+		phase: 2,
+		fn() {
+			calls++;
+		},
+	};
+	// A retained declaration list is not proof of current hook membership.
+	// Rollback/remount can remove a slot; same-scope body reuse can replace its
+	// Map entry. No old callback or cleanup may survive either invalidation.
+	for (const hooks of [null, new Map(), new Map([[key, { deps: [], value: 'replacement' }]])]) {
+		scope.hooks = hooks;
+		runtime.clean(entry);
+		runtime.run(entry);
+		assert.equal(calls, 0);
+		assert.equal(cleanups, 0);
+	}
+	scope.hooks = new Map([[key, slot]]);
+	slot.cleanup = () => {
+		cleanups++;
+		// User cleanup can revoke membership before the corresponding body pass.
+		scope.hooks.delete(key);
+	};
+	runtime.clean(entry);
+	runtime.run(entry);
+	assert.equal(cleanups, 1);
+	assert.equal(calls, 0);
+	assert.equal(runtime.errors.length, 0);
+}
+
 function errorControls(code) {
 	const runtime = instantiate(code);
 	const slotKey = Symbol();
-	const slot = { revision: 1 };
+	const slot = { slot: slotKey, order: 0, revision: 1 };
 	const block = {};
 	const entry = {
 		args: undefined,
 		phase: 2,
 		revision: 1,
 		slot: slotKey,
-		scope: { block, hooks: new Map([[slotKey, slot]]) },
+		order: 0,
+		scope: { block, hooks: new Map([[slotKey, slot]]), effectSlots: [slot] },
 	};
 	const error = new Error('effect failure');
 	runtime.run({
@@ -157,13 +218,15 @@ function measure(source) {
 	}
 	errorControls(clean);
 	errorControls(observed);
+	membershipControls(clean);
+	membershipControls(observed);
 	delete globalThis[COUNTER_GLOBAL];
 	return { sourceHash: sha256(source), helperHash: sha256(clean), cases };
 }
 
 const result = {
 	suite: 'effect-dispatch',
-	metric: 'source array-literal creation events in the production dispatch helper',
+	metric: 'source array-literal creations and hook Map reads in production effect dispatch',
 	node: process.version,
 	v8: process.versions.v8,
 	effectsPerCase: count * 3,
@@ -179,10 +242,20 @@ if (baselineRef) {
 		}),
 	);
 	for (const name of ['omitted', 'empty', 'values']) {
-		const { emptyArrayCreations: before, ...beforeBehavior } = result.baseline.cases[name];
-		const { emptyArrayCreations: after, ...afterBehavior } = result.candidate.cases[name];
+		const {
+			emptyArrayCreations: before,
+			hookMapReads: beforeReads,
+			...beforeBehavior
+		} = result.baseline.cases[name];
+		const {
+			emptyArrayCreations: after,
+			hookMapReads: afterReads,
+			...afterBehavior
+		} = result.candidate.cases[name];
 		assert.deepEqual(afterBehavior, beforeBehavior);
-		console.log(`${name}: ${result.effectsPerCase} effects; array creations ${before} → ${after}`);
+		console.log(
+			`${name}: ${result.effectsPerCase} effects; array creations ${before} → ${after}; hook Map reads ${beforeReads} → ${afterReads}`,
+		);
 	}
 } else console.log(JSON.stringify(result.candidate.cases, null, 2));
 if (process.env.BENCH_JSON)
@@ -193,6 +266,10 @@ if (!measureOnly) {
 			scenario.emptyArrayCreations,
 			0,
 			`${name}: dispatch must not create argument arrays`,
+		);
+		assert.ok(
+			scenario.hookMapReads <= count * 3 * 7,
+			`${name}: at most one hook Map read per nonempty cleanup/body attempt`,
 		);
 	}
 }

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -143,6 +143,7 @@ export const BENCHMARK_SUITES = [
 	'bundle-reachability',
 	'three-renderer',
 	'three-bundle-size',
+	'effect-scheduling',
 	'spread-hosts',
 ];
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1049,7 +1049,9 @@ export interface Block extends Scope {
 	 * many times it rendered within that pass. A block that keeps re-queueing
 	 * itself from its own render body (an unguarded render-phase setState) is a
 	 * non-converging loop — drainQueue throws after RENDER_PHASE_UPDATE_LIMIT,
-	 * mirroring React's "Too many re-renders".
+	 * mirroring React's "Too many re-renders". Negative stamps are transient
+	 * scheduler-sort epochs: drainRenders holds depth until the first render
+	 * resets it under the positive drain id.
 	 */
 	drainStamp: number;
 	drainRenders: number;
@@ -4638,34 +4640,41 @@ function drainHydrationRenderPhaseUpdates(root: Block): void {
 	}
 }
 
-// Sort a render wave shallow-first (ancestors before descendants). If A is an
-// ancestor of B then depth(A) < depth(B), so A renders first and its cascade can
-// clear B's `pending` (skipping B's redundant standalone render) regardless of
-// the order their setStates were queued. Depths are precomputed so the comparator
-// doesn't re-walk the chain on every compare. Resolve each unknown path to its
-// nearest cached queued ancestor, retaining depths only for blocks in this wave.
-function sortWaveByDepth(wave: Block[]): Block[] {
-	const queued = new Set(wave);
-	const depth = new Map<Block, number>();
-	const path: Block[] = [];
+// Sort a render wave shallow-first so an ancestor can consume or remove queued
+// descendants before their standalone updates. No user code runs during this
+// sort. Negative drain stamps temporarily reuse the loop-guard fields for depth;
+// the positive drain id resets them to a render count before executing a block.
+// Cache every real ancestor for this wave, including unqueued intermediates.
+// Two walks over each unknown path avoid allocating a path stack or collections.
+function sortWaveByDepth(wave: Block[], drainId: number): Block[] {
+	const stamp = -drainId;
 	for (let i = 0; i < wave.length; i++) {
-		let current: Block | null = wave[i];
-		let knownDepth: number | undefined;
-		while (current !== null) {
-			knownDepth = depth.get(current);
-			if (knownDepth !== undefined) break;
-			path.push(current);
+		const start = wave[i];
+		if (start.drainStamp === stamp) continue;
+		let current: Block | null = start;
+		let depth = 0;
+		while (current !== null && current.drainStamp !== stamp) {
+			depth++;
 			current = current.parentBlock;
 		}
-		let currentDepth = knownDepth ?? -1;
-		while (path.length > 0) {
-			const block = path.pop()!;
-			currentDepth++;
-			if (queued.has(block)) depth.set(block, currentDepth);
+		depth += current === null ? -1 : current.drainRenders;
+		current = start;
+		while (current !== null && current.drainStamp !== stamp) {
+			// Lite ancestry proxies intentionally have no scheduler fields.
+			if (current.drainStamp !== undefined) {
+				current.drainStamp = stamp;
+				current.drainRenders = depth;
+			}
+			depth--;
+			current = current.parentBlock;
 		}
 	}
-	wave.sort((a, b) => depth.get(a)! - depth.get(b)!);
+	wave.sort(compareWaveDepth);
 	return wave;
+}
+
+function compareWaveDepth(a: Block, b: Block): number {
+	return a.drainRenders - b.drainRenders;
 }
 
 // Visibility-owner scheduling is optional: roots without Suspense or hidden
@@ -4717,7 +4726,7 @@ function drainQueue(): { err: any } | null {
 	let pendingError: { err: any; all: any[] } | null = null;
 	let activitiesToRehide: Set<ActivitySlot> | null = null;
 	const drainId = ++DRAIN_ID;
-	if (QUEUE.length > 1) sortWaveByDepth(QUEUE);
+	if (QUEUE.length > 1) sortWaveByDepth(QUEUE, drainId);
 	// Iterate by index. A render may enqueue MORE work (e.g. a setState during
 	// render) — it appends to QUEUE, and `i < QUEUE.length` is re-evaluated every
 	// step, so those are drained in this same pass. The loop only exits once i has
@@ -5828,7 +5837,17 @@ function drainRefAttaches(): void {
 	const q = refAttachQueue.splice(0);
 	// ES stable sort preserves the queue's DFS/source order for disjoint subtrees;
 	// comparePostOrder moves only descendants ahead of their queued ancestors.
-	q.sort((a, b) => comparePostOrder(a.block, 0, b.block, 0));
+	// Entries with one immediate parent are siblings (or on the same block), so
+	// every comparison is zero and their existing queue order is already final.
+	if (q.length > 1) {
+		const parent = q[0].block?.parentBlock ?? null;
+		for (let i = 1; i < q.length; i++) {
+			if ((q[i].block?.parentBlock ?? null) !== parent) {
+				q.sort(compareRefPostOrder);
+				break;
+			}
+		}
+	}
 	for (const r of q) {
 		// Skip attaches whose owning subtree was unmounted earlier in THIS flush
 		// (e.g. a try boundary caught a mount-time throw and ran unmountBlock +
@@ -6304,6 +6323,9 @@ function comparePostOrder(
 function compareEffectPostOrder(a: PendingEffect, b: PendingEffect): number {
 	if (a.scope === b.scope) return a.order - b.order || a.seq - b.seq;
 	return comparePostOrder(a.scope.block, a.seq, b.scope.block, b.seq);
+}
+function compareRefPostOrder(a: RefAttach, b: RefAttach): number {
+	return comparePostOrder(a.block, 0, b.block, 0);
 }
 
 function finishEffectCommit(): void {

--- a/packages/octane/tests/_fixtures/ref-postorder-batches.tsrx
+++ b/packages/octane/tests/_fixtures/ref-postorder-batches.tsrx
@@ -1,0 +1,37 @@
+type Props = { log: (entry: string) => void; label: string };
+
+function Leaf({ log, label }: Props) @{
+	<span
+		ref={(el) => {
+			if (el) log(label);
+		}}
+	>{label}</span>
+}
+
+function FirstBranch({ log, label }: Props) @{
+	<section
+		ref={(el) => {
+			if (el) log('first parent');
+		}}
+	>
+		<Leaf log={log} label={'first ' + label} />
+		<Leaf log={log} label={'second ' + label} />
+	</section>
+}
+
+function SecondBranch({ log, label }: Props) @{
+	<aside
+		ref={(el) => {
+			if (el) log('second parent');
+		}}
+	>
+		<Leaf log={log} label={'deep ' + label} />
+	</aside>
+}
+
+export function RefPostorderBatch({ log, label }: Props) @{
+	<main>
+		<FirstBranch log={log} label={label} />
+		<SecondBranch log={log} label={label} />
+	</main>
+}

--- a/packages/octane/tests/_fixtures/scheduler-depth-ordering.tsx
+++ b/packages/octane/tests/_fixtures/scheduler-depth-ordering.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource octane */
 
-import { useState } from 'octane';
+import { useLayoutEffect, useState } from 'octane';
 
 let removeChild: (() => void) | null = null;
 let invalidateChild: (() => void) | null = null;
@@ -24,4 +24,78 @@ export function queueDescendantBeforeRemoval() {
 	}
 	invalidateChild();
 	removeChild();
+}
+
+export interface SchedulerControls {
+	update?: () => void;
+	remove?: () => void;
+}
+
+function DeepCounter({ controls }: { controls: SchedulerControls }) {
+	const [value, setValue] = useState(0);
+	controls.update = () => setValue(1);
+	if (value > 0 && value < 3) setValue(value + 1);
+	return <output>{value}</output>;
+}
+
+function DeepBranch({ depth, controls }: { depth: number; controls: SchedulerControls }) {
+	return depth === 0 ? (
+		<DeepCounter controls={controls} />
+	) : (
+		<DeepBranch depth={depth - 1} controls={controls} />
+	);
+}
+
+export function DeepSchedulerApp({ controls }: { controls: SchedulerControls }) {
+	const [visible, setVisible] = useState(true);
+	controls.remove = () => setVisible(false);
+	return <section>{visible ? <DeepBranch depth={40} controls={controls} /> : 'removed'}</section>;
+}
+
+interface OrderedCounterProps {
+	label: string;
+	controls: SchedulerControls;
+	onCommit(label: string): void;
+}
+
+function OrderedCounter({ label, controls, onCommit }: OrderedCounterProps) {
+	const [value, setValue] = useState(0);
+	controls.update = () => setValue(value + 1);
+	useLayoutEffect(() => {
+		if (value > 0) onCommit(label + ':' + value);
+	}, [value, label, onCommit]);
+	return <output data-counter={label}>{value}</output>;
+}
+
+function CounterWrapper({ label, controls, onCommit }: OrderedCounterProps) {
+	return (
+		<section>
+			<OrderedCounter label={label} controls={controls} onCommit={onCommit} />
+		</section>
+	);
+}
+
+export function SiblingSchedulerApp({
+	first,
+	second,
+	onCommit,
+}: {
+	first: SchedulerControls;
+	second: SchedulerControls;
+	onCommit(label: string): void;
+}) {
+	return (
+		<main>
+			<CounterWrapper label="first" controls={first} onCommit={onCommit} />
+			<CounterWrapper label="second" controls={second} onCommit={onCommit} />
+		</main>
+	);
+}
+
+export function RunawaySchedulerApp({ controls }: { controls: SchedulerControls }) {
+	const [value, setValue] = useState(0);
+	controls.update = () => setValue(1);
+	// The upper bound makes a missing render-loop error fail without hanging the test.
+	if (value > 0 && value < 100) setValue(value + 1);
+	return <output>{value}</output>;
 }

--- a/packages/octane/tests/effect-callback-contract.test.ts
+++ b/packages/octane/tests/effect-callback-contract.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createElement,
+	createRoot,
+	drainPassiveEffects,
+	flushSync,
+	useEffect,
+	useInsertionEffect,
+	useLayoutEffect,
+} from '../src/index.js';
+
+const phases = [
+	['insertion', useInsertionEffect],
+	['layout', useLayoutEffect],
+	['passive', useEffect],
+] as const;
+
+describe.each(phases)('%s effect callback contract', (_phase, usePhaseEffect) => {
+	it.each([
+		['omitted', undefined],
+		['null', null],
+		['empty', []],
+		['one', [1]],
+		['two', [1, undefined]],
+		['three', [1, undefined, 'third']],
+		['four', [1, undefined, 'third', null]],
+	] as const)('preserves the null receiver and %s positional dependencies', (_name, deps) => {
+		const calls: { receiver: unknown; args: unknown[] }[] = [];
+		const cleanup = vi.fn();
+		const slot = Symbol('effect callback arguments');
+		function effect(this: unknown, ...args: unknown[]) {
+			calls.push({ receiver: this, args });
+			return cleanup;
+		}
+		function App() {
+			usePhaseEffect(effect, deps as unknown[] | null | undefined, slot);
+			return createElement('div', { children: 'mounted' });
+		}
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		try {
+			flushSync(() => root.render(App));
+			drainPassiveEffects();
+			expect(container.textContent).toBe('mounted');
+			expect(calls).toEqual([{ receiver: null, args: deps ?? [] }]);
+			expect(cleanup).not.toHaveBeenCalled();
+			root.unmount();
+			drainPassiveEffects();
+			expect(cleanup).toHaveBeenCalledTimes(1);
+		} finally {
+			root.unmount();
+			drainPassiveEffects();
+		}
+	});
+
+	it('reads the callback apply property before positional dependency getters', () => {
+		const events: string[] = [];
+		const token = {};
+		const deps: unknown[] = [token, undefined, undefined];
+		delete deps[1];
+		Object.defineProperty(deps, 2, {
+			get() {
+				events.push('dependency');
+				return 'third';
+			},
+		});
+		const calls: { receiver: unknown; args: unknown[] }[] = [];
+		function effect(this: unknown, ...args: unknown[]) {
+			events.push('body');
+			calls.push({ receiver: this, args });
+			return () => {
+				events.push('cleanup');
+			};
+		}
+		Object.defineProperty(effect, 'apply', {
+			get() {
+				events.push('apply');
+				return function (this: unknown, receiver: unknown, args: unknown[]) {
+					expect(this).toBe(effect);
+					expect(receiver).toBe(null);
+					expect(args).toBe(deps);
+					return Reflect.apply(effect, receiver, args);
+				};
+			},
+		});
+		const slot = Symbol('observable effect apply');
+		function App() {
+			usePhaseEffect(effect, deps, slot);
+			return createElement('span', { children: 'mounted' });
+		}
+		const root = createRoot(document.createElement('div'));
+		try {
+			flushSync(() => root.render(App));
+			drainPassiveEffects();
+			expect(events).toEqual(['apply', 'dependency', 'body']);
+			expect(calls).toEqual([{ receiver: null, args: [token, undefined, 'third'] }]);
+			expect(calls[0].args[0]).toBe(token);
+			root.unmount();
+			drainPassiveEffects();
+			expect(events).toEqual(['apply', 'dependency', 'body', 'cleanup']);
+		} finally {
+			root.unmount();
+			drainPassiveEffects();
+		}
+	});
+
+	it('routes an exception from the callback apply getter to the root', () => {
+		const failure = new Error('effect apply getter');
+		const onUncaughtError = vi.fn();
+		const body = vi.fn();
+		Object.defineProperty(body, 'apply', {
+			get() {
+				throw failure;
+			},
+		});
+		const slot = Symbol('throwing effect apply');
+		function App() {
+			usePhaseEffect(body, [], slot);
+			return createElement('span', { children: 'mounted' });
+		}
+		const container = document.createElement('div');
+		const root = createRoot(container, { onUncaughtError });
+		try {
+			flushSync(() => root.render(App));
+			drainPassiveEffects();
+			expect(body).not.toHaveBeenCalled();
+			expect(onUncaughtError).toHaveBeenCalledTimes(1);
+			expect(onUncaughtError.mock.calls[0][0]).toBe(failure);
+			expect(container.textContent).toBe('');
+		} finally {
+			root.unmount();
+			drainPassiveEffects();
+		}
+	});
+});

--- a/packages/octane/tests/hydration/render-phase-queue.test.ts
+++ b/packages/octane/tests/hydration/render-phase-queue.test.ts
@@ -54,7 +54,9 @@ describe('hydrateRoot — render-phase queue isolation', () => {
 		queueForeignUpdates(4);
 		const targetRoot = hydrateRoot(target, SettlingRows, { count: 4, settle: true });
 
-		expect(Array.from(target.querySelectorAll('[data-settling-row]'))).toEqual(serverRows);
+		const hydratedRows = target.querySelectorAll('[data-settling-row]');
+		expect(hydratedRows.length).toBe(serverRows.length);
+		for (let i = 0; i < serverRows.length; i++) expect(hydratedRows[i]).toBe(serverRows[i]);
 		expect(rowText(target, '[data-settling-row]')).toEqual(Array(4).fill('target:2'));
 		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(4).fill('foreign:0'));
 		expect(renders).toEqual([]);
@@ -121,6 +123,7 @@ describe('hydrateRoot — render-phase queue isolation', () => {
 	it('survives flushSync nested in a hydration replay', () => {
 		const renders: number[] = [];
 		const foreignRoot = mountForeign(3, renders);
+		const foreignNodes = foreign.querySelectorAll('[data-foreign-row]');
 		target.innerHTML = renderToString(server.NestedFlush, { flush: false }).html;
 		const serverNode = target.querySelector('[data-nested-flush]');
 		queueForeignUpdates(3);
@@ -134,6 +137,11 @@ describe('hydrateRoot — render-phase queue isolation', () => {
 		expect(serverNode?.textContent).toBe('nested-flush:1');
 		expect(rowText(foreign, '[data-foreign-row]')).toEqual(Array(3).fill('foreign:1'));
 		expect(renders).toEqual([0, 1, 2]);
+		const updatedForeignNodes = foreign.querySelectorAll('[data-foreign-row]');
+		expect(updatedForeignNodes.length).toBe(foreignNodes.length);
+		for (let i = 0; i < foreignNodes.length; i++) {
+			expect(updatedForeignNodes[i]).toBe(foreignNodes[i]);
+		}
 
 		targetRoot.unmount();
 		foreignRoot.unmount();

--- a/packages/octane/tests/ref-postorder-batches.test.ts
+++ b/packages/octane/tests/ref-postorder-batches.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from 'vitest';
+import { act, mount } from './_helpers';
+import { RefPostorderBatch } from './_fixtures/ref-postorder-batches.tsrx';
+
+it('attaches child refs before parent refs while preserving sibling branch order', async () => {
+	const log: string[] = [];
+	const props = { log: (entry: string) => log.push(entry), label: 'initial' };
+	const r = mount(RefPostorderBatch, props);
+	try {
+		await act(() => {});
+		expect(r.html()).toBe(
+			'<main><section><span>first initial</span><span>second initial</span></section><aside><span>deep initial</span></aside></main>',
+		);
+		expect(log).toEqual([
+			'first initial',
+			'second initial',
+			'first parent',
+			'deep initial',
+			'second parent',
+		]);
+		const first = r.find('section span');
+		log.length = 0;
+		r.update(RefPostorderBatch, { ...props, label: 'updated' });
+		await act(() => {});
+		expect(r.find('section span')).toBe(first);
+		expect(r.html()).toBe(
+			'<main><section><span>first updated</span><span>second updated</span></section><aside><span>deep updated</span></aside></main>',
+		);
+		expect(log).toEqual([
+			'first updated',
+			'second updated',
+			'first parent',
+			'deep updated',
+			'second parent',
+		]);
+	} finally {
+		r.unmount();
+	}
+});

--- a/packages/octane/tests/scheduler-depth-ordering.test.ts
+++ b/packages/octane/tests/scheduler-depth-ordering.test.ts
@@ -3,6 +3,10 @@ import { flushSync } from '../src/index.js';
 import { mount } from './_helpers';
 import {
 	SchedulerDepthOrderingApp,
+	DeepSchedulerApp,
+	RunawaySchedulerApp,
+	SiblingSchedulerApp,
+	type SchedulerControls,
 	queueDescendantBeforeRemoval,
 } from './_fixtures/scheduler-depth-ordering.tsx';
 
@@ -15,4 +19,92 @@ it('drains a queued ancestor before stale work in a descendant it removes', () =
 	expect(r.find('.removed').textContent).toBe('removed');
 
 	r.unmount();
+});
+
+it('preserves update order for sibling layout notifications', () => {
+	const first: SchedulerControls = {};
+	const second: SchedulerControls = {};
+	const commits: string[] = [];
+	const r = mount(SiblingSchedulerApp, {
+		first,
+		second,
+		onCommit: (label: string) => commits.push(label),
+	});
+	const firstNode = r.find('[data-counter="first"]');
+	const secondNode = r.find('[data-counter="second"]');
+	try {
+		flushSync(() => {
+			second.update!();
+			first.update!();
+		});
+		expect(commits).toEqual(['second:1', 'first:1']);
+		expect(r.find('[data-counter="first"]')).toBe(firstNode);
+		expect(r.find('[data-counter="second"]')).toBe(secondNode);
+		expect(firstNode.textContent).toBe('1');
+		expect(secondNode.textContent).toBe('1');
+
+		commits.length = 0;
+		flushSync(() => {
+			first.update!();
+			second.update!();
+		});
+		expect(commits).toEqual(['first:2', 'second:2']);
+		expect(firstNode.textContent).toBe('2');
+		expect(secondNode.textContent).toBe('2');
+	} finally {
+		r.unmount();
+	}
+});
+
+it('reports a render-loop error while committing an independent root', () => {
+	const looping: SchedulerControls = {};
+	const healthy: SchedulerControls = {};
+	const failedRoot = mount(RunawaySchedulerApp, { controls: looping });
+	const survivingRoot = mount(DeepSchedulerApp, { controls: healthy });
+	const output = survivingRoot.find('output');
+	try {
+		expect(() =>
+			flushSync(() => {
+				looping.update!();
+				healthy.update!();
+			}),
+		).toThrow(/Too many re-renders|error #9/);
+		expect(failedRoot.container.textContent).toBe('');
+		expect(survivingRoot.find('output')).toBe(output);
+		expect(output.textContent).toBe('3');
+
+		flushSync(() => healthy.remove!());
+		expect(survivingRoot.container.textContent).toBe('removed');
+		expect(output.isConnected).toBe(false);
+	} finally {
+		failedRoot.unmount();
+		survivingRoot.unmount();
+	}
+});
+
+it('converges deep render-phase updates across repeated batches and independent roots', () => {
+	const first: SchedulerControls = {};
+	const second: SchedulerControls = {};
+	const a = mount(DeepSchedulerApp, { controls: first });
+	const b = mount(DeepSchedulerApp, { controls: second });
+	try {
+		for (let i = 0; i < 3; i++) {
+			flushSync(() => {
+				second.update!();
+				first.update!();
+			});
+			expect(a.find('output').textContent).toBe('3');
+			expect(b.find('output').textContent).toBe('3');
+		}
+		flushSync(() => {
+			first.update!();
+			second.update!();
+			first.remove!();
+		});
+		expect(a.container.textContent).toBe('removed');
+		expect(b.find('output').textContent).toBe('3');
+	} finally {
+		a.unmount();
+		b.unmount();
+	}
 });


### PR DESCRIPTION
## Summary

Address the remaining **Effects and scheduling** findings in #981.

- Replace per-wave scheduler Set/Map/path/comparator allocations with temporary depths in existing loop-guard fields. Preserve shallow-first updates, stable ties, new-wave invalidation, and lightweight ancestry shapes.
- Skip ref sorting for single and sibling-only queues; use a shared comparator for mixed ancestry. Preserve nullable owners, descendant-before-ancestor attachment, and callback/disposal/error behavior.
- Audit and retain effect hook-Map membership checks and `apply(null, args)`. Unchecked effect-list indexing admits replaced slots; unguarded arity specialization changes observable callback invocation. Add regressions and measured controls for those decisions.
- Keep the deep-disjoint effect ordering fallback: the ordinary effectful-list workload already uses constant-time sibling comparisons. New deep controls preserve postorder; no per-Block depth field is added.

## Why

Scheduler sorting rebuilt collections on every batch and repeatedly walked unqueued shared ancestors. Ref queues with one immediate parent were already in their final order. These changes remove that work while retaining the lifecycle checks required for rollback, replacement, cleanup, and reentrant commits.

## Performance evidence

Frozen baseline: `8a45222ab493efa23930e7e2fb4bce8eb5c57160` (merged #1068).

- Wave Set/Map constructions: **2 → 0** per batch. Path arrays and comparator closures are removed as well.
- 1,000 updates sharing 40 unqueued ancestors: **42,000 → 2,082 parent reads**. The second path walk costs more reads on some shapes: reversed-chain 400 → 800; mixed roots 734 → 1,370. No extra Block fields or retained pointers.
- 1,000 sibling ref attaches: **1 → 0 native sorts**. Mixed/deep batches retain their sort. Ownerless entries remain supported.
- Dispatch workload: **21,000 Map reads and zero argument-array constructions** per 3,000-effect argument case, unchanged. Separate replacement and cleanup-revocation controls pass.
- **17 deterministic ratio guards** pass. Final Chromium A–B–B–A comparison passes **48/48 lifecycle gates** across TSRX and JSX.
- Production bundle delta: **+259 minified bytes**, **+53 gzip bytes (TSRX) / +58 (JSX)**. Timings vary substantially; no application-latency or actual heap-allocation gain is claimed.

Reproducible commands, semantic controls, final bundle hashes, and measurements: `benchmarks/effect-scheduling/README.md`, `benchmarks/effect-postorder/README.md`, and `benchmarks/effectful-list/README.md`.

## Validation

- [x] Final focused dev/prod validation: **93 project-files / 942 tests** covering effects, refs, scheduling, Activity, root transactions, hydration, error handling, and the Volar type regression.
- [x] Broad local core sweep: **17,033 passed / 14 expected failures**. Its nullable-ref type finding was fixed and verified in the final focused run. Three dependency-path assertions reproduce identically with frozen baseline source; two additional suites require the unavailable local React fixture precompile.
- [x] Deliberate regressions fail: positive depth stamp, reversed sibling ties, omitted mixed-ref sorting, callback `apply` bypass, unchecked indexed membership. Sources restored; final tests/guards pass.
- [x] Core source and public `tsgo` typechecks; isolated callback-contract test typecheck.
- [x] MCP catalog tests: **15/15**.
- [x] `node benchmarks/bench.mjs effect-scheduling --ratios` (**17/17**), dispatch and postorder controls.
- [x] Scoped formatting, `pnpm sync`, and changeset checks.
- [ ] Full local `pnpm test` / monorepo `pnpm typecheck`: not run. TSRX fixture typechecking cannot launch locally because the copied dependency tree lacks `@tsrx/react-runtime`; both fixture dialects compile and execute in dev/prod tests. Current-head CI passed the full required suite, including monorepo typechecking, in the lockfile-installed environment.

## Current-head CI and review

- [x] [CI attempt 2](https://github.com/octanejs/octane/actions/runs/34724933094/attempts/2): **26/26 jobs passed** at `78bc3c81f`.
- [x] Cursor Bugbot passed with no findings; no unresolved review threads.
- The first attempt reported a Vitest browser-runner error in `AvatarRoot.test.tsx`, without an assertion failure. The exact fixture passed **15/15** locally with the CI test project, Node 24.20.0, and Chromium 149. A targeted retry of the failed jobs passed on the unchanged commit; no test or configuration was weakened.
- The ready PR contains the live base branch and is mergeable. Agent-authored provenance is declared.

## Risk / follow-ups

- Existing scheduler fields have a temporary negative-epoch meaning during sorting; positive drain IDs reset them before any render. Tests cover deep convergence, loop failure isolation, repeated waves, hydration, and stable notification order.
- Native sort fallback and effect membership/dispatch checks are deliberately retained. Removing them needs stronger semantic or performance evidence.
- Browser measurements cover Chromium, not Firefox/WebKit.
- Updates #981; does not close the umbrella issue. A patch changeset includes Octane and the MCP benchmark catalog.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core render-queue ordering and commit-time ref attachment using transient overload of loop-guard fields; behavior is heavily guarded but mistakes would affect update/effect ordering across the runtime.
> 
> **Overview**
> **Replaces per-batch scheduler sorting allocations** by caching shallow-first depths in existing `drainStamp` / `drainRenders` fields (negative drain epochs, reset before render) instead of building a Set, Map, and path stack each wave. **Skips ref-attach sorting** when every queued ref shares one immediate parent (including single-ref queues), and uses a shared `compareRefPostOrder` only when ancestry differs—keeping descendant-before-ancestor order and ownerless entries.
> 
> Adds an **`effect-scheduling` benchmark suite** (wave + ref probes, 17 ratio guards) and registers it in the MCP benchmark catalog. **Expands regression coverage** for scheduler depth/ties/loop limits, ref postorder batches, effect callback contract (`apply` ordering, null receiver), and stricter dispatch membership controls—without changing the retained hook-Map + `apply(null, args)` dispatch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78bc3c81f4c6425149faf328b4285509f3f9d8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791846625&installation_model_id=432790&pr_number=1070&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1070&signature=e6e593a93df873da1b4eb863f52bea05cdb868e6dcab146fc3a32f5ddb95411a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->