### PR TITLE
perf: split SSR escape pre-scan by string length

### DIFF
--- a/.changeset/ssr-escape-guard-length-scan.md
+++ b/.changeset/ssr-escape-guard-length-scan.md
@@ -1,0 +1,11 @@
+---
+'octane': patch
+---
+
+Speed up server rendering by picking the escape pre-scan by string length in
+`escapeHtml`: a stateless non-global regexp test for short strings, three
+`indexOf` scans for long ones.
+
+The previous global regexp paid `lastIndex` bookkeeping on every call; the
+length split keeps the cheaper scan in each regime. ~20% faster median render
+on the 500-card SSR benchmark with byte-identical output.

--- a/benchmarks/ssr-throughput/README.md
+++ b/benchmarks/ssr-throughput/README.md
@@ -231,6 +231,39 @@ pnpm exec vite build benchmarks/ssr-throughput/fixtures --ssr src/entry-server.t
 CONFIGS=deopt-page,escape-heavy BENCH_JSON=/tmp/ssr-sample.json node benchmarks/ssr-throughput/run.mjs 2 --no-build
 ```
 
+### Escape pre-scan split by length — 2026-09-12
+
+Compared main `58da3448b` against a candidate that makes `escapeHtml`'s
+no-escape guard length-keyed — a stateless non-global `/[&<>]/` test under 32
+chars, three `indexOf` scans at or above — and drops the `/g`+`lastIndex`
+bookkeeping from `escapeAttr`. Node 22 / macOS / Apple Silicon. A CPU profile
+of the baseline news-500 loop showed the global-regexp guard scan at ~30% of
+render time. Baseline and candidate each ran three fresh processes of the same
+command (fixture bundles rebuilt per revision, then `--no-build`):
+
+```bash
+CONFIGS=news-500/octane-tsrx,news-50/octane-tsrx,waterfall-d1 \
+  node benchmarks/ssr-throughput/run.mjs 8
+```
+
+| Config | Baseline score ms, runs | Candidate score ms, runs | Delta |
+| --- | --- | --- | --- |
+| news-500/octane-tsrx | 0.552 / 0.544 / 0.531 | 0.427 / 0.435 / 0.512 | −20% on median (0.435 vs 0.544) |
+| news-50/octane-tsrx | 0.045 / 0.048 / 0.047 | 0.038 / 0.041 / 0.041 | −14% |
+| waterfall-d1 (control) | 0.070 / 0.071 / 0.066 | 0.072 / 0.070 / 0.081 | inside spread |
+
+Body bytes and marker counts were identical across every run (41 KB/2,
+409 KB/2, 30 KB/5). waterfall-d1 re-serializes a ~1,000-node page per Suspense
+pass and is the noisiest config in this suite — same-binary repeats spanned
+0.066–0.122 across the session, so its small residual elevation is noise, not
+a measured regression; the mechanism there is strictly less work than the old
+`/g` scan (its strings are all under 32 chars and take the non-global regexp).
+
+An intermediate version used three `indexOf` scans at all lengths: it kept the
+news-500 win but measurably regressed waterfall-d1 (~+13%), because three
+builtin calls cost more than one regexp entry on tiny strings. The measured
+crossover sits at ~32 chars, which is what the length split encodes.
+
 ## Production HTML payload audit
 
 `pnpm --dir benchmarks/ssr-throughput bench:payload` builds only the Octane and

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1668,12 +1668,16 @@ export function createPortal(body: unknown, target: unknown, props: any = undefi
 // Escaping
 // ---------------------------------------------------------------------------
 
-// Guarded escapers: a single .test() scan first, so the common no-escape case
-// returns the ORIGINAL string with zero allocation (~5x on clean text). When
-// something does need escaping, native replacement passes are kept —
-// measured faster than an exec-loop or replace-with-callback single pass on V8
-// for both sparse and dense escape densities.
-const HTML_ESCAPE_RE = /[&<>]/g;
+// Guarded escapers: a cheap pre-scan decides whether the ORIGINAL string can
+// be returned with zero allocation. The regexps are deliberately non-global —
+// no lastIndex to reset per call, and a nested render cannot corrupt a shared
+// scan position. escapeHtml splits the pre-scan by length: a regexp .test()
+// has lower fixed cost on short strings, while three memchr-backed indexOf
+// scans win on long ones (crossover measured at ~32 chars). When something
+// does need escaping, native replacement passes are kept — measured faster
+// than an exec-loop or replace-with-callback single pass on V8 for both
+// sparse and dense escape densities.
+const HTML_ESCAPE_RE = /[&<>]/;
 
 // A primitive component return is user text. Only compiler-owned HTML may
 // bypass escaping; carrying the proof with the value also preserves it through
@@ -1703,17 +1707,19 @@ function serverComponentOutput(out: unknown, scope: SSRScope): string {
 
 export function escapeHtml(v: unknown): string {
 	const s = typeof v === 'string' ? v : String(v);
-	HTML_ESCAPE_RE.lastIndex = 0;
-	if (!HTML_ESCAPE_RE.test(s)) return s;
+	const needsEscape =
+		s.length < 32
+			? HTML_ESCAPE_RE.test(s)
+			: s.indexOf('&') !== -1 || s.indexOf('<') !== -1 || s.indexOf('>') !== -1;
+	if (!needsEscape) return s;
 	return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
 
-const ATTR_ESCAPE_RE = /[&"]/g;
+const ATTR_ESCAPE_RE = /[&"]/;
 export function escapeAttr(v: unknown): string {
 	const s = typeof v === 'string' ? v : String(v);
-	ATTR_ESCAPE_RE.lastIndex = 0;
 	if (!ATTR_ESCAPE_RE.test(s)) return s;
-	return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+	return s.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -484,6 +484,22 @@ describe('SSR Phase 1 — semantics', () => {
 			'😀\ud800&\udfff<\u0000>',
 			'😀\ud800&amp;\udfff&lt;\u0000&gt;',
 		],
+		// Boundary inputs at and around 32 chars plus long strings whose only
+		// escapable char is late — covers both sides of escapeHtml's length-keyed
+		// pre-scan and each of its detection disjuncts.
+		['a 31-char string ending in >', 'a'.repeat(30) + '>', 'a'.repeat(30) + '&gt;'],
+		['a 32-char string ending in >', 'a'.repeat(31) + '>', 'a'.repeat(31) + '&gt;'],
+		['a 32-char string ending in <', 'a'.repeat(31) + '<', 'a'.repeat(31) + '&lt;'],
+		[
+			'a long string whose only escapable char is a late &',
+			'word '.repeat(10) + '& done',
+			'word '.repeat(10) + '&amp; done',
+		],
+		[
+			'a long string needing no escape',
+			'long string without anything sensitive, padded past the threshold',
+			'long string without anything sensitive, padded past the threshold',
+		],
 	])('escapes %s identically in buffered and static markup', (_label, value, expected) => {
 		const expectedMarkup = `<span>${expected}</span>`;
 		expect(RT.renderToString(basic.Counter, { n: value }).html).toBe(expectedMarkup);


### PR DESCRIPTION
## Summary

`escapeHtml`'s no-escape guard scanned every SSR text value with a global regexp — `/[&<>]/g` plus a `lastIndex` reset on every call. A CPU profile of the 500-card SSR benchmark attributed ~30% of render time to that scan (`RegExp: [&<>]` ≈ 5.6s self in a 19s profile). The scan strategy is now picked by string length, where the cost model actually differs:

- strings under 32 chars: a **non-global** `/[&<>]/` test — one regexp entry, no `lastIndex` bookkeeping, and no shared scan state a nested render could corrupt;
- strings at or above 32: three `indexOf` scans — V8's memchr-backed search beats the regexp engine on long inputs (crossover measured at ~32 chars).

`escapeAttr` gets the matching half of the fix: non-global `[&"]` test and `replaceAll` escapes (attr values are short, so it keeps the regexp scan). The escape path itself is unchanged — same characters, same order, same double-escaping, output is byte-identical.

An unconditional-`indexOf` version was tried first and rejected on evidence: it won long strings but regressed the short-string control (waterfall-d1) ~13%, because three builtin calls cost more than one regexp entry on tiny strings. The length split keeps the winner in each regime.

## Benchmarks

`benchmarks/ssr-throughput`, Node 22 / macOS / Apple Silicon, 3 fresh processes per side, fixture bundles rebuilt per revision (commands and raw runs recorded in `benchmarks/ssr-throughput/README.md`):

| Config | Baseline median | Candidate median | Delta |
| --- | --- | --- | --- |
| news-500/octane-tsrx (primary) | 0.544 ms | 0.435 ms | **−20%** |
| news-50/octane-tsrx (control) | 0.047 ms | 0.040 ms | −14% |
| waterfall-d1 (control) | 0.069 ms | 0.074 ms | inside run spread |

HTML body bytes and marker counts identical on every config (41 KB/2, 409 KB/2, 30 KB/5). waterfall-d1 re-renders a ~1,000-node page per Suspense pass and is the noisiest config in the suite (same-binary repeats spanned 0.066–0.122); its strings are all under 32 chars so the mechanism there is strictly less work than the old `/g` scan — the residual elevation is noise, not a measured regression.

## Validation

- [x] `pnpm format:check` (changed files: `pnpm format:files:check`)
- [x] `pnpm typecheck` (`typecheck:files` on `runtime.server.ts`; the repo's plain-tsgo helper can't resolve `.tsrx` test imports — `tsrx-tsc` is the right tool there)
- [x] `pnpm test` — see note
- [x] targeted tests: `packages/octane/tests/ssr.test.ts` 162/162 dev+prod on the rebased head; 10 SSR-adjacent files, 390 tests; deliberate-break check (dropping `>` from the guard) fails the suite as expected

`pnpm test` locally covered the full project list through `rspeedy-plugin` — every octane/octane-prod/SSR/hydration project green — before the root vitest process hit the default Node heap limit (~4 GB) near the end of the run. The one observed failure, `drei/tests/splat.test.ts`, reproduces identically on the base commit with this diff stashed (pre-existing, unrelated). A rerun with a larger heap is in progress; CI remains the authoritative full-suite gate.

## Risk / follow-ups

- The 32-char threshold is a measured crossover on Apple Silicon/Node 22; it only selects between two equivalent detection scans, so a different engine's crossover shifts performance, never correctness.
- `escapeAttr` could take a similar length split for very long attribute values — not profile-hot in these workloads; left as a possible follow-up.
- `pnpm test` did not reach a clean local completion due to the heap limit described above.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving optimization on hot SSR paths; the 32-char threshold only affects performance, not correctness of escaping.
> 
> **Overview**
> **SSR text escaping is faster** by changing how `escapeHtml` and `escapeAttr` decide whether a string needs escaping, without changing escaped output.
> 
> `escapeHtml` no longer uses a global `/[&<>]/g` regexp plus `lastIndex` reset on every call. **Strings under 32 characters** use a non-global regexp `.test()`; **longer strings** use three `indexOf` checks for `&`, `<`, and `>`. `escapeAttr` similarly drops the global flag and `lastIndex`, and uses `replaceAll` for the escape path.
> 
> Documentation adds a changeset and **ssr-throughput benchmark notes** (~20% median improvement on news-500, byte-identical HTML). **Tests** cover the 32-character boundary and long strings with late escapable characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5a05ef5601dcc7a04b2b70bded7ad22826b7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791860604&installation_model_id=432790&pr_number=1073&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F1073&signature=8a1a4041f66e861ffa9b4763e2b315d7a867eb3edbed02c1484b691f86978659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->